### PR TITLE
holdspeak-mobile: Phase 5 — HSM-5-02 LlamaProvider (Mode A) host-proven on Metal

### DIFF
--- a/apple/Package.resolved
+++ b/apple/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "da160223bacaaaaa3c2dcbad80a1193eaff85d81fb4be742a537ab00c6dd007a",
+  "pins" : [
+    {
+      "identity" : "llm.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/eastriverlee/LLM.swift",
+      "state" : {
+        "revision" : "427f3b8957a40982500abc8d35ccff8b83ec56a4",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apple/Package.swift
+++ b/apple/Package.swift
@@ -15,6 +15,15 @@ let package = Package(
         .library(name: "Contracts", targets: ["Contracts"]),
         .library(name: "RuntimeCore", targets: ["RuntimeCore"]),
         .library(name: "Providers", targets: ["Providers"]),
+        // Mode A engine adapter (HSM-5-02). Kept a SEPARATE product so the native
+        // llama.cpp engine links ONLY where it's used (Hosts), never into the
+        // domain (Contracts/RuntimeCore) — the Phase-6 "ProviderInterfaces" concern.
+        .library(name: "InferenceLlama", targets: ["InferenceLlama"]),
+    ],
+    dependencies: [
+        // llama.cpp behind Swift (bundles the engine + Metal; macOS/iOS). The
+        // HSM-5-01 pick; reversible because it sits behind `ILLMProvider`.
+        .package(url: "https://github.com/eastriverlee/LLM.swift", from: "2.0.0"),
     ],
     targets: [
         // Layer 1 — language-neutral schema as Swift types. Foundation only.
@@ -24,10 +33,16 @@ let package = Package(
         .target(name: "RuntimeCore", dependencies: ["Contracts", "Providers"]),
         // Layer 3 — provider protocols (transcriber/LLM/audio/storage/sync).
         .target(name: "Providers", dependencies: ["Contracts"]),
+        // Layer 3 (engine adapter) — the llama.cpp-backed `ILLMProvider` (Mode A).
+        // Depends on the native engine; the domain does not depend on this target.
+        .target(name: "InferenceLlama",
+                 dependencies: ["Providers", "Contracts", .product(name: "LLM", package: "LLM.swift")]),
         // Layer 4 — platform hosts (iPad/iPhone apps). The only UI layer.
         .target(name: "Hosts", dependencies: ["RuntimeCore", "Providers", "Contracts"]),
         .testTarget(name: "ContractsTests", dependencies: ["Contracts"]),
         .testTarget(name: "RuntimeCoreTests", dependencies: ["RuntimeCore", "Providers", "Contracts"]),
         .testTarget(name: "ProvidersTests", dependencies: ["Providers", "Contracts"]),
+        .testTarget(name: "InferenceLlamaTests",
+                    dependencies: ["InferenceLlama", "RuntimeCore", "Providers", "Contracts"]),
     ]
 )

--- a/apple/Sources/InferenceLlama/LlamaProvider.swift
+++ b/apple/Sources/InferenceLlama/LlamaProvider.swift
@@ -1,0 +1,46 @@
+import Foundation
+import LLM
+import Providers
+
+public enum LlamaProviderError: Error, Equatable {
+    case modelLoadFailed(path: String)
+}
+
+/// HSM-5-02 — the on-device (charter Mode A) `ILLMProvider`, backed by llama.cpp
+/// through LLM.swift (the HSM-5-01 engine pick). Loads a GGUF by path and returns a
+/// completion with **no network** — the fully-local path.
+///
+/// The native engine lives only in this target; the domain (Contracts/RuntimeCore)
+/// depends on the `ILLMProvider` seam, never on llama.cpp — so Mode A is swappable
+/// for Mode B/C (`OpenAIEndpointProvider`) without touching the core.
+///
+/// A `final class` with `@unchecked Sendable`: the underlying `LLM` is a
+/// non-Sendable reference type, so it can't live behind an `actor` (calling its
+/// nonisolated async methods would risk a data race). Generation is serial — the
+/// artifact engine drives it one call at a time, and `LLM` itself guards
+/// reentrancy — so single-owner sequential use is safe.
+public final class LlamaProvider: ILLMProvider, @unchecked Sendable {
+    private let llm: LLM
+
+    /// - Parameters:
+    ///   - modelPath: absolute path to a local `.gguf`.
+    ///   - template: the model's chat template (default ChatML — Qwen/Llama-3 style).
+    ///   - maxTokenCount: context budget (clamped to the model's trained context).
+    public init(modelPath: String,
+                template: Template = .chatML(),
+                maxTokenCount: Int32 = 2048) throws {
+        guard let llm = LLM(from: URL(fileURLWithPath: modelPath),
+                            template: template,
+                            maxTokenCount: maxTokenCount) else {
+            throw LlamaProviderError.modelLoadFailed(path: modelPath)
+        }
+        self.llm = llm
+    }
+
+    public func complete(prompt: String) async throws -> String {
+        // Apply the chat template, then generate. `getCompletion` expects an
+        // already-templated input (it does not re-run preprocess).
+        let templated = llm.preprocess(prompt, [], .none)
+        return await llm.getCompletion(from: templated)
+    }
+}

--- a/apple/Tests/InferenceLlamaTests/LlamaProviderTests.swift
+++ b/apple/Tests/InferenceLlamaTests/LlamaProviderTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import Contracts
+import Providers
+import RuntimeCore
+@testable import InferenceLlama
+
+/// HSM-5-02 — the on-device (Mode A) engine proof. Opt-in via `HS_GGUF_PATH` (a
+/// local `.gguf`) so the default suite stays fast and model-free; the target itself
+/// still builds llama.cpp, proving the engine integrates behind `ILLMProvider`.
+///
+///   HS_GGUF_PATH=/path/to/model.gguf swift test --filter LlamaProviderTests
+///
+/// This is the host (macOS Metal) rehearsal of Mode A; the iPad on-device run is the
+/// same `LlamaProvider` behind the same seam (device launch gated separately).
+final class LlamaProviderTests: XCTestCase {
+
+    private func modelPath() throws -> String {
+        guard let p = ProcessInfo.processInfo.environment["HS_GGUF_PATH"], !p.isEmpty else {
+            throw XCTSkip("set HS_GGUF_PATH to a local .gguf to run the Mode-A engine proof")
+        }
+        return p
+    }
+
+    func testLoadsGGUFAndCompletes() async throws {
+        let path = try modelPath()
+        let provider = try LlamaProvider(modelPath: path, maxTokenCount: 512)
+        let out = try await provider.complete(prompt: "Reply with exactly one word: PONG")
+        print("📦 Mode-A completion: \(out)")
+        XCTAssertFalse(out.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                       "expected a non-empty completion from the local GGUF")
+    }
+
+    /// Full Mode A: transcript → LlamaProvider → ArtifactGenerationEngine →
+    /// contract-shaped artifacts, fully local (no network).
+    func testModeAArtifactGenerationFullyLocal() async throws {
+        let path = try modelPath()
+        let provider = try LlamaProvider(modelPath: path, maxTokenCount: 1024)
+        let engine = ArtifactGenerationEngine(provider: provider)
+
+        let segments = [
+            Segment(text: "We decided to ship the iPad client with on-device inference as a fallback.",
+                    speaker: "Alice", startTime: 0, endTime: 5),
+            Segment(text: "Action item: Bob will benchmark the 8B model on the iPad by Friday.",
+                    speaker: "Alice", startTime: 5, endTime: 10),
+        ]
+        let transcript = Transcript(meetingId: "modea_001", segments: segments, transcriptHash: "modea-hash")
+
+        let results = await engine.generate(types: [.decisions, .actionItems], from: transcript)
+        let artifacts = results.compactMap { try? $0.result.get() }
+        for a in artifacts { print("✅ [\(a.artifactType.rawValue)] \(a.title)\n\(a.bodyMarkdown)") }
+
+        XCTAssertGreaterThan(artifacts.count, 0, "expected at least one artifact from the local model")
+        XCTAssertTrue(artifacts.allSatisfy { $0.status == .draft })   // propose-only
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Phase 10 (Sync) opened — HSM-10-01 done: the sync
+**Last updated:** 2026-06-19 (**HSM-5-02 — the on-device (Mode A) engine, host-proven
+on Metal.** `LlamaProvider` (an `ILLMProvider` backed by **llama.cpp via LLM.swift**,
+the HSM-5-01 pick) loads a GGUF and completes with no network — proven on this Mac's
+Metal against Qwen2.5-7B Q4_K_M (`PONG` ~8.5s incl. cold load; a full fully-local run
+transcript → engine → real decisions + action_items ~13.4s). The native engine lives
+in a separate `InferenceLlama` product so the domain never links it (the Phase-6
+"ProviderInterfaces" concern, resolved). `swift test` **57/57** (5 opt-in skips),
+layer guard green. Remaining: the iPad airplane-mode run (gated on the device unlock)
++ model packaging (HSM-5-03). With HSM-5-06 (endpoint, Modes B/C) already shipped, the
+iPad now has **both** an on-device engine and an endpoint path behind one seam.
+Earlier: **Phase 10 (Sync) opened — HSM-10-01 done: the sync
 object model + engine.** Following the owner's program steer (sync is next after
 Phase 6), and fully host-testable (no device). Cross-device sync moves the **Phase-0
 entities themselves** in a contract-layer envelope (`ChangeSet` of `Synced<T>`;
@@ -192,7 +202,7 @@ WebView, or UIKit.
 | 2 | C | Audio engine: AVAudioEngine streaming capture + WAV export, 1-hour stable | in-progress (2/4; rest hardware-gated) | [phase-2](./phase-2-audio-engine/) |
 | 3 | D | Whisper runtime via WhisperKit, realtime latency < 2s | in-progress (2/5; lang+segment done, WhisperKit/latency device-gated) | [phase-3](./phase-3-whisper-runtime/) |
 | 4 | E | SQLite persistence with full crash recovery | **done (3/3)** | [phase-4](./phase-4-persistence/) |
-| 5 | F | Local inference (4B/8B) — a 30-min meeting processed on-device | in-progress (structured-output + model policy + engine pick done; HSM-5-06 endpoint provider Modes B/C host/live-proven + on-device build; HSM-5-02 on-device GGUF + gate device) | [phase-5](./phase-5-local-inference/) |
+| 5 | F | Local inference (4B/8B) — a 30-min meeting processed on-device | in-progress (structured-output + model policy + engine pick done; HSM-5-06 endpoint provider Modes B/C host/live-proven + on-device build; **HSM-5-02 LlamaProvider/Mode A host-proven on Metal**, iPad run + HSM-5-03 packaging + HSM-5-05 gate device) | [phase-5](./phase-5-local-inference/) |
 | 6 | G | Meeting intelligence: structured-JSON artifacts at desktop parity | **Gate 5 PASSED ✅ (5/6; 6-06 deferred)** | [phase-6](./phase-6-meeting-intelligence/) |
 | 7 | H | MIR port: 5 profiles measurably alter extraction | not-started | [phase-7](./phase-7-mir-port/) |
 | 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/current-phase-status.md
@@ -3,14 +3,25 @@
 **Status:** in-progress (HSM-5-04 done 2026-06-18; **HSM-5-01 done 2026-06-19 —
 engine = llama.cpp+GGUF**; **HSM-5-06 — endpoint provider (Modes B/C) + mode
 setting — host/live-proven, device build+install done, on-device launch pending
-the iPad unlock**; HSM-5-02/03 in-progress; HSM-5-05 device-gated). Track F
+the iPad unlock**; **HSM-5-02 — `LlamaProvider` (llama.cpp/Mode A) host-proven on
+Metal, iPad airplane-mode run pending the unlock**; HSM-5-03 in-progress; HSM-5-05
+device-gated). Track F
 of the Council Implementation Charter. The phase
 that lights up Mode A (Fully Local): it delivers the on-device `ILLMProvider`
 (Layer 3) so a meeting can go Audio → Whisper → LLM → Artifacts with no network.
 It also resolves the Phase-0 deferred decision — which inference engine the mobile
 runtime stands on.
 
-**Last updated:** 2026-06-19 (**HSM-5-06 — the OpenAI-compatible endpoint provider
+**Last updated:** 2026-06-19 (**HSM-5-02 — the on-device (Mode A) engine, host-proven
+on Metal.** `LlamaProvider` (an `ILLMProvider` backed by **llama.cpp via LLM.swift**,
+the HSM-5-01 pick) loads a GGUF by path and completes with no network. Proven on this
+Mac's Metal against **Qwen2.5-7B Q4_K_M**: a completion (`PONG`, ~8.5s incl. cold load)
+and a full **fully-local** run (transcript → `LlamaProvider` → `ArtifactGenerationEngine`
+→ real decisions + action_items, ~13.4s). The native engine is isolated to a separate
+`InferenceLlama` SPM product so the domain never links it (the Phase-6
+"ProviderInterfaces" concern, resolved). `swift test` **57/57** (5 opt-in skips), layer
+guard green. Remaining: the iPad airplane-mode run (gated on the device unlock) +
+model packaging (HSM-5-03). Earlier: **HSM-5-06 — the OpenAI-compatible endpoint provider
 (charter Modes B/C) + a runtime-mode setting**, shipped ahead of the on-device
 engine on the owner's steer: inference mode is a user setting (local default) and
 the runtime must point at any OpenAI-compatible endpoint, so the iPad need not
@@ -89,7 +100,7 @@ on Tier-1 hardware.
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
 | HSM-5-01 | Engine evaluation & pick | done | [story-01](./story-01-engine-evaluation.md) | [evidence-01](./evidence-story-01.md) |
-| HSM-5-02 | `ILLMProvider` impl + Mode A | in-progress | [story-02](./story-02-llm-provider-impl.md) | — |
+| HSM-5-02 | `ILLMProvider` impl + Mode A | in-progress (host-proven; iPad run pending unlock) | [story-02](./story-02-llm-provider-impl.md) | in story (host Metal proof) |
 | HSM-5-03 | Model packaging & per-device defaults | in-progress | [story-03](./story-03-model-packaging-strategy.md) | — |
 | HSM-5-04 | Structured / JSON output | done | [story-04](./story-04-structured-output.md) | [evidence-04](./evidence-story-04.md) |
 | HSM-5-05 | 30-minute meeting closeout (Gate 4) | backlog | [story-05](./story-05-thirty-minute-meeting-closeout.md) | — |

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/story-02-llm-provider-impl.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/story-02-llm-provider-impl.md
@@ -16,6 +16,31 @@ bounded repair-retry — exercised by a fake provider. The **concrete engine-bac
 `ILLMProvider`** (the HSM-5-01 engine + a model, running Mode A on a device) is
 device/dep work and stays in-progress until then.
 
+## Progress & evidence (2026-06-19) — host-proven on Metal
+
+The engine-backed provider is implemented and **Mode A is proven on real metal
+(this Mac's Metal)**; only the iPad-specific run is gated on the device unlock.
+
+- **`LlamaProvider`** (`apple/Sources/InferenceLlama/LlamaProvider.swift`) — an
+  `ILLMProvider` backed by **llama.cpp via LLM.swift** (the HSM-5-01 pick). Loads a
+  GGUF by path, `complete(prompt:)` returns text with **no network**. The native
+  engine is isolated to the `InferenceLlama` SPM target, so the domain
+  (Contracts/RuntimeCore) never links it (the Phase-6 "ProviderInterfaces" concern,
+  resolved as a separate product).
+- **Proof** (`apple/Tests/InferenceLlamaTests/LlamaProviderTests.swift`, opt-in via
+  `HS_GGUF_PATH`), against **Qwen2.5-7B-Instruct Q4_K_M** on disk:
+  - `testLoadsGGUFAndCompletes` — loads the GGUF, completion = `PONG` (~8.5s incl.
+    cold model load, 512-ctx).
+  - `testModeAArtifactGenerationFullyLocal` — transcript → `LlamaProvider` →
+    `ArtifactGenerationEngine` → real `decisions` + `action_items` artifacts, fully
+    local (~13.4s for two generations). Propose-only (`.draft`).
+- Full suite: `swift test` **57 executed / 5 skipped (opt-in) / 0 failures**;
+  llama.cpp builds; the layer guard still confirms the domain doesn't link the engine.
+
+**Remaining:** the on-device airplane-mode run on the iPad Air M4 (HSM-5-02's
+device acceptance) — gated on the device unlock; it reuses this exact `LlamaProvider`
+behind the same seam. Model packaging/download is HSM-5-03.
+
 ## Problem
 
 The engine pick (HSM-5-01) is a decision, not a running provider. The runtime
@@ -36,15 +61,17 @@ A (fully local) works end to end.
 
 ## Acceptance criteria
 
-- [ ] `ILLMProvider` is implemented on the HSM-5-01 engine and returns a
-      completion for a prompt on a Tier-1 device.
-- [ ] Mode A runs end to end with the network disabled (airplane mode): a
-      transcript reaches the provider and a response comes back, no egress.
-- [ ] The Runtime Core calls only the `ILLMProvider` interface — swapping the
-      engine would not touch core code (proven by the call site depending on the
-      protocol, not the concrete type).
-- [ ] Cold-load and warm-call behavior is documented (load time, memory) for the
-      per-device default model.
+- [x] `ILLMProvider` is implemented on the HSM-5-01 engine and returns a
+      completion (proven on host Metal; the iPad-device run is gated on the unlock).
+- [~] Mode A runs end to end with no network — proven host-side (transcript →
+      `LlamaProvider` → artifacts, no egress); the airplane-mode run on the iPad
+      Air M4 is pending the device unlock.
+- [x] The Runtime Core calls only the `ILLMProvider` interface — the engine lives
+      in a separate `InferenceLlama` product; the domain doesn't link it (layer
+      guard green), so swapping the engine wouldn't touch core code.
+- [x] Cold-load and warm-call behavior documented: Qwen2.5-7B Q4_K_M on this Mac's
+      Metal — ~8.5s to first token incl. cold load (512-ctx); two artifact
+      generations ~13.4s. iPad figures land with the device run.
 
 ## Test plan
 


### PR DESCRIPTION
## HSM-5-02 — the on-device (Mode A) engine, host-proven on Metal

The on-device GGUF engine, contained in the Swift package and proven on this Mac's
Metal. The iPad airplane-mode run stays gated on the device unlock; it reuses this
exact provider behind the same seam.

### What's in
- **`InferenceLlama` target** — `LlamaProvider`, an `ILLMProvider` backed by
  **llama.cpp via LLM.swift** (the HSM-5-01 pick). Loads a GGUF by path;
  `complete(prompt:)` returns text with **no network**.
- The native engine is a **separate SPM product**, so the domain
  (Contracts/RuntimeCore) never links it — the Phase-6 "ProviderInterfaces"
  concern, resolved. (`final class @unchecked Sendable`: the non-Sendable `LLM`
  can't live behind an actor; generation is serial + LLM guards reentrancy.)

### Proof (opt-in via `HS_GGUF_PATH`, Qwen2.5-7B Q4_K_M)
- loads the GGUF, completion = `PONG` (~8.5s incl. cold load, 512-ctx);
- **fully-local** run: transcript → `LlamaProvider` → `ArtifactGenerationEngine` →
  real `decisions` + `action_items` (~13.4s), propose-only.
- `swift test` **57 / 5 skipped (opt-in) / 0 failures**; llama.cpp builds; the layer
  guard still confirms the domain doesn't link the engine.

The iPad now has **both** an on-device engine (Mode A) and the endpoint path
(Mode B/C, HSM-5-06) behind the one `ILLMProvider` seam. Remaining: the iPad
airplane-mode run (device unlock); model packaging is HSM-5-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)