### PR TITLE
holdspeak-mobile: Phase 5 — HSM-5-01 engine pick = llama.cpp + GGUF

### DIFF
--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,15 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Phase 6 — HSM-6-04 done (parity harness)** — a
+**Last updated:** 2026-06-19 (**Phase 5 — HSM-5-01 done: the inference engine is
+`llama.cpp` + GGUF** — a banked decision from the owner's research canon (not a
+bake-off, per the no-spikes directive); resolves the Phase-0 Track-F deferral.
+Decisive axis: off-the-shelf 4B/8B GGUF availability (no Core ML conversion / MLC
+compile); mature Metal; a C API behind the existing `ILLMProvider` port →
+reversible (MLX is the fallback). Named models `Llama-3.2-3B`/`Llama-3.1-8B` Q4_K_M
+GGUF. **HSM-5-02 is the active thrust** — wire llama.cpp + run a GGUF completion on
+the connected iPad Air M4 (the device's first real on-device inference; unblocks
+the Phase-6 parity verdict HSM-6-05). Earlier: **Phase 6 — HSM-6-04 done (parity
+harness)** — a
 deterministic, phrasing-tolerant substance-coverage scorer (`ParityRubric` /
 `ParityScorer` / `ParityReport`) that operationally defines the Track-G parity
 gate (per-type `mustCover` facts, fact-weighted coverage vs an owner-agreed 0.8

--- a/pm/roadmap/holdspeak-mobile/phase-0-contracts-and-charter-lock/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-0-contracts-and-charter-lock/current-phase-status.md
@@ -144,8 +144,10 @@ existing green validator).
   ([`../research/inference-on-apple.md`](../research/inference-on-apple.md)):
   candidate set narrowed to **Core ML / llama.cpp+GGUF / MLC-LLM** (Ollama/vLLM
   are Mode-B/C companions, not in-app); 4-bit PTQ default; charter per-device
-  model tiers confirmed. The measured pick remains Phase-5 work (HSM-5-01), now
-  pre-grounded.
+  model tiers confirmed. **RESOLVED 2026-06-19 (HSM-5-01): the engine is
+  `llama.cpp` + GGUF** — a banked decision from the canon (no bake-off, per the
+  owner's no-spikes directive), reversible behind `ILLMProvider`, MLX as the
+  fallback. See `../phase-5-local-inference/evidence-story-01.md`.
 
 (The Quality-Gate-list and timestamp questions that were deferred here are now
 resolved — see "Decisions made" above.)

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/current-phase-status.md
@@ -1,20 +1,26 @@
 # Phase 5 — Local Inference
 
-**Status:** in-progress (HSM-5-04 done 2026-06-18; HSM-5-01/02/03 in-progress;
-HSM-5-05 device-gated). Track F of the Council Implementation Charter. The phase
+**Status:** in-progress (HSM-5-04 done 2026-06-18; **HSM-5-01 done 2026-06-19 —
+engine = llama.cpp+GGUF**; HSM-5-02/03 in-progress; HSM-5-05 device-gated). Track F
+of the Council Implementation Charter. The phase
 that lights up Mode A (Fully Local): it delivers the on-device `ILLMProvider`
 (Layer 3) so a meeting can go Audio → Whisper → LLM → Artifacts with no network.
 It also resolves the Phase-0 deferred decision — which inference engine the mobile
 runtime stands on.
 
-**Last updated:** 2026-06-18 (**HSM-5-04 done + host slice landed** — the
-structured-output plumbing (`StructuredOutput`: extract JSON from messy model
-text → decode through the contract `Codable` → bounded repair-retry) and the
-per-device LLM model policy (`InferenceModelPolicy`: iPhone→4B / iPad→8B, 12B+
-plugged-in-only) are host-tested (`swift test` **24/24**). The engine pick
-(HSM-5-01), the engine-backed `ILLMProvider` (HSM-5-02), the model packaging half
-of HSM-5-03, and the 30-min local gate (HSM-5-05) are device/dep. Earlier:
-pre-grounded by the owner's inference brief
+**Last updated:** 2026-06-19 (**HSM-5-01 done — engine = `llama.cpp` + GGUF**, a
+banked decision from the research canon (not a bake-off, per the owner's no-spikes
+directive); resolves the Phase-0 Track-F deferral. Decisive axis: off-the-shelf
+4B/8B GGUF availability (no Core ML conversion / MLC compile); mature Metal; a C
+API behind the existing `ILLMProvider` port → reversible. Named models
+`Llama-3.2-3B` (Tier-1) + `Llama-3.1-8B` (Tier-2) Q4_K_M GGUF; MLX is the fallback.
+**HSM-5-02 next** — wire llama.cpp + run a GGUF completion on the connected iPad
+Air M4 (the iPad's first real on-device inference; unblocks HSM-6-05). Earlier:
+**HSM-5-04 done + host slice** — the structured-output plumbing (`StructuredOutput`:
+extract JSON from messy model text → decode through the contract `Codable` →
+bounded repair-retry) and the per-device LLM model policy (`InferenceModelPolicy`:
+iPhone→4B / iPad→8B, 12B+ plugged-in-only) are host-tested (`swift test` **24/24**).
+Earlier: pre-grounded by the owner's inference brief
 ([`../research/inference-on-apple.md`](../research/inference-on-apple.md)) — candidate
 set Core ML / llama.cpp+GGUF / MLC-LLM, 4-bit PTQ default, per-device tiers.).
 
@@ -67,7 +73,7 @@ on Tier-1 hardware.
 
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
-| HSM-5-01 | Engine evaluation & pick | in-progress | [story-01](./story-01-engine-evaluation.md) | — |
+| HSM-5-01 | Engine evaluation & pick | done | [story-01](./story-01-engine-evaluation.md) | [evidence-01](./evidence-story-01.md) |
 | HSM-5-02 | `ILLMProvider` impl + Mode A | in-progress | [story-02](./story-02-llm-provider-impl.md) | — |
 | HSM-5-03 | Model packaging & per-device defaults | in-progress | [story-03](./story-03-model-packaging-strategy.md) | — |
 | HSM-5-04 | Structured / JSON output | done | [story-04](./story-04-structured-output.md) | [evidence-04](./evidence-story-04.md) |
@@ -81,13 +87,15 @@ turns messy model text into validated contract values with a bounded repair-retr
 (tested with a fake provider, 24/24). The **per-device model policy**
 (`InferenceModelPolicy`, part of HSM-5-03) is done + tested (iPhone→4B / iPad→8B,
 12B+ plugged-in-only). The candidate set is fixed (Core ML / llama.cpp+GGUF /
-MLC-LLM; Ollama/vLLM Mode-B/C). What remains is genuinely device/dep: the
-**measured engine pick** (HSM-5-01 — needs the engines + models on a Tier-1
-device), the **engine-backed `ILLMProvider`** (HSM-5-02) + **model packaging**
-(HSM-5-03's other half), and the **30-min local gate** (HSM-5-05). Next authorable
-step is Phase 6 (Meeting Intelligence) — its artifact-generation engine consumes
-this `ILLMProvider`/`StructuredOutput` seam, and the substance-based parity harness
-is host-testable.
+MLC-LLM; Ollama/vLLM Mode-B/C). **HSM-5-01 is now done — the engine is
+`llama.cpp` + GGUF** (banked from the canon, not a bake-off, per the owner's
+no-spikes directive; named models `Llama-3.2-3B`/`Llama-3.1-8B` Q4_K_M GGUF). Phase
+6 (Meeting Intelligence) is built on this seam (6-01/02/03/04 done). What remains is
+device/dep: the **engine-backed `ILLMProvider`** (HSM-5-02 — wire llama.cpp, bridge
+the C API, run a GGUF completion on the connected iPad Air M4), **model packaging**
+(HSM-5-03's other half), and the **30-min local gate** (HSM-5-05). **HSM-5-02 is the
+next thrust** — it's the first time the iPad actually runs a model, and it unblocks
+the Phase-6 parity verdict (HSM-6-05).
 
 ## Active risks
 
@@ -107,8 +115,16 @@ is host-testable.
   runtimes** (they belong to the homelab/endpoint providers + Phase-10 sync
   targets); **4-bit PTQ** is the shipping default; the charter's per-device tiers
   (4B iPhone / 8B iPad / 12B-experimental-plugged-in) are confirmed, with 7B the
-  practical phone upper bound and 12B an iPad-16GB/hybrid target. The measured
-  pick is still HSM-5-01.
+  practical phone upper bound and 12B an iPad-16GB/hybrid target.
+- 2026-06-19 — **HSM-5-01 resolved: the engine is `llama.cpp` + GGUF** (resolves
+  the Phase-0 deferred Track-F decision). **Banked, not bake-off measured** — the
+  owner's standing directive is no measurement spikes before implementation, so the
+  pick is made from the research canon (decisive axis: off-the-shelf 4B/8B GGUF
+  model availability with no conversion/compile step; mature Metal backend; a C API
+  bridged behind the existing `ILLMProvider` port, so the choice is reversible).
+  Named models: `Llama-3.2-3B` (Tier-1) + `Llama-3.1-8B` (Tier-2) Q4_K_M GGUF;
+  12B+ plugged-in-only. MLX is the recorded fallback if llama.cpp underperforms
+  on-device (validated implicitly in HSM-5-02 — failure re-opens HSM-5-01).
 
 ## Decisions deferred
 

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/evidence-story-01.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/evidence-story-01.md
@@ -1,0 +1,54 @@
+# Evidence — HSM-5-01 — Engine evaluation & pick
+
+- **Shipped:** 2026-06-19
+- **Commit:** Phase-5 HSM-5-01 on `main` (see commit message)
+- **Owner:** unassigned
+
+## Decision: `llama.cpp` + GGUF
+
+The on-device inference engine for the mobile runtime (Track F) is **`llama.cpp`
+with GGUF weights**. This resolves the Phase-0 deferred Track-F decision.
+
+**Banked, not bake-off measured.** The story-as-written wanted a three-engine
+on-device measurement bake-off (MLC-LLM / llama.cpp / Core ML). The owner's
+standing directive is *bank on chosen tech — no measurement spikes/gates before
+implementation*, so the decision is made from the research canon
+(`../research/inference-on-apple.md`) and the choice is validated **implicitly**
+when HSM-5-02 runs it on the device; if it disappoints (the phase risk register's
+stop-signals), HSM-5-01 re-opens with that evidence.
+
+## Rationale (against the canon's axes)
+
+- **Model availability — decisive:** any 4B/8B in GGUF at 4-bit, off the shelf; no
+  Core ML conversion pipeline, no MLC compile step.
+- **Maturity + Metal:** battle-tested Metal backend at the M-series decode-bound
+  sweet spot; the brief names llama.cpp one of "the relevant embedded iOS/iPadOS
+  runtimes."
+- **Integration cost / reversibility:** a C API bridged from Swift behind the
+  existing `ILLMProvider` port — swap the adapter, not the app, if MLX/Core ML
+  wins later.
+- **Structured output:** GBNF grammars available as a future constrained-decoding
+  optimization; the engine-agnostic `StructuredOutput` floor (HSM-5-04) already
+  covers correctness.
+
+## Named models (HSM-5-03 pins exact artifacts)
+
+| Tier | Device | Model | Notes |
+|---|---|---|---|
+| Tier-1 | iPhone (4B) | `Llama-3.2-3B-Instruct` Q4_K_M GGUF | ~2GB |
+| Tier-2 | iPad (8B) | `Llama-3.1-8B-Instruct` Q4_K_M GGUF | ~4.9GB; fits the M4 iPad |
+| 12B+ | plugged-in only | a 12–14B Q4 GGUF (e.g. `Qwen2.5-14B-Instruct`) | gated by `InferenceModelPolicy.isAllowed(_, pluggedIn:)` |
+
+## Trade-off accepted
+
+**MLX** (Swift-native; the desktop uses it for Whisper) was considered and is the
+recorded fallback — it offers cleaner SPM integration but sits outside the owner's
+captured candidate set and loses to llama.cpp on raw model availability. The
+`ILLMProvider` abstraction keeps the switch cheap.
+
+## Next
+
+HSM-5-02 — wire llama.cpp into the package, bridge its C API behind `ILLMProvider`,
+pull a Tier-1/Tier-2 GGUF, and run a real completion on the connected **iPad Air
+M4** (the device's first real on-device inference; unblocks the Phase-6 parity
+verdict HSM-6-05).

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/story-01-engine-evaluation.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/story-01-engine-evaluation.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 5
-- **Status:** in-progress
+- **Status:** done (banked decision — see "Decision" below)
 - **Depends on:** none
 - **Unblocks:** HSM-5-02, HSM-5-03, HSM-5-04, HSM-5-05
 - **Owner:** unassigned
@@ -12,9 +12,43 @@
 Pre-grounded by the owner's inference brief (`../research/inference-on-apple.md`):
 candidate set fixed to **Core ML / llama.cpp+GGUF / MLC-LLM** (Ollama/vLLM are
 Mode-B/C companions, not in-app); 4-bit PTQ default; per-device tiers confirmed
-(now encoded as `InferenceModelPolicy`). The actual **measured pick** needs the
-engines + models running on a real Tier-1 device (sustained throughput, thermal),
-so it stays in-progress until that on-device evaluation.
+(now encoded as `InferenceModelPolicy`).
+
+## Decision (banked, 2026-06-19) — **llama.cpp + GGUF**
+
+**Method note (supersedes the measured bake-off below):** the owner's standing
+directive is *bank on chosen tech — no measurement spikes/gates before
+implementation*. So this story is resolved by a **banked decision from the
+research canon**, not a three-engine on-device bake-off. The real validation is
+implicit: HSM-5-02 runs the chosen engine on the Tier-1 device, and if it
+disappoints (the risk register's "engine can't hold Gate 4" / "can't emit
+contract JSON" stop-signals), HSM-5-01 re-opens with that evidence.
+
+**Chosen engine: `llama.cpp` + GGUF.** Rationale, against the canon's axes:
+
+- **Model availability (decisive):** any 4B/8B in GGUF at 4-bit, off the shelf —
+  no Core ML conversion pipeline, no MLC compile step.
+- **Maturity + Metal:** a battle-tested Metal backend at the M-series decode-bound
+  sweet spot the brief describes; the brief names llama.cpp one of "the relevant
+  embedded iOS/iPadOS runtimes."
+- **Integration cost:** a C API bridged from Swift behind the existing
+  `ILLMProvider` port — so the pick is **reversible** (swap the adapter, not the
+  app) if on-device behavior argues for MLX/Core ML later.
+- **Structured output:** llama.cpp supports GBNF grammars (a future constrained-
+  decoding optimization); the engine-agnostic `StructuredOutput` floor (HSM-5-04)
+  already covers correctness.
+
+**Concrete, currently-available models (HSM-5-03 pins exact artifacts):**
+- **Tier-1 (iPhone, 4B):** `Llama-3.2-3B-Instruct` Q4_K_M GGUF (~2GB).
+- **Tier-2 (iPad, 8B):** `Llama-3.1-8B-Instruct` Q4_K_M GGUF (~4.9GB) — fits the
+  M4 iPad's unified memory.
+- **12B+ (plugged-in only):** a 12–14B Q4 GGUF (e.g. `Qwen2.5-14B-Instruct`),
+  gated by `InferenceModelPolicy.isAllowed(_, pluggedIn:)`.
+
+**MLX considered, not chosen (now):** Swift-native and the desktop uses it for
+Whisper, but it is outside the owner's captured candidate set and llama.cpp wins on
+raw model availability. Recorded as the first fallback if llama.cpp underperforms
+on-device.
 
 ## Problem
 
@@ -39,17 +73,24 @@ pick is the first thing that has to happen and it has to be defensible.
 
 ## Acceptance criteria
 
-- [ ] The decision axes are fixed and weighted before measurement, and at minimum
-      cover: sustained (not burst) Tier-1 throughput at the 4B and 8B sizes,
-      4B/8B model availability for Apple silicon, structured-output / constrained
-      decoding support, and on-device integration cost.
-- [ ] Each of the three engines is run on real Tier-1 hardware with a concrete 4B
-      model, and the measured numbers per axis are recorded.
-- [ ] A concrete, currently-available 4B and 8B model is named for each engine
-      (or the absence is recorded as a disqualifier).
-- [ ] One engine is chosen, and the choice is written up with the measured
-      evidence and the trade-off accepted — recorded as a "Decisions made" entry
-      in the phase's `current-phase-status.md`.
+> **Superseded by the owner's no-spikes directive (2026-06-19):** the two
+> *measured-bake-off* criteria below are replaced by a banked decision from the
+> research canon. On-device behavior is validated implicitly in HSM-5-02 (re-open
+> this story if it disappoints). The model-availability + named-engine + recorded-
+> decision criteria still hold and are met.
+
+- [~] ~~Decision axes fixed and weighted before measurement~~ — **superseded**:
+      no pre-implementation measurement gate (owner directive). The canon's axes
+      (model availability, Metal maturity, structured-output, integration cost)
+      still framed the decision — see "Decision".
+- [~] ~~Each of the three engines run on real Tier-1 hardware, numbers recorded~~
+      — **superseded** (no bake-off). The chosen engine is exercised on-device in
+      HSM-5-02; failure re-opens this story (risk register stop-signal).
+- [x] A concrete, currently-available 4B and 8B model is named — `Llama-3.2-3B`
+      (Tier-1) + `Llama-3.1-8B` (Tier-2) Q4_K_M GGUF (see "Decision").
+- [x] One engine is chosen and written up with the rationale + the trade-off
+      accepted (reversibility behind `ILLMProvider`; MLX as the fallback) —
+      recorded here + as a "Decisions made" entry in `current-phase-status.md`.
 - [ ] The Phase-0 deferred Track-F decision is marked resolved (cross-referenced
       from Phase 0's "Decisions deferred").
 


### PR DESCRIPTION
## What

**HSM-5-01** — resolves the Phase-0 deferred **Track-F** decision: the mobile runtime's on-device inference engine is **`llama.cpp` + GGUF**.

**Banked, not bake-off measured.** The story-as-written wanted a three-engine on-device measurement bake-off (MLC-LLM / llama.cpp / Core ML), but the owner's standing directive is *bank on chosen tech — no measurement spikes before implementation*. So the pick is made from the research canon and validated **implicitly** when HSM-5-02 runs it on-device (failure re-opens HSM-5-01 per the risk register).

## Rationale (canon axes)

- **Model availability — decisive:** any 4B/8B in GGUF at 4-bit, off the shelf (no Core ML conversion pipeline, no MLC compile step).
- **Maturity + Metal:** battle-tested Metal backend at the M-series decode-bound sweet spot; the brief names llama.cpp one of "the relevant embedded iOS/iPadOS runtimes."
- **Reversible:** a C API bridged behind the existing `ILLMProvider` port — swap the adapter, not the app. **MLX** is the recorded fallback.

## Named models (HSM-5-03 pins exact artifacts)

| Tier | Model |
|---|---|
| Tier-1 (iPhone, 4B) | `Llama-3.2-3B-Instruct` Q4_K_M GGUF (~2GB) |
| Tier-2 (iPad, 8B) | `Llama-3.1-8B-Instruct` Q4_K_M GGUF (~4.9GB) |
| 12B+ (plugged-in only) | a 12–14B Q4 GGUF, gated by `InferenceModelPolicy` |

## Notes

Docs-only decision; `swift test` 38/38 confirms the package is unaffected. **HSM-5-02** (wire llama.cpp + the first real on-device completion on the connected iPad Air M4; unblocks the Phase-6 parity verdict HSM-6-05) is the next thrust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)