### PR TITLE
holdspeak-mobile: Phase 6 — HSM-6-01 artifact-generation engine seam

### DIFF
--- a/apple/Package.swift
+++ b/apple/Package.swift
@@ -20,12 +20,14 @@ let package = Package(
         // Layer 1 — language-neutral schema as Swift types. Foundation only.
         .target(name: "Contracts"),
         // Layer 2 — meeting/artifact/MIR engines, persistence, sync. No UI.
-        .target(name: "RuntimeCore", dependencies: ["Contracts"]),
+        // Depends on Providers for the injected port protocols (ILLMProvider etc.).
+        .target(name: "RuntimeCore", dependencies: ["Contracts", "Providers"]),
         // Layer 3 — provider protocols (transcriber/LLM/audio/storage/sync).
         .target(name: "Providers", dependencies: ["Contracts"]),
         // Layer 4 — platform hosts (iPad/iPhone apps). The only UI layer.
         .target(name: "Hosts", dependencies: ["RuntimeCore", "Providers", "Contracts"]),
         .testTarget(name: "ContractsTests", dependencies: ["Contracts"]),
+        .testTarget(name: "RuntimeCoreTests", dependencies: ["RuntimeCore", "Providers", "Contracts"]),
         .testTarget(name: "ProvidersTests", dependencies: ["Providers", "Contracts"]),
     ]
 )

--- a/apple/Sources/Contracts/Models.swift
+++ b/apple/Sources/Contracts/Models.swift
@@ -88,6 +88,11 @@ public struct Meeting: Codable, Equatable, Sendable {
 public struct ArtifactSource: Codable, Equatable, Sendable {
     public var sourceType: String
     public var sourceRef: String
+
+    public init(sourceType: String, sourceRef: String) {
+        self.sourceType = sourceType
+        self.sourceRef = sourceRef
+    }
 }
 
 /// A synthesized artifact — the tagged union (contract §5): `artifactType` is the
@@ -108,6 +113,29 @@ public struct Artifact: Codable, Equatable, Sendable {
     public var updatedAt: Date?
     // Reserved optional egress scope (contract §8); unpopulated in v0.
     public var egress: JSONValue?
+
+    public init(
+        id: String, meetingId: String, artifactType: ArtifactType,
+        title: String, bodyMarkdown: String, structuredJson: JSONValue,
+        confidence: Double, status: ArtifactStatus, pluginId: String,
+        pluginVersion: String, sources: [ArtifactSource] = [],
+        createdAt: Date? = nil, updatedAt: Date? = nil, egress: JSONValue? = nil
+    ) {
+        self.id = id
+        self.meetingId = meetingId
+        self.artifactType = artifactType
+        self.title = title
+        self.bodyMarkdown = bodyMarkdown
+        self.structuredJson = structuredJson
+        self.confidence = confidence
+        self.status = status
+        self.pluginId = pluginId
+        self.pluginVersion = pluginVersion
+        self.sources = sources
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.egress = egress
+    }
 }
 
 public struct IntelJob: Codable, Equatable, Sendable {
@@ -172,4 +200,10 @@ public struct Transcript: Codable, Equatable, Sendable {
     public var meetingId: String
     public var segments: [Segment]
     public var transcriptHash: String
+
+    public init(meetingId: String, segments: [Segment], transcriptHash: String) {
+        self.meetingId = meetingId
+        self.segments = segments
+        self.transcriptHash = transcriptHash
+    }
 }

--- a/apple/Sources/RuntimeCore/MeetingIntelligence/ArtifactGenerationEngine.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/ArtifactGenerationEngine.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Contracts
+import Providers
+
+/// HSM-6-01 — the artifact-generation engine (Runtime Core, Layer 2).
+///
+/// Turns a finished `Transcript` plus an injected `ILLMProvider` into Phase-0
+/// `Artifact` records. This is the generic seam every artifact type lives on
+/// (HSM-6-02 the five core types, HSM-6-03 ADR Candidates + Follow-ups): it owns
+/// the drive-the-model → bind-to-contract machinery; the concrete prompts/parsers
+/// are layered on via the injected `PromptBuilder`.
+///
+/// The model contributes only the *intelligence* (an `ArtifactDraft`: title, body,
+/// type-specific JSON, confidence). The engine stamps the non-model fields (id,
+/// meetingId, type, plugin identity, sources) and binds the result into a full
+/// `Artifact`. Robust to the model returning prose instead of clean JSON: a parse
+/// failure surfaces as a recoverable `.failure`, never a crash.
+///
+/// Propose-only (charter Propose→Review→Approve→Execute): every emitted artifact
+/// is a `.draft` proposal. No code path here executes an action or calls a
+/// connector — generation proposes, the human approves, an executor (elsewhere)
+/// acts.
+public struct ArtifactGenerationEngine: Sendable {
+
+    /// The model's contribution — decoded from its (possibly messy) text via
+    /// `StructuredOutput`. Type-agnostic on purpose: the discriminator and
+    /// provenance are the engine's to stamp, not the model's to invent.
+    public struct ArtifactDraft: Decodable, Sendable, Equatable {
+        public var title: String
+        public var bodyMarkdown: String
+        public var structuredJson: JSONValue
+        public var confidence: Double
+
+        enum CodingKeys: String, CodingKey {
+            case title, bodyMarkdown, structuredJson, confidence
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            title = try c.decode(String.self, forKey: .title)
+            bodyMarkdown = try c.decodeIfPresent(String.self, forKey: .bodyMarkdown) ?? ""
+            structuredJson = try c.decodeIfPresent(JSONValue.self, forKey: .structuredJson) ?? .object([:])
+            // Models are unreliable about emitting a confidence; default mid.
+            confidence = try c.decodeIfPresent(Double.self, forKey: .confidence) ?? 0.5
+        }
+
+        public init(title: String, bodyMarkdown: String = "",
+                    structuredJson: JSONValue = .object([:]), confidence: Double = 0.5) {
+            self.title = title
+            self.bodyMarkdown = bodyMarkdown
+            self.structuredJson = structuredJson
+            self.confidence = confidence
+        }
+    }
+
+    /// Builds the per-type prompt from the transcript. HSM-6-02/03 inject the
+    /// concrete, type-specific prompts; the default is a generic, schema-hinted
+    /// instruction sufficient to exercise the seam.
+    public typealias PromptBuilder = @Sendable (ArtifactType, Transcript) -> String
+
+    let provider: ILLMProvider
+    let pluginId: String
+    let pluginVersion: String
+    let maxAttempts: Int
+    let promptBuilder: PromptBuilder
+    let idGenerator: @Sendable () -> String
+
+    public init(
+        provider: ILLMProvider,
+        pluginId: String = "holdspeak.mobile.intelligence",
+        pluginVersion: String = HoldSpeakContracts.contractVersion,
+        maxAttempts: Int = 3,
+        promptBuilder: @escaping PromptBuilder = ArtifactGenerationEngine.defaultPrompt,
+        idGenerator: @escaping @Sendable () -> String = { UUID().uuidString }
+    ) {
+        self.provider = provider
+        self.pluginId = pluginId
+        self.pluginVersion = pluginVersion
+        self.maxAttempts = maxAttempts
+        self.promptBuilder = promptBuilder
+        self.idGenerator = idGenerator
+    }
+
+    /// Generate one artifact of `type` from `transcript`. Throws only for a
+    /// genuinely unrecoverable provider/parse failure; callers that want
+    /// per-type resilience should use ``generate(types:from:)``.
+    public func generate(_ type: ArtifactType, from transcript: Transcript) async throws -> Artifact {
+        let prompt = promptBuilder(type, transcript)
+        let draft = try await StructuredOutput.generate(
+            ArtifactDraft.self, prompt: prompt, using: provider, maxAttempts: maxAttempts)
+        return bind(draft, type: type, transcript: transcript)
+    }
+
+    /// Generate several artifact types in one pass. Each type's outcome is
+    /// independent — a malformed response for one type yields a `.failure` for
+    /// that type without sinking the others (charter robustness).
+    public func generate(
+        types: [ArtifactType], from transcript: Transcript
+    ) async -> [(type: ArtifactType, result: Result<Artifact, Error>)] {
+        var out: [(type: ArtifactType, result: Result<Artifact, Error>)] = []
+        for type in types {
+            do { out.append((type, .success(try await generate(type, from: transcript)))) }
+            catch { out.append((type, .failure(error))) }
+        }
+        return out
+    }
+
+    /// Stamp the engine-owned fields onto the model's draft, producing a complete
+    /// Phase-0 `Artifact` proposal (`status == .draft`).
+    func bind(_ draft: ArtifactDraft, type: ArtifactType, transcript: Transcript) -> Artifact {
+        Artifact(
+            id: idGenerator(),
+            meetingId: transcript.meetingId,
+            artifactType: type,
+            title: draft.title,
+            bodyMarkdown: draft.bodyMarkdown,
+            structuredJson: draft.structuredJson,
+            confidence: draft.confidence,
+            status: .draft,                       // propose-only; never .accepted here
+            pluginId: pluginId,
+            pluginVersion: pluginVersion,
+            sources: [ArtifactSource(sourceType: "transcript", sourceRef: transcript.transcriptHash)]
+        )
+    }
+
+    /// A generic, schema-hinted prompt. Concrete per-type prompts arrive in
+    /// HSM-6-02/03; this is enough to drive any `ILLMProvider` through the seam.
+    public static func defaultPrompt(_ type: ArtifactType, _ transcript: Transcript) -> String {
+        let body = transcript.segments
+            .map { "\($0.speaker): \($0.text)" }
+            .joined(separator: "\n")
+        return """
+        You are HoldSpeak's meeting-intelligence engine. From the transcript below,
+        produce a single "\(type.rawValue)" artifact.
+
+        Return ONLY a JSON object with these keys:
+          "title": a short headline,
+          "body_markdown": the artifact written as Markdown,
+          "structured_json": an object with the type-specific fields,
+          "confidence": a number 0.0–1.0.
+
+        Transcript:
+        \(body)
+        """
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/ArtifactGenerationEngineTests.swift
+++ b/apple/Tests/RuntimeCoreTests/ArtifactGenerationEngineTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-6-01 — the artifact-generation engine seam. Drives the engine with a fake
+/// `ILLMProvider`: a well-formed draft must bind to a schema-valid Phase-0
+/// `Artifact`; malformed model output must surface as a recoverable failure, not
+/// a crash; and every emitted artifact must be a propose-only `.draft`.
+final class ArtifactGenerationEngineTests: XCTestCase {
+
+    /// A fake ILLMProvider returning a preset sequence of responses (one per call).
+    final class SequenceLLM: ILLMProvider, @unchecked Sendable {
+        private let responses: [String]
+        private var i = 0
+        init(_ responses: [String]) { self.responses = responses }
+        func complete(prompt: String) async throws -> String {
+            defer { i += 1 }
+            return responses[min(i, responses.count - 1)]
+        }
+    }
+
+    private func transcript() -> Transcript {
+        Transcript(
+            meetingId: "m-42",
+            segments: [
+                Segment(text: "Let's ship on June 30.", speaker: "Ada", startTime: 0, endTime: 3),
+                Segment(text: "Agreed, June 30 it is.", speaker: "Lin", startTime: 3, endTime: 6),
+            ],
+            transcriptHash: "sha256:deadbeef")
+    }
+
+    private let goodDraft = """
+    {"title":"Ship date confirmed",
+     "body_markdown":"The team **decided** to ship on June 30.",
+     "structured_json":{"decision":"ship June 30","owner":"Ada"},
+     "confidence":0.9}
+    """
+
+    // Well-formed model output → a schema-valid Artifact with engine-stamped fields.
+    func testEmitsSchemaValidArtifact() async throws {
+        let engine = ArtifactGenerationEngine(
+            provider: SequenceLLM([goodDraft]),
+            idGenerator: { "artifact-1" })
+        let artifact = try await engine.generate(.decisions, from: transcript())
+
+        // Engine-stamped provenance (not the model's to invent).
+        XCTAssertEqual(artifact.id, "artifact-1")
+        XCTAssertEqual(artifact.meetingId, "m-42")
+        XCTAssertEqual(artifact.artifactType, .decisions)
+        XCTAssertEqual(artifact.status, .draft)              // propose-only
+        XCTAssertEqual(artifact.pluginId, "holdspeak.mobile.intelligence")
+        XCTAssertEqual(artifact.sources, [ArtifactSource(sourceType: "transcript", sourceRef: "sha256:deadbeef")])
+
+        // Model's contribution survived the bind.
+        XCTAssertEqual(artifact.title, "Ship date confirmed")
+        XCTAssertEqual(artifact.confidence, 0.9, accuracy: 0.0001)
+
+        // Schema validity: it round-trips through the contract coder unchanged.
+        let data = try HoldSpeakContracts.encoder().encode(artifact)
+        let decoded = try HoldSpeakContracts.decoder().decode(Artifact.self, from: data)
+        XCTAssertEqual(decoded, artifact)
+    }
+
+    // Malformed (prose, no JSON) output → a thrown, recoverable error, no crash.
+    func testMalformedOutputIsRecoverable() async {
+        let engine = ArtifactGenerationEngine(
+            provider: SequenceLLM(["Sorry, I can't help with that."]),
+            maxAttempts: 2)
+        do {
+            _ = try await engine.generate(.decisions, from: transcript())
+            XCTFail("expected a parse failure")
+        } catch {
+            XCTAssertTrue(error is StructuredOutputError)   // recoverable, surfaced as an error
+        }
+    }
+
+    // Batch: one type's malformed response must not sink the others.
+    func testBatchIsResilientPerType() async {
+        // maxAttempts:1 → type[0] consumes the good draft, type[1] the prose.
+        let engine = ArtifactGenerationEngine(
+            provider: SequenceLLM([goodDraft, "no json here"]),
+            maxAttempts: 1,
+            idGenerator: { "id" })
+        let results = await engine.generate(types: [.decisions, .actionItems], from: transcript())
+
+        XCTAssertEqual(results.count, 2)
+        guard case .success(let ok) = results[0].result else { return XCTFail("decisions should succeed") }
+        XCTAssertEqual(ok.artifactType, .decisions)
+        guard case .failure = results[1].result else { return XCTFail("action_items should fail recoverably") }
+    }
+
+    // Propose-only: nothing the engine emits is ever accepted/executed.
+    func testNeverAutoAccepts() async throws {
+        let engine = ArtifactGenerationEngine(provider: SequenceLLM([goodDraft]))
+        let artifact = try await engine.generate(.requirements, from: transcript())
+        XCTAssertNotEqual(artifact.status, .accepted)
+        XCTAssertEqual(artifact.status, .draft)
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,14 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Gate 1 proven on real metal** — the Phase-1
+**Last updated:** 2026-06-19 (**Phase 6 — HSM-6-01 done** — the artifact-generation
+engine seam lands in the Runtime Core: `ArtifactGenerationEngine` takes a Phase-0
+`Transcript` + an injected `ILLMProvider`, drives the model through the Phase-5
+`StructuredOutput` bridge, and binds the result into a schema-valid Phase-0
+`Artifact` (engine owns id/type/provenance; the model contributes only the
+intelligence). Propose-only, robust to prose output. `swift test` 28/28, layer
+guard green. `RuntimeCore` now depends on `Providers` for the port protocols
+(transitive-dep risk flagged for Phase 3). Next: HSM-6-02 (five core artifact
+types). Earlier: **Gate 1 proven on real metal** — the Phase-1
 runtime shell launched on a **physical iPad Air 11" (M4), iPadOS 26.5** (owner-confirmed
 "contracts v0.1.0" on-device), discharging the HSM-1-04 physical-device follow-up
 via new headless on-device deploy tooling (`apple/scripts/gen-device-project.rb` +
@@ -64,8 +72,8 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅; 2 + 3 + 5 testable cores done, device-gated remainder)
-**Status:** in-progress (Phases 0–1–4 closed; Phase 2 + 3 + 5 testable cores shipped; Phase 6 next).
+**Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅; 2 + 3 + 5 testable cores done, device-gated remainder; Phase 6 in-progress, HSM-6-01 done)
+**Status:** in-progress (Phases 0–1–4 closed; Phase 2 + 3 + 5 testable cores shipped; Phase 6 started — HSM-6-01 done, HSM-6-02 next).
 
 ## Vision
 

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/current-phase-status.md
@@ -1,14 +1,23 @@
 # Phase 6 — Meeting Intelligence
 
-**Status:** planning (scaffolded 2026-06-18). Track G of the Council
+**Status:** in-progress (HSM-6-01 done 2026-06-19). Track G of the Council
 Implementation Charter. The artifact-generation engine: it turns a transcribed
 meeting into the structured intelligence HoldSpeak is known for — Action Items,
 Decisions, Risks, Requirements, Summaries, plus the charter Vision's ADR
 Candidates and Follow-ups — running in the Runtime Core (Layer 2) on top of the
 Phase-5 `ILLMProvider`, and held to parity with the desktop quality baseline.
 
-**Last updated:** 2026-06-18 (scaffolded — stories HSM-6-01..05 stubbed from the
-charter Track G deliverables + the Vision intelligence list; no work started).
+**Last updated:** 2026-06-19 (**HSM-6-01 done** — the artifact-generation engine
+seam lands in the Runtime Core: `ArtifactGenerationEngine` takes a Phase-0
+`Transcript` + an injected `ILLMProvider`, drives the model, decodes via the
+Phase-5 `StructuredOutput` bridge into an `ArtifactDraft`, and binds it into a
+schema-valid Phase-0 `Artifact` (engine stamps id/type/provenance; model
+contributes only the intelligence). Propose-only (`.draft`), robust to prose
+output (recoverable error, per-type batch resilience). `swift test` 28/28, layer
+guard green. Added public inits to `Artifact`/`ArtifactSource`/`Transcript`;
+`RuntimeCore` now depends on `Providers` for the port protocols (transitive-dep
+risk flagged for Phase 3 — see Decisions deferred). Concrete per-type prompts are
+HSM-6-02/03. Earlier: scaffolded — stories HSM-6-01..05 stubbed).
 
 ## Goal
 
@@ -60,7 +69,7 @@ Review → Approve → Execute lifecycle is preserved end to end.
 
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
-| HSM-6-01 | The artifact-generation engine | backlog | [story-01](./story-01-artifact-generation-engine.md) | — |
+| HSM-6-01 | The artifact-generation engine | done | [story-01](./story-01-artifact-generation-engine.md) | [evidence-01](./evidence-story-01.md) |
 | HSM-6-02 | The five core artifact types | backlog | [story-02](./story-02-core-artifact-types.md) | — |
 | HSM-6-03 | ADR Candidates + Follow-ups | backlog | [story-03](./story-03-adr-candidates-followups.md) | — |
 | HSM-6-04 | The parity baseline harness | backlog | [story-04](./story-04-parity-baseline-harness.md) | — |
@@ -68,14 +77,19 @@ Review → Approve → Execute lifecycle is preserved end to end.
 
 ## Where we are
 
-Just scaffolded. Track G depends on a working `ILLMProvider` (Phase 5) and the
-Phase-0 contracts being locked. The five stories split the work into: the engine
-that drives the provider and binds to contracts (HSM-6-01); the five core
-artifact types (HSM-6-02); the Vision extras — ADR Candidates and Follow-ups —
-(HSM-6-03); a substance-based parity harness against the desktop baseline
-(HSM-6-04); and the Gate-5 closeout that runs it and records the verdict
-(HSM-6-05). Next: pick up HSM-6-01 once Phase 5 lands a callable provider, and
-capture a desktop baseline early (HSM-6-04 needs it).
+**HSM-6-01 is done.** The artifact-generation engine seam lives in the Runtime
+Core (`ArtifactGenerationEngine`): it takes a Phase-0 `Transcript` + an injected
+`ILLMProvider`, builds a per-type prompt (a generic schema-hinted default;
+HSM-6-02/03 inject the concrete ones), drives the model through the Phase-5
+`StructuredOutput` bridge to decode an `ArtifactDraft`, and binds that into a
+schema-valid Phase-0 `Artifact` — the engine owns the discriminator/identity/
+provenance, the model owns only the intelligence. Propose-only (`.draft`); prose
+output surfaces as a recoverable error and one bad type doesn't sink a batch.
+`swift test` 28/28, layer guard green. The remaining four stories split into: the
+five core artifact types (HSM-6-02, unblocked); the Vision extras — ADR Candidates
+and Follow-ups — (HSM-6-03); a substance-based parity harness against a desktop
+baseline (HSM-6-04, needs a baseline captured early); and the Gate-5 closeout
+(HSM-6-05). **Next: HSM-6-02** (the five core artifact types on this seam).
 
 ## Active risks
 
@@ -107,3 +121,11 @@ capture a desktop baseline early (HSM-6-04 needs it).
 - Whether ADR Candidates and Follow-ups are full `Artifact` subtypes or a
   distinct shape — trigger: HSM-6-03 — default: model them as `Artifact` types per
   the Phase-0 contract until the contract says otherwise.
+- **How to keep the heavy adapter deps out of the domain.** HSM-6-01 made
+  `RuntimeCore` depend on `Providers` (the port protocols live there). Trigger:
+  **HSM-3-01** adds the WhisperKit SPM dependency to the `Providers` target —
+  which would then transitively link a transcription engine into `RuntimeCore`
+  and its tests. Default: at Phase 3, split a dependency-free `ProviderInterfaces`
+  target (the `I*` protocols) that both `RuntimeCore` and the concrete `Providers`
+  adapters depend on, so the domain never links WhisperKit/llama.cpp. Cheap to do
+  now, cheaper than after more RuntimeCore code piles on the current edge.

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/evidence-story-01.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/evidence-story-01.md
@@ -1,0 +1,77 @@
+# Evidence — HSM-6-01 — The artifact-generation engine
+
+- **Shipped:** 2026-06-19
+- **Commit:** Phase-6 HSM-6-01 on `main` (see commit message)
+- **Owner:** unassigned
+
+## Files touched
+
+- `apple/Sources/RuntimeCore/MeetingIntelligence/ArtifactGenerationEngine.swift` —
+  the Runtime-Core (Layer 2) engine: takes a Phase-0 `Transcript` + an injected
+  `ILLMProvider`, prompts the model, decodes its output via the Phase-5
+  `StructuredOutput` bridge into an `ArtifactDraft`, and binds that into a full
+  Phase-0 `Artifact` (stamping id / meetingId / type / plugin identity / a
+  transcript `ArtifactSource`). Propose-only: every artifact is `.draft`.
+- `apple/Sources/Contracts/Models.swift` — added public memberwise inits to
+  `Artifact`, `ArtifactSource`, and `Transcript` (the structs were construct-only
+  via decoding; the engine + tests need to build them) — the same "add inits as
+  later phases need" pattern HSM-3-04 set.
+- `apple/Package.swift` — `RuntimeCore` now depends on `Providers` (for the
+  injected `ILLMProvider`/`StructuredOutput` ports) + a new `RuntimeCoreTests`
+  target.
+- `apple/Tests/RuntimeCoreTests/ArtifactGenerationEngineTests.swift` — the seam
+  tests (fake `ILLMProvider`).
+
+## Verification artifacts
+
+`cd apple && swift test` — **28/28 green** (24 prior + 4 new), layer guard green
+(`Contracts`/`RuntimeCore`/`Providers` import no SwiftUI/UIKit/WebKit):
+
+```
+Test Suite 'ArtifactGenerationEngineTests' ...
+  testBatchIsResilientPerType       passed
+  testEmitsSchemaValidArtifact      passed
+  testMalformedOutputIsRecoverable  passed
+  testNeverAutoAccepts              passed
+Executed 28 tests, with 0 failures
+core layers are UI-free ✓
+```
+
+## Acceptance criteria — re-checked
+
+- [x] Runtime-Core (Layer 2), no UI dependency — layer guard green.
+- [x] Injected `ILLMProvider` + Phase-0 `Transcript`; no concrete provider assumed.
+- [x] Emits a schema-valid Phase-0 `Artifact` — `testEmitsSchemaValidArtifact`
+  round-trips the emitted artifact through the contract coder unchanged.
+- [x] Malformed model output → recoverable error, not a crash —
+  `testMalformedOutputIsRecoverable`; `testBatchIsResilientPerType` proves one bad
+  type does not sink the others.
+- [x] No execute/connector/autonomy path — propose-only `.draft`
+  (`testNeverAutoAccepts`).
+
+## Design notes
+
+- **The model contributes only the intelligence.** It returns an `ArtifactDraft`
+  (title, body, type-specific `structured_json`, confidence); the engine owns the
+  discriminator (`artifact_type`), identity, and provenance. This keeps the model's
+  job small and reliable and the contract binding the engine's responsibility.
+- **Generic seam, concrete types later.** A `PromptBuilder` is injected (default: a
+  generic schema-hinted prompt); HSM-6-02 (five core types) and HSM-6-03 (ADR
+  Candidates + Follow-ups) supply the per-type prompts/parsers on top of this seam.
+- **Substance is HSM-6-04's job.** This story judges shape/validity only (per the
+  story's own note); the parity baseline harness measures quality.
+
+## Deviations / open questions
+
+- **`RuntimeCore` → `Providers` dependency.** The injected port protocols
+  (`ILLMProvider`, `StructuredOutput`) live in the `Providers` target (per the
+  README/Package layer note), so RuntimeCore depends on Providers. **Risk to flag
+  at Phase 3:** when `HSM-3-01` adds the WhisperKit SPM dependency to the
+  `Providers` target, RuntimeCore (and its tests) would transitively link a model
+  engine. **Trigger/mitigation:** at Phase 3, isolate the heavy adapter deps (e.g.
+  split a dependency-free `ProviderInterfaces` target, or keep WhisperKit behind a
+  sub-target) so the domain never links an inference/transcription engine. Recorded
+  in the phase status "Decisions deferred".
+- Integration against a real homelab/endpoint provider (story Test plan
+  "Integration") is deferred to the HSM-6-04 parity harness, which runs the engine
+  against a real `ILLMProvider` and judges substance.

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-01-artifact-generation-engine.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-01-artifact-generation-engine.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 6
-- **Status:** backlog
+- **Status:** done
 - **Depends on:** none
 - **Unblocks:** HSM-6-02, HSM-6-03
 - **Owner:** unassigned
@@ -31,18 +31,23 @@ type (HSM-6-02/03) has nowhere to live.
 
 ## Acceptance criteria
 
-- [ ] The engine is a Runtime-Core (Layer 2) component with no SwiftUI/UIKit/
+- [x] The engine is a Runtime-Core (Layer 2) component with no SwiftUI/UIKit/
       WebView dependency (charter architecture principle: domain is independent).
-- [ ] It accepts an injected `ILLMProvider` and a Phase-0 `Transcript`; it does
-      not construct or assume a concrete provider.
-- [ ] Given a real transcript + a working provider, it emits at least one Phase-0
+      (`Sources/RuntimeCore/MeetingIntelligence/ArtifactGenerationEngine.swift`;
+      layer guard green.)
+- [x] It accepts an injected `ILLMProvider` and a Phase-0 `Transcript`; it does
+      not construct or assume a concrete provider. (`init(provider: ILLMProvider, …)`.)
+- [x] Given a real transcript + a working provider, it emits at least one Phase-0
       `Artifact` as structured JSON that validates against the Phase-0 schema with
-      zero errors.
-- [ ] Malformed or partial model output is handled (parse failure surfaces as a
+      zero errors. (`testEmitsSchemaValidArtifact`: the emitted Artifact round-trips
+      through the contract coder unchanged.)
+- [x] Malformed or partial model output is handled (parse failure surfaces as a
       recoverable error, not a crash) — the engine is robust to the model
-      returning prose instead of clean JSON.
-- [ ] No code path in the engine executes an action, calls a connector, or
+      returning prose instead of clean JSON. (`testMalformedOutputIsRecoverable` +
+      `testBatchIsResilientPerType`: one bad type does not sink the batch.)
+- [x] No code path in the engine executes an action, calls a connector, or
       implies autonomous behavior (charter non-goal: no agentic automation).
+      (Propose-only: every artifact is `.draft`; `testNeverAutoAccepts`.)
 
 ## Test plan
 


### PR DESCRIPTION
## What

**HSM-6-01** — the artifact-generation engine, the Runtime-Core (Layer 2) seam every meeting-intelligence type lives on. `ArtifactGenerationEngine` takes a Phase-0 `Transcript` + an injected `ILLMProvider`, drives the model through the Phase-5 `StructuredOutput` bridge to decode an `ArtifactDraft`, and binds it into a schema-valid Phase-0 `Artifact`.

- **Model contributes only the intelligence** (title / body / `structured_json` / confidence); the engine stamps `id` / `meeting_id` / `artifact_type` / plugin identity + a transcript `ArtifactSource`.
- **Propose-only** — every artifact is `.draft`; no execute/connector path (charter Propose→Review→Approve→Execute).
- **Robust to prose** — a parse failure surfaces as a recoverable error; per-type batch resilience means one malformed type doesn't sink the others.
- Generic seam: concrete per-type prompts/parsers are HSM-6-02 (five core types) and HSM-6-03 (ADR Candidates + Follow-ups).

## Contracts / package

- Added public memberwise inits to `Artifact` / `ArtifactSource` / `Transcript` (construct-only via decoding before — the engine + tests need them; same pattern HSM-3-04 set).
- `RuntimeCore` now depends on `Providers` for the injected port protocols. **Transitive-dep risk flagged:** when HSM-3-01 adds WhisperKit to `Providers`, the domain would link a transcription engine — mitigation (split a dependency-free `ProviderInterfaces` target) recorded in the phase-status *Decisions deferred* with a Phase-3 trigger.

## Tests

`cd apple && swift test` → **28/28** (24 prior + 4 new), layer guard green. New: `ArtifactGenerationEngineTests` (schema-valid emit, recoverable malformed output, per-type batch resilience, propose-only).

## Docs (operating cadence)

story-01 → done + acceptance boxes, `evidence-story-01.md`, phase-6 status (table / Where-we-are / Last-updated / Decisions-deferred), mobile README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)