### PR TITLE
docs: PyPI-ready README + lead with pip install (0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,22 @@ All notable changes to HoldSpeak are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **Pre-release.** HoldSpeak has not been formally released or published to PyPI.
-> Everything below is **Unreleased** — install from source. Version `0.2.1` in
-> `pyproject.toml` is an in-development marker, not a published tag.
+> **0.x, early but real.** HoldSpeak is published on PyPI (`pip install
+> holdspeak`). APIs, config, and defaults can still change while it is pre-1.0;
+> upgrades are safe by default (your database is backed up first).
 
-## [Unreleased]
+## [0.2.2] - 2026-06-07
+
+### Changed
+- README is now PyPI-ready: `pip install holdspeak` is the headline install,
+  every image uses an absolute URL so screenshots render on the PyPI project
+  page, and every doc link resolves from PyPI. The "isn't on PyPI yet" status
+  line is gone.
+
+## [0.2.1] - 2026-06-07
+
+First release published to PyPI, cut after Phase 50 (Release Readiness). The
+items below shipped in this release.
 
 ### Added
 - **Bring-your-own model contract** (`docs/MODELS.md`): GGUF in-process, MLX on

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # HoldSpeak
 
 <p align="center">
-  <img src="docs/assets/pixellab/holdspeak-mark.png" alt="HoldSpeak logo, a held key with rising soundwaves" width="120">
+  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/holdspeak-mark.png" alt="HoldSpeak logo, a held key with rising soundwaves" width="120">
 </p>
 
 <p align="center"><strong>Hold a key. Speak. It types in any app. 100% local. And it learns how you work.</strong></p>
 
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/karolswdev/HoldSpeak/blob/main/LICENSE)
 [![Tests](https://github.com/karolswdev/HoldSpeak/actions/workflows/test.yml/badge.svg)](https://github.com/karolswdev/HoldSpeak/actions/workflows/test.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Platform: macOS | Linux](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)](#platform-support)
@@ -17,49 +17,50 @@ telemetry. Nothing leaves your machine except the model endpoint you choose to
 point at. Use it on its own as a voice-typing tool, or grow into meeting
 intelligence, project-aware dictation, and the AIPI-Lite companion device.
 
-> **Status: early / pre-release.** The features are mature, but it isn't on PyPI
-> yet, so you install from source (below). APIs, config, and defaults can still
-> change. Feedback and contributions welcome.
+> **Status: 0.x, early but real.** HoldSpeak is on PyPI (`pip install holdspeak`).
+> The features are mature; APIs, config, and defaults can still change while it is
+> pre-1.0. Upgrades are safe by default (your data is backed up first). Feedback
+> and contributions welcome.
 
 ## Why it's different
 
 - **100% local by default.** Whisper transcription and your own LLM. Nothing is
   sent anywhere unless you deliberately point it at a cloud endpoint. See
-  [Security & privacy](docs/SECURITY.md).
+  [Security & privacy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/SECURITY.md).
 - **It gets better at your voice, and shows you the proof.** Every dictation is
   saved: what you said, what it typed, where it routed, how long it took. Fix a
   wrong one with a single tap and it learns; a "What HoldSpeak learned" digest
   shows the honest "learned from N similar" count; replay an utterance through the
   updated pipeline and watch the routing change. Local, off by default for
   routing, no hidden retraining.
-  See [the learning loop](docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay).
+  See [the learning loop](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay).
 - **Your voice gets the afterlife your meetings already have.** A dictation doesn't
   vanish the second it's typed. It's saved, searchable, and reviewable, the same
   way a recorded meeting is.
 - **14 real LLM-backed meeting plugins.** Architecture diagrams, ADRs, risk
   registers, incident timelines, decisions, and stakeholder updates, all pulled out
-  of the transcript. See [meeting intelligence](docs/MEETING_MODE_GUIDE.md).
+  of the transcript. See [meeting intelligence](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md).
 - **Bring your own model.** GGUF in-process, MLX on Apple Silicon, or any
-  OpenAI-compatible endpoint. See [Models](docs/MODELS.md).
+  OpenAI-compatible endpoint. See [Models](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md).
 - **Ambient desktop presence, if you want it.** A native, focus-safe HUD shows
   whether it's listening, transcribing, or typing while you dictate into another
   app. Off by default. See
-  [Desktop Presence](docs/INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
+  [Desktop Presence](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
 - **AIPI-Lite companion, if you have one.** A small device for meeting-capture
   controls, and for speaking a reply to your coding agent from another room. See
-  [the workflow](docs/AIPI_LITE_DEV_WORKFLOW.md).
+  [the workflow](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AIPI_LITE_DEV_WORKFLOW.md).
 
 ## What it does, at a glance
 
 | Voice typing | Meeting intelligence | Project-aware typing |
 | --- | --- | --- |
-| ![Pixel art microphone with hold-to-talk waves](docs/assets/pixellab/hold-to-talk-microphone.png) | ![Pixel art meeting notebook with action items](docs/assets/pixellab/meeting-intelligence-notebook.png) | ![Pixel art code editor connected to local context](docs/assets/pixellab/project-aware-typing.png) |
+| ![Pixel art microphone with hold-to-talk waves](https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/hold-to-talk-microphone.png) | ![Pixel art meeting notebook with action items](https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/meeting-intelligence-notebook.png) | ![Pixel art code editor connected to local context](https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/project-aware-typing.png) |
 | Hold the hotkey, speak, release. The text goes into the active app. Punctuation commands (`"period"`, `"comma"`) and `"clipboard"` substitution work out of the box. | Capture mic and system audio together, get a live transcript with speaker labels, and let the AI pull out topics, actions, and artifacts you can review at `/history`. | Rough speech runs through intent classification, project-KB enrichment, and an LLM rewrite before it lands, tuned for Codex, Claude, the terminal, the browser, or your editor. |
 
 ## See it learn
 
 <p align="center">
-  <img src="docs/assets/pixellab/operator-working-loop.gif" alt="Animated pixel art operator working at a terminal while companion and task cards update" width="280">
+  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/operator-working-loop.gif" alt="Animated pixel art operator working at a terminal while companion and task cards update" width="280">
 </p>
 
 Speech turns into transcript context, reviewable actions, summaries, and replies
@@ -67,10 +68,10 @@ for your coding agent, while the local runtime stays in charge. Because every
 dictation is recorded, you can look back at what it heard, fix a mistake in one tap
 (which teaches it), and replay the utterance through the updated pipeline. Instead
 of trusting that it improved, you watch it happen.
-[See the full walkthrough](docs/DICTATION_COPILOT.md).
+[See the full walkthrough](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_COPILOT.md).
 
 <p align="center">
-  <img src="docs/assets/screenshots/journal.png" alt="The HoldSpeak dictation Journal: a said-to-typed timeline of recent dictations, each card showing the spoken transcript, the typed result, its routing target, and a per-utterance latency strip; one row marked corrected." width="760">
+  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/journal.png" alt="The HoldSpeak dictation Journal: a said-to-typed timeline of recent dictations, each card showing the spoken transcript, the typed result, its routing target, and a per-utterance latency strip; one row marked corrected." width="760">
 </p>
 <p align="center"><em>The dictation journal. Every utterance, with what you said, what it typed, where it routed, and how long it took.</em></p>
 
@@ -80,24 +81,30 @@ and for each correction a real "learned from N similar" count, computed by the
 same matcher that nudges routing. No inflated numbers, quiet when nothing matched.
 
 <p align="center">
-  <img src="docs/assets/screenshots/learning-digest-week.png" alt="The 'What HoldSpeak learned' digest: a this-week / all-time toggle, headline counts for corrections made, dictations corrected, and utterances nudged, a breakdown by block and target, and per-correction 'learned from N similar' rows." width="760">
+  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/learning-digest-week.png" alt="The 'What HoldSpeak learned' digest: a this-week / all-time toggle, headline counts for corrections made, dictations corrected, and utterances nudged, a breakdown by block and target, and per-correction 'learned from N similar' rows." width="760">
 </p>
 <p align="center"><em>What HoldSpeak learned. Honest, windowed counts from the same matcher that nudges your routing.</em></p>
 
 ## Quickstart
 
-The install script clones the repo, `doctor` checks your setup, and `holdspeak`
-launches the web runtime:
+Install from PyPI, check your setup, and launch the web runtime:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/scripts/install.sh | bash
+pip install holdspeak
 holdspeak doctor   # check mic permissions and backends
 holdspeak          # launch the web runtime
 ```
 
-Or from a clone, with [`uv`](https://docs.astral.sh/uv/):
+Prefer [`uv`](https://docs.astral.sh/uv/)? `uv pip install holdspeak`.
+
+Or use the install script (creates an isolated venv and a `holdspeak` launcher),
+or work from a clone:
 
 ```bash
+# one-line install
+curl -fsSL https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/scripts/install.sh | bash
+
+# or from a clone (for development)
 git clone https://github.com/karolswdev/HoldSpeak.git && cd HoldSpeak
 uv pip install -e .
 holdspeak doctor && holdspeak
@@ -106,14 +113,16 @@ holdspeak doctor && holdspeak
 Install only the extras you need:
 
 ```bash
-uv pip install -e '.[meeting]'         # meeting mode and AI intelligence
-uv pip install -e '.[dictation-mlx]'   # intelligent dictation on Apple Silicon (MLX)
-uv pip install -e '.[dictation-llama]' # intelligent dictation, cross-platform (GGUF)
-uv pip install -e '.[dictation-openai]'# intelligent dictation via an OpenAI-compatible endpoint
+pip install 'holdspeak[meeting]'          # meeting mode and AI intelligence
+pip install 'holdspeak[dictation-mlx]'    # intelligent dictation on Apple Silicon (MLX)
+pip install 'holdspeak[dictation-llama]'  # intelligent dictation, cross-platform (GGUF)
+pip install 'holdspeak[dictation-openai]' # intelligent dictation via an OpenAI-compatible endpoint
 ```
 
+(From a clone, use the editable form instead, e.g. `uv pip install -e '.[meeting]'`.)
+
 The dictation and meeting LLM is yours to choose. See
-[`docs/MODELS.md`](docs/MODELS.md) for the contract and current suggestions.
+[`docs/MODELS.md`](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md) for the contract and current suggestions.
 
 ### Upgrading and your data
 
@@ -123,7 +132,7 @@ restore`. Upgrades are safe by default: HoldSpeak backs up an older database
 before it touches it, and refuses to open a database written by a newer build
 rather than risk your data. `holdspeak doctor` reports the schema and config
 state it found. The full policy is in
-[`docs/RELEASING.md`](docs/RELEASING.md).
+[`docs/RELEASING.md`](https://github.com/karolswdev/HoldSpeak/blob/main/docs/RELEASING.md).
 
 ## Platform support
 
@@ -148,8 +157,8 @@ ships 14 built-in plugins, all real and backed by an LLM.
 Plugins can also propose actions. An actuator proposes an external side effect,
 like filing a ticket or posting an update, that only runs after you approve it for
 that specific action. Actuators are off by default. Write your own with the
-[Plugin Authoring guide](docs/PLUGIN_AUTHORING.md); for endpoints and routing, see
-the [Meeting Mode Guide](docs/MEETING_MODE_GUIDE.md).
+[Plugin Authoring guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/PLUGIN_AUTHORING.md); for endpoints and routing, see
+the [Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md).
 
 Then close the loop. After a meeting, the "Your next move" aftercare panel at
 `/history` shows what is still open (by owner), what was decided, and what changed
@@ -157,12 +166,12 @@ since the last meeting. Jump to the transcript moment that justifies any result,
 file an accepted action as a human-approved issue through that same actuator flow,
 or draft a copyable follow-up. It is read-only and local: nothing is sent, and
 nothing runs, without your approval. See the
-[Meeting Mode Guide](docs/MEETING_MODE_GUIDE.md#meeting-aftercare-close-the-loop).
+[Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md#meeting-aftercare-close-the-loop).
 
 ## AIPI-Lite companion
 
 <p align="center">
-  <img src="docs/assets/pixellab/aipi-lite-companion.png" alt="Pixel art AIPI-Lite companion device" width="220">
+  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/aipi-lite-companion.png" alt="Pixel art AIPI-Lite companion device" width="220">
 </p>
 
 AIPI-Lite is an optional ESPHome-based device you can carry between rooms. Put it
@@ -171,36 +180,36 @@ status feedback. With Claude/Codex hooks on, it tells you when an agent is waiti
 so you can speak the reply back into the coding session. Buy the hardware from the
 [official page](https://aipi.com/products/aipi-lite) or the
 [Amazon listing](https://www.amazon.com/dp/B0FQNNVV36); firmware and bridge setup
-are in the [AIPI-Lite Developer Workflow](docs/AIPI_LITE_DEV_WORKFLOW.md).
+are in the [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AIPI_LITE_DEV_WORKFLOW.md).
 
 ## Where to go next
 
 | I want to… | Read this |
 |---|---|
-| Browse all the docs | [Documentation index](docs/README.md) |
-| Get it running and verify my setup | [Getting Started](docs/GETTING_STARTED.md) |
-| Choose / configure a model | [Models (bring your own)](docs/MODELS.md) |
-| See speech become a project-grounded task | [The Dictation Copilot](docs/DICTATION_COPILOT.md) |
-| Set up project-aware dictation for Codex / Claude | [Intelligent Typing Setup](docs/INTELLIGENT_TYPING_GUIDE.md) |
-| Review, correct, and replay past dictations | [Dictation journal & replay](docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay) |
-| Use meeting mode and configure AI intelligence | [Meeting Mode Guide](docs/MEETING_MODE_GUIDE.md) |
-| Wire up the AIPI-Lite companion | [AIPI-Lite Developer Workflow](docs/AIPI_LITE_DEV_WORKFLOW.md) |
-| Install Claude / Codex agent hooks | [Agent Hook Install](docs/AGENT_HOOK_INSTALL.md) |
-| Understand what's stored and what can leave my machine | [Security & Privacy](docs/SECURITY.md) |
+| Browse all the docs | [Documentation index](https://github.com/karolswdev/HoldSpeak/blob/main/docs/README.md) |
+| Get it running and verify my setup | [Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) |
+| Choose / configure a model | [Models (bring your own)](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md) |
+| See speech become a project-grounded task | [The Dictation Copilot](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_COPILOT.md) |
+| Set up project-aware dictation for Codex / Claude | [Intelligent Typing Setup](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md) |
+| Review, correct, and replay past dictations | [Dictation journal & replay](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay) |
+| Use meeting mode and configure AI intelligence | [Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md) |
+| Wire up the AIPI-Lite companion | [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AIPI_LITE_DEV_WORKFLOW.md) |
+| Install Claude / Codex agent hooks | [Agent Hook Install](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AGENT_HOOK_INSTALL.md) |
+| Understand what's stored and what can leave my machine | [Security & Privacy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/SECURITY.md) |
 
 ## Configuration
 
 Config lives at `~/.config/holdspeak/config.json`, but you rarely edit it by hand.
 The Settings page in the web runtime exposes the hotkey, model, meeting intel,
 dictation pipeline, and presence options. The full reference is in
-[Getting Started](docs/GETTING_STARTED.md) and the guides above.
+[Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) and the guides above.
 
 ## Contributing
 
-Contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup
+Contributions are welcome. See [`CONTRIBUTING.md`](https://github.com/karolswdev/HoldSpeak/blob/main/CONTRIBUTING.md) for setup
 (`uv`, the git hooks, the test command) and the commit-contract workflow. Recent
-changes are in [`CHANGELOG.md`](CHANGELOG.md).
+changes are in [`CHANGELOG.md`](https://github.com/karolswdev/HoldSpeak/blob/main/CHANGELOG.md).
 
 ## License
 
-Licensed under the Apache License 2.0. See [`LICENSE`](LICENSE).
+Licensed under the Apache License 2.0. See [`LICENSE`](https://github.com/karolswdev/HoldSpeak/blob/main/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holdspeak"
-version = "0.2.1"
+version = "0.2.2"
 description = "Voice typing for macOS and Linux - hold a hotkey, speak, release. Local & private."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,13 +13,13 @@ VENV_DIR="$INSTALL_ROOT/venv"
 # Override this to pin a release tag/commit or use a local/package spec.
 # Examples:
 #   HOLDSPEAK_PIP_SPEC="holdspeak[linux]==0.2.0"
-#   HOLDSPEAK_PIP_SPEC="holdspeak[linux] @ git+https://github.com/karolswdev/HoldSpeak.git@v0.2.1"
+#   HOLDSPEAK_PIP_SPEC="holdspeak[linux] @ git+https://github.com/karolswdev/HoldSpeak.git@v0.2.2"
 HOLDSPEAK_PIP_SPEC="${HOLDSPEAK_PIP_SPEC:-}"
 
 # Git ref to install from when no explicit HOLDSPEAK_PIP_SPEC is given. The
 # default pins a release tag so an install is reproducible. For a development
 # install off the latest commit, set HOLDSPEAK_REF=main.
-HOLDSPEAK_REF="${HOLDSPEAK_REF:-v0.2.1}"
+HOLDSPEAK_REF="${HOLDSPEAK_REF:-v0.2.2}"
 
 WITH_MEETING=0
 SKIP_SYSTEM_DEPS="${HOLDSPEAK_SKIP_SYSTEM_DEPS:-0}"

--- a/uv.lock
+++ b/uv.lock
@@ -762,7 +762,7 @@ wheels = [
 
 [[package]]
 name = "holdspeak"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
The PyPI project page **is** the README, and it was underselling the project: screenshots were broken (PyPI doesn't resolve relative image paths) and the copy still said "isn't on PyPI yet" with `curl | bash` as the headline.

## Changes
- **Images render on PyPI:** every README image now uses an absolute `raw.githubusercontent.com` URL; every repo-relative doc link uses an absolute `github.com/blob` URL so it resolves from the PyPI page too.
- **Lead with `pip install holdspeak`:** it's now the headline Quickstart; the install script and clone path are secondary; extras use the PyPI form (`pip install 'holdspeak[meeting]'`).
- **Honest status line:** "0.x, early but real" (it's on PyPI now), dropped "isn't on PyPI yet."
- **CHANGELOG:** removed the stale pre-release banner; recorded `0.2.1` (first PyPI release) and `0.2.2` (this docs release).

## Release
Bumps to **0.2.2** because a PyPI description can only be updated by a new release. `install.sh` default ref → `v0.2.2`. The version drift test and doc guards pass. Merging + tagging `v0.2.2` will trigger `release.yml` and refresh the PyPI page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)