### PR TITLE
Release 0.3.1 — the architecture map (docs patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
 > holdspeak`). APIs, config, and defaults can still change while it is pre-1.0;
 > upgrades are safe by default (your database is backed up first).
 
+## [0.3.1] - 2026-06-13
+
+Documentation. No runtime change from 0.3.0.
+
+### Added
+- **An architecture map** (`docs/ARCHITECTURE.md`): the runtime view of how
+  the pieces fit and how a single utterance flows through them, with
+  rendered diagrams for the component map, the dictation and meeting
+  pipelines, the learning loop, the device path, and the trust boundary.
+  Linked from the docs index, the README, and CONTRIBUTING.
+- A docs guard that renders every Mermaid diagram and fails on any that
+  does not, so a broken diagram cannot ship.
+
 ## [0.3.0] - 2026-06-13
 
 The first release since 0.2.x, gathering fourteen development phases. Both

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holdspeak"
-version = "0.3.0"
+version = "0.3.1"
 description = "Voice typing for macOS and Linux - hold a hotkey, speak, release. Local & private."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts 0.3.1 to ship the Phase-66 architecture map (docs/ARCHITECTURE.md with rendered diagrams) and its pointers onto PyPI and the project page.

- Docs-only delta since v0.3.0 (`git diff v0.3.0..HEAD`): docs/ARCHITECTURE.md, README + CONTRIBUTING + docs-index pointers, and tests/e2e/test_mermaid_renders.py. No runtime change.
- CHANGELOG [0.3.1] entry added.
- After this merges on green, v0.3.1 is tagged on the merge commit → the trusted-publishing workflow publishes → verified from PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)