### PR TITLE
docs: humanize the Phase-46 docs prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,57 @@
 # HoldSpeak
 
 <p align="center">
-  <img src="docs/assets/pixellab/holdspeak-mark.png" alt="HoldSpeak logo — a held key with rising soundwaves" width="120">
+  <img src="docs/assets/pixellab/holdspeak-mark.png" alt="HoldSpeak logo, a held key with rising soundwaves" width="120">
 </p>
 
-<p align="center"><strong>Hold a key. Speak. It types — anywhere. 100% local. And it learns you.</strong></p>
+<p align="center"><strong>Hold a key. Speak. It types in any app. 100% local. And it learns how you work.</strong></p>
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Tests](https://github.com/karolswdev/HoldSpeak/actions/workflows/test.yml/badge.svg)](https://github.com/karolswdev/HoldSpeak/actions/workflows/test.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Platform: macOS | Linux](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)](#platform-support)
 
-HoldSpeak is **local-first voice input** for macOS and Linux. Hold your hotkey,
-speak, release — text lands in whatever app you're in. No cloud, no account, no
-telemetry: nothing leaves your machine except the model endpoint *you* choose to
-point at. It works standalone as a voice-typing tool, or scales up into meeting
-intelligence, project-aware dictation, and an AIPI-Lite companion device.
+HoldSpeak is local-first voice input for macOS and Linux. Hold your hotkey, speak,
+release, and the text appears in whatever app you're in. No cloud, no account, no
+telemetry. Nothing leaves your machine except the model endpoint you choose to
+point at. Use it on its own as a voice-typing tool, or grow into meeting
+intelligence, project-aware dictation, and the AIPI-Lite companion device.
 
-> **Status: early / pre-release.** Mature in features but not yet published to
-> PyPI — install from source (below). APIs, config, and defaults may still
+> **Status: early / pre-release.** The features are mature, but it isn't on PyPI
+> yet, so you install from source (below). APIs, config, and defaults can still
 > change. Feedback and contributions welcome.
 
 ## Why it's different
 
-- 🔒 **100% local by default** — Whisper transcription plus *your* LLM; private unless you deliberately point at a cloud endpoint. [Security & privacy →](docs/SECURITY.md)
-- 🧠 **It learns you** — every dictation is journaled (said → typed → routed → latency); **correct it in the moment** with one tap, and **replay** it through the tuned pipeline to watch the copilot improve. [See it learn →](docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay)
-- 🎙️ **Voice *and* meetings both get an afterlife** — not a transcript that evaporates the instant it types: a searchable, reviewable record on both sides.
-- 🧩 **14 real LLM-backed meeting plugins** — architecture diagrams, ADRs, risk registers, incident timelines, decisions, stakeholder updates… all extracted from the transcript. [Meeting intelligence →](docs/MEETING_MODE_GUIDE.md)
-- 🔌 **Bring your own model** — GGUF in-process, MLX on Apple Silicon, or any OpenAI-compatible endpoint. [Models →](docs/MODELS.md)
-- 🪟 **Ambient desktop presence** *(opt-in)* — a native, focus-safe HUD shows *listening / transcribing / typing* while you dictate into another app, without the dashboard on screen. [More →](docs/INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status)
-- 📟 **AIPI-Lite companion** *(optional)* — a portable device for meeting-capture controls and speak-the-reply-to-your-agent, between rooms. [Workflow →](docs/AIPI_LITE_DEV_WORKFLOW.md)
+- **100% local by default.** Whisper transcription and your own LLM. Nothing is
+  sent anywhere unless you deliberately point it at a cloud endpoint. See
+  [Security & privacy](docs/SECURITY.md).
+- **It learns how you work.** Every dictation is saved: what you said, what it
+  typed, where it routed, how long it took. Fix a wrong one with a single tap and
+  it remembers; replay it through the updated pipeline and watch the result change.
+  See [the dictation journal](docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay).
+- **Your voice gets the afterlife your meetings already have.** A dictation doesn't
+  vanish the second it's typed. It's saved, searchable, and reviewable, the same
+  way a recorded meeting is.
+- **14 real LLM-backed meeting plugins.** Architecture diagrams, ADRs, risk
+  registers, incident timelines, decisions, and stakeholder updates, all pulled out
+  of the transcript. See [meeting intelligence](docs/MEETING_MODE_GUIDE.md).
+- **Bring your own model.** GGUF in-process, MLX on Apple Silicon, or any
+  OpenAI-compatible endpoint. See [Models](docs/MODELS.md).
+- **Ambient desktop presence, if you want it.** A native, focus-safe HUD shows
+  whether it's listening, transcribing, or typing while you dictate into another
+  app. Off by default. See
+  [Desktop Presence](docs/INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
+- **AIPI-Lite companion, if you have one.** A small device for meeting-capture
+  controls, and for speaking a reply to your coding agent from another room. See
+  [the workflow](docs/AIPI_LITE_DEV_WORKFLOW.md).
 
 ## What it does, at a glance
 
 | Voice typing | Meeting intelligence | Project-aware typing |
 | --- | --- | --- |
 | ![Pixel art microphone with hold-to-talk waves](docs/assets/pixellab/hold-to-talk-microphone.png) | ![Pixel art meeting notebook with action items](docs/assets/pixellab/meeting-intelligence-notebook.png) | ![Pixel art code editor connected to local context](docs/assets/pixellab/project-aware-typing.png) |
-| Hold the hotkey, speak, release — text inserts into the active app. Punctuation commands (`"period"`, `"comma"`) and `"clipboard"` substitution work out of the box. | Dual-stream capture (mic + system audio), live transcript with speaker labels, AI-extracted topics, actions, and artifacts — reviewable at `/history`. | Route rough speech through intent classification, project-KB enrichment, and LLM rewriting before it lands — tuned for Codex, Claude, terminal, browser, or editor. |
+| Hold the hotkey, speak, release. The text goes into the active app. Punctuation commands (`"period"`, `"comma"`) and `"clipboard"` substitution work out of the box. | Capture mic and system audio together, get a live transcript with speaker labels, and let the AI pull out topics, actions, and artifacts you can review at `/history`. | Rough speech runs through intent classification, project-KB enrichment, and an LLM rewrite before it lands, tuned for Codex, Claude, the terminal, the browser, or your editor. |
 
 ## See it learn
 
@@ -44,28 +59,30 @@ intelligence, project-aware dictation, and an AIPI-Lite companion device.
   <img src="docs/assets/pixellab/operator-working-loop.gif" alt="Animated pixel art operator working at a terminal while companion and task cards update" width="280">
 </p>
 
-Speech becomes transcript context, reviewable actions, summaries, and
-coding-agent replies — while the local runtime stays in control. Because every
-dictation is recorded, you can **review** what it heard, **correct** a misfire in
-one tap (which teaches it), and **replay** it through the updated pipeline — so
-"it got better" becomes something you can watch. [End to end →](docs/DICTATION_COPILOT.md)
+Speech turns into transcript context, reviewable actions, summaries, and replies
+for your coding agent, while the local runtime stays in charge. Because every
+dictation is recorded, you can look back at what it heard, fix a mistake in one tap
+(which teaches it), and replay the utterance through the updated pipeline. Instead
+of trusting that it improved, you watch it happen.
+[See the full walkthrough](docs/DICTATION_COPILOT.md).
 
 <p align="center">
   <img src="docs/assets/screenshots/journal.png" alt="The HoldSpeak dictation Journal: a said-to-typed timeline of recent dictations, each card showing the spoken transcript, the typed result, its routing target, and a per-utterance latency strip; one row marked corrected." width="760">
 </p>
-<p align="center"><em>The dictation Journal — every utterance: what you said, what it typed, where it routed, and how long it took.</em></p>
+<p align="center"><em>The dictation journal. Every utterance, with what you said, what it typed, where it routed, and how long it took.</em></p>
 
 ## Quickstart
 
-The install script clones it; `doctor` checks your setup; `holdspeak` launches:
+The install script clones the repo, `doctor` checks your setup, and `holdspeak`
+launches the web runtime:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/scripts/install.sh | bash
-holdspeak doctor   # verify mic permissions + backends
+holdspeak doctor   # check mic permissions and backends
 holdspeak          # launch the web runtime
 ```
 
-Or from a clone, using [`uv`](https://docs.astral.sh/uv/):
+Or from a clone, with [`uv`](https://docs.astral.sh/uv/):
 
 ```bash
 git clone https://github.com/karolswdev/HoldSpeak.git && cd HoldSpeak
@@ -73,16 +90,17 @@ uv pip install -e .
 holdspeak doctor && holdspeak
 ```
 
-Optional extras (install only what you need):
+Install only the extras you need:
 
 ```bash
-uv pip install -e '.[meeting]'         # meeting mode + AI intelligence
-uv pip install -e '.[dictation-mlx]'   # intelligent dictation — Apple Silicon (MLX)
-uv pip install -e '.[dictation-llama]' # intelligent dictation — cross-platform (GGUF)
-uv pip install -e '.[dictation-openai]'# intelligent dictation — OpenAI-compatible endpoint
+uv pip install -e '.[meeting]'         # meeting mode and AI intelligence
+uv pip install -e '.[dictation-mlx]'   # intelligent dictation on Apple Silicon (MLX)
+uv pip install -e '.[dictation-llama]' # intelligent dictation, cross-platform (GGUF)
+uv pip install -e '.[dictation-openai]'# intelligent dictation via an OpenAI-compatible endpoint
 ```
 
-The dictation/meeting LLM is **bring-your-own** — see [`docs/MODELS.md`](docs/MODELS.md) for the contract and current suggestions.
+The dictation and meeting LLM is yours to choose. See
+[`docs/MODELS.md`](docs/MODELS.md) for the contract and current suggestions.
 
 ## Platform support
 
@@ -94,21 +112,21 @@ The dictation/meeting LLM is **bring-your-own** — see [`docs/MODELS.md`](docs/
 | Meeting mode | ✅ | ✅ | ✅ |
 | System audio capture | ✅ BlackHole | ✅ Pulse/PipeWire | ✅ Pulse/PipeWire |
 
-Wayland often blocks global hooks and synthetic typing — HoldSpeak falls back to clipboard paste for injection.
+Wayland often blocks global hooks and synthetic typing, so HoldSpeak falls back to clipboard paste for injection.
 
 ## Meeting intelligence
 
 Record or save a meeting and HoldSpeak turns the transcript into structured,
-reviewable artifacts via **multi-intent routing**: the transcript is scored for
-intent (architecture, delivery, product, incident, comms), a plugin chain runs,
-and each plugin calls your LLM to produce a typed artifact — rendered **read-only**
-at `/history`. HoldSpeak ships **14 built-in plugins**, all real and LLM-backed.
+reviewable artifacts. It scores the transcript for intent (architecture, delivery,
+product, incident, comms), runs a chain of plugins, and has each one call your LLM
+to produce a typed artifact. The results render read-only at `/history`. HoldSpeak
+ships 14 built-in plugins, all real and backed by an LLM.
 
-Plugins can also **propose actions** — an *actuator* proposes an external side
-effect (file a ticket, post an update) that only happens after an explicit,
-audited, **per-action human approval**, **off by default**. Write your own with
-the [Plugin Authoring guide](docs/PLUGIN_AUTHORING.md); for endpoints and routing
-see the [Meeting Mode Guide](docs/MEETING_MODE_GUIDE.md).
+Plugins can also propose actions. An actuator proposes an external side effect,
+like filing a ticket or posting an update, that only runs after you approve it for
+that specific action. Actuators are off by default. Write your own with the
+[Plugin Authoring guide](docs/PLUGIN_AUTHORING.md); for endpoints and routing, see
+the [Meeting Mode Guide](docs/MEETING_MODE_GUIDE.md).
 
 ## AIPI-Lite companion
 
@@ -116,13 +134,13 @@ see the [Meeting Mode Guide](docs/MEETING_MODE_GUIDE.md).
   <img src="docs/assets/pixellab/aipi-lite-companion.png" alt="Pixel art AIPI-Lite companion device" width="220">
 </p>
 
-The optional **AIPI-Lite** is a portable ESPHome-based device you carry between
-rooms. On Wi-Fi (a phone hotspot works), it gives you meeting-capture controls
-and status feedback — and with Claude/Codex hooks enabled, it notifies you when
-an agent is waiting so you can **speak the reply** back into the coding session.
-Hardware: the [official page](https://aipi.com/products/aipi-lite) or the
-[Amazon listing](https://www.amazon.com/dp/B0FQNNVV36); firmware + bridge setup in
-the [AIPI-Lite Developer Workflow](docs/AIPI_LITE_DEV_WORKFLOW.md).
+AIPI-Lite is an optional ESPHome-based device you can carry between rooms. Put it
+on Wi-Fi (a phone hotspot works), and it gives you meeting-capture controls and
+status feedback. With Claude/Codex hooks on, it tells you when an agent is waiting
+so you can speak the reply back into the coding session. Buy the hardware from the
+[official page](https://aipi.com/products/aipi-lite) or the
+[Amazon listing](https://www.amazon.com/dp/B0FQNNVV36); firmware and bridge setup
+are in the [AIPI-Lite Developer Workflow](docs/AIPI_LITE_DEV_WORKFLOW.md).
 
 ## Where to go next
 
@@ -130,7 +148,7 @@ the [AIPI-Lite Developer Workflow](docs/AIPI_LITE_DEV_WORKFLOW.md).
 |---|---|
 | Browse all the docs | [Documentation index](docs/README.md) |
 | Get it running and verify my setup | [Getting Started](docs/GETTING_STARTED.md) |
-| Choose / configure a model | [Models — bring your own](docs/MODELS.md) |
+| Choose / configure a model | [Models (bring your own)](docs/MODELS.md) |
 | See speech become a project-grounded task | [The Dictation Copilot](docs/DICTATION_COPILOT.md) |
 | Set up project-aware dictation for Codex / Claude | [Intelligent Typing Setup](docs/INTELLIGENT_TYPING_GUIDE.md) |
 | Review, correct, and replay past dictations | [Dictation journal & replay](docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay) |
@@ -141,17 +159,17 @@ the [AIPI-Lite Developer Workflow](docs/AIPI_LITE_DEV_WORKFLOW.md).
 
 ## Configuration
 
-Config lives at `~/.config/holdspeak/config.json`, but you rarely touch it by
-hand — **Settings** in the web runtime exposes the hotkey, model, meeting intel,
-dictation pipeline, and presence knobs. Full reference in
+Config lives at `~/.config/holdspeak/config.json`, but you rarely edit it by hand.
+The Settings page in the web runtime exposes the hotkey, model, meeting intel,
+dictation pipeline, and presence options. The full reference is in
 [Getting Started](docs/GETTING_STARTED.md) and the guides above.
 
 ## Contributing
 
 Contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup
 (`uv`, the git hooks, the test command) and the commit-contract workflow. Recent
-changes are tracked in [`CHANGELOG.md`](CHANGELOG.md).
+changes are in [`CHANGELOG.md`](CHANGELOG.md).
 
 ## License
 
-Licensed under the **Apache License 2.0** — see [`LICENSE`](LICENSE).
+Licensed under the Apache License 2.0. See [`LICENSE`](LICENSE).

--- a/docs/AGENT_HOOK_INSTALL.md
+++ b/docs/AGENT_HOOK_INSTALL.md
@@ -351,8 +351,8 @@ Confirm HoldSpeak sees the expected project root and context files.
 
 ## See also
 
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md) — how captured agent
-  context shapes a rewrite.
-- [The Dictation Copilot](DICTATION_COPILOT.md) — see the agent-grounded rewrite
-  end to end.
-- [Security & Privacy](SECURITY.md) — what hook capture stores and what it doesn't.
+- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md): how captured agent context
+  shapes a rewrite.
+- [The Dictation Copilot](DICTATION_COPILOT.md): see the agent-grounded rewrite end
+  to end.
+- [Security & Privacy](SECURITY.md): what hook capture stores and what it doesn't.

--- a/docs/AIPI_LITE_DEV_WORKFLOW.md
+++ b/docs/AIPI_LITE_DEV_WORKFLOW.md
@@ -141,8 +141,8 @@ still making tests and operation first-class from the unified checkout.
 
 ## See also
 
-- [Device Protocol](DEVICE_PROTOCOL.md) — the remote-audio WebSocket protocol the
+- [Device Protocol](DEVICE_PROTOCOL.md): the remote-audio WebSocket protocol the
   bridge speaks.
-- [Agent Hook Install](AGENT_HOOK_INSTALL.md) — wire agent replies through to the
+- [Agent Hook Install](AGENT_HOOK_INSTALL.md): wire agent replies through to the
   device.
-- [Meeting Mode Guide](MEETING_MODE_GUIDE.md) — what the device controls.
+- [Meeting Mode Guide](MEETING_MODE_GUIDE.md): what the device controls.

--- a/docs/CONNECTOR_DEVELOPMENT.md
+++ b/docs/CONNECTOR_DEVELOPMENT.md
@@ -455,8 +455,8 @@ the current roadmap.
 
 ## See also
 
-- [Firefox Extension Guide](FIREFOX_EXTENSION_GUIDE.md) — a first-party
+- [Firefox Extension Guide](FIREFOX_EXTENSION_GUIDE.md): a first-party
   `extension_events` connector, end to end.
-- [Plugin Authoring](PLUGIN_AUTHORING.md) — the sibling contract for meeting-intel
+- [Plugin Authoring](PLUGIN_AUTHORING.md): the sibling contract for meeting-intel
   plugins.
-- [Security & Privacy](SECURITY.md) — the permission model connectors declare against.
+- [Security & Privacy](SECURITY.md): the permission model connectors declare against.

--- a/docs/DEVICE_PROTOCOL.md
+++ b/docs/DEVICE_PROTOCOL.md
@@ -413,6 +413,6 @@ server → device  {"type":"status","text":"Saving meeting...","ttl_ms":0}
 
 ## See also
 
-- [AIPI-Lite Developer Workflow](AIPI_LITE_DEV_WORKFLOW.md) — the firmware + bridge
+- [AIPI-Lite Developer Workflow](AIPI_LITE_DEV_WORKFLOW.md): the firmware and bridge
   workflow that implements this protocol.
-- [Security & Privacy](SECURITY.md) — the device PSK + loopback trust boundary.
+- [Security & Privacy](SECURITY.md): the device PSK and loopback trust boundary.

--- a/docs/FIREFOX_EXTENSION_GUIDE.md
+++ b/docs/FIREFOX_EXTENSION_GUIDE.md
@@ -78,7 +78,7 @@ extensions/firefox/
 
 ## See also
 
-- [Connector Development](CONNECTOR_DEVELOPMENT.md) — the connector contract this
+- [Connector Development](CONNECTOR_DEVELOPMENT.md): the connector contract this
   extension is an instance of.
-- [Security & Privacy](SECURITY.md) — what the browser connector posts and where
-  it goes.
+- [Security & Privacy](SECURITY.md): what the browser connector posts and where it
+  goes.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -75,7 +75,7 @@ takes you from install to your first words, **no file editing**:
 
 ![The HoldSpeak welcome wizard: a full-screen first-run screen headlined "Hold a key. Speak. Watch it type." with a step rail (Welcome · Permissions · Model · First dictation · Presence · You're set) and a "Get started" button; the footer reads "Local · 127.0.0.1 · nothing leaves your machine".](assets/screenshots/welcome.png)
 
-*The `/welcome` wizard on a fresh install — fresh clone to a verified first dictation, no file editing.*
+*The `/welcome` wizard on a fresh install. It takes you from a fresh clone to a verified first dictation, with no file editing.*
 
 A returning user lands on the dashboard instead (the wizard never nags). If
 something later needs attention, **`/setup`** is the calm status surface, and the
@@ -108,13 +108,13 @@ Default hotkey:
 If global hotkeys or synthetic typing are blocked, keep the HoldSpeak window
 focused and use the focused hold-to-talk fallback.
 
-> **Tip — see what the copilot is doing without the dashboard.** Flip on
-> **desktop presence** in **Settings** (or set `presence.enabled` in your config)
-> to get an ambient, native surface (a floating HUD on macOS / X11, a tray glyph +
-> notification everywhere) that shows *listening / transcribing / typing* while you
-> dictate into another app — and never steals keyboard focus. For a headless launch
-> you can force it on with `HOLDSPEAK_DESKTOP_PRESENCE=1 holdspeak`. See
-> [Desktop Presence](INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
+> **Tip: see what the copilot is doing without the dashboard.** Turn on **desktop
+> presence** in **Settings** (or set `presence.enabled` in your config) to get an
+> ambient, native surface (a floating HUD on macOS and X11, a tray glyph plus
+> notification everywhere). It shows whether it's listening, transcribing, or typing
+> while you dictate into another app, and it never takes keyboard focus. For a
+> headless launch you can force it on with `HOLDSPEAK_DESKTOP_PRESENCE=1 holdspeak`.
+> See [Desktop Presence](INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
 
 ## 6. Use Punctuation Commands
 
@@ -196,8 +196,8 @@ When ready, continue with:
 
 ## See also
 
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md) — once basic voice
-  typing works, turn on the project-aware copilot.
-- [Meeting Mode Guide](MEETING_MODE_GUIDE.md) — meeting-specific setup and capture.
-- [Models — bring your own](MODELS.md) — pick and point at an LLM.
-- [Security & Privacy](SECURITY.md) — what's stored and what can leave your machine.
+- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md): once basic voice typing
+  works, turn on the project-aware copilot.
+- [Meeting Mode Guide](MEETING_MODE_GUIDE.md): meeting-specific setup and capture.
+- [Models (bring your own)](MODELS.md): pick and point at an LLM.
+- [Security & Privacy](SECURITY.md): what's stored and what can leave your machine.

--- a/docs/INTELLIGENT_TYPING_GUIDE.md
+++ b/docs/INTELLIGENT_TYPING_GUIDE.md
@@ -27,15 +27,14 @@ The pipeline can:
 - adapt output for Codex, Claude, terminal, browser, editor, or chat;
 - suggest narrow `.hs/.../*.md` project documentation updates for review.
 
-> **Heads-up — "project KB" and "project context" are two different things.**
-> Your **project KB** is a small key-value map (`kb:`) in
-> `<repo>/.holdspeak/project.yaml`; its keys become `{project.kb.<key>}`
-> placeholders that the default **`kb-enricher`** stage substitutes into a block's
-> template — deterministic, no LLM. Edit it on the **Project KB** tab.
-> **Project context** is the *separate* `.hs/` folder of Markdown files
-> (`instructions`, `context`, `workflows`, `targets`, plus an `ignore` for secrets)
-> that the **optional `project-rewriter`** (LLM) stage uses to rewrite your speech —
-> edit it on the **Project Context** tab; set it up in
+> **"Project KB" and "project context" are two different things.** Your project KB
+> is a small key-value map (`kb:`) in `<repo>/.holdspeak/project.yaml`. Its keys
+> become `{project.kb.<key>}` placeholders, and the default **`kb-enricher`** stage
+> substitutes them into a block's template (deterministic, no LLM). You edit it on
+> the **Project KB** tab. Project context is the *separate* `.hs/` folder of Markdown
+> files (`instructions`, `context`, `workflows`, `targets`, plus an `ignore` for
+> secrets), and the **optional `project-rewriter`** (LLM) stage uses it to rewrite
+> your speech. You edit it on the **Project Context** tab, and set it up in
 > [§5. Create Project Context](#5-create-project-context). HoldSpeak reads both but
 > never writes them without your approval.
 
@@ -690,10 +689,10 @@ holdspeak dictation dry-run "ask codex to summarize what changed and suggest a n
 
 ## See also
 
-- [Getting Started](GETTING_STARTED.md) — install and basic voice typing first.
-- [The Dictation Copilot](DICTATION_COPILOT.md) — see the pipeline turn rough
-  speech into a project-grounded task, end to end.
-- [Models — bring your own](MODELS.md) — choosing and pointing at an LLM.
-- [Agent Hook Install](AGENT_HOOK_INSTALL.md) — feed Claude/Codex context into the
+- [Getting Started](GETTING_STARTED.md): install and basic voice typing first.
+- [The Dictation Copilot](DICTATION_COPILOT.md): see the pipeline turn rough speech
+  into a project-grounded task, end to end.
+- [Models (bring your own)](MODELS.md): choosing and pointing at an LLM.
+- [Agent Hook Install](AGENT_HOOK_INSTALL.md): feed Claude/Codex context into the
   rewriter.
-- [Security & Privacy](SECURITY.md) — what's stored and what can leave your machine.
+- [Security & Privacy](SECURITY.md): what's stored and what can leave your machine.

--- a/docs/MEETING_MODE_GUIDE.md
+++ b/docs/MEETING_MODE_GUIDE.md
@@ -184,12 +184,12 @@ Multiple local browser tabs can connect at once. Live pages receive real-time up
 
 ## Meeting Intelligence
 
-A saved meeting's transcript is turned into structured, reviewable artifacts —
-each an elevated, copy-as-Markdown card at `/history`:
+A saved meeting's transcript becomes structured, reviewable artifacts. Each one is
+a copy-as-Markdown card at `/history`:
 
 ![A saved meeting open at /history: the transcript on the left, and on the right a stack of elevated artifact cards — a Risk register table (impact / likelihood / mitigation / owner), Decisions & open questions, and typed Requirements — each with a confidence score and a copy button.](assets/screenshots/history.png)
 
-*The meeting detail at `/history` — requirements, decisions, and a risk register, each extracted by an LLM-backed plugin and rendered read-only.*
+*The meeting detail at `/history`. Requirements, decisions, and a risk register, each extracted by an LLM-backed plugin and rendered read-only.*
 
 HoldSpeak supports three intelligence modes:
 - `local`: requires a local GGUF model
@@ -604,7 +604,7 @@ GitHub Issues, Slack, or any other external system.
 
 ## See also
 
-- [Getting Started](GETTING_STARTED.md) — install and first-run setup.
-- [Models — bring your own](MODELS.md) — configure the LLM that powers intel.
-- [Plugin Authoring](PLUGIN_AUTHORING.md) — write your own meeting-intel plugin.
-- [Security & Privacy](SECURITY.md) — what's stored and what can leave your machine.
+- [Getting Started](GETTING_STARTED.md): install and first-run setup.
+- [Models (bring your own)](MODELS.md): configure the LLM that powers intel.
+- [Plugin Authoring](PLUGIN_AUTHORING.md): write your own meeting-intel plugin.
+- [Security & Privacy](SECURITY.md): what's stored and what can leave your machine.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -128,7 +128,7 @@ makes the larger tiers practical.
 
 ## See also
 
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md) — where the dictation
-  model is used.
-- [Meeting Mode Guide](MEETING_MODE_GUIDE.md) — where the meeting-intel model is used.
-- [Security & Privacy](SECURITY.md) — what a cloud endpoint changes about egress.
+- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md): where the dictation model
+  is used.
+- [Meeting Mode Guide](MEETING_MODE_GUIDE.md): where the meeting-intel model is used.
+- [Security & Privacy](SECURITY.md): what a cloud endpoint changes about egress.

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -809,9 +809,9 @@ This contract deliberately does **not** cover:
 
 ## See also
 
-- [Meeting Mode Guide](MEETING_MODE_GUIDE.md) — configure the intel endpoint +
+- [Meeting Mode Guide](MEETING_MODE_GUIDE.md): configure the intel endpoint and the
   routing your plugin runs under.
-- [Connector Development](CONNECTOR_DEVELOPMENT.md) — the sibling contract for
-  local activity connectors.
-- [`internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md`](internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md)
-  — the design rationale (the parent plugin-system RFC).
+- [Connector Development](CONNECTOR_DEVELOPMENT.md): the sibling contract for local
+  activity connectors.
+- [`internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md`](internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md):
+  the design rationale (the parent plugin-system RFC).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,75 +1,77 @@
 # HoldSpeak documentation
 
 HoldSpeak is a local, private, hold-to-talk voice typing tool for macOS and
-Linux — plus a meeting mode with AI-extracted intel and a project-aware
-intelligent-typing layer. This is the map; pick a journey.
+Linux, plus a meeting mode with AI-extracted intel and a project-aware
+intelligent-typing layer. This page is the map. Pick a journey.
 
-> New here? Start with the [main README](../README.md) for the pitch + a
+> New here? Start with the [main README](../README.md) for the pitch and a
 > quickstart, then follow **Start here** below.
 
 ## Start here
 
-- **[Getting Started](./GETTING_STARTED.md)** — install, grant permissions, and
-  land your first hold-to-talk dictation in another app.
+- **[Getting Started](./GETTING_STARTED.md)**: install, grant permissions, and land
+  your first hold-to-talk dictation in another app.
 
-## Dictate — voice typing & the intelligent copilot
+## Dictate: voice typing and the intelligent copilot
 
-- **[User Guide](./USER_GUIDE.md)** — the day-to-day: workflows, the web runtime,
-  and how the two halves (typing + meetings) fit together.
-- **[Intelligent Typing Setup](./INTELLIGENT_TYPING_GUIDE.md)** — the project-aware
-  pipeline: intent routing, project-KB enrichment, target profiles, LLM rewriting.
-- **[The Dictation Copilot](./DICTATION_COPILOT.md)** — see it work: rough speech →
-  a project-grounded coding-agent task, with a reproducible demo.
-- **[Dictation journal, corrections & replay](./INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay)**
-  — the local-only record of every dictation; correct a misfire in the moment, and
-  replay it to watch the copilot improve.
-- **[Desktop Presence](./INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status)**
-  — an opt-in, native, focus-safe status surface (macOS HUD · Linux tray +
-  notification) for *listening / transcribing / typing* while you dictate elsewhere.
-- **[Models — bring your own](./MODELS.md)** — the model contract: GGUF in-process,
+- **[User Guide](./USER_GUIDE.md)**: the day-to-day. Workflows, the web runtime, and
+  how the two halves (typing and meetings) fit together.
+- **[Intelligent Typing Setup](./INTELLIGENT_TYPING_GUIDE.md)**: the project-aware
+  pipeline. Intent routing, project-KB enrichment, target profiles, LLM rewriting.
+- **[The Dictation Copilot](./DICTATION_COPILOT.md)**: see it work. Rough speech
+  becomes a project-grounded coding-agent task, with a demo you can reproduce.
+- **[Dictation journal, corrections & replay](./INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay)**:
+  the local-only record of every dictation. Fix a misfire in the moment, then replay
+  it to watch the copilot improve.
+- **[Desktop Presence](./INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status)**:
+  an opt-in, native, focus-safe status surface (a macOS HUD, a Linux tray and
+  notification) that shows whether it's listening, transcribing, or typing while you
+  dictate elsewhere.
+- **[Models (bring your own)](./MODELS.md)**: the model contract. GGUF in-process,
   MLX on Apple Silicon, or any OpenAI-compatible endpoint.
 
-## Meet — meeting intelligence
+## Meet: meeting intelligence
 
-- **[Meeting Mode Guide](./MEETING_MODE_GUIDE.md)** — dual-stream capture (mic +
-  system audio), live transcript with speaker labels, and AI-extracted topics,
-  actions, and artifacts at `/history`.
+- **[Meeting Mode Guide](./MEETING_MODE_GUIDE.md)**: capture mic and system audio
+  together, get a live transcript with speaker labels, and review AI-extracted
+  topics, actions, and artifacts at `/history`.
 
-## Extend — build on it
+## Extend: build on it
 
-- **[Plugin Authoring](./PLUGIN_AUTHORING.md)** — write a meeting-intel plugin: the
-  `HostPlugin` contract, prompt → LLM → structured output, rendering, chains, and
-  the **actuator** propose → approve → execute flow.
-- **[Connector Development](./CONNECTOR_DEVELOPMENT.md)** — build a local activity
-  connector (the `cli_enrichment` / `pipeline` / … kinds).
-- **[Agent Hook Install](./AGENT_HOOK_INSTALL.md)** — wire Claude/Codex agent hooks
+- **[Plugin Authoring](./PLUGIN_AUTHORING.md)**: write a meeting-intel plugin. The
+  `HostPlugin` contract, prompt to LLM to structured output, rendering, chains, and
+  the actuator propose/approve/execute flow.
+- **[Connector Development](./CONNECTOR_DEVELOPMENT.md)**: build a local activity
+  connector (the `cli_enrichment` / `pipeline` / other kinds).
+- **[Agent Hook Install](./AGENT_HOOK_INSTALL.md)**: wire Claude/Codex agent hooks
   into the intelligent-typing layer.
-- **[Firefox Extension Guide](./FIREFOX_EXTENSION_GUIDE.md)** — the browser activity
+- **[Firefox Extension Guide](./FIREFOX_EXTENSION_GUIDE.md)**: the browser activity
   connector.
-- **[AIPI-Lite Developer Workflow](./AIPI_LITE_DEV_WORKFLOW.md)** + **[Device
-  Protocol](./DEVICE_PROTOCOL.md)** — the portable companion device: firmware +
+- **[AIPI-Lite Developer Workflow](./AIPI_LITE_DEV_WORKFLOW.md)** and **[Device
+  Protocol](./DEVICE_PROTOCOL.md)**: the portable companion device. The firmware and
   bridge workflow, and the remote-audio WebSocket protocol.
 
 ## Operate & Trust
 
-- **[Security & Privacy](./SECURITY.md)** — the threat model: what's stored, the
-  trust boundaries, and exactly what can (and can't) leave your machine.
+- **[Security & Privacy](./SECURITY.md)**: the threat model. What's stored, the trust
+  boundaries, and exactly what can (and can't) leave your machine.
 
 ## Internal / historical plans
 
 Design RFCs, phase specs, and cross-platform/port planning live in
-**[`internal/`](./internal/)** — kept for provenance and contributor context, *not*
-user-facing guides; some describe work in progress or already shipped. Also there:
-the docs working notes — **[`internal/DOCS_STYLE.md`](./internal/DOCS_STYLE.md)**
-(voice + page skeleton) and **[`internal/DOC_AUDIT_2026-06.md`](./internal/DOC_AUDIT_2026-06.md)**
-(the accuracy audit + canonical facts). Highlights:
+**[`internal/`](./internal/)**. They're kept for provenance and contributor
+context, not as user-facing guides, and some describe work in progress or already
+shipped. Also there: the docs working notes,
+**[`internal/DOCS_STYLE.md`](./internal/DOCS_STYLE.md)** (voice and page skeleton)
+and **[`internal/DOC_AUDIT_2026-06.md`](./internal/DOC_AUDIT_2026-06.md)** (the
+accuracy audit and canonical facts). A few highlights:
 
-- `internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md` — the parent plugin-system RFC.
-- `internal/PLAN_PHASE_DICTATION_INTENT_ROUTING.md` — DIR-01 dictation pipeline spec.
-- `internal/PLAN_PHASE_MULTI_INTENT_ROUTING.md` — MIR-01 meeting-side routing spec.
-- `internal/PLAN_PHASE_WEB_FLAGSHIP_RUNTIME.md` — the web-first runtime migration.
-- `internal/CROSS_PLATFORM_ROADMAP.md`, `internal/LINUX_PORT_PLAN.md` — platform work.
-- `internal/RELEASE_HARDENING_CHECKLIST.md` — release-gate checklist.
+- `internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md`: the parent plugin-system RFC.
+- `internal/PLAN_PHASE_DICTATION_INTENT_ROUTING.md`: the DIR-01 dictation pipeline spec.
+- `internal/PLAN_PHASE_MULTI_INTENT_ROUTING.md`: the MIR-01 meeting-side routing spec.
+- `internal/PLAN_PHASE_WEB_FLAGSHIP_RUNTIME.md`: the web-first runtime migration.
+- `internal/CROSS_PLATFORM_ROADMAP.md`, `internal/LINUX_PORT_PLAN.md`: platform work.
+- `internal/RELEASE_HARDENING_CHECKLIST.md`: the release-gate checklist.
 
 > The project's planning of record (roadmap, phases, evidence) lives under
 > [`pm/roadmap/holdspeak/`](../pm/roadmap/holdspeak/), not here.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -138,7 +138,7 @@ issue describing the data class, trust boundary, and egress point involved.
 
 ## See also
 
-- [Models — bring your own](MODELS.md) — pointing at a cloud endpoint is the one
+- [Models (bring your own)](MODELS.md): pointing at a cloud endpoint is the one
   deliberate egress choice.
-- [Getting Started](GETTING_STARTED.md) — the local-by-default setup this posture
+- [Getting Started](GETTING_STARTED.md): the local-by-default setup this posture
   describes.


### PR DESCRIPTION
A follow-up prose pass (the humanizer skill) over the docs authored in Phase 46, so they read like a person wrote them rather than a model.

## What changed
- **README**: dropped the emoji feature bullets and every em dash; rewrote the negative parallelisms (*"not a transcript that evaporates"* → *"a dictation doesn't vanish the second it's typed"*) and the rule-of-three cadence; varied the rhythm. Facts, links, and all six graphics unchanged; still 157 lines.
- **docs/README.md** index: same treatment on the journey descriptions.
- The **project-KB callout**, the welcome/history **screenshot captions**, and the **See also footers** across the guides: em dashes → colons / plain sentences; `Models — bring your own` link labels → `Models (bring your own)`.

Left original-author prose and the internal roadmap bookkeeping untouched.

## Verification
- `uv run pytest -q -k "doc_drift or link"` → **8 passed** (every link + image ref resolves; the README plugin-count guard still matches).
- 0 em/en dashes left in README + the docs index (grep-verified). `(cd web && npm run build)` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)