### PR TITLE
holdspeak-mobile: Phase 10 opened — HSM-10-01 sync object model + engine

### DIFF
--- a/apple/Sources/Contracts/Sync.swift
+++ b/apple/Sources/Contracts/Sync.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// HSM-10-01 — the sync object model.
+///
+/// Cross-device continuity syncs the **Phase-0 contract entities themselves**
+/// (Meetings, Artifacts), never a parallel sync schema that could drift from them.
+/// The sync metadata a transport needs — a stable id, a last-modified instant, and
+/// a tombstone for deletes — rides in a thin contract-layer *envelope* (`Synced`)
+/// whose payload is the unmodified entity. So the wire carries the real contract
+/// object plus its sync header; the entity structs stay pure.
+///
+/// (Contract addition, HSM-10-01 → escalated to the serialization contract per the
+/// story's note — additive, not a side field on each entity.)
+
+public enum SyncKind: String, Codable, Sendable, CaseIterable {
+    case meeting
+    case artifact
+}
+
+/// The sync header for one entity: which entity, when it last changed, and whether
+/// this is a tombstone (a propagated delete). Instants are UTC `Z` per the contract.
+public struct SyncMetadata: Codable, Equatable, Sendable {
+    public var id: String
+    public var kind: SyncKind
+    public var lastModified: Date
+    public var deleted: Bool
+
+    public init(id: String, kind: SyncKind, lastModified: Date, deleted: Bool = false) {
+        self.id = id
+        self.kind = kind
+        self.lastModified = lastModified
+        self.deleted = deleted
+    }
+}
+
+/// An entity wrapped with its sync header. `value` is the real Phase-0 contract
+/// object; it is `nil` exactly when `meta.deleted` (a tombstone carries no payload).
+public struct Synced<Value: Codable & Equatable & Sendable>: Codable, Equatable, Sendable {
+    public var meta: SyncMetadata
+    public var value: Value?
+
+    public init(meta: SyncMetadata, value: Value?) {
+        self.meta = meta
+        self.value = value
+    }
+
+    /// A live (non-tombstone) record.
+    public static func live(_ value: Value, id: String, kind: SyncKind, modifiedAt: Date) -> Synced<Value> {
+        Synced(meta: SyncMetadata(id: id, kind: kind, lastModified: modifiedAt, deleted: false), value: value)
+    }
+
+    /// A tombstone (a propagated delete).
+    public static func tombstone(id: String, kind: SyncKind, at: Date) -> Synced<Value> {
+        Synced(meta: SyncMetadata(id: id, kind: kind, lastModified: at, deleted: true), value: nil)
+    }
+}
+
+/// A set of changes to push or pull: the syncable contract entities, each as a
+/// `Synced` envelope. Actions are not a top-level store entity (they live inside an
+/// Action-Items artifact), so the store-backed sync set is Meetings + Artifacts.
+public struct ChangeSet: Codable, Equatable, Sendable {
+    public var meetings: [Synced<Meeting>]
+    public var artifacts: [Synced<Artifact>]
+
+    public init(meetings: [Synced<Meeting>] = [], artifacts: [Synced<Artifact>] = []) {
+        self.meetings = meetings
+        self.artifacts = artifacts
+    }
+
+    public var isEmpty: Bool { meetings.isEmpty && artifacts.isEmpty }
+    public var count: Int { meetings.count + artifacts.count }
+}

--- a/apple/Sources/Providers/Providers.swift
+++ b/apple/Sources/Providers/Providers.swift
@@ -32,6 +32,27 @@ public protocol IStorage: Sendable {
 }
 
 public protocol ISyncProvider: Sendable {
-    /// Push/pull contract objects across devices (Phase 10).
-    func sync() async throws
+    /// Push a local change-set to the peer (desktop / homelab / Tailscale — the
+    /// concrete transports are HSM-10-02). The Runtime Core depends on this seam,
+    /// never on a transport.
+    func push(_ changeSet: ChangeSet) async throws
+    /// Pull the peer's change-set (its live entities + tombstones since last sync).
+    func pull() async throws -> ChangeSet
+}
+
+/// The sync-facing view of the local store (HSM-10-01): modified-time tracking and
+/// soft-delete tombstones on top of the Phase-4 store, so a change-set can be
+/// produced from and applied to it. Kept separate from `IStorage` so the base CRUD
+/// surface stays lean.
+public protocol ISyncStore: Sendable {
+    func saveMeeting(_ meeting: Meeting, modifiedAt: Date) throws
+    func saveArtifact(_ artifact: Artifact, modifiedAt: Date) throws
+    /// Soft-delete: record a tombstone (`deleted=1`) so the delete can propagate.
+    func deleteMeeting(id: String, at: Date) throws
+    func deleteArtifact(id: String, at: Date) throws
+    /// Live (non-tombstoned) entities with their last-modified instant.
+    func allMeetings() throws -> [(meeting: Meeting, modifiedAt: Date)]
+    func allArtifacts() throws -> [(artifact: Artifact, modifiedAt: Date)]
+    /// Tombstones (propagated deletes) for both kinds.
+    func tombstones() throws -> [SyncMetadata]
 }

--- a/apple/Sources/Providers/Storage/SQLiteStorage.swift
+++ b/apple/Sources/Providers/Storage/SQLiteStorage.swift
@@ -9,15 +9,18 @@ public enum StorageError: Error, Equatable {
     case open(String), exec(String), prepare(String)
 }
 
-/// SQLite-backed `IStorage` (HSM-4-01). Greenfield: ships at `SCHEMA_VERSION = 1`,
-/// WAL mode for crash safety. Each entity is stored as its Phase-0 contract JSON
-/// in a keyed row, so what comes back is exactly the contract (the round-trip is
-/// the Swift Codable layer the tests already trust).
+/// SQLite-backed `IStorage` + `ISyncStore` (HSM-4-01, HSM-10-01). Greenfield, WAL
+/// for crash safety. Each entity is stored as its Phase-0 contract JSON in a keyed
+/// row, so what comes back is exactly the contract.
 ///
-/// Note: there is intentionally NO `deinit` close — abandoning an instance models
-/// a crash (used by the crash-recovery test). Call `close()` for clean shutdown.
-public final class SQLiteStorage: IStorage, @unchecked Sendable {
-    public static let schemaVersion: Int32 = 1
+/// Schema v2 (HSM-10-01) adds per-row `modified_at` (UTC `Z`) and a `deleted`
+/// soft-delete flag (tombstones) so a sync change-set can be produced from and
+/// applied to the store. `json` is nullable now: a tombstone row carries no payload.
+///
+/// Note: there is intentionally NO `deinit` close — abandoning an instance models a
+/// crash (the crash-recovery test). Call `close()` for clean shutdown.
+public final class SQLiteStorage: IStorage, ISyncStore, @unchecked Sendable {
+    public static let schemaVersion: Int32 = 2
 
     private var db: OpaquePointer?
     private let encoder = HoldSpeakContracts.encoder()
@@ -32,12 +35,29 @@ public final class SQLiteStorage: IStorage, @unchecked Sendable {
         try exec("PRAGMA foreign_keys=ON;")
         try exec("""
             CREATE TABLE IF NOT EXISTS meetings(
-              id TEXT PRIMARY KEY, started_at TEXT, json TEXT NOT NULL);
+              id TEXT PRIMARY KEY, started_at TEXT, json TEXT,
+              modified_at TEXT, deleted INTEGER NOT NULL DEFAULT 0);
             CREATE TABLE IF NOT EXISTS artifacts(
-              id TEXT PRIMARY KEY, meeting_id TEXT, json TEXT NOT NULL);
+              id TEXT PRIMARY KEY, meeting_id TEXT, json TEXT,
+              modified_at TEXT, deleted INTEGER NOT NULL DEFAULT 0);
             CREATE INDEX IF NOT EXISTS idx_artifacts_meeting ON artifacts(meeting_id);
             """)
+        try migrateIfNeeded()
         try exec("PRAGMA user_version=\(Self.schemaVersion);")
+    }
+
+    /// v1 → v2: a pre-existing v1 DB lacks `modified_at`/`deleted`. Add them
+    /// (guarded — ignore "duplicate column"). Greenfield, so this is the only step.
+    private func migrateIfNeeded() throws {
+        guard (try? userVersion()) ?? 0 < 2 else { return }
+        for sql in [
+            "ALTER TABLE meetings ADD COLUMN modified_at TEXT;",
+            "ALTER TABLE meetings ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;",
+            "ALTER TABLE artifacts ADD COLUMN modified_at TEXT;",
+            "ALTER TABLE artifacts ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;",
+        ] {
+            _ = sqlite3_exec(db, sql, nil, nil, nil)   // duplicate-column is benign
+        }
     }
 
     public func close() {
@@ -47,26 +67,69 @@ public final class SQLiteStorage: IStorage, @unchecked Sendable {
 
     // MARK: - IStorage
 
-    public func saveMeeting(_ meeting: Meeting) throws {
-        let json = try jsonString(meeting)
-        try upsert("meetings", ["id", "started_at", "json"],
-                   [meeting.id, isoString(meeting.startedAt), json])
-    }
+    public func saveMeeting(_ meeting: Meeting) throws { try saveMeeting(meeting, modifiedAt: Date()) }
 
     public func loadMeeting(id: String) throws -> Meeting? {
-        guard let json = try queryOne("SELECT json FROM meetings WHERE id=?;", [id]) else { return nil }
+        guard let json = try queryOne("SELECT json FROM meetings WHERE id=? AND deleted=0;", [id])
+        else { return nil }
         return try decoder.decode(Meeting.self, from: Data(json.utf8))
     }
 
-    public func saveArtifact(_ artifact: Artifact) throws {
-        let json = try jsonString(artifact)
-        try upsert("artifacts", ["id", "meeting_id", "json"],
-                   [artifact.id, artifact.meetingId, json])
-    }
+    public func saveArtifact(_ artifact: Artifact) throws { try saveArtifact(artifact, modifiedAt: Date()) }
 
     public func loadArtifacts(meetingId: String) throws -> [Artifact] {
-        try queryAll("SELECT json FROM artifacts WHERE meeting_id=? ORDER BY id;", [meetingId])
+        try queryAll("SELECT json FROM artifacts WHERE meeting_id=? AND deleted=0 ORDER BY id;", [meetingId])
             .map { try decoder.decode(Artifact.self, from: Data($0.utf8)) }
+    }
+
+    // MARK: - ISyncStore (HSM-10-01)
+
+    public func saveMeeting(_ meeting: Meeting, modifiedAt: Date) throws {
+        try run("""
+            INSERT INTO meetings(id, started_at, json, modified_at, deleted) VALUES(?,?,?,?,0)
+            ON CONFLICT(id) DO UPDATE SET started_at=excluded.started_at, json=excluded.json,
+              modified_at=excluded.modified_at, deleted=0;
+            """, [meeting.id, isoString(meeting.startedAt), try jsonString(meeting), isoString(modifiedAt)])
+    }
+
+    public func saveArtifact(_ artifact: Artifact, modifiedAt: Date) throws {
+        try run("""
+            INSERT INTO artifacts(id, meeting_id, json, modified_at, deleted) VALUES(?,?,?,?,0)
+            ON CONFLICT(id) DO UPDATE SET meeting_id=excluded.meeting_id, json=excluded.json,
+              modified_at=excluded.modified_at, deleted=0;
+            """, [artifact.id, artifact.meetingId, try jsonString(artifact), isoString(modifiedAt)])
+    }
+
+    public func deleteMeeting(id: String, at: Date) throws {
+        try run("""
+            INSERT INTO meetings(id, started_at, json, modified_at, deleted) VALUES(?,NULL,NULL,?,1)
+            ON CONFLICT(id) DO UPDATE SET json=NULL, modified_at=excluded.modified_at, deleted=1;
+            """, [id, isoString(at)])
+    }
+
+    public func deleteArtifact(id: String, at: Date) throws {
+        try run("""
+            INSERT INTO artifacts(id, meeting_id, json, modified_at, deleted) VALUES(?,NULL,NULL,?,1)
+            ON CONFLICT(id) DO UPDATE SET json=NULL, modified_at=excluded.modified_at, deleted=1;
+            """, [id, isoString(at)])
+    }
+
+    public func allMeetings() throws -> [(meeting: Meeting, modifiedAt: Date)] {
+        try queryRows("SELECT json, modified_at FROM meetings WHERE deleted=0 ORDER BY id;", [], 2)
+            .map { (try decoder.decode(Meeting.self, from: Data(($0[0] ?? "").utf8)), parseDate($0[1])) }
+    }
+
+    public func allArtifacts() throws -> [(artifact: Artifact, modifiedAt: Date)] {
+        try queryRows("SELECT json, modified_at FROM artifacts WHERE deleted=0 ORDER BY id;", [], 2)
+            .map { (try decoder.decode(Artifact.self, from: Data(($0[0] ?? "").utf8)), parseDate($0[1])) }
+    }
+
+    public func tombstones() throws -> [SyncMetadata] {
+        let m = try queryRows("SELECT id, modified_at FROM meetings WHERE deleted=1 ORDER BY id;", [], 2)
+            .map { SyncMetadata(id: $0[0] ?? "", kind: .meeting, lastModified: parseDate($0[1]), deleted: true) }
+        let a = try queryRows("SELECT id, modified_at FROM artifacts WHERE deleted=1 ORDER BY id;", [], 2)
+            .map { SyncMetadata(id: $0[0] ?? "", kind: .artifact, lastModified: parseDate($0[1]), deleted: true) }
+        return m + a
     }
 
     // MARK: - Transactions (for the crash-recovery test + batch writes)
@@ -99,21 +162,31 @@ public final class SQLiteStorage: IStorage, @unchecked Sendable {
         return f.string(from: date)
     }
 
+    private func parseDate(_ s: String?) -> Date {
+        guard let s else { return Date(timeIntervalSince1970: 0) }
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: s) ?? Date(timeIntervalSince1970: 0)
+    }
+
     private func exec(_ sql: String) throws {
         if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK { throw StorageError.exec(lastError) }
     }
 
-    private func upsert(_ table: String, _ columns: [String], _ values: [String]) throws {
-        let cols = columns.joined(separator: ",")
-        let placeholders = values.map { _ in "?" }.joined(separator: ",")
-        let sql = "INSERT OR REPLACE INTO \(table)(\(cols)) VALUES(\(placeholders));"
+    /// Prepared write with nullable text binds (nil → SQL NULL).
+    private func run(_ sql: String, _ binds: [String?]) throws {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { throw StorageError.prepare(lastError) }
         defer { sqlite3_finalize(stmt) }
-        for (i, v) in values.enumerated() {
-            sqlite3_bind_text(stmt, Int32(i + 1), v, -1, SQLITE_TRANSIENT)
-        }
+        bind(stmt, binds)
         guard sqlite3_step(stmt) == SQLITE_DONE else { throw StorageError.exec(lastError) }
+    }
+
+    private func bind(_ stmt: OpaquePointer?, _ binds: [String?]) {
+        for (i, v) in binds.enumerated() {
+            if let v { sqlite3_bind_text(stmt, Int32(i + 1), v, -1, SQLITE_TRANSIENT) }
+            else { sqlite3_bind_null(stmt, Int32(i + 1)) }
+        }
     }
 
     private func queryOne(_ sql: String, _ bind: [String]) throws -> String? {
@@ -126,13 +199,22 @@ public final class SQLiteStorage: IStorage, @unchecked Sendable {
     }
 
     private func queryAll(_ sql: String, _ bind: [String]) throws -> [String] {
+        try queryRows(sql, bind, 1).compactMap { $0[0] }
+    }
+
+    /// Run a query returning `columns` text columns per row (nil for NULL cells).
+    private func queryRows(_ sql: String, _ binds: [String], _ columns: Int32) throws -> [[String?]] {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { throw StorageError.prepare(lastError) }
         defer { sqlite3_finalize(stmt) }
-        for (i, v) in bind.enumerated() { sqlite3_bind_text(stmt, Int32(i + 1), v, -1, SQLITE_TRANSIENT) }
-        var out: [String] = []
+        for (i, v) in binds.enumerated() { sqlite3_bind_text(stmt, Int32(i + 1), v, -1, SQLITE_TRANSIENT) }
+        var out: [[String?]] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
-            if let c = sqlite3_column_text(stmt, 0) { out.append(String(cString: c)) }
+            var row: [String?] = []
+            for c in 0..<columns {
+                if let t = sqlite3_column_text(stmt, c) { row.append(String(cString: t)) } else { row.append(nil) }
+            }
+            out.append(row)
         }
         return out
     }

--- a/apple/Sources/RuntimeCore/Sync/SyncEngine.swift
+++ b/apple/Sources/RuntimeCore/Sync/SyncEngine.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Contracts
+import Providers
+
+/// HSM-10-01 — the sync engine (Runtime Core, Layer 2).
+///
+/// Produces a `ChangeSet` from the local store and applies a `ChangeSet` back to
+/// it, both expressed in Phase-0 contract entities. It depends only on the
+/// `ISyncStore` + `ISyncProvider` seams — never a concrete transport — so the same
+/// engine drives desktop / homelab / Tailscale once those land (HSM-10-02).
+///
+/// Conflict resolution (idempotent round-trip, last-writer policy) is HSM-10-03;
+/// this story establishes the object model and the produce/apply machinery. `apply`
+/// validates every payload against the Phase-0 contract (encode→decode through the
+/// shared coder, which is the schema) **before** it touches the store.
+public struct SyncEngine: Sendable {
+
+    public init() {}
+
+    public enum SyncError: Error, Equatable {
+        case tombstoneMissingMetadata
+        case liveRecordMissingPayload(kind: SyncKind, id: String)
+    }
+
+    /// The full local state as a change-set: live entities + tombstones.
+    public func snapshot(of store: ISyncStore) throws -> ChangeSet {
+        let meetings = try store.allMeetings().map {
+            Synced<Meeting>.live($0.meeting, id: $0.meeting.id, kind: .meeting, modifiedAt: $0.modifiedAt)
+        }
+        let artifacts = try store.allArtifacts().map {
+            Synced<Artifact>.live($0.artifact, id: $0.artifact.id, kind: .artifact, modifiedAt: $0.modifiedAt)
+        }
+        let tombs = try store.tombstones()
+        let meetingTombs = tombs.filter { $0.kind == .meeting }
+            .map { Synced<Meeting>(meta: $0, value: nil) }
+        let artifactTombs = tombs.filter { $0.kind == .artifact }
+            .map { Synced<Artifact>(meta: $0, value: nil) }
+        return ChangeSet(meetings: meetings + meetingTombs, artifacts: artifacts + artifactTombs)
+    }
+
+    /// Apply a change-set to the store: live records upserted with their carried
+    /// `lastModified`; tombstones soft-deleted. Every live payload is validated
+    /// against the Phase-0 contract before any write.
+    public func apply(_ changeSet: ChangeSet, to store: ISyncStore) throws {
+        // Validate first — nothing touches the store until every payload is schema-valid.
+        for rec in changeSet.meetings where !rec.meta.deleted {
+            guard let v = rec.value else { throw SyncError.liveRecordMissingPayload(kind: .meeting, id: rec.meta.id) }
+            try validate(v)
+        }
+        for rec in changeSet.artifacts where !rec.meta.deleted {
+            guard let v = rec.value else { throw SyncError.liveRecordMissingPayload(kind: .artifact, id: rec.meta.id) }
+            try validate(v)
+        }
+
+        for rec in changeSet.meetings {
+            if rec.meta.deleted { try store.deleteMeeting(id: rec.meta.id, at: rec.meta.lastModified) }
+            else { try store.saveMeeting(rec.value!, modifiedAt: rec.meta.lastModified) }
+        }
+        for rec in changeSet.artifacts {
+            if rec.meta.deleted { try store.deleteArtifact(id: rec.meta.id, at: rec.meta.lastModified) }
+            else { try store.saveArtifact(rec.value!, modifiedAt: rec.meta.lastModified) }
+        }
+    }
+
+    /// Drive one round-trip through a provider: push the local snapshot, pull the
+    /// peer's change-set, and apply it locally. (Bidirectional conflict policy is
+    /// HSM-10-03; here the pulled set is applied as-is.)
+    public func sync(local store: ISyncStore, via provider: ISyncProvider) async throws {
+        try await provider.push(snapshot(of: store))
+        let incoming = try await provider.pull()
+        try apply(incoming, to: store)
+    }
+
+    /// Schema validation: round-trip the value through the contract coder. A value
+    /// the contract can't hold throws here, before the store is touched.
+    private func validate<T: Codable>(_ value: T) throws {
+        let data = try HoldSpeakContracts.encoder().encode(value)
+        _ = try HoldSpeakContracts.decoder().decode(T.self, from: data)
+    }
+}

--- a/apple/Tests/ProvidersTests/StorageTests.swift
+++ b/apple/Tests/ProvidersTests/StorageTests.swift
@@ -36,10 +36,10 @@ final class StorageTests: XCTestCase {
         XCTAssertEqual(try db.loadArtifacts(meetingId: "other"), [])
     }
 
-    func testSchemaVersionIsOne() throws {
+    func testSchemaVersionIsTwo() throws {
         let db = try SQLiteStorage(path: tempPath()); defer { db.close() }
         XCTAssertEqual(try db.userVersion(), SQLiteStorage.schemaVersion)
-        XCTAssertEqual(try db.userVersion(), 1)
+        XCTAssertEqual(try db.userVersion(), 2)   // HSM-10-01: modified_at + tombstones
     }
 
     /// Durability + no-corruption across an unclean shutdown: a committed write

--- a/apple/Tests/RuntimeCoreTests/SyncEngineTests.swift
+++ b/apple/Tests/RuntimeCoreTests/SyncEngineTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-10-01 — the sync object model + engine. Host-testable end to end: a
+/// change-set is produced from a seeded Phase-4 store and applied to an empty one
+/// (directly and across a JSON "wire" via a fake provider), proving the Runtime
+/// Core depends only on the `ISyncProvider`/`ISyncStore` seams.
+final class SyncEngineTests: XCTestCase {
+
+    struct Sample: Codable { let meeting: Meeting; let artifact: Artifact }
+
+    private func fixture() throws -> Sample {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<4 { url.deleteLastPathComponent() }
+        url.appendPathComponent("pm/roadmap/holdspeak-mobile/contracts/fixtures/meeting-sample.json")
+        return try HoldSpeakContracts.decoder().decode(Sample.self, from: Data(contentsOf: url))
+    }
+
+    private func tempStore() throws -> SQLiteStorage {
+        try SQLiteStorage(path: NSTemporaryDirectory() + "hsm-sync-\(UUID().uuidString).sqlite")
+    }
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)   // whole seconds (ISO precision)
+
+    /// A transport-free `ISyncProvider` that relays a change-set through real JSON —
+    /// so push/pull exercises the wire encoding + schema-validating decode.
+    final class JSONRelayProvider: ISyncProvider, @unchecked Sendable {
+        private var stored = Data()
+        func push(_ changeSet: ChangeSet) async throws {
+            stored = try HoldSpeakContracts.encoder().encode(changeSet)
+        }
+        func pull() async throws -> ChangeSet {
+            guard !stored.isEmpty else { return ChangeSet() }
+            return try HoldSpeakContracts.decoder().decode(ChangeSet.self, from: stored)
+        }
+    }
+
+    func testSnapshotApplyRoundTrip() throws {
+        let s = try fixture()
+        let a = try tempStore(); defer { a.close() }
+        let b = try tempStore(); defer { b.close() }
+        try a.saveMeeting(s.meeting, modifiedAt: t0)
+        try a.saveArtifact(s.artifact, modifiedAt: t0)
+
+        let engine = SyncEngine()
+        try engine.apply(engine.snapshot(of: a), to: b)
+
+        XCTAssertEqual(try b.loadMeeting(id: s.meeting.id), s.meeting)          // exact contract
+        XCTAssertEqual(try b.loadArtifacts(meetingId: s.artifact.meetingId), [s.artifact])
+        // last-modified is carried, not restamped.
+        XCTAssertEqual(try b.allMeetings().first?.modifiedAt, t0)
+    }
+
+    func testRoundTripAcrossJSONProvider() async throws {
+        let s = try fixture()
+        let source = try tempStore(); defer { source.close() }
+        let dest = try tempStore(); defer { dest.close() }
+        try source.saveMeeting(s.meeting, modifiedAt: t0)
+        try source.saveArtifact(s.artifact, modifiedAt: t0)
+
+        let engine = SyncEngine()
+        let relay = JSONRelayProvider()
+        try await relay.push(engine.snapshot(of: source))      // source -> wire
+        try engine.apply(try await relay.pull(), to: dest)     // wire -> dest
+
+        XCTAssertEqual(try dest.loadMeeting(id: s.meeting.id), s.meeting)
+        XCTAssertEqual(try dest.loadArtifacts(meetingId: s.artifact.meetingId), [s.artifact])
+    }
+
+    func testSyncFlowDependsOnlyOnProviderSeam() async throws {
+        let s = try fixture()
+        let store = try tempStore(); defer { store.close() }
+        try store.saveMeeting(s.meeting, modifiedAt: t0)
+
+        let engine = SyncEngine()
+        // sync() pushes the local snapshot then applies whatever pull returns; with
+        // a loopback relay that's the same set → store is unchanged + intact.
+        try await engine.sync(local: store, via: JSONRelayProvider())
+        XCTAssertEqual(try store.loadMeeting(id: s.meeting.id), s.meeting)
+    }
+
+    func testTombstonePropagatesDelete() throws {
+        let s = try fixture()
+        let a = try tempStore(); defer { a.close() }
+        let b = try tempStore(); defer { b.close() }
+        let engine = SyncEngine()
+
+        try a.saveMeeting(s.meeting, modifiedAt: t0)
+        try engine.apply(engine.snapshot(of: a), to: b)
+        XCTAssertNotNil(try b.loadMeeting(id: s.meeting.id))
+
+        try a.deleteMeeting(id: s.meeting.id, at: t0.addingTimeInterval(60))
+        try engine.apply(engine.snapshot(of: a), to: b)
+
+        XCTAssertNil(try b.loadMeeting(id: s.meeting.id))                       // gone
+        XCTAssertEqual(try b.tombstones().map(\.id), [s.meeting.id])            // tombstone recorded
+    }
+
+    func testApplyIsIdempotent() throws {
+        let s = try fixture()
+        let a = try tempStore(); defer { a.close() }
+        let b = try tempStore(); defer { b.close() }
+        try a.saveMeeting(s.meeting, modifiedAt: t0)
+        try a.saveArtifact(s.artifact, modifiedAt: t0)
+
+        let engine = SyncEngine()
+        let cs = try engine.snapshot(of: a)
+        try engine.apply(cs, to: b)
+        try engine.apply(cs, to: b)                                            // twice → no change
+
+        XCTAssertEqual(try b.allMeetings().count, 1)
+        XCTAssertEqual(try b.loadArtifacts(meetingId: s.artifact.meetingId), [s.artifact])
+    }
+
+    func testMalformedChangeSetRejectedAtWire() {
+        // A live meeting record missing the required `id` — schema-invalid; the
+        // contract decoder must reject it before it could ever reach the store.
+        let bad = #"""
+        {"meetings":[{"meta":{"id":"m1","kind":"meeting","last_modified":"2026-01-01T00:00:00Z","deleted":false},
+         "value":{"started_at":"2026-01-01T00:00:00Z","tags":[],"segments":[],"bookmarks":[],
+                  "intel_status":"none","mic_label":"m","remote_label":"r","devices":[]}}],"artifacts":[]}
+        """#
+        XCTAssertThrowsError(
+            try HoldSpeakContracts.decoder().decode(ChangeSet.self, from: Data(bad.utf8)))
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,18 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Phase 6 CLOSED ✅ — Gate 5 (desktop-parity) PASSED.**
+**Last updated:** 2026-06-19 (**Phase 10 (Sync) opened — HSM-10-01 done: the sync
+object model + engine.** Following the owner's program steer (sync is next after
+Phase 6), and fully host-testable (no device). Cross-device sync moves the **Phase-0
+entities themselves** in a contract-layer envelope (`ChangeSet` of `Synced<T>`;
+payload = the unmodified entity, `nil` ⇔ tombstone) — no parallel schema, no drift
+(SERIALIZATION-CONTRACT §11). `ISyncProvider` is now a `push`/`pull` seam;
+`ISyncStore` adds modified-time + soft-delete tombstones to the Phase-4 store
+(SQLite schema v2, guarded migration); the RuntimeCore `SyncEngine` does
+`snapshot`/`apply` (schema-validated) / `sync(local:via:)`. `swift test` **55/55**
+incl. 6 sync tests (round-trip, JSON-wire round-trip, tombstone propagation,
+idempotent apply, malformed-wire rejection), Phase-4 storage intact through the
+migration. Next: HSM-10-02 (transport + the Python-side sync API + the envelope's
+JSON Schema). Earlier: **Phase 6 CLOSED ✅ — Gate 5 (desktop-parity) PASSED.**
 HSM-6-05: the parity harness over a fixed baseline meeting, with real mobile
 generation through the Mode-B/C endpoint provider, scores **mean coverage 0.92 over
 3 runs vs the pre-fixed 0.8 threshold (3/3 pass)** — mobile meeting intelligence is
@@ -121,7 +133,7 @@ Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction �
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
 **Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5 PASSED**; 2 + 3 + 5 testable cores done, device-gated remainder; Phase 5 — HSM-5-06 endpoint provider host/live-proven + on-device build; 6-06 Follow-ups deferred on a contract decision)
-**Status:** in-progress (Phases 0–1–4 closed, **Phase 6 closed — Gate 5 desktop-parity PASSED at mean 0.92 vs 0.8**; Phase 2 + 3 + 5 testable cores shipped; **HSM-5-06 makes the iPad run real meeting intelligence today via an OpenAI-compatible endpoint** — built/signed/installed on the iPad Air M4, on-device launch pending the device unlock. Next: the on-device capture, then HSM-5-02 on-device GGUF and/or the sync-by-default thrust).
+**Status:** in-progress (Phases 0–1–4 closed, **Phase 6 closed — Gate 5 desktop-parity PASSED at mean 0.92 vs 0.8**; Phase 2 + 3 + 5 testable cores shipped; HSM-5-06 makes the iPad run real meeting intelligence via an OpenAI-compatible endpoint, on-device launch pending the device unlock; **Phase 10 (Sync) opened — HSM-10-01 object model + engine host-proven**. Next: HSM-10-02 sync transport + Python sync API; the iPad on-device captures (HSM-5-06 launch, HSM-5-02 GGUF) when the device is unlocked).
 
 ## Vision
 
@@ -185,7 +197,7 @@ WebView, or UIKit.
 | 7 | H | MIR port: 5 profiles measurably alter extraction | not-started | [phase-7](./phase-7-mir-port/) |
 | 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes | not-started | [phase-9](./phase-9-iphone-experience/) |
-| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | not-started | [phase-10](./phase-10-sync/) |
+| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (1/4; HSM-10-01 object model + engine host-proven) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios, production readiness | not-started | [phase-11](./phase-11-hardening/) |
 
 Phases are sequenced as the charter lists the tracks. The contract layer (Phase

--- a/pm/roadmap/holdspeak-mobile/contracts/SERIALIZATION-CONTRACT.md
+++ b/pm/roadmap/holdspeak-mobile/contracts/SERIALIZATION-CONTRACT.md
@@ -163,6 +163,27 @@ no ambiguity — which is the HSM-0-03 acceptance bar.
 
 ---
 
+## §11 — Sync envelope (HSM-10-01)
+
+Cross-device sync moves the **contract entities themselves**, never a parallel sync
+schema. The sync metadata a transport needs rides in a thin additive envelope; the
+entity structs are unchanged (no `last_modified`/`deleted` field bolted onto each
+entity — that was the escalation the story flagged, resolved this way):
+
+- `sync_metadata`: `{ id (string), kind ("meeting"|"artifact"), last_modified
+  (ISO-8601 UTC Z, §2), deleted (bool) }`. `deleted=true` is a **tombstone** — a
+  propagated delete that carries no payload.
+- `synced<T>`: `{ meta: sync_metadata, value: T|null }`; `value` is the unmodified
+  Phase-0 entity, and is `null` exactly when `meta.deleted`.
+- `change_set`: `{ meetings: synced<Meeting>[], artifacts: synced<Artifact>[] }`.
+  Actions are not a top-level store entity (they live inside an Action-Items
+  artifact), so the store-backed sync set is Meetings + Artifacts.
+
+The envelope is the wire shape; the entities inside it validate against their
+existing schemas (meeting/artifact). The **JSON Schema for the envelope + the
+Python-side mirror** land with the transport story (HSM-10-02), which introduces the
+desktop sync API; HSM-10-01 is the Swift object model + engine, host-proven.
+
 ## Decisions locked here (carried to the phase status)
 
 1. Wire = desktop `to_dict()` snake_case; Swift maps via key strategy (§1).

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
@@ -1,13 +1,25 @@
 # Phase 10 — Sync
 
-**Status:** planning (scaffolded 2026-06-18). Track K of the Council
+**Status:** in-progress (HSM-10-01 done 2026-06-19 — the sync object model + engine
+are host-proven; transport/conflict/gate remain). Track K of the Council
 Implementation Charter. The `ISyncProvider` (Layer 3): cross-device continuity so
 a meeting captured on the phone shows up on the desktop, and edits round-trip —
 over the user's own network (desktop / homelab / Tailscale), local-first and
 never destructive.
 
-**Last updated:** 2026-06-18 (scaffolded — stories HSM-10-01..04 stubbed from
-charter Track K; no work started).
+**Last updated:** 2026-06-19 (**HSM-10-01 done — the sync object model + engine**.
+The sync set is the Phase-0 entities themselves, carried in a contract-layer
+envelope (`ChangeSet` of `Synced<T>`; payload = the unmodified entity, `nil` ⇔
+tombstone) — no parallel schema, no drift; recorded in SERIALIZATION-CONTRACT §11.
+`ISyncProvider` is now a `push`/`pull` seam; `ISyncStore` adds modified-time +
+soft-delete tombstones to the Phase-4 store (SQLite **schema v2**, guarded
+migration); the RuntimeCore `SyncEngine` does `snapshot`/`apply` (schema-validated
+before any write) / `sync(local:via:)`. `swift test` **55/55** incl. 6 sync tests
+(round-trip, JSON-wire round-trip, tombstone propagation, idempotent apply,
+malformed-wire rejection) — and the Phase-4 storage tests still pass through the
+migration. The envelope's JSON Schema + the Python-side mirror land with HSM-10-02
+(transport). Earlier: scaffolded — stories HSM-10-01..04 stubbed from charter Track
+K.)
 
 ## Goal
 
@@ -48,21 +60,24 @@ local-first; it never acts autonomously.
 
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
-| HSM-10-01 | Sync provider + object model | backlog | [story-01](./story-01-sync-provider-object-model.md) | — |
+| HSM-10-01 | Sync provider + object model | done | [story-01](./story-01-sync-provider-object-model.md) | [evidence-01](./evidence-story-01.md) |
 | HSM-10-02 | Transport targets | backlog | [story-02](./story-02-transport-targets.md) | — |
 | HSM-10-03 | Conflict + round-trip | backlog | [story-03](./story-03-conflict-and-roundtrip.md) | — |
 | HSM-10-04 | Continuity closeout (Gate 6) | backlog | [story-04](./story-04-continuity-closeout.md) | — |
 
 ## Where we are
 
-Just scaffolded. Sync sits on the Phase-0 contracts (the interop spine) and the
-Phase-4 store, and it reuses the Phase-0 conformance fixtures as its round-trip
-test bed — the same golden payloads both runtimes already round-trip become the
-sync payloads. The four stories split the work: the provider + object model
-(HSM-10-01), the transport to the user's own targets (HSM-10-02), the
-conflict/idempotency policy (HSM-10-03), and the continuity gate on real devices
-(HSM-10-04). Next: HSM-10-01 once Phase 4 (the local store) and the Phase-0
-fixtures are in hand.
+**HSM-10-01 is done.** The object model + engine are host-proven on the Phase-0
+contracts + the Phase-4 store, reusing the Phase-0 conformance fixture as the
+round-trip test bed. The sync set is the entities themselves in a `ChangeSet` of
+`Synced<T>` envelopes; the `SyncEngine` produces a snapshot from the store and
+applies one back (schema-validated), driven through the `ISyncProvider` push/pull
+seam — so the Runtime Core depends on the interface, never a transport. The store
+gained modified-time + tombstones (schema v2). **Next: HSM-10-02 (transport to the
+user's own desktop/homelab/Tailscale targets, incl. the new Python-side sync API +
+the envelope's JSON Schema), then HSM-10-03 (conflict/idempotency) and HSM-10-04
+(the continuity gate on real devices).** The remaining stories are where sync
+touches real hardware/network; HSM-10-01 is fully host-proven.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/evidence-story-01.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/evidence-story-01.md
@@ -1,0 +1,63 @@
+# Evidence — HSM-10-01 — Sync provider + object model
+
+- **Shipped:** 2026-06-19
+- **Branch:** `holdspeak-mobile/phase-10-sync-object-model`
+- **Owner:** unassigned
+
+## Files touched
+
+- `apple/Sources/Contracts/Sync.swift` — the sync object model: `SyncKind`,
+  `SyncMetadata` (id/kind/last_modified/deleted), `Synced<T>` (envelope; payload is
+  the unmodified entity, `nil` ⇔ tombstone), `ChangeSet` (meetings/artifacts).
+- `apple/Sources/Providers/Providers.swift` — `ISyncProvider` fleshed to
+  `push(_:)`/`pull()`; new `ISyncStore` (modified-time + tombstone surface).
+- `apple/Sources/Providers/Storage/SQLiteStorage.swift` — schema **v2**:
+  `modified_at` + `deleted` columns (nullable `json` for tombstones), a guarded
+  v1→v2 migration, `ISyncStore` impl (`allMeetings`/`allArtifacts`/`tombstones`,
+  `save…(modifiedAt:)`, `delete…(at:)`), and `deleted=0` filters on the loads.
+- `apple/Sources/RuntimeCore/Sync/SyncEngine.swift` — `snapshot(of:)`,
+  `apply(_:to:)` (validates every payload against the contract before any write),
+  `sync(local:via:)`.
+- `apple/Tests/RuntimeCoreTests/SyncEngineTests.swift` (6 tests),
+  `apple/Tests/ProvidersTests/StorageTests.swift` (schema-version test → v2).
+- `pm/roadmap/holdspeak-mobile/contracts/SERIALIZATION-CONTRACT.md` — §11 records
+  the sync envelope as an additive contract addition (the story's escalation).
+
+## Verification
+
+`cd apple && swift test` → **55 executed, 3 skipped (opt-in live), 0 failures.**
+The Phase-4 storage tests still pass through the v2 migration (round-trip +
+crash-recovery + atomicity intact). New sync tests:
+
+```
+SyncEngineTests:
+  testSnapshotApplyRoundTrip          # seed A -> snapshot -> apply to B; exact contract back; modified_at carried
+  testRoundTripAcrossJSONProvider     # A -> JSON wire (encoder) -> decode -> apply to B; entities match
+  testSyncFlowDependsOnlyOnProviderSeam  # engine.sync(local:via:) over a fake provider; store intact
+  testTombstonePropagatesDelete       # delete in A propagates; B loses the entity; tombstone recorded
+  testApplyIsIdempotent               # apply same change-set twice -> one row, unchanged
+  testMalformedChangeSetRejectedAtWire# a schema-invalid meeting is rejected by the contract decoder
+```
+
+## Acceptance criteria — re-checked
+
+- [x] `ISyncProvider` exists; the Runtime Core depends on the interface (a fake
+  JSON-relay provider drives the flow), not a concrete transport.
+- [x] The sync object set is the Phase-0 entities; sync metadata is carried in a
+  contract-layer envelope (payload = the real entity), not bolted onto each entity.
+- [x] A change-set is produced from the Phase-4 store and applied to it, both in
+  contract objects (`snapshot`/`apply` over `ISyncStore`/`SQLiteStorage`).
+- [x] Applying validates every object against the Phase-0 contract before it
+  touches the store (encode→decode through the shared coder = the schema; the wire
+  decode rejects malformed payloads — `testMalformedChangeSetRejectedAtWire`).
+
+## Deviations / notes
+
+- Sync metadata is an **additive envelope** (`Synced`/`SyncMetadata`/`ChangeSet`),
+  not new fields on the entities — recorded in SERIALIZATION-CONTRACT §11. This is
+  the resolution of the story's "escalate to HSM-0-03" note.
+- The envelope's **JSON Schema + the Python-side mirror** are deferred to HSM-10-02
+  (the transport story that introduces the desktop sync API); HSM-10-01 is the
+  Swift object model + engine, host-proven.
+- Conflict policy / full idempotency across divergent edits is **HSM-10-03**; this
+  story's `apply` is straight upsert-by-carried-`last_modified`.

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/story-01-sync-provider-object-model.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/story-01-sync-provider-object-model.md
@@ -2,7 +2,10 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 10
-- **Status:** backlog
+- **Status:** done (2026-06-19 — `ChangeSet`/`Synced` object model + `ISyncStore`
+  (SQLite schema v2: modified-time + tombstones) + RuntimeCore `SyncEngine`
+  snapshot/apply/round-trip; `swift test` 55/55 incl. 6 sync tests. See
+  [evidence-01](./evidence-story-01.md).)
 - **Depends on:** HSM-0-04, HSM-4-01
 - **Unblocks:** HSM-10-02, HSM-10-03, HSM-10-04
 - **Owner:** unassigned


### PR DESCRIPTION
## HSM-10-01 — Sync provider + object model (opens Phase 10)

Following the owner's program steer (**sync is next after Phase 6**) and fully
host-testable — no iPad required. Cross-device sync moves the **Phase-0 entities
themselves** in a contract-layer envelope; no parallel schema that can drift.

### What's in
- **Contracts** — `SyncKind`, `SyncMetadata` (id/kind/last_modified/deleted),
  `Synced<T>` (payload = the unmodified entity, `nil` ⇔ tombstone), `ChangeSet`.
- **Providers** — `ISyncProvider` is now a `push`/`pull` seam; new `ISyncStore`
  (modified-time + soft-delete tombstones). `SQLiteStorage` **schema v2**
  (`modified_at` + `deleted`, nullable `json`, guarded v1→v2 migration); loads
  exclude tombstoned rows.
- **RuntimeCore** — `SyncEngine`: `snapshot(of:)`, `apply(_:to:)` (validates every
  payload against the contract **before** any write), `sync(local:via:)`.
- **Canon** — SERIALIZATION-CONTRACT §11 records the envelope (the story's
  "escalate to HSM-0-03" note); the JSON Schema + Python mirror land with HSM-10-02.

### Proof
`swift test` **55 / 3 skipped (opt-in live) / 0 failures**, incl. 6 sync tests
(round-trip, JSON-wire round-trip, tombstone propagation, idempotent apply,
malformed-wire rejection). Phase-4 storage tests still pass through the migration.

Next: HSM-10-02 (transport to desktop/homelab/Tailscale + the Python-side sync API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)