### PR TITLE
holdspeak-mobile: Gate 1 on real metal (HSM-1-04 physical-device proof + deploy tooling)

### DIFF
--- a/apple/README.md
+++ b/apple/README.md
@@ -33,6 +33,22 @@ The `Contracts` types are written against
 (the schemas + serialization contract + golden fixtures). The tests read those
 same fixtures, so the Swift and Python runtimes are validated against one source.
 
+### Launch the shell on a device
+
+```bash
+# Simulator (Gate 1, no signing): iPhone + iPad simulators, screenshots each.
+scripts/gate1-launch.sh
+
+# Physical device (Gate 1 on real metal): build → sign → install → launch via
+# devicectl. Auto-selects a connected iPad. One-time prereqs (all persist):
+#   Xcode > Settings > Accounts signed in · latest Apple Developer PLA accepted ·
+#   Developer Mode on the device · the device registered in the account.
+scripts/gate1-device.sh [device-udid]
+```
+
+`gate1-device.sh` calls `gen-device-project.rb` to generate a signed iOS app
+project under `build/` (gitignored). Override the signing team with `HS_TEAM=…`.
+
 ## Status
 
 Phase 1 (Mobile Foundation): the SPM package + `Contracts` types are in

--- a/apple/scripts/gate1-device.sh
+++ b/apple/scripts/gate1-device.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# HSM Gate 1 (real metal): build + sign the Phase-1 runtime shell for a *physical*
+# device and launch it via devicectl, capturing a screenshot as proof. This is the
+# on-device counterpart to gate1-launch.sh (which targets simulators only).
+#
+# Prereqs (one-time): Xcode > Settings > Accounts > sign in with the Apple ID that
+# owns the HXY77XFPS4 team, so automatic provisioning can mint a profile + register
+# the device. Then plug in the iPad/iPhone and trust this Mac.
+#
+# Usage: apple/scripts/gate1-device.sh [device-udid]
+#   device-udid: hardware UDID from `xcrun devicectl list devices`; defaults to the
+#   first available paired device.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ruby scripts/gen-device-project.rb
+
+DEVID="${1:-}"
+if [ -z "$DEVID" ]; then
+  # Prefer a connected iPad; the Identifier is the UUID-shaped token on its row.
+  # Guard greps with `|| true` so an empty match doesn't trip `set -e`.
+  UUID_RE='[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+  LIST="$(xcrun devicectl list devices 2>/dev/null || true)"
+  DEVID="$(printf '%s\n' "$LIST" | grep -i 'iPad' | grep -oE "$UUID_RE" | head -1 || true)"
+  [ -z "$DEVID" ] && DEVID="$(printf '%s\n' "$LIST" | grep -iE 'iPad|iPhone' | grep -oE "$UUID_RE" | head -1 || true)"
+fi
+echo "== target device: ${DEVID:-<none found>} =="
+
+# Hardware UDID (distinct from the coredevice UUID): xcodebuild's -destination
+# wants this, and targeting the device explicitly makes -allowProvisioningUpdates
+# register its UDID into the development profile (else install fails 0xe8008012).
+HWUDID="$(xcrun devicectl device info details --device "$DEVID" 2>/dev/null | awk -F': ' '/ udid:/{print $2; exit}' | tr -d ' ')"
+# Clear the cached wildcard team profile so automatic signing regenerates one
+# that includes this device (a stale cache can omit a newly-targeted device).
+rm -f ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision 2>/dev/null || true
+echo "== build + sign (destination id=$HWUDID) =="
+# Destination-only (no -sdk): a concrete connected device makes automatic signing
+# register its UDID into the development profile.
+xcodebuild -project build/HoldSpeakMobile.xcodeproj -scheme HoldSpeakMobile \
+  -configuration Debug \
+  -destination "platform=iOS,id=$HWUDID" \
+  -allowProvisioningUpdates \
+  CONFIGURATION_BUILD_DIR="$PWD/build/device" \
+  build
+
+APP="$PWD/build/device/HoldSpeakMobile.app"
+echo "== install $APP =="
+xcrun devicectl device install app --device "$DEVID" "$APP"
+
+echo "== launch =="
+xcrun devicectl device process launch --device "$DEVID" dev.holdspeak.mobile
+
+echo "== Gate 1 (device): launched dev.holdspeak.mobile on $DEVID =="
+echo "(screenshot the iPad to attach as the real-metal proof)"

--- a/apple/scripts/gen-device-project.rb
+++ b/apple/scripts/gen-device-project.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# HSM Gate 1 (real metal): generate a minimal, automatically-signed Xcode project
+# for the Phase-1 runtime shell so it can be installed on a *physical* iPad/iPhone
+# (the simulator path in gate1-launch.sh cannot reach a real device). The project
+# compiles the same App/ shell + the real Contracts layer — a successful on-device
+# launch exercises the contract layer on Apple hardware. Output: build/HoldSpeakMobile.xcodeproj
+#
+# Usage: ruby apple/scripts/gen-device-project.rb
+require 'xcodeproj'
+require 'fileutils'
+
+ROOT = File.expand_path('..', __dir__)          # apple/
+BUILD = File.join(ROOT, 'build')
+PROJ_PATH = File.join(BUILD, 'HoldSpeakMobile.xcodeproj')
+TEAM = ENV.fetch('HS_TEAM', 'M84954HNL6')   # account signed into Xcode; override with HS_TEAM
+BUNDLE_ID = 'dev.holdspeak.mobile'
+DEPLOY = '17.0'
+
+FileUtils.mkdir_p(BUILD)
+FileUtils.rm_rf(PROJ_PATH)
+
+project = Xcodeproj::Project.new(PROJ_PATH)
+target = project.new_target(:application, 'HoldSpeakMobile', :ios, DEPLOY)
+
+# Source files: the App shell + the real Contracts layer (Foundation-only).
+sources = Dir[File.join(ROOT, 'Sources/Contracts/*.swift')].sort +
+          [File.join(ROOT, 'App/HoldSpeakApp.swift')]
+group = project.new_group('Sources', ROOT)
+sources.each do |path|
+  ref = group.new_reference(path)
+  target.add_file_references([ref])
+end
+
+# Signing + identity. Automatic provisioning so xcodebuild registers the device
+# and mints a development profile for this bundle id on the personal team.
+target.build_configurations.each do |config|
+  s = config.build_settings
+  s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
+  s['PRODUCT_NAME'] = 'HoldSpeakMobile'
+  s['INFOPLIST_KEY_CFBundleDisplayName'] = 'HoldSpeak'
+  s['MARKETING_VERSION'] = '0.1.0'
+  s['CURRENT_PROJECT_VERSION'] = '1'
+  s['GENERATE_INFOPLIST_FILE'] = 'YES'
+  s['INFOPLIST_KEY_UILaunchScreen_Generation'] = 'YES'
+  s['TARGETED_DEVICE_FAMILY'] = '1,2'           # iPhone + iPad
+  s['IPHONEOS_DEPLOYMENT_TARGET'] = DEPLOY
+  s['SWIFT_VERSION'] = '6.0'
+  s['CODE_SIGN_STYLE'] = 'Automatic'
+  s['DEVELOPMENT_TEAM'] = TEAM
+  s['CODE_SIGN_IDENTITY'] = 'Apple Development'
+  s['SDKROOT'] = 'iphoneos'
+end
+
+project.save
+puts "generated #{PROJ_PATH}"
+puts "  sources: #{sources.map { |p| p.sub(ROOT + '/', '') }.join(', ')}"
+puts "  team=#{TEAM} bundle=#{BUNDLE_ID} deploy=iOS #{DEPLOY}"

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,15 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-18 (**Phase 5 — HSM-5-04 done + host slice** — the
+**Last updated:** 2026-06-19 (**Gate 1 proven on real metal** — the Phase-1
+runtime shell launched on a **physical iPad Air 11" (M4), iPadOS 26.5** (owner-confirmed
+"contracts v0.1.0" on-device), discharging the HSM-1-04 physical-device follow-up
+via new headless on-device deploy tooling (`apple/scripts/gen-device-project.rb` +
+`gate1-device.sh`: build → sign → install → launch over `devicectl`). One-time
+enrollment (account sign-in, Apple Developer PLA, Developer Mode, device
+registration) is done and persists, so the on-device path is now repeatable for
+the heavier device-gated gates (capture/Whisper/inference). Phase 1 stays CLOSED.
+See [`phase-1…/gate1-ipadair-m4-realmetal.log`](./phase-1-mobile-foundation/gate1-ipadair-m4-realmetal.log).
+Earlier: **Phase 5 — HSM-5-04 done + host slice** — the
 structured-output bridge (`StructuredOutput`: extract JSON from messy model text →
 decode through the contract → bounded repair-retry) + the per-device LLM model
 policy (4B iPhone / 8B iPad / 12B+ plugged-in); `swift test` 24/24. Engine pick +

--- a/pm/roadmap/holdspeak-mobile/phase-1-mobile-foundation/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-1-mobile-foundation/current-phase-status.md
@@ -2,6 +2,14 @@
 
 **Status:** CLOSED ✅ (4/4) 2026-06-18 — Gate 1 proven, CI green on a hosted run.
 See [`final-summary.md`](./final-summary.md).
+**Real-metal addendum (2026-06-19):** the HSM-1-04 follow-up is discharged — the
+shell launched on a **physical iPad Air 11" (M4), iPadOS 26.5** (owner-confirmed
+"contracts v0.1.0" on-device), via the new headless deploy tooling
+(`apple/scripts/gen-device-project.rb` + `gate1-device.sh`). Stronger than the
+simulator bar; phase stays CLOSED. Evidence:
+[`gate1-ipadair-m4-realmetal.log`](./gate1-ipadair-m4-realmetal.log)
+(`** BUILD SUCCEEDED **` → `Launched application with dev.holdspeak.mobile`),
+discharging the HSM-1-04 physical-device follow-up.
 Track B
 of the Council Implementation Charter. The first Swift-bearing phase: it stands up
 the four-layer SPM target structure (Contracts / Runtime Core / Providers /

--- a/pm/roadmap/holdspeak-mobile/phase-1-mobile-foundation/gate1-ipadair-m4-realmetal.log
+++ b/pm/roadmap/holdspeak-mobile/phase-1-mobile-foundation/gate1-ipadair-m4-realmetal.log
@@ -1,0 +1,26 @@
+# Gate 1 — real-metal launch (physical iPad Air 11" M4, iPadOS 26.5)
+#
+# Discharges the HSM-1-04 follow-up ("a physical-device launch when Tier-1/Tier-2
+# hardware is available"). The Phase-1 Gate-1 bar was the simulator launch on both
+# device classes (met, screenshots committed); this is the stronger physical-device
+# proof, run fully headless via apple/scripts/gate1-device.sh.
+#
+# Device: AjPed — iPad Air 11-inch (M4) (iPad16,9) — coredevice 6B2F424D-…, hw udid 00008132-…
+# Team: M84954HNL6 (automatic signing) · Bundle: dev.holdspeak.mobile · Xcode 26.5
+
+== target device: 6B2F424D-707F-51F7-A33E-259427861CB1 ==
+== build + sign (destination id=00008132-001928291E45401C) ==
+** BUILD SUCCEEDED **
+== install /Users/karol/dev/tools/HoldSpeak/apple/build/device/HoldSpeakMobile.app ==
+Acquired tunnel connection to device.
+Enabling developer disk image services.
+Launched application with dev.holdspeak.mobile bundle identifier.
+== Gate 1 (device): launched dev.holdspeak.mobile on 6B2F424D-707F-51F7-A33E-259427861CB1 ==
+
+# On-screen (confirmed by owner): "HoldSpeak Mobile — Runtime foundation — Phase 1
+# — contracts v0.1.0" — the version is read from the Contracts layer compiled into
+# the app, so the launch exercises real contract code on Apple hardware.
+#
+# One-time enrollment done to reach this (all persist): Xcode signed into the
+# M84954HNL6 account, latest Apple Developer PLA accepted, Developer Mode enabled
+# on the iPad, device registered in the account. After that the deploy is headless.


### PR DESCRIPTION
## What

Discharges the **HSM-1-04** follow-up: the Phase-1 runtime shell launched on a **physical iPad Air 11\" (M4), iPadOS 26.5** — owner-confirmed "Runtime foundation — Phase 1 — contracts v0.1.0" on-device, the version read from the real `Contracts` layer compiled into the app. This is stronger than the Phase-1 Gate-1 bar (simulator on both classes); **Phase 1 stays CLOSED**.

## Reusable on-device deploy tooling

The simulator `gate1-launch.sh` cannot reach a physical device, so:

- **`apple/scripts/gen-device-project.rb`** — generates a signed iOS app project (Contracts + the App shell, automatic signing, team `M84954HNL6`); artifacts land under `apple/build/` (gitignored). `HS_TEAM=…` overrides the team.
- **`apple/scripts/gate1-device.sh`** — one-shot build → sign → install → launch on a paired device via `devicectl`; auto-selects a connected iPad.

The last run was **fully headless** (exit 0): `** BUILD SUCCEEDED **` → `Launched application with dev.holdspeak.mobile bundle identifier` (see `gate1-ipadair-m4-realmetal.log`).

## Why it matters

The one-time enrollment (Xcode account sign-in, Apple Developer PLA, Developer Mode on the iPad, device registration) is **done and persists** — so the on-device path is now repeatable for the heavier device-gated gates (capture / Whisper / inference).

## Docs touched (operating cadence)

- `phase-1.../current-phase-status.md` — real-metal addendum (phase stays CLOSED)
- `holdspeak-mobile/README.md` — Last-updated line
- `apple/README.md` — "Launch the shell on a device" section
- `gate1-ipadair-m4-realmetal.log` — committed launch evidence

## Tests

`cd apple && swift test` → **24/24**, 0 failures. Plus the on-device launch itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)