### PR TITLE
hardening: Config.load() drops unknown keys instead of discarding whole config

### DIFF
--- a/holdspeak/config.py
+++ b/holdspeak/config.py
@@ -3,13 +3,37 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field, asdict
+import logging
+from dataclasses import dataclass, field, asdict, fields
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # Default config location
 CONFIG_DIR = Path.home() / ".config" / "holdspeak"
 CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+def _coerce(dc_type, data, *, section: str):
+    """Build a config dataclass from a dict, dropping unknown/legacy keys.
+
+    A stale or unknown key — e.g. a config option retired in a later version
+    (the HS-32-06-removed ``meeting.web_enabled`` was found in the wild) — must
+    **not** discard the user's whole config. Previously ``load()`` constructed
+    each sub-config as ``DcType(**data)`` inside a broad ``except: return
+    cls()``, so one unrecognized key made the *entire* config silently fall back
+    to defaults (a configured ``intel_cloud_base_url`` would be ignored on every
+    load with no error). Here unknown keys are dropped with a warning so the rest
+    of the section still loads.
+    """
+    known = {f.name for f in fields(dc_type)}
+    extra = sorted(k for k in data if k not in known)
+    if extra:
+        logger.warning(
+            "config: ignoring unknown key(s) in [%s]: %s", section, ", ".join(extra)
+        )
+    return dc_type(**{k: v for k, v in data.items() if k in known})
 
 
 @dataclass
@@ -277,20 +301,30 @@ class Config:
             pipeline_data = dictation_data.get("pipeline", {}) or {}
             runtime_data = dictation_data.get("runtime", {}) or {}
             dictation = DictationConfig(
-                pipeline=DictationPipelineConfig(**pipeline_data),
-                runtime=LLMRuntimeConfig(**runtime_data),
+                pipeline=_coerce(
+                    DictationPipelineConfig, pipeline_data, section="dictation.pipeline"
+                ),
+                runtime=_coerce(
+                    LLMRuntimeConfig, runtime_data, section="dictation.runtime"
+                ),
             )
 
             return cls(
-                hotkey=HotkeyConfig(**data.get("hotkey", {})),
-                model=ModelConfig(**data.get("model", {})),
-                ui=UIConfig(**data.get("ui", {})),
-                meeting=MeetingConfig(**data.get("meeting", {})),
+                hotkey=_coerce(HotkeyConfig, data.get("hotkey", {}) or {}, section="hotkey"),
+                model=_coerce(ModelConfig, data.get("model", {}) or {}, section="model"),
+                ui=_coerce(UIConfig, data.get("ui", {}) or {}, section="ui"),
+                meeting=_coerce(MeetingConfig, data.get("meeting", {}) or {}, section="meeting"),
                 dictation=dictation,
-                device=DeviceConfig(**data.get("device", {})),
+                device=_coerce(DeviceConfig, data.get("device", {}) or {}, section="device"),
             )
-        except Exception:
-            # Fall back to defaults on any error
+        except Exception as exc:
+            # Last-resort fallback for a genuinely broken config (bad JSON, wrong
+            # top-level type, or a value a sub-config's __post_init__ rejects).
+            # Unknown/legacy keys no longer reach here — _coerce drops them — so
+            # this should be rare; log it rather than swallowing silently.
+            logger.warning(
+                "config: failed to load %s (%s); using defaults", config_path, exc
+            )
             return cls()
 
     def save(self, path: Optional[Path] = None) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -379,34 +379,72 @@ class TestConfigLoad:
         assert config.hotkey.key == "alt_r"
 
     def test_load_with_extra_fields_ignores_unknown(self, tmp_path):
-        """load() ignores unknown fields in config file."""
+        """load() drops unknown keys \u2014 both unknown sections AND unknown
+        keys *within* a section \u2014 without discarding the rest of the config."""
         path = tmp_path / "extra.json"
         data = {
+            # an unknown key inside a section no longer breaks the whole load
             "hotkey": {"key": "alt_l", "display": "\u2325L", "unknown_field": "value"},
             "model": {"name": "tiny"},
             "ui": {},
             "meeting": {},
-            "unknown_section": {"foo": "bar"},
+            "unknown_section": {"foo": "bar"},  # unknown top-level section
         }
         with open(path, "w") as f:
             json.dump(data, f)
 
-        # Should not raise, unknown_section is ignored
-        # But hotkey unknown_field will cause TypeError
-        # Let's test with just unknown section
-        data2 = {
-            "hotkey": {"key": "alt_l", "display": "\u2325L"},
-            "model": {"name": "tiny"},
-            "unknown_section": {"foo": "bar"},
-        }
-        path2 = tmp_path / "extra2.json"
-        with open(path2, "w") as f:
-            json.dump(data2, f)
-
-        config = Config.load(path2)
+        config = Config.load(path)
+        # The known keys in the same section still load (no total fallback).
         assert config.hotkey.key == "alt_l"
+        assert config.hotkey.display == "\u2325L"
         assert config.model.name == "tiny"
         assert config.model.warm_on_start is True
+
+    def test_load_legacy_key_does_not_discard_whole_config(self, tmp_path):
+        """A retired/legacy key in one section must not nuke the user's config.
+
+        Regression for the wild case surfaced post-HS-32-06: the removed
+        ``meeting.web_enabled`` key tripped ``MeetingConfig(**data)`` and the old
+        broad ``except: return cls()`` silently discarded the *entire* config \u2014
+        so a configured ``intel_cloud_base_url`` was ignored on every load. The
+        legacy key must be dropped while every other configured value survives.
+        """
+        path = tmp_path / "legacy.json"
+        data = {
+            "meeting": {
+                "web_enabled": True,  # retired in HS-32-06 \u2014 must be ignored
+                "intel_provider": "cloud",
+                "intel_cloud_base_url": "http://192.168.1.43:8080/v1",
+                "intel_cloud_model": "Qwen3.5-9B-UD-Q6_K_XL.gguf",
+            },
+            "model": {"name": "small"},
+        }
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+        config = Config.load(path)
+        # The configured cloud endpoint survives \u2014 not silently dropped to defaults.
+        assert config.meeting.intel_provider == "cloud"
+        assert config.meeting.intel_cloud_base_url == "http://192.168.1.43:8080/v1"
+        assert config.meeting.intel_cloud_model == "Qwen3.5-9B-UD-Q6_K_XL.gguf"
+        # The legacy key is not present on the dataclass.
+        assert not hasattr(config.meeting, "web_enabled")
+        # A sibling section is unaffected.
+        assert config.model.name == "small"
+
+    def test_load_unknown_key_logs_warning(self, tmp_path, caplog):
+        """Dropping an unknown key emits a warning (not a silent swallow)."""
+        path = tmp_path / "warn.json"
+        with open(path, "w") as f:
+            json.dump({"meeting": {"web_enabled": True, "mic_label": "Host"}}, f)
+
+        with caplog.at_level("WARNING", logger="holdspeak.config"):
+            config = Config.load(path)
+
+        assert config.meeting.mic_label == "Host"
+        assert any(
+            "web_enabled" in r.message and "meeting" in r.message for r in caplog.records
+        ), caplog.text
 
 
 # ============================================================


### PR DESCRIPTION
Foundation-hardening fix surfaced during Phase 35 (HS-35-04) and flagged in that phase's `final-summary.md` / HANDOVER as a follow-up.

## The bug

`Config.load()` built each sub-config as `DcType(**data)` inside a broad `except Exception: return cls()`. A single unknown/legacy key therefore made the **entire** config silently fall back to defaults. Found live: the HS-32-06-retired `meeting.web_enabled` key in a real user config, which caused a configured `intel_cloud_base_url` (a LAN intel endpoint) to be **ignored on every load** with no error.

## The fix

- A `_coerce(dc_type, data, *, section)` helper filters each section's dict to the dataclass's known fields, dropping unknown/legacy keys with a per-section **WARNING** rather than letting one bad key discard everything.
- The outer `try/except` is kept as a last resort for genuinely broken configs (bad JSON, wrong top-level type, a value a sub-config `__post_init__` rejects) but now **logs** the error instead of swallowing it silently.

## Tests

- Corrected `test_load_with_extra_fields_ignores_unknown` (it previously *documented* the bug — "hotkey unknown_field will cause TypeError" — and avoided exercising it).
- Added `test_load_legacy_key_does_not_discard_whole_config` (the exact `web_enabled` wild case: the cloud endpoint survives, the legacy key is dropped, siblings unaffected) and `test_load_unknown_key_logs_warning`.
- Config tests **63 passed**; full suite **2009 passed / 15 skipped**; `config.py` + test ruff-clean. Verified against the real backed-up config (endpoint resolves; warning emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)