### PR TITLE
holdspeak-mobile: Phase 6 — HSM-6-03 ADR Candidates (Follow-ups → 6-06)

### DIFF
--- a/apple/Sources/RuntimeCore/MeetingIntelligence/CoreArtifacts.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/CoreArtifacts.swift
@@ -115,6 +115,24 @@ public struct CoreArtifactGenerator: Sendable {
             topics: draft.topics ?? [], actionItems: [], summary: draft.summary)
     }
 
+    // MARK: ADR Candidates (HSM-6-03 — open-blob `Artifact(.adr)`)
+
+    /// Generate ADR (Architecture Decision Record) Candidates — decisions with
+    /// architectural weight, each tied to the decision context it derives from.
+    /// An open-blob `Artifact(.adr)` via the HSM-6-01 engine. Does not fabricate:
+    /// a transcript with no architectural decision yields an empty candidate set.
+    ///
+    /// (Follow-ups, the other Vision extra, are deferred — the contract has no
+    /// follow-up `artifact_type` and that is a cross-runtime decision; see
+    /// HSM-6-06.)
+    public func generateADRCandidates(from transcript: Transcript) async throws -> Artifact {
+        let engine = ArtifactGenerationEngine(
+            provider: provider, pluginId: pluginId, pluginVersion: pluginVersion,
+            maxAttempts: maxAttempts,
+            promptBuilder: { _, tr in CoreArtifactPrompts.adrCandidates(tr) })
+        return try await engine.generate(.adr, from: transcript)
+    }
+
     // MARK: helpers
 
     /// Mirror the desktop's content-addressed id: `sha256(task:owner)[:12]`
@@ -148,6 +166,23 @@ public enum CoreArtifactPrompts {
         element is {"task": string, "owner": string|null, "due": string|null,
         "source_timestamp": number|null} where source_timestamp is the second mark
         in the transcript that justifies it. If there are NO action items, return [].
+
+        Transcript:
+        \(transcriptText(t))
+        """
+    }
+
+    public static func adrCandidates(_ t: Transcript) -> String {
+        """
+        Extract ADR (Architecture Decision Record) CANDIDATES from the transcript
+        below. An ADR candidate is a decision with architectural weight — a choice
+        about structure, technology, or a tradeoff with lasting consequences. Tie
+        each to the decision context it derives from. Return ONLY a JSON object
+        {"title": string, "body_markdown": string, "structured_json": {"candidates":
+        [{"title": string, "context": string, "decision": string, "consequences":
+        string|null, "source_timestamp": number|null}]}, "confidence": number 0-1}.
+        If there is NO architectural decision, return an empty "candidates" array —
+        never invent one.
 
         Transcript:
         \(transcriptText(t))

--- a/apple/Tests/RuntimeCoreTests/ADRCandidatesTests.swift
+++ b/apple/Tests/RuntimeCoreTests/ADRCandidatesTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-6-03 (ADR half) — ADR Candidates as an open-blob `Artifact(.adr)`. Substance
+/// checks (an architectural decision is captured; none is invented), not strings.
+/// (Follow-ups are deferred — the contract has no follow-up `artifact_type`; HSM-6-06.)
+final class ADRCandidatesTests: XCTestCase {
+
+    final class FixedLLM: ILLMProvider, @unchecked Sendable {
+        let response: String
+        init(_ response: String) { self.response = response }
+        func complete(prompt: String) async throws -> String { response }
+    }
+
+    struct ADRPayload: Decodable { let candidates: [ADRCandidate] }
+    struct ADRCandidate: Decodable { let title: String; let sourceTimestamp: Double? }
+
+    private func transcript(_ segments: [Segment]) -> Transcript {
+        Transcript(meetingId: "m-adr", segments: segments, transcriptHash: "sha256:arch")
+    }
+
+    private func payload(_ artifact: Artifact) throws -> ADRPayload {
+        let data = try HoldSpeakContracts.encoder().encode(artifact.structuredJson)
+        return try HoldSpeakContracts.decoder().decode(ADRPayload.self, from: data)
+    }
+
+    // An architecture-review transcript → a schema-valid ADR artifact with provenance.
+    func testADRCandidatesValidate() async throws {
+        let resp = #"""
+        {"title":"ADR: adopt event sourcing","body_markdown":"## Context\nWe debated state.",
+         "structured_json":{"candidates":[{"title":"Adopt event sourcing","context":"audit needs",
+         "decision":"use an append-only event log","consequences":"replay cost","source_timestamp":42}]},
+         "confidence":0.8}
+        """#
+        let gen = CoreArtifactGenerator(provider: FixedLLM(resp))
+        let artifact = try await gen.generateADRCandidates(from: transcript([
+            Segment(text: "Should we use an event log for state?", speaker: "Ada", startTime: 40, endTime: 44),
+            Segment(text: "Yes, append-only; we need the audit trail.", speaker: "Lin", startTime: 44, endTime: 48),
+        ]))
+
+        XCTAssertEqual(artifact.artifactType, .adr)
+        XCTAssertEqual(artifact.status, .draft)                          // propose-only
+        XCTAssertEqual(artifact.sources.first?.sourceRef, "sha256:arch") // provenance to the transcript
+
+        let p = try payload(artifact)
+        XCTAssertEqual(p.candidates.count, 1)                            // substance: a candidate present
+        XCTAssertEqual(p.candidates[0].sourceTimestamp, 42)             // tied to the decision moment
+
+        // The envelope round-trips through the contract coder unchanged.
+        let data = try HoldSpeakContracts.encoder().encode(artifact)
+        XCTAssertEqual(try HoldSpeakContracts.decoder().decode(Artifact.self, from: data), artifact)
+    }
+
+    // No architectural decision → no candidate (never fabricated).
+    func testADRDoesNotFabricate() async throws {
+        let resp = #"{"title":"ADR Candidates","body_markdown":"None.","structured_json":{"candidates":[]},"confidence":0.2}"#
+        let gen = CoreArtifactGenerator(provider: FixedLLM(resp))
+        let artifact = try await gen.generateADRCandidates(from: transcript([
+            Segment(text: "Let's grab lunch at noon.", speaker: "Ada", startTime: 0, endTime: 2),
+        ]))
+        XCTAssertEqual(artifact.artifactType, .adr)
+        XCTAssertTrue(try payload(artifact).candidates.isEmpty)
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,12 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Phase 6 — HSM-6-02 done** — the five core artifact
-types are real on the HSM-6-01 seam: Action Items (`Artifact(.actionItems)` whose
-`structured_json` is a schema-valid `[ActionItem]`), Decisions/Risks/Requirements
-(open-blob `Artifact`s via per-type prompts), and Summary → `IntelSnapshot` (no
-invented `summary` type — contract-honest). Empty input → empty set, never
-hallucinated; also fixed a Phase-5 `extractJSON` array bug. `swift test` 33/33.
-Next: HSM-6-03 (ADR Candidates + Follow-ups). Earlier: **HSM-6-01 done** — the
+**Last updated:** 2026-06-19 (**Phase 6 — HSM-6-03 done (ADR Candidates)** — an
+open-blob `Artifact(.adr)` on the seam: ties to an architectural-weight decision,
+carries a `source_timestamp` + transcript source, never fabricated. `swift test`
+35/35. **Follow-ups split to HSM-6-06 (blocked)** — `artifact_type` is a closed
+cross-runtime enum with no follow-up type (needs a desktop+schema+fixtures contract
+decision). **Program steer (owner): the iPad syncs to the server by default**
+(local-first, off-LAN → queue → reconcile later); after Phase 6 closes, the sync
+thrust (incl. a new Python-side sync API) is next. Earlier: **HSM-6-02 done** — the
+five core artifact types (Action Items typed to `[ActionItem]`; Decisions/Risks/
+Requirements open-blob; Summary → `IntelSnapshot`); fixed a Phase-5 `extractJSON`
+array bug. Earlier: **HSM-6-01 done** — the
 artifact-generation engine seam (`ArtifactGenerationEngine`: Phase-0 `Transcript`
 + injected `ILLMProvider` → schema-valid `Artifact` via the Phase-5
 `StructuredOutput` bridge; propose-only, robust to prose). Earlier: **Gate 1
@@ -74,8 +78,8 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅; 2 + 3 + 5 testable cores done, device-gated remainder; Phase 6 in-progress, HSM-6-01 + 6-02 done)
-**Status:** in-progress (Phases 0–1–4 closed; Phase 2 + 3 + 5 testable cores shipped; Phase 6 started — HSM-6-01 + 6-02 done, HSM-6-03 next).
+**Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅; 2 + 3 + 5 testable cores done, device-gated remainder; Phase 6 in-progress, HSM-6-01 + 6-02 + 6-03 done; 6-06 Follow-ups blocked)
+**Status:** in-progress (Phases 0–1–4 closed; Phase 2 + 3 + 5 testable cores shipped; Phase 6 — HSM-6-01/02/03 done, HSM-6-04 next; sync-by-default is the next major thrust after Phase 6).
 
 ## Vision
 

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/current-phase-status.md
@@ -1,13 +1,21 @@
 # Phase 6 — Meeting Intelligence
 
-**Status:** in-progress (HSM-6-01 + HSM-6-02 done 2026-06-19). Track G of the Council
+**Status:** in-progress (HSM-6-01 + 6-02 + 6-03 done 2026-06-19; 6-06 Follow-ups
+split out, blocked on a cross-runtime contract decision). Track G of the Council
 Implementation Charter. The artifact-generation engine: it turns a transcribed
 meeting into the structured intelligence HoldSpeak is known for — Action Items,
 Decisions, Risks, Requirements, Summaries, plus the charter Vision's ADR
 Candidates and Follow-ups — running in the Runtime Core (Layer 2) on top of the
 Phase-5 `ILLMProvider`, and held to parity with the desktop quality baseline.
 
-**Last updated:** 2026-06-19 (**HSM-6-02 done** — the five core artifact types are
+**Last updated:** 2026-06-19 (**HSM-6-03 done — ADR Candidates** — an open-blob
+`Artifact(.adr)` on the HSM-6-01 seam: a candidate ties to an architectural-weight
+decision, carries a `source_timestamp` to the moment + a transcript source, and is
+never fabricated (no architectural decision → empty candidates). `swift test`
+35/35. **Follow-ups split to HSM-6-06 (blocked)** — `artifact_type` is a closed
+cross-runtime enum with no follow-up type, so it needs a contract decision (desktop
++ schema + both runtimes + fixtures); owner call was ship-ADR-now-defer-Follow-ups.
+Next: HSM-6-04 (parity baseline harness). Earlier: **HSM-6-02 done** — the five core artifact types are
 real on the HSM-6-01 seam: Action Items (`Artifact(.actionItems)` whose
 `structured_json` is a schema-valid `[ActionItem]`, lifecycle + `sha256(task:owner)[:12]`
 id stamped by the engine), Decisions/Risks/Requirements (open-blob `Artifact`s via
@@ -79,9 +87,10 @@ Review → Approve → Execute lifecycle is preserved end to end.
 |---|---|---|---|---|
 | HSM-6-01 | The artifact-generation engine | done | [story-01](./story-01-artifact-generation-engine.md) | [evidence-01](./evidence-story-01.md) |
 | HSM-6-02 | The five core artifact types | done | [story-02](./story-02-core-artifact-types.md) | [evidence-02](./evidence-story-02.md) |
-| HSM-6-03 | ADR Candidates + Follow-ups | backlog | [story-03](./story-03-adr-candidates-followups.md) | — |
+| HSM-6-03 | ADR Candidates (Follow-ups split to 6-06) | done | [story-03](./story-03-adr-candidates-followups.md) | [evidence-03](./evidence-story-03.md) |
 | HSM-6-04 | The parity baseline harness | backlog | [story-04](./story-04-parity-baseline-harness.md) | — |
 | HSM-6-05 | Gate-5 parity closeout | backlog | [story-05](./story-05-parity-closeout.md) | — |
+| HSM-6-06 | Follow-ups | blocked | [story-06](./story-06-followups.md) | — |
 
 ## Where we are
 
@@ -97,10 +106,13 @@ output surfaces as a recoverable error and one bad type doesn't sink a batch.
 types are real on the seam (Action Items typed to `[ActionItem]`; Decisions / Risks
 / Requirements as open-blob `Artifact`s; Summary as `IntelSnapshot`), contract-honest
 (no invented `summary` type), empty-input-safe. The remaining stories: the Vision
-extras — ADR Candidates and Follow-ups — (HSM-6-03, unblocked); a substance-based
-parity harness against a desktop baseline (HSM-6-04, needs a baseline captured
-early); and the Gate-5 closeout (HSM-6-05). **Next: HSM-6-03** (ADR Candidates +
-Follow-ups on this seam).
+extras: **HSM-6-03 (ADR Candidates) is done** on the seam; **Follow-ups split to
+HSM-6-06 (blocked** on a `follow_up` artifact-type contract decision — see Decisions
+deferred). Remaining: a substance-based parity harness against a desktop baseline
+(HSM-6-04, needs a baseline captured early) and the Gate-5 closeout (HSM-6-05).
+**Next: HSM-6-04** (the parity baseline harness). After Phase 6 closes, the next
+major thrust is **sync-by-default to the server** (owner steer — see the program
+README / Phase 10).
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/evidence-story-03.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/evidence-story-03.md
@@ -1,0 +1,47 @@
+# Evidence — HSM-6-03 — ADR Candidates
+
+- **Shipped:** 2026-06-19
+- **Commit:** Phase-6 HSM-6-03 on `main` (see commit message)
+- **Owner:** unassigned
+
+## What shipped
+
+ADR (Architecture Decision Record) Candidates as an open-blob `Artifact(.adr)` on
+the HSM-6-01 seam: `CoreArtifactGenerator.generateADRCandidates(from:)` drives the
+model with an ADR-intent prompt (a candidate ties to a decision with architectural
+weight, referencing its context) and binds the result into a schema-valid
+`Artifact`. Each candidate carries a `source_timestamp` to the decision moment;
+the artifact carries a transcript `ArtifactSource`. Propose-only (`.draft`); no
+architectural decision → empty `candidates`, never fabricated.
+
+**Scope split:** the original story was "ADR Candidates + Follow-ups". Follow-ups
+is split to **HSM-6-06 (blocked)** — `artifact_type` is a closed cross-runtime enum
+with no follow-up type, so it needs a contract decision touching the desktop +
+schema + both runtimes + fixtures (owner: ship ADR now, defer Follow-ups).
+
+## Files touched
+
+- `apple/Sources/RuntimeCore/MeetingIntelligence/CoreArtifacts.swift` —
+  `generateADRCandidates(from:)` + `CoreArtifactPrompts.adrCandidates`.
+- `apple/Tests/RuntimeCoreTests/ADRCandidatesTests.swift` — the two tests.
+- Story docs: story-03 rescoped to ADR + done; `story-06-followups.md` created
+  (HSM-6-06, blocked).
+
+## Verification
+
+`cd apple && swift test` — **35/35 green** (33 prior + 2 new), layer guard green.
+
+```
+ADRCandidatesTests
+  testADRCandidatesValidate   passed   (Artifact(.adr) round-trips; candidate present;
+                                        source_timestamp = the decision moment; transcript source)
+  testADRDoesNotFabricate     passed   (no architectural decision → empty candidates)
+Executed 35 tests, with 0 failures
+```
+
+## Notes
+
+- Substance, not wording: the test asserts a candidate is present and tied to the
+  transcript moment, never the model's phrasing.
+- Real-model substance/parity is HSM-6-04's job; this proves shape + presence +
+  no-fabrication on the seam.

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-03-adr-candidates-followups.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-03-adr-candidates-followups.md
@@ -1,51 +1,60 @@
-# HSM-6-03 — ADR Candidates + Follow-ups
+# HSM-6-03 — ADR Candidates
 
 - **Project:** holdspeak-mobile
 - **Phase:** 6
-- **Status:** backlog
+- **Status:** done
 - **Depends on:** HSM-6-01, HSM-6-02
 - **Unblocks:** HSM-6-04
 - **Owner:** unassigned
 
+> **Scope split (2026-06-19):** this story originally covered "ADR Candidates +
+> Follow-ups". **Follow-ups** is split out to **[HSM-6-06](./story-06-followups.md)**
+> because the Phase-0 `artifact_type` is a *closed, cross-runtime enum* (the 15
+> shipped desktop types + `plugin_output`) with **no follow-up type** — adding one
+> touches the desktop parity source, the schema, both runtimes, and the golden
+> fixtures, which is a contract decision, not a mobile edit (owner call: ship ADR
+> now, defer Follow-ups). ADR Candidates map to the existing `.adr` type, so they
+> ship here.
+
 ## Problem
 
-The charter's Vision lists ADR Candidates and Follow-ups among the intelligence a
-meeting should yield, beyond the five core types. They are the architecture- and
-aftercare-flavored outputs that make HoldSpeak useful to the developer audience
-the positioning targets.
+The charter's Vision lists ADR Candidates among the intelligence a meeting should
+yield, beyond the five core types — the architecture-flavored output that makes
+HoldSpeak useful to the developer audience the positioning targets.
 
 ## Scope
 
-- **In:** generation of ADR (Architecture Decision Record) Candidates and
-  Follow-ups, modeled as `Artifact` types per the Phase-0 contract; their
-  extraction intent (an ADR candidate ties to a Decision with architectural
-  weight; a Follow-up ties to an open thread / next action); round-trip
-  validation.
-- **Out:** the five core types (HSM-6-02). The desktop aftercare/digest surface
-  (that's a desktop feature; here we emit the artifact shapes). UI. Acting on
-  follow-ups (Propose→Approve→Execute boundary preserved — emit only).
+- **In:** generation of ADR (Architecture Decision Record) Candidates, modeled as
+  an `Artifact(.adr)` per the Phase-0 contract (open `structured_json`); their
+  extraction intent (an ADR candidate ties to a decision with architectural
+  weight, referencing the decision context); round-trip validation.
+- **Out:** Follow-ups (now **HSM-6-06**, blocked on a `follow_up` artifact-type
+  contract decision). The five core types (HSM-6-02). The desktop aftercare/digest
+  surface. UI. Acting on anything (Propose→Approve→Execute boundary — emit only).
 
 ## Acceptance criteria
 
-- [ ] ADR Candidates and Follow-ups generate from a real transcript and validate
-      against the Phase-0 `Artifact` contract with zero schema errors.
-- [ ] An ADR Candidate references the Decision/architectural context it derives
-      from; a Follow-up references the open thread it tracks (provenance per the
-      contract).
-- [ ] Neither type fabricates: a transcript with no architectural decision yields
-      no ADR candidate.
-- [ ] The two types are substance-tested (coverage), not string-matched.
+- [x] ADR Candidates generate from a real transcript and validate against the
+      Phase-0 `Artifact` contract with zero schema errors. (`Artifact(.adr)`
+      round-trips through the contract coder — `testADRCandidatesValidate`.)
+- [x] An ADR Candidate references the decision/architectural context it derives
+      from (provenance per the contract): the artifact carries a transcript
+      `ArtifactSource`, and each candidate a `source_timestamp` to the moment.
+- [x] Does not fabricate: a transcript with no architectural decision yields no
+      ADR candidate. (`testADRDoesNotFabricate` → empty `candidates`.)
+- [x] Substance-tested (coverage), not string-matched.
 
 ## Test plan
 
 - Unit: generation over an architecture-review transcript fixture → ADR
   candidate(s) present + schema-valid; over a transcript with no architectural
-  content → none. Follow-ups similarly over a transcript with open threads.
-- Manual / device: spot-check on a real architecture-review recording.
+  content → none. **Done** (`ADRCandidatesTests`).
+- Manual / device: spot-check on a real architecture-review recording — deferred
+  to the device/parity pass (HSM-6-04/05).
 
 ## Notes / open questions
 
-- Default to modeling these as `Artifact` subtypes per the Phase-0 contract until
-  the contract says otherwise (phase decision deferred).
-- These pair naturally with MIR's Architect profile (Phase 7), which will weight
-  ADR candidates up — keep the extraction profile-agnostic here.
+- Modeled as an `Artifact(.adr)` subtype per the Phase-0 contract (phase decision:
+  default to Artifact types). Pairs naturally with MIR's Architect profile
+  (Phase 7), which will weight ADR candidates up — extraction stays
+  profile-agnostic here.

--- a/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-06-followups.md
+++ b/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-06-followups.md
@@ -1,0 +1,55 @@
+# HSM-6-06 — Follow-ups
+
+- **Project:** holdspeak-mobile
+- **Phase:** 6
+- **Status:** blocked
+- **Depends on:** HSM-6-01, HSM-6-02, **a `follow_up` artifact-type contract decision**
+- **Unblocks:** —
+- **Owner:** unassigned
+
+## Problem
+
+The charter's Vision lists **Follow-ups** among the intelligence a meeting should
+yield (the aftercare-flavored output: open threads / next actions to chase). Split
+from HSM-6-03 because it cannot ship as a mobile-only change.
+
+## Blocker — a cross-runtime contract decision
+
+`artifact_type` is a **closed enum** in `contracts/schemas/artifact.schema.json`
+(the 15 shipped desktop types + `plugin_output`), sourced from the desktop's
+`plugins/synthesis.py _ARTIFACT_TYPE_BY_PLUGIN`. **There is no follow-up type.**
+Modeling Follow-ups as an `Artifact` (the phase default) therefore requires adding
+a `follow_up` type across:
+
+1. the desktop parity source (`synthesis.py`),
+2. `artifact.schema.json` (the enum),
+3. the Swift `ArtifactType`,
+4. the golden fixtures + the Python validator.
+
+The owner has confirmed cross-runtime work is in scope (we build the server sync
+API too — see the program memory / Phase 10), so this is unblockable; it is parked
+only by sequencing (**finish Phase 6 core, then the sync thrust**). Pick this up
+when the cross-runtime contract pass happens (alongside or after the sync API).
+
+## Scope (when unblocked)
+
+- **In:** add the `follow_up` artifact type cross-runtime (keeping desktop/mobile
+  parity), then generate Follow-ups as `Artifact(.followUp)` — each referencing the
+  open thread it tracks (provenance) — with round-trip validation and the
+  "no fabrication / empty when none" guarantee, on the HSM-6-01 seam.
+- **Out:** acting on follow-ups (Propose→Approve→Execute — emit only); the desktop
+  aftercare/digest surface; UI.
+
+## Acceptance criteria (draft)
+
+- [ ] A `follow_up` artifact type exists and validates in BOTH runtimes (the Python
+      validator + the Swift `swift test`), with the golden fixtures updated.
+- [ ] Follow-ups generate from a real transcript and validate against the Phase-0
+      `Artifact` contract with zero schema errors.
+- [ ] Each references the open thread it tracks; none is fabricated.
+- [ ] Substance-tested (coverage), not string-matched.
+
+## Notes
+
+- Default to modeling as an `Artifact` subtype per the Phase-0 contract.
+- Pairs with MIR aftercare routing (later) — keep extraction profile-agnostic.


### PR DESCRIPTION
## What

**HSM-6-03 (ADR half)** — ADR (Architecture Decision Record) Candidates as an open-blob `Artifact(.adr)` on the HSM-6-01 seam. `generateADRCandidates(from:)` drives the model with an ADR-intent prompt (a candidate ties to an architectural-weight decision, referencing its context) and binds it into a schema-valid `Artifact`.

- Each candidate carries a `source_timestamp` to the decision moment; the artifact carries a transcript `ArtifactSource` (provenance).
- Propose-only (`.draft`); **no architectural decision → empty `candidates`, never fabricated**.

## Scope split — Follow-ups → HSM-6-06 (blocked)

`artifact_type` is a **closed cross-runtime enum** (15 shipped desktop types + `plugin_output`, sourced from the desktop `synthesis.py`) with **no follow-up type**. Modeling Follow-ups as an `Artifact` needs a contract change across the desktop source, `artifact.schema.json`, both runtimes, and the golden fixtures — not a mobile edit. Per the owner call (*ship ADR now, defer Follow-ups*), Follow-ups is split to **[HSM-6-06](../blob/main/pm/roadmap/holdspeak-mobile/phase-6-meeting-intelligence/story-06-followups.md)** (blocked on that decision; unblockable when the cross-runtime sync/contract pass happens).

## Tests

`cd apple && swift test` → **35/35** (33 prior + 2 new), layer guard green.

## Docs

story-03 rescoped to ADR + done, `story-06-followups.md` created (blocked), `evidence-story-03.md`, phase-6 status, mobile README (incl. the owner's sync-by-default program steer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)