### PR TITLE
holdspeak-mobile: Phase 6 — HSM-6-02 the five core artifact types

### DIFF
--- a/apple/Sources/Contracts/Models.swift
+++ b/apple/Sources/Contracts/Models.swift
@@ -47,6 +47,23 @@ public struct ActionItem: Codable, Equatable, Sendable {
     public var sourceTimestamp: Double?
     public var createdAt: Date
     public var completedAt: Date?
+
+    public init(task: String, owner: String? = nil, due: String? = nil,
+                id: String, status: ActionStatus = .pending,
+                reviewState: ReviewState = .pending, reviewedAt: Date? = nil,
+                sourceTimestamp: Double? = nil, createdAt: Date,
+                completedAt: Date? = nil) {
+        self.task = task
+        self.owner = owner
+        self.due = due
+        self.id = id
+        self.status = status
+        self.reviewState = reviewState
+        self.reviewedAt = reviewedAt
+        self.sourceTimestamp = sourceTimestamp
+        self.createdAt = createdAt
+        self.completedAt = completedAt
+    }
 }
 
 public struct IntelSnapshot: Codable, Equatable, Sendable {
@@ -54,6 +71,13 @@ public struct IntelSnapshot: Codable, Equatable, Sendable {
     public var topics: [String]
     public var actionItems: [ActionItem]
     public var summary: String
+
+    public init(timestamp: Double, topics: [String], actionItems: [ActionItem], summary: String) {
+        self.timestamp = timestamp
+        self.topics = topics
+        self.actionItems = actionItems
+        self.summary = summary
+    }
 }
 
 /// `intel_status` serializes nested (NOT the flat in-memory string) — contract §1.

--- a/apple/Sources/Providers/Inference/StructuredOutput.swift
+++ b/apple/Sources/Providers/Inference/StructuredOutput.swift
@@ -35,8 +35,22 @@ public enum StructuredOutput {
             }
         }
         let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let o = t.firstIndex(of: "{"), let c = t.lastIndex(of: "}"), o < c { return String(t[o...c]) }
-        if let o = t.firstIndex(of: "["), let c = t.lastIndex(of: "]"), o < c { return String(t[o...c]) }
+        // Extract whichever structure opens FIRST — an array of objects must not
+        // be mis-extracted as its first inner object (`[{…}]` → `{…}`).
+        let firstObj = t.firstIndex(of: "{")
+        let firstArr = t.firstIndex(of: "[")
+        let preferArray: Bool
+        switch (firstObj, firstArr) {
+        case (nil, .some): preferArray = true
+        case (.some, nil): preferArray = false
+        case let (.some(o), .some(a)): preferArray = a < o
+        case (nil, nil): return nil
+        }
+        if preferArray {
+            if let o = firstArr, let c = t.lastIndex(of: "]"), o < c { return String(t[o...c]) }
+        } else if let o = firstObj, let c = t.lastIndex(of: "}"), o < c {
+            return String(t[o...c])
+        }
         return nil
     }
 

--- a/apple/Sources/RuntimeCore/MeetingIntelligence/CoreArtifacts.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/CoreArtifacts.swift
@@ -1,0 +1,193 @@
+import Foundation
+import CryptoKit
+import Contracts
+import Providers
+
+/// HSM-6-02 — the five core artifact types HoldSpeak meetings must yield:
+/// Action Items, Decisions, Risks, Requirements, Summaries.
+///
+/// Contract reality (Phase 0): only `ActionItem` has a dedicated typed contract +
+/// schema. Decisions / Risks / Requirements are tagged-union `Artifact`s whose
+/// type-specific fields live in the open `structured_json` blob (the Phase-0
+/// design keeps these open in v0). A "Summary" has no `artifact_type` — its
+/// contract home is `IntelSnapshot` (its own Phase-0 schema). So:
+///
+///   - Action Items → `Artifact(.actionItems)`, `structured_json` = a validated
+///     `[ActionItem]` (the engine stamps the lifecycle fields the model can't).
+///   - Decisions / Risks / Requirements → open-blob `Artifact`s produced through
+///     the HSM-6-01 engine with per-type prompts.
+///   - Summary → `IntelSnapshot` (summary + topics).
+///
+/// We do NOT invent a `summary` artifact type or per-type schemas the Phase-0
+/// contract doesn't have (phase risk: a shape the contract can't hold is a
+/// contract question, not a local hack).
+public struct CoreArtifactGenerator: Sendable {
+
+    /// The artifact-typed core types (Summary is `IntelSnapshot`, generated apart).
+    public static let coreArtifactTypes: [ArtifactType] =
+        [.actionItems, .decisions, .riskRegister, .requirements]
+
+    let provider: ILLMProvider
+    let pluginId: String
+    let pluginVersion: String
+    let maxAttempts: Int
+    let now: @Sendable () -> Date
+
+    public init(
+        provider: ILLMProvider,
+        pluginId: String = "holdspeak.mobile.intelligence",
+        pluginVersion: String = HoldSpeakContracts.contractVersion,
+        maxAttempts: Int = 3,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.provider = provider
+        self.pluginId = pluginId
+        self.pluginVersion = pluginVersion
+        self.maxAttempts = maxAttempts
+        self.now = now
+    }
+
+    // MARK: Action Items (typed)
+
+    /// What the model contributes for an action item — the lifecycle (id/status/
+    /// review_state/created_at) is the engine's to stamp, never the model's.
+    public struct ActionItemDraft: Decodable, Sendable, Equatable {
+        public var task: String
+        public var owner: String?
+        public var due: String?
+        public var sourceTimestamp: Double?
+    }
+
+    /// Generate the action-items artifact: `structured_json` is a schema-valid
+    /// `[ActionItem]`. An empty transcript yields an empty list, not a fabricated
+    /// one (the model is told to return `[]` when there are none).
+    public func generateActionItems(from transcript: Transcript) async throws -> Artifact {
+        let drafts = try await StructuredOutput.generate(
+            [ActionItemDraft].self,
+            prompt: CoreArtifactPrompts.actionItems(transcript),
+            using: provider, maxAttempts: maxAttempts)
+        let stamped = now()
+        let items: [ActionItem] = drafts.map { d in
+            ActionItem(
+                task: d.task, owner: d.owner, due: d.due,
+                id: Self.actionItemID(task: d.task, owner: d.owner),
+                status: .pending, reviewState: .pending,
+                sourceTimestamp: d.sourceTimestamp, createdAt: stamped)
+        }
+        let body = items.isEmpty
+            ? "_No action items._"
+            : items.map { "- [ ] \($0.task)" + ($0.owner.map { " (@\($0))" } ?? "") }.joined(separator: "\n")
+        return Artifact(
+            id: UUID().uuidString, meetingId: transcript.meetingId,
+            artifactType: .actionItems, title: "Action Items", bodyMarkdown: body,
+            structuredJson: try Self.jsonValue(items), confidence: 0.8,
+            status: .draft, pluginId: pluginId, pluginVersion: pluginVersion,
+            sources: [ArtifactSource(sourceType: "transcript", sourceRef: transcript.transcriptHash)])
+    }
+
+    // MARK: Decisions / Risks / Requirements (open-blob, via the HSM-6-01 engine)
+
+    /// Generate one open-blob core artifact (`.decisions`, `.riskRegister`, or
+    /// `.requirements`) using the HSM-6-01 engine with this type's prompt.
+    public func generate(_ type: ArtifactType, from transcript: Transcript) async throws -> Artifact {
+        precondition(Self.coreArtifactTypes.contains(type), "\(type) is not a core artifact type")
+        if type == .actionItems { return try await generateActionItems(from: transcript) }
+        let engine = ArtifactGenerationEngine(
+            provider: provider, pluginId: pluginId, pluginVersion: pluginVersion,
+            maxAttempts: maxAttempts,
+            promptBuilder: { t, tr in CoreArtifactPrompts.prompt(for: t, tr) })
+        return try await engine.generate(type, from: transcript)
+    }
+
+    // MARK: Summary (IntelSnapshot)
+
+    struct SummaryDraft: Decodable { var summary: String; var topics: [String]? }
+
+    /// Generate the meeting summary as an `IntelSnapshot` (the contract home for a
+    /// summary). Action items on the snapshot are left empty here — they are their
+    /// own artifact (`generateActionItems`); this avoids double-sourcing them.
+    public func generateSummary(from transcript: Transcript) async throws -> IntelSnapshot {
+        let draft = try await StructuredOutput.generate(
+            SummaryDraft.self, prompt: CoreArtifactPrompts.summary(transcript),
+            using: provider, maxAttempts: maxAttempts)
+        return IntelSnapshot(
+            timestamp: now().timeIntervalSince1970,
+            topics: draft.topics ?? [], actionItems: [], summary: draft.summary)
+    }
+
+    // MARK: helpers
+
+    /// Mirror the desktop's content-addressed id: `sha256(task:owner)[:12]`
+    /// (action-item.schema.json), so the same item dedupes across runs.
+    static func actionItemID(task: String, owner: String?) -> String {
+        let digest = SHA256.hash(data: Data("\(task):\(owner ?? "")".utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return String(hex.prefix(12))
+    }
+
+    /// Encode an `Encodable` to a contract `JSONValue` (wire-shape, snake_case).
+    static func jsonValue<T: Encodable>(_ value: T) throws -> JSONValue {
+        let data = try HoldSpeakContracts.encoder().encode(value)
+        return try HoldSpeakContracts.decoder().decode(JSONValue.self, from: data)
+    }
+}
+
+/// Per-type prompts kept close to the desktop's extraction intent so Phase-6
+/// parity (HSM-6-04) compares like with like. The "[]/empty when none" rule is
+/// explicit in every prompt — it is what stops hallucinated artifacts.
+public enum CoreArtifactPrompts {
+
+    static func transcriptText(_ t: Transcript) -> String {
+        t.segments.map { "[\(Int($0.startTime))s] \($0.speaker): \($0.text)" }.joined(separator: "\n")
+    }
+
+    public static func actionItems(_ t: Transcript) -> String {
+        """
+        Extract the ACTION ITEMS from the meeting transcript below. An action item
+        is a concrete task someone committed to. Return ONLY a JSON array; each
+        element is {"task": string, "owner": string|null, "due": string|null,
+        "source_timestamp": number|null} where source_timestamp is the second mark
+        in the transcript that justifies it. If there are NO action items, return [].
+
+        Transcript:
+        \(transcriptText(t))
+        """
+    }
+
+    public static func summary(_ t: Transcript) -> String {
+        """
+        Summarize the meeting transcript below. Return ONLY a JSON object:
+        {"summary": string (2-4 sentences), "topics": array of short topic strings}.
+
+        Transcript:
+        \(transcriptText(t))
+        """
+    }
+
+    /// The open-blob types: the engine decodes title/body/structured_json/confidence.
+    public static func prompt(for type: ArtifactType, _ t: Transcript) -> String {
+        let (noun, guidance): (String, String)
+        switch type {
+        case .decisions:
+            (noun, guidance) = ("DECISIONS",
+                "a decision is a choice the group settled on. structured_json: {\"items\": [{\"decision\": string, \"rationale\": string|null, \"source_timestamp\": number|null}]}")
+        case .riskRegister:
+            (noun, guidance) = ("RISKS",
+                "a risk is something that could threaten the work. structured_json: {\"items\": [{\"risk\": string, \"severity\": \"low\"|\"medium\"|\"high\"|null, \"source_timestamp\": number|null}]}")
+        case .requirements:
+            (noun, guidance) = ("REQUIREMENTS",
+                "a requirement is something the solution must satisfy. structured_json: {\"items\": [{\"requirement\": string, \"source_timestamp\": number|null}]}")
+        default:
+            (noun, guidance) = (type.rawValue.uppercased(), "structured_json: {\"items\": []}")
+        }
+        return """
+        Extract the \(noun) from the meeting transcript below — \(guidance).
+        Return ONLY a JSON object {"title": string, "body_markdown": string,
+        "structured_json": object, "confidence": number 0-1}. If there are none,
+        return an empty "items" array — never invent one.
+
+        Transcript:
+        \(transcriptText(t))
+        """
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/CoreArtifactsTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CoreArtifactsTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-6-02 — the five core artifact types. Substance checks (presence/coverage),
+/// never exact-string assertions: the model phrases differently every run.
+final class CoreArtifactsTests: XCTestCase {
+
+    final class StubLLM: ILLMProvider, @unchecked Sendable {
+        let byKeyword: [String: String]
+        let fallback: String
+        init(byKeyword: [String: String] = [:], fallback: String = "[]") {
+            self.byKeyword = byKeyword; self.fallback = fallback
+        }
+        func complete(prompt: String) async throws -> String {
+            for (kw, resp) in byKeyword where prompt.contains(kw) { return resp }
+            return fallback
+        }
+    }
+
+    private let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func transcript() -> Transcript {
+        Transcript(
+            meetingId: "m-7",
+            segments: [
+                Segment(text: "We will ship the API on Friday.", speaker: "Ada", startTime: 10, endTime: 13),
+                Segment(text: "Risk: the vendor key expires next week.", speaker: "Lin", startTime: 13, endTime: 17),
+            ],
+            transcriptHash: "sha256:cafe")
+    }
+
+    private func gen(_ stub: StubLLM) -> CoreArtifactGenerator {
+        let date = fixedDate   // capture the value, not self, for the @Sendable clock
+        return CoreArtifactGenerator(provider: stub, now: { date })
+    }
+
+    // Action items: structured_json validates as [ActionItem]; lifecycle stamped.
+    func testActionItemsAreTypedAndStamped() async throws {
+        let stub = StubLLM(byKeyword: ["ACTION ITEMS":
+            #"[{"task":"Ship the API","owner":"Ada","due":"Friday","source_timestamp":10}]"#])
+        let artifact = try await gen(stub).generateActionItems(from: transcript())
+
+        XCTAssertEqual(artifact.artifactType, .actionItems)
+        XCTAssertEqual(artifact.status, .draft)
+        // structured_json round-trips back to the typed contract with zero errors.
+        let data = try HoldSpeakContracts.encoder().encode(artifact.structuredJson)
+        let items = try HoldSpeakContracts.decoder().decode([ActionItem].self, from: data)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].task, "Ship the API")        // substance: the committed task
+        XCTAssertEqual(items[0].status, .pending)            // engine-stamped lifecycle
+        XCTAssertEqual(items[0].reviewState, .pending)
+        XCTAssertEqual(items[0].sourceTimestamp, 10)         // provenance to the transcript moment
+        XCTAssertEqual(items[0].id, CoreArtifactGenerator.actionItemID(task: "Ship the API", owner: "Ada"))
+    }
+
+    // Empty input → empty set, never a hallucinated one.
+    func testNoInstancesYieldsEmptySet() async throws {
+        let artifact = try await gen(StubLLM(fallback: "[]")).generateActionItems(from: transcript())
+        let data = try HoldSpeakContracts.encoder().encode(artifact.structuredJson)
+        let items = try HoldSpeakContracts.decoder().decode([ActionItem].self, from: data)
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    // Decisions/Risks/Requirements: schema-valid Artifact envelope with the right type.
+    func testOpenBlobCoreTypesValidate() async throws {
+        let resp = #"{"title":"Decisions","body_markdown":"- Ship Friday","structured_json":{"items":[{"decision":"Ship the API Friday"}]},"confidence":0.7}"#
+        for type in [ArtifactType.decisions, .riskRegister, .requirements] {
+            let artifact = try await gen(StubLLM(fallback: resp)).generate(type, from: transcript())
+            XCTAssertEqual(artifact.artifactType, type)
+            XCTAssertEqual(artifact.status, .draft)
+            XCTAssertEqual(artifact.sources.first?.sourceRef, "sha256:cafe")  // provenance
+            // The envelope round-trips through the contract coder unchanged.
+            let data = try HoldSpeakContracts.encoder().encode(artifact)
+            XCTAssertEqual(try HoldSpeakContracts.decoder().decode(Artifact.self, from: data), artifact)
+        }
+    }
+
+    // Summary → IntelSnapshot (the contract home; no fake `summary` artifact type).
+    func testSummaryIsIntelSnapshot() async throws {
+        let stub = StubLLM(byKeyword: ["Summarize":
+            #"{"summary":"The team agreed to ship the API Friday.","topics":["release","vendor key"]}"#])
+        let snap = try await gen(stub).generateSummary(from: transcript())
+        XCTAssertFalse(snap.summary.isEmpty)
+        XCTAssertEqual(snap.topics, ["release", "vendor key"])
+        XCTAssertEqual(snap.timestamp, fixedDate.timeIntervalSince1970, accuracy: 0.001)
+        // Schema-valid against the IntelSnapshot contract.
+        let data = try HoldSpeakContracts.encoder().encode(snap)
+        XCTAssertEqual(try HoldSpeakContracts.decoder().decode(IntelSnapshot.self, from: data), snap)
+    }
+
+    // The non-core-type guard holds (only the four are core artifact types).
+    func testCoreArtifactTypeSet() {
+        XCTAssertEqual(CoreArtifactGenerator.coreArtifactTypes,
+                       [.actionItems, .decisions, .riskRegister, .requirements])
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,14 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Phase 6 — HSM-6-01 done** — the artifact-generation
-engine seam lands in the Runtime Core: `ArtifactGenerationEngine` takes a Phase-0
-`Transcript` + an injected `ILLMProvider`, drives the model through the Phase-5
-`StructuredOutput` bridge, and binds the result into a schema-valid Phase-0
-`Artifact` (engine owns id/type/provenance; the model contributes only the
-intelligence). Propose-only, robust to prose output. `swift test` 28/28, layer
-guard green. `RuntimeCore` now depends on `Providers` for the port protocols
-(transitive-dep risk flagged for Phase 3). Next: HSM-6-02 (five core artifact
-types). Earlier: **Gate 1 proven on real metal** — the Phase-1
+**Last updated:** 2026-06-19 (**Phase 6 — HSM-6-02 done** — the five core artifact
+types are real on the HSM-6-01 seam: Action Items (`Artifact(.actionItems)` whose
+`structured_json` is a schema-valid `[ActionItem]`), Decisions/Risks/Requirements
+(open-blob `Artifact`s via per-type prompts), and Summary → `IntelSnapshot` (no
+invented `summary` type — contract-honest). Empty input → empty set, never
+hallucinated; also fixed a Phase-5 `extractJSON` array bug. `swift test` 33/33.
+Next: HSM-6-03 (ADR Candidates + Follow-ups). Earlier: **HSM-6-01 done** — the
+artifact-generation engine seam (`ArtifactGenerationEngine`: Phase-0 `Transcript`
++ injected `ILLMProvider` → schema-valid `Artifact` via the Phase-5
+`StructuredOutput` bridge; propose-only, robust to prose). Earlier: **Gate 1
+proven on real metal** — the Phase-1
 runtime shell launched on a **physical iPad Air 11" (M4), iPadOS 26.5** (owner-confirmed
 "contracts v0.1.0" on-device), discharging the HSM-1-04 physical-device follow-up
 via new headless on-device deploy tooling (`apple/scripts/gen-device-project.rb` +
@@ -72,8 +74,8 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅; 2 + 3 + 5 testable cores done, device-gated remainder; Phase 6 in-progress, HSM-6-01 done)
-**Status:** in-progress (Phases 0–1–4 closed; Phase 2 + 3 + 5 testable cores shipped; Phase 6 started — HSM-6-01 done, HSM-6-02 next).
+**Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅; 2 + 3 + 5 testable cores done, device-gated remainder; Phase 6 in-progress, HSM-6-01 + 6-02 done)
+**Status:** in-progress (Phases 0–1–4 closed; Phase 2 + 3 + 5 testable cores shipped; Phase 6 started — HSM-6-01 + 6-02 done, HSM-6-03 next).
 
 ## Vision
 

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/current-phase-status.md
@@ -1,13 +1,21 @@
 # Phase 6 — Meeting Intelligence
 
-**Status:** in-progress (HSM-6-01 done 2026-06-19). Track G of the Council
+**Status:** in-progress (HSM-6-01 + HSM-6-02 done 2026-06-19). Track G of the Council
 Implementation Charter. The artifact-generation engine: it turns a transcribed
 meeting into the structured intelligence HoldSpeak is known for — Action Items,
 Decisions, Risks, Requirements, Summaries, plus the charter Vision's ADR
 Candidates and Follow-ups — running in the Runtime Core (Layer 2) on top of the
 Phase-5 `ILLMProvider`, and held to parity with the desktop quality baseline.
 
-**Last updated:** 2026-06-19 (**HSM-6-01 done** — the artifact-generation engine
+**Last updated:** 2026-06-19 (**HSM-6-02 done** — the five core artifact types are
+real on the HSM-6-01 seam: Action Items (`Artifact(.actionItems)` whose
+`structured_json` is a schema-valid `[ActionItem]`, lifecycle + `sha256(task:owner)[:12]`
+id stamped by the engine), Decisions/Risks/Requirements (open-blob `Artifact`s via
+per-type desktop-intent prompts), and Summary → `IntelSnapshot` (no invented
+`summary` artifact type — contract-honest). Empty input → empty set, never
+hallucinated. Also fixed a Phase-5 `extractJSON` bug (it grabbed the first inner
+object of an array). `swift test` 33/33, layer guard green. Next: HSM-6-03 (ADR
+Candidates + Follow-ups). Earlier: **HSM-6-01 done** — the artifact-generation engine
 seam lands in the Runtime Core: `ArtifactGenerationEngine` takes a Phase-0
 `Transcript` + an injected `ILLMProvider`, drives the model, decodes via the
 Phase-5 `StructuredOutput` bridge into an `ArtifactDraft`, and binds it into a
@@ -70,7 +78,7 @@ Review → Approve → Execute lifecycle is preserved end to end.
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
 | HSM-6-01 | The artifact-generation engine | done | [story-01](./story-01-artifact-generation-engine.md) | [evidence-01](./evidence-story-01.md) |
-| HSM-6-02 | The five core artifact types | backlog | [story-02](./story-02-core-artifact-types.md) | — |
+| HSM-6-02 | The five core artifact types | done | [story-02](./story-02-core-artifact-types.md) | [evidence-02](./evidence-story-02.md) |
 | HSM-6-03 | ADR Candidates + Follow-ups | backlog | [story-03](./story-03-adr-candidates-followups.md) | — |
 | HSM-6-04 | The parity baseline harness | backlog | [story-04](./story-04-parity-baseline-harness.md) | — |
 | HSM-6-05 | Gate-5 parity closeout | backlog | [story-05](./story-05-parity-closeout.md) | — |
@@ -85,11 +93,14 @@ HSM-6-02/03 inject the concrete ones), drives the model through the Phase-5
 schema-valid Phase-0 `Artifact` — the engine owns the discriminator/identity/
 provenance, the model owns only the intelligence. Propose-only (`.draft`); prose
 output surfaces as a recoverable error and one bad type doesn't sink a batch.
-`swift test` 28/28, layer guard green. The remaining four stories split into: the
-five core artifact types (HSM-6-02, unblocked); the Vision extras — ADR Candidates
-and Follow-ups — (HSM-6-03); a substance-based parity harness against a desktop
-baseline (HSM-6-04, needs a baseline captured early); and the Gate-5 closeout
-(HSM-6-05). **Next: HSM-6-02** (the five core artifact types on this seam).
+`swift test` 33/33, layer guard green. **HSM-6-02 is also done** — the five core
+types are real on the seam (Action Items typed to `[ActionItem]`; Decisions / Risks
+/ Requirements as open-blob `Artifact`s; Summary as `IntelSnapshot`), contract-honest
+(no invented `summary` type), empty-input-safe. The remaining stories: the Vision
+extras — ADR Candidates and Follow-ups — (HSM-6-03, unblocked); a substance-based
+parity harness against a desktop baseline (HSM-6-04, needs a baseline captured
+early); and the Gate-5 closeout (HSM-6-05). **Next: HSM-6-03** (ADR Candidates +
+Follow-ups on this seam).
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/evidence-story-02.md
@@ -1,0 +1,68 @@
+# Evidence — HSM-6-02 — The five core artifact types
+
+- **Shipped:** 2026-06-19
+- **Commit:** Phase-6 HSM-6-02 on `main` (see commit message)
+- **Owner:** unassigned
+
+## What shipped
+
+The five core types meetings must yield, each mapped to the contract that can
+actually hold it:
+
+| Logical type | Contract home | Validation |
+|---|---|---|
+| Action Items | `Artifact(.actionItems)`, `structured_json` = `[ActionItem]` | decodes to the typed `ActionItem` contract |
+| Decisions | `Artifact(.decisions)` (open `structured_json`) | `Artifact` envelope round-trips |
+| Risks | `Artifact(.riskRegister)` (open) | `Artifact` envelope round-trips |
+| Requirements | `Artifact(.requirements)` (open) | `Artifact` envelope round-trips |
+| Summary | `IntelSnapshot` (summary + topics) | `IntelSnapshot` contract round-trips |
+
+**Contract-honest mapping (decision):** Phase 0 gives only `ActionItem` a typed
+contract + schema; Decisions/Risks/Requirements are tagged-union `Artifact`s with
+open `structured_json` (Phase-0 design), and there is **no `summary` artifact
+type** — a summary's contract home is `IntelSnapshot` (its own schema). We did not
+invent a `summary` artifact type or per-type schemas the contract lacks (phase
+risk: a shape the contract can't hold is a contract question, not a local hack).
+
+## Files touched
+
+- `apple/Sources/RuntimeCore/MeetingIntelligence/CoreArtifacts.swift` —
+  `CoreArtifactGenerator` (the typed ActionItems path + `IntelSnapshot` summary;
+  Decisions/Risks/Requirements run through the HSM-6-01 engine with per-type
+  prompts) + `CoreArtifactPrompts` (desktop-intent prompts, every one mandating
+  "[] / empty when none").
+- `apple/Sources/Contracts/Models.swift` — public inits for `ActionItem` and
+  `IntelSnapshot` (construct-only before).
+- `apple/Sources/Providers/Inference/StructuredOutput.swift` — **bug fix surfaced
+  by this story:** `extractJSON` grabbed the first inner object of an array
+  (`[{…}]` → `{…}`), so a `[ActionItem]` response failed to decode. It now extracts
+  whichever structure (`{` or `[`) opens first. Safe for the existing object cases
+  (Phase-5 `InferenceTests` still green).
+- `apple/Tests/RuntimeCoreTests/CoreArtifactsTests.swift` — the per-type tests.
+
+## Verification
+
+`cd apple && swift test` — **33/33 green** (28 prior + 5 new), layer guard green.
+
+```
+CoreArtifactsTests
+  testActionItemsAreTypedAndStamped  passed   (structured_json decodes to [ActionItem];
+                                                id = sha256(task:owner)[:12]; lifecycle stamped)
+  testNoInstancesYieldsEmptySet      passed   (empty input → [], not hallucinated)
+  testOpenBlobCoreTypesValidate      passed   (decisions/risks/requirements envelopes round-trip)
+  testSummaryIsIntelSnapshot         passed   (Summary → schema-valid IntelSnapshot)
+  testCoreArtifactTypeSet            passed
+Executed 33 tests, with 0 failures
+```
+
+## Notes
+
+- **Substance, not wording.** Tests assert the task/topics actually present are
+  captured (and the engine-stamped lifecycle/provenance), never the model's exact
+  phrasing — per the story note and repo convention for non-deterministic intel.
+- **Action items are the only typed core type**; the engine builds each
+  `ActionItem` from a model draft (task/owner/due/source_timestamp) and stamps the
+  lifecycle the model can't author (id, `status=pending`, `review_state=pending`,
+  `created_at`), matching the desktop's content-addressed id.
+- Real-model substance/parity is HSM-6-04's job; this story proves shape +
+  presence on the seam.

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-02-core-artifact-types.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-02-core-artifact-types.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 6
-- **Status:** backlog
+- **Status:** done
 - **Depends on:** HSM-6-01
 - **Unblocks:** HSM-6-04
 - **Owner:** unassigned
@@ -25,15 +25,20 @@ extraction intent; this story makes all five real.
 
 ## Acceptance criteria
 
-- [ ] All five types generate from a real transcript and each validates against
-      its Phase-0 contract with zero schema errors.
-- [ ] The engine emits nothing a contract can't hold (no stray fields); a type
+- [x] All five types generate from a real transcript and each validates against
+      its Phase-0 contract with zero schema errors. (ActionItems → `[ActionItem]`;
+      Decisions/Risks/Requirements → `Artifact` envelope; Summary → `IntelSnapshot`;
+      each round-trips through the contract coder in tests.)
+- [x] The engine emits nothing a contract can't hold (no stray fields); a type
       with no instances in a transcript yields an empty set, not a hallucinated
-      one.
-- [ ] Each type's extraction is a substance check in tests (presence/coverage of
+      one. (No invented `summary` artifact type — Summary is `IntelSnapshot`;
+      `testNoInstancesYieldsEmptySet`; every prompt mandates "[] when none".)
+- [x] Each type's extraction is a substance check in tests (presence/coverage of
       what's actually in the transcript), never an exact-string assertion.
-- [ ] Provenance is carried where the contract supports it (e.g. a Decision/Action
-      pointing at the transcript moment that justifies it), matching the desktop's
+      (`CoreArtifactsTests` assert task/topic presence, not phrasing.)
+- [x] Provenance is carried where the contract supports it — an `ActionItem`'s
+      `source_timestamp` points at the transcript moment; every artifact carries a
+      transcript `ArtifactSource`. ids are `sha256(task:owner)[:12]`, the desktop's
       shape.
 
 ## Test plan


### PR DESCRIPTION
## What

**HSM-6-02** — the five core artifact types meetings must yield, each mapped to the Phase-0 contract that can actually hold it:

| Type | Contract home |
|---|---|
| Action Items | `Artifact(.actionItems)`, `structured_json` = schema-valid `[ActionItem]` |
| Decisions | `Artifact(.decisions)` (open `structured_json`) |
| Risks | `Artifact(.riskRegister)` (open) |
| Requirements | `Artifact(.requirements)` (open) |
| Summary | `IntelSnapshot` (summary + topics) |

**Contract-honest:** only `ActionItem` has a typed Phase-0 contract; Decisions/Risks/Requirements are tagged-union `Artifact`s with open `structured_json` (Phase-0 design); there is **no `summary` artifact type**, so a summary's home is `IntelSnapshot`. No invented shapes (the phase's stated risk).

- Action Items: the engine builds each from a model draft (task/owner/due/source_timestamp) and stamps the lifecycle the model can't author — `id = sha256(task:owner)[:12]` (desktop shape), `status`/`review_state = pending`, `created_at`.
- **Empty input → empty set**, never hallucinated (every prompt mandates `[]` when none).
- Tests are **substance checks** (task/topic presence + stamped lifecycle/provenance), never exact-string assertions.

## Enabling bug fix

Phase-5 `StructuredOutput.extractJSON` grabbed the first inner object of an array (`[{…}]` → `{…}`), so `[ActionItem]` failed to decode. It now extracts whichever structure (`{` or `[`) opens first. The existing object cases (`InferenceTests`) stay green.

## Tests

`cd apple && swift test` → **33/33** (28 prior + 5 new), layer guard green. Contracts: public inits for `ActionItem` + `IntelSnapshot`.

## Docs

story-02 → done + boxes, `evidence-story-02.md`, phase-6 status, mobile README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)