### PR TITLE
holdspeak-mobile: Phase 7 CLOSED — MIR port (profile-driven extraction)

### DIFF
--- a/apple/Sources/RuntimeCore/MeetingIntelligence/MIRRouter.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/MIRRouter.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Contracts
+
+/// HSM-7-01/02 — the MIR routing decision, ported into the Runtime Core (Layer 2).
+///
+/// Desktop MIR-01 is a full web-runtime feature (rolling windows, hysteresis, a
+/// plugin host, synthesis, DB lineage). The mobile port keeps only the **routing
+/// decision** the Track-H gate needs: from `(active profile, per-window intent
+/// scores)` choose an ordered set of artifact types to emphasize, and feed that to
+/// the Phase-6 `ArtifactGenerationEngine`. It is **deterministic** (MIR-F-006: same
+/// input + profile → same chain) and model-free — intent scoring is the desktop
+/// lexical signal, not the LLM — so the gate is reproducible.
+///
+/// Intent vocabulary is MIR-01's verbatim five (MIR-F-003): architecture, delivery,
+/// product, incident, comms. Parked (desktop-fidelity follow-ups): windowing,
+/// hysteresis, transition events, synthesis, lineage persistence, per-window
+/// profile override (v1 is one profile per meeting).
+
+/// Per-window (here: whole-transcript) multi-label intent scores, normalized 0…1.
+public struct IntentScores: Sendable, Equatable {
+    public var scores: [MIRIntent: Double]
+    public init(_ scores: [MIRIntent: Double]) { self.scores = scores }
+
+    public func score(_ intent: MIRIntent) -> Double { scores[intent] ?? 0 }
+
+    /// Intents at/above `threshold`, strongest first; ties broken by raw value so
+    /// the order is deterministic.
+    public func above(_ threshold: Double) -> [MIRIntent] {
+        MIRIntent.allCases
+            .filter { score($0) >= threshold && score($0) > 0 }
+            .sorted { a, b in
+                let (sa, sb) = (score(a), score(b))
+                return sa == sb ? a.rawValue < b.rawValue : sa > sb
+            }
+    }
+}
+
+/// Deterministic lexical intent scoring (the desktop signal extractor's shape):
+/// count per-intent keyword hits in the transcript, normalize by total hits.
+public enum IntentScorer {
+    static let lexicons: [MIRIntent: [String]] = [
+        .architecture: ["architecture", "design", "api", "schema", "interface", "coupling",
+                        "scalability", "tradeoff", "adr", "pattern", "service", "module",
+                        "dependency", "abstraction", "contract"],
+        .delivery: ["deadline", "milestone", "sprint", "ship", "release", "timeline",
+                    "estimate", "blocker", "deliver", "schedule", "due", "velocity",
+                    "backlog", "scope creep"],
+        .product: ["user", "users", "customer", "feature", "requirement", "roadmap",
+                   "persona", "market", "priority", "feedback", "adoption", "value",
+                   "experience", "usability"],
+        .incident: ["incident", "outage", "postmortem", "root cause", "severity",
+                    "rollback", "alert", "downtime", "mitigation", "runbook", "on-call",
+                    "failure", "regression", "sev"],
+        .comms: ["announce", "stakeholder", "update", "communicate", "notify", "summary",
+                 "email", "newsletter", "broadcast", "memo", "report"],
+    ]
+
+    public static func score(_ transcript: Transcript) -> IntentScores {
+        score(text: transcript.segments.map(\.text).joined(separator: " "))
+    }
+
+    public static func score(text: String) -> IntentScores {
+        let hay = text.lowercased()
+        var hits: [MIRIntent: Int] = [:]
+        var total = 0
+        for (intent, words) in lexicons {
+            var n = 0
+            for w in words { n += occurrences(of: w, in: hay) }
+            hits[intent] = n
+            total += n
+        }
+        guard total > 0 else { return IntentScores([:]) }
+        var scores: [MIRIntent: Double] = [:]
+        for (intent, n) in hits where n > 0 { scores[intent] = Double(n) / Double(total) }
+        return IntentScores(scores)
+    }
+
+    /// Count non-overlapping occurrences of `needle` in `hay` (both lowercased).
+    static func occurrences(of needle: String, in hay: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var range = hay.startIndex..<hay.endIndex
+        while let found = hay.range(of: needle, range: range) {
+            count += 1
+            range = found.upperBound..<hay.endIndex
+        }
+        return count
+    }
+}
+
+/// Routes `(profile, intent scores)` → an ordered, de-duplicated set of artifact
+/// types for the Phase-6 engine to generate. The profile sets the base emphasis;
+/// off-profile intents that score above threshold add their signature artifact
+/// (so a "balanced" meeting that's really an incident still surfaces an incident
+/// timeline). Pure + deterministic.
+public struct MIRRouter: Sendable {
+    public let threshold: Double
+    public init(threshold: Double = 0.15) { self.threshold = threshold }
+
+    /// Each profile's base emphasis — distinct from Balanced's (HSM-7-02 gate).
+    public static let baseEmphasis: [MIRProfile: [ArtifactType]] = [
+        .balanced:  [.decisions, .actionItems, .riskRegister, .requirements],
+        .architect: [.adr, .decisions, .dependencyMap, .requirements],
+        .delivery:  [.milestonePlan, .actionItems, .riskRegister, .decisions],
+        .product:   [.requirements, .customerSignals, .scopeReview, .decisions],
+        .incident:  [.incidentTimeline, .runbookDelta, .riskRegister, .actionItems],
+    ]
+
+    /// The profile's "home" intent (its base already covers it, so we don't re-add it).
+    static let homeIntent: [MIRProfile: MIRIntent] = [
+        .architect: .architecture, .delivery: .delivery,
+        .product: .product, .incident: .incident,
+    ]
+
+    /// The signature artifact an above-threshold off-profile intent contributes.
+    static let intentSignature: [MIRIntent: ArtifactType] = [
+        .architecture: .adr, .delivery: .milestonePlan, .product: .customerSignals,
+        .incident: .incidentTimeline, .comms: .stakeholderUpdate,
+    ]
+
+    public func emphasis(for profile: MIRProfile) -> [ArtifactType] {
+        Self.baseEmphasis[profile] ?? Self.baseEmphasis[.balanced]!
+    }
+
+    /// The routed artifact chain for this profile + scores.
+    public func route(profile: MIRProfile, scores: IntentScores) -> [ArtifactType] {
+        var chain = emphasis(for: profile)
+        let home = Self.homeIntent[profile]
+        for intent in scores.above(threshold) where intent != home {
+            if let sig = Self.intentSignature[intent], !chain.contains(sig) {
+                chain.append(sig)
+            }
+        }
+        return chain
+    }
+}

--- a/apple/Sources/RuntimeCore/MeetingIntelligence/RoutedArtifactGenerator.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/RoutedArtifactGenerator.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Contracts
+import Providers
+
+/// HSM-7-01/03 — profile-driven artifact generation: the MIR routing decision in
+/// front of the Phase-6 engine. Score the transcript's intents, route to an
+/// artifact chain for the active profile, then generate. This is what makes Phase-6
+/// generation profile-driven instead of one-size-fits-all.
+public struct RoutedArtifactGenerator: Sendable {
+    let engine: ArtifactGenerationEngine
+    let router: MIRRouter
+
+    public init(engine: ArtifactGenerationEngine, router: MIRRouter = MIRRouter()) {
+        self.engine = engine
+        self.router = router
+    }
+
+    public struct RoutedRun: Sendable {
+        /// The routed artifact chain (the routing decision — deterministic).
+        public let routedTypes: [ArtifactType]
+        public let scores: IntentScores
+        public let results: [(type: ArtifactType, result: Result<Artifact, Error>)]
+        /// The artifacts that generated successfully.
+        public var artifacts: [Artifact] { results.compactMap { try? $0.result.get() } }
+    }
+
+    /// Route + generate for an explicit profile.
+    public func generate(from transcript: Transcript, profile: MIRProfile) async -> RoutedRun {
+        let scores = IntentScorer.score(transcript)
+        let types = router.route(profile: profile, scores: scores)
+        let results = await engine.generate(types: types, from: transcript)
+        return RoutedRun(routedTypes: types, scores: scores, results: results)
+    }
+
+    /// Route + generate using the meeting's carried profile (the HSM-7-03 seam).
+    public func generate(from transcript: Transcript, for meeting: Meeting) async -> RoutedRun {
+        await generate(from: transcript, profile: meeting.routingProfile)
+    }
+}
+
+public extension Meeting {
+    /// HSM-7-03 — the profile-selection seam: the routing profile rides on the
+    /// `Meeting` per the Phase-0 contract (`mir_profile`). A host UI reads/writes
+    /// `mirProfile`; the engine reads this, defaulting to `.balanced` when unset.
+    var routingProfile: MIRProfile { mirProfile ?? .balanced }
+}

--- a/apple/Tests/RuntimeCoreTests/MIRRouterTests.swift
+++ b/apple/Tests/RuntimeCoreTests/MIRRouterTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-7-01..04 — the MIR routing port. All host-testable + deterministic (the
+/// routing decision is model-free; the gate measures artifact-type set differences,
+/// which depend only on the router).
+final class MIRRouterTests: XCTestCase {
+
+    // A fake provider so generation succeeds for any routed type — the gate measures
+    // the routed TYPE SET, not model output.
+    final class StubLLM: ILLMProvider, @unchecked Sendable {
+        func complete(prompt: String) async throws -> String {
+            #"{"title":"t","body_markdown":"b","structured_json":{},"confidence":0.5}"#
+        }
+    }
+
+    struct Sample: Codable { let meeting: Meeting; let artifact: Artifact }
+    private func fixtureMeeting() throws -> Meeting {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<4 { url.deleteLastPathComponent() }
+        url.appendPathComponent("pm/roadmap/holdspeak-mobile/contracts/fixtures/meeting-sample.json")
+        return try HoldSpeakContracts.decoder().decode(Sample.self, from: Data(contentsOf: url)).meeting
+    }
+
+    private func transcript(_ lines: [String]) -> Transcript {
+        var t = 0.0
+        let segs = lines.map { line -> Segment in
+            defer { t += 5 }
+            return Segment(text: line, speaker: "S", startTime: t, endTime: t + 5)
+        }
+        return Transcript(meetingId: "mir_001", segments: segs, transcriptHash: "h")
+    }
+
+    // MARK: - HSM-7-01: intent scoring
+
+    func testIntentScorerDetectsDominantIntent() {
+        let arch = IntentScorer.score(text: "Let's discuss the API design, the schema, the service interface and the dependency tradeoffs.")
+        XCTAssertEqual(arch.above(0.15).first, .architecture)
+
+        let inc = IntentScorer.score(text: "We had an outage; severity high, the postmortem found the root cause, we did a rollback and updated the runbook.")
+        XCTAssertEqual(inc.above(0.15).first, .incident)
+
+        XCTAssertTrue(IntentScorer.score(text: "hello there").scores.isEmpty)
+    }
+
+    // MARK: - HSM-7-02: five profiles, distinct emphasis
+
+    func testEveryProfileExistsAndDiffersFromBalanced() {
+        let balanced = Set(MIRRouter.baseEmphasis[.balanced]!)
+        for profile in MIRProfile.allCases {
+            XCTAssertNotNil(MIRRouter.baseEmphasis[profile], "\(profile) has no emphasis")
+            if profile != .balanced {
+                XCTAssertNotEqual(Set(MIRRouter.baseEmphasis[profile]!), balanced,
+                                  "\(profile) emphasis must differ from balanced")
+            }
+        }
+        XCTAssertEqual(MIRProfile.allCases.count, 5)   // charter five
+    }
+
+    // MARK: - HSM-7-01: deterministic routing + score-driven additions
+
+    func testRouteIsDeterministic() {
+        let scores = IntentScorer.score(text: "incident outage severity rollback runbook")
+        let r = MIRRouter()
+        XCTAssertEqual(r.route(profile: .balanced, scores: scores),
+                       r.route(profile: .balanced, scores: scores))
+    }
+
+    func testOffProfileIntentAddsItsSignatureArtifact() {
+        // A "balanced" meeting that is really an incident picks up the incident timeline.
+        let scores = IntentScorer.score(text: "outage outage incident severity postmortem rollback runbook downtime mitigation alert")
+        let chain = MIRRouter().route(profile: .balanced, scores: scores)
+        XCTAssertTrue(chain.contains(.incidentTimeline), "off-profile incident should add its signature")
+        XCTAssertTrue(chain.starts(with: MIRRouter.baseEmphasis[.balanced]!), "base emphasis preserved first")
+    }
+
+    func testHomeIntentNotDuplicated() {
+        let scores = IntentScorer.score(text: "architecture design api schema service module dependency pattern")
+        let chain = MIRRouter().route(profile: .architect, scores: scores)
+        XCTAssertEqual(chain.filter { $0 == .adr }.count, 1, "architect's home intent must not double-add adr")
+    }
+
+    // MARK: - HSM-7-03: profile seam on Meeting
+
+    func testProfileSeamRoundTripsOnMeeting() throws {
+        var meeting = try fixtureMeeting()
+        meeting.mirProfile = .architect
+        let data = try HoldSpeakContracts.encoder().encode(meeting)
+        let back = try HoldSpeakContracts.decoder().decode(Meeting.self, from: data)
+        XCTAssertEqual(back.mirProfile, .architect)
+        XCTAssertEqual(back.routingProfile, .architect)
+
+        meeting.mirProfile = nil
+        XCTAssertEqual(meeting.routingProfile, .balanced)   // safe default
+    }
+
+    // MARK: - HSM-7-04: the gate — profile measurably changes extraction
+
+    func testGateProfileChangesExtraction() async {
+        // One identical input; everything constant except the profile.
+        let input = transcript([
+            "We need to lock the API design and the service schema and the module dependencies.",
+            "There was also an incident: an outage with high severity; we did a rollback and a postmortem.",
+            "And the customer feedback on the feature roadmap matters for the user requirements.",
+        ])
+        let gen = RoutedArtifactGenerator(engine: ArtifactGenerationEngine(provider: StubLLM()))
+
+        let control = await gen.generate(from: input, profile: .balanced)
+        let treatment = await gen.generate(from: input, profile: .architect)
+
+        let controlTypes = Set(control.artifacts.map(\.artifactType))
+        let treatmentTypes = Set(treatment.artifacts.map(\.artifactType))
+        let delta = controlTypes.symmetricDifference(treatmentTypes)
+
+        print("HSM-7-04 gate: balanced=\(controlTypes.map(\.rawValue).sorted()) "
+            + "architect=\(treatmentTypes.map(\.rawValue).sorted()) delta=\(delta.map(\.rawValue).sorted())")
+
+        XCTAssertFalse(delta.isEmpty, "switching profile must measurably change the artifact set")
+        XCTAssertGreaterThan(control.artifacts.count, 0)
+        XCTAssertGreaterThan(treatment.artifacts.count, 0)
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,15 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**HSM-5-03 — model packaging: both delivery paths
+**Last updated:** 2026-06-19 (**Phase 7 CLOSED ✅ — the MIR port, host-proven.** The
+profile-driven routing decision lives in RuntimeCore: `IntentScorer` (deterministic
+lexical scoring of MIR-01's five intents) → `MIRRouter` (per-profile emphasis +
+score-driven additions → ordered `ArtifactType` chain) → `RoutedArtifactGenerator`
+driving the Phase-6 engine. Five distinct profiles; profile rides on
+`Meeting.mirProfile` (Phase-0 contract). **Track-H gate PASSED**: same transcript,
+balanced vs architect → artifact-type delta `{action_items, dependency_map,
+risk_register}`. `swift test` **69/6-skip/0-fail**; model-free + deterministic.
+See [`phase-7…/final-summary.md`](./phase-7-mir-port/final-summary.md). Earlier:
+**HSM-5-03 — model packaging: both delivery paths
 host-proven (Files sideload + Hugging Face download).** A `ModelCatalog` pins the
 per-tier GGUFs (4B Llama-3.2-3B / 8B Llama-3.1-8B / 12B+ Mistral-Nemo, Q4_K_M; HF
 URLs verified live), a Foundation `ModelStore` is the model manager (list /
@@ -152,8 +161,8 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-6-meeting-intelligence](./phase-6-meeting-intelligence/current-phase-status.md) (Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5 PASSED**; 2 + 3 + 5 testable cores done, device-gated remainder; Phase 5 — HSM-5-06 endpoint provider host/live-proven + on-device build; 6-06 Follow-ups deferred on a contract decision)
-**Status:** in-progress (Phases 0–1–4 closed, **Phase 6 closed — Gate 5 desktop-parity PASSED at mean 0.92 vs 0.8**; Phase 2 + 3 + 5 testable cores shipped; HSM-5-06 makes the iPad run real meeting intelligence via an OpenAI-compatible endpoint, on-device launch pending the device unlock; **Phase 10 (Sync) opened — HSM-10-01 object model + engine host-proven**. Next: HSM-10-02 sync transport + Python sync API; the iPad on-device captures (HSM-5-06 launch, HSM-5-02 GGUF) when the device is unlocked).
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred.
+**Status:** in-progress (Phases 0–1–4 closed, **Phase 6 closed (Gate 5 desktop-parity PASSED 0.92)**, **Phase 7 closed (MIR port — profile measurably changes extraction)**; Phase 5 host-complete — on-device Mode A + endpoint Modes B/C + sideload/HF packaging, device runs await the iPad unlock; Phase 10 opened (sync object model + engine). Next device-free: HSM-10-02 sync transport + Python sync API, or Phases 8/9 experience. iPad on-device batch (HSM-5-02/03/06 + Gate-4) when the device is unlocked).
 
 ## Vision
 
@@ -214,7 +223,7 @@ WebView, or UIKit.
 | 4 | E | SQLite persistence with full crash recovery | **done (3/3)** | [phase-4](./phase-4-persistence/) |
 | 5 | F | Local inference (4B/8B) — a 30-min meeting processed on-device | in-progress (engine pick + structured-output + model policy done; HSM-5-06 endpoint Modes B/C; **HSM-5-02 LlamaProvider/Mode A host-proven on Metal**; **HSM-5-03 packaging — sideload + HF download host-proven**; iPad runs + HSM-5-05 gate device) | [phase-5](./phase-5-local-inference/) |
 | 6 | G | Meeting intelligence: structured-JSON artifacts at desktop parity | **Gate 5 PASSED ✅ (5/6; 6-06 deferred)** | [phase-6](./phase-6-meeting-intelligence/) |
-| 7 | H | MIR port: 5 profiles measurably alter extraction | not-started | [phase-7](./phase-7-mir-port/) |
+| 7 | H | MIR port: 5 profiles measurably alter extraction | **done (4/4) ✅** | [phase-7](./phase-7-mir-port/) |
 | 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes | not-started | [phase-9](./phase-9-iphone-experience/) |
 | 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (1/4; HSM-10-01 object model + engine host-proven) | [phase-10](./phase-10-sync/) |

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/current-phase-status.md
@@ -1,13 +1,21 @@
 # Phase 7 — MIR Port
 
-**Status:** planning (scaffolded 2026-06-18). Track H of the Council
+**Status:** CLOSED ✅ 2026-06-19 — Track-H gate met (4/4). Track H of the Council
 Implementation Charter. Ports the desktop's Meeting Intelligence Routing
 (MIR-01 canon, `docs/internal/PLAN_PHASE_MULTI_INTENT_ROUTING.md`) into the
 mobile Runtime Core (Layer 2), so the artifact generation Phase 6 stood up
 becomes profile-driven instead of one-size-fits-all.
 
-**Last updated:** 2026-06-18 (scaffolded — stories HSM-7-01..04 stubbed from
-charter Track H and the MIR-01 canon; no work started).
+**Last updated:** 2026-06-19 (**Phase 7 CLOSED — the MIR port, host-proven.** The
+routing decision (`IntentScorer` deterministic lexical scoring of MIR-01's five
+intents → `MIRRouter` profile-emphasis tables + score-driven additions → ordered
+`ArtifactType` chain) lives in RuntimeCore and drives the Phase-6 engine via
+`RoutedArtifactGenerator`. Five profiles with distinct emphasis; profile rides on
+`Meeting.mirProfile` (Phase-0 contract). **Track-H gate PASSED**: same transcript,
+balanced vs architect → artifact-type delta `{action_items, dependency_map,
+risk_register}`. `swift test` 69/6-skip/0-fail. Model-free + deterministic; desktop
+windows/hysteresis/synthesis/lineage + per-window override parked. See
+[`final-summary.md`](./final-summary.md).)
 
 ## Goal
 
@@ -62,10 +70,10 @@ measurably different extraction.
 
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
-| HSM-7-01 | Port the MIR routing engine | backlog | [story-01](./story-01-mir-engine-port.md) | — |
-| HSM-7-02 | The five profiles | backlog | [story-02](./story-02-five-profiles.md) | — |
-| HSM-7-03 | Profile-selection seam | backlog | [story-03](./story-03-profile-selection-seam.md) | — |
-| HSM-7-04 | Profile-effect gate closeout | backlog | [story-04](./story-04-profile-effect-closeout.md) | — |
+| HSM-7-01 | Port the MIR routing engine | done | [story-01](./story-01-mir-engine-port.md) | [evidence-01](./evidence-story-01.md) |
+| HSM-7-02 | The five profiles | done | [story-02](./story-02-five-profiles.md) | [evidence-02](./evidence-story-02.md) |
+| HSM-7-03 | Profile-selection seam | done | [story-03](./story-03-profile-selection-seam.md) | [evidence-03](./evidence-story-03.md) |
+| HSM-7-04 | Profile-effect gate closeout | done | [story-04](./story-04-profile-effect-closeout.md) | [evidence-04](./evidence-story-04.md) |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-01.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-01.md
@@ -1,0 +1,22 @@
+# Evidence — HSM-7-01 — Port the MIR routing engine
+
+- **Shipped:** 2026-06-19 · **Branch:** `holdspeak-mobile/phase-7-mir-port`
+
+## Files
+- `apple/Sources/RuntimeCore/MeetingIntelligence/MIRRouter.swift` — `IntentScorer`
+  (deterministic lexical scoring of MIR-01's five intents), `IntentScores`,
+  `MIRRouter` (`route(profile:scores:) -> [ArtifactType]`).
+- `apple/Sources/RuntimeCore/MeetingIntelligence/RoutedArtifactGenerator.swift` —
+  scores intents → routes → drives the Phase-6 `ArtifactGenerationEngine`.
+
+## Verification (`swift test`, RuntimeCoreTests/MIRRouterTests)
+- `testIntentScorerDetectsDominantIntent` — architecture/incident text scores its intent top; empty → no scores.
+- `testRouteIsDeterministic` — same (profile, scores) → identical chain (MIR-F-006).
+- `testOffProfileIntentAddsItsSignatureArtifact` — an above-threshold off-profile intent appends its signature artifact (MIR-F-004 multi-intent reaches generation).
+- `testHomeIntentNotDuplicated` — a profile's home intent doesn't double-add.
+- Full suite **69 / 6 skipped / 0 failures**.
+
+## Notes
+Ported only the routing **decision** (profile + scores → emphasis), model-free
+(lexical, not the LLM) so the gate is reproducible. Parked desktop-fidelity:
+windows/hysteresis/transitions/synthesis/lineage (Decisions deferred).

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-02.md
@@ -1,0 +1,21 @@
+# Evidence — HSM-7-02 — The five profiles
+
+- **Shipped:** 2026-06-19 · **Branch:** `holdspeak-mobile/phase-7-mir-port`
+
+## What
+`MIRRouter.baseEmphasis` defines the five charter profiles' per-profile artifact
+emphasis (distinct ordered `ArtifactType` chains), over MIR-01's intent set:
+
+- **balanced** → decisions, action_items, risk_register, requirements
+- **architect** → adr, decisions, dependency_map, requirements
+- **delivery** → milestone_plan, action_items, risk_register, decisions
+- **product** → requirements, customer_signals, scope_review, decisions
+- **incident** → incident_timeline, runbook_delta, risk_register, action_items
+
+Off-profile intents above threshold contribute their signature artifact
+(`intentSignature`), so content also shapes the chain.
+
+## Verification
+`testEveryProfileExistsAndDiffersFromBalanced` — all five profiles present; every
+non-balanced emphasis differs from balanced; `MIRProfile.allCases.count == 5`.
+`swift test` 69 / 6 skipped / 0 failures.

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-03.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-03.md
@@ -1,0 +1,17 @@
+# Evidence — HSM-7-03 — Profile-selection seam
+
+- **Shipped:** 2026-06-19 · **Branch:** `holdspeak-mobile/phase-7-mir-port`
+
+## What
+The routing profile rides on the Phase-0 contract field `Meeting.mirProfile` (no
+side-table, no contract fork). A RuntimeCore helper `Meeting.routingProfile` reads
+it, defaulting to `.balanced` when unset; `RoutedArtifactGenerator.generate(from:for:)`
+uses it. A host UI reads/writes `mirProfile` without touching engine internals.
+
+## Verification
+`testProfileSeamRoundTripsOnMeeting` — a `Meeting` with `mirProfile = .architect`
+round-trips through the contract coder (`mirProfile` + `routingProfile` == `.architect`);
+`nil` → `routingProfile == .balanced`. `swift test` 69 / 6 skipped / 0 failures.
+
+## Note
+v1 is one profile per meeting; per-window override (MIR-F-007) is parked (Decisions deferred).

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-04.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/evidence-story-04.md
@@ -1,0 +1,25 @@
+# Evidence — HSM-7-04 — Profile-effect gate closeout (Track-H gate)
+
+- **Shipped:** 2026-06-19 · **Branch:** `holdspeak-mobile/phase-7-mir-port`
+
+## The gate — PASSED
+
+Control-vs-treatment over **one identical transcript** (mixed architecture +
+incident + product content), holding everything constant except the profile, with a
+deterministic fake provider so the measured difference is purely the routing:
+
+```
+balanced  → {action_items, adr, customer_signals, decisions, incident_timeline, requirements, risk_register}
+architect → {adr, customer_signals, decisions, dependency_map, incident_timeline, requirements}
+delta (symmetric difference) → {action_items, dependency_map, risk_register}
+```
+
+**Metric:** artifact-type set symmetric difference. **Result:** non-empty (3 types) —
+switching the profile measurably changes the extracted artifact set. (Both profiles
+also picked up `customer_signals` + `incident_timeline` from the off-profile intents
+scored in the transcript — the score-driven additions working.)
+
+## Verification
+`testGateProfileChangesExtraction` (RuntimeCoreTests/MIRRouterTests) asserts the
+delta is non-empty and both runs produce artifacts. Deterministic + reproducible.
+`swift test` **69 / 6 skipped / 0 failures**. Closes Phase 7 (see `final-summary.md`).

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/final-summary.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/final-summary.md
@@ -1,0 +1,37 @@
+# Phase 7 — MIR Port — final summary
+
+**Closed:** 2026-06-19 (Track-H gate met). Track H of the Council Implementation Charter.
+
+## Charter gate — PASSED
+
+**Track H: profile changes measurably alter extraction.** A control-vs-treatment
+run over one identical transcript, everything constant except the profile:
+balanced vs architect produced an artifact-type **delta of `{action_items,
+dependency_map, risk_register}`** (symmetric difference of the routed type sets).
+Deterministic + reproducible. See [`evidence-story-04.md`](./evidence-story-04.md).
+
+## What shipped
+
+| Story | Outcome |
+|---|---|
+| HSM-7-01 | The MIR routing decision in RuntimeCore: `IntentScorer` (deterministic lexical scoring of MIR-01's five intents) + `MIRRouter` (profile + scores → ordered `ArtifactType` chain) + `RoutedArtifactGenerator` driving the Phase-6 engine. |
+| HSM-7-02 | The five charter profiles (Balanced/Architect/Delivery/Product/Incident) with distinct per-profile artifact emphasis; each differs from Balanced. |
+| HSM-7-03 | Profile seam on the Phase-0 contract (`Meeting.mirProfile` + `routingProfile` helper); round-trip proven. |
+| HSM-7-04 | **Gate PASSED** (above). |
+
+`swift test` **69 / 6 skipped (opt-in) / 0 failures**.
+
+## Scope honored / parked
+
+- Ported only the **routing decision** (charter Track H), model-free (lexical, not
+  the LLM) so the gate is reproducible — the artifact generators themselves are
+  Phase 6.
+- **Parked desktop-fidelity follow-ups** (per Decisions deferred): rolling windows,
+  hysteresis, intent-transition events, synthesis, lineage persistence, and
+  per-window profile override (v1 is one profile per meeting). File as a parity
+  story if/when a surface needs them.
+
+## Decisions of record
+- Routing is deterministic + lexical (MIR-F-006), one profile per `Meeting` for v1,
+  carried on the contract field (no fork). Intent vocabulary is MIR-01's verbatim
+  five (architecture/delivery/product/incident/comms).

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-01-mir-engine-port.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-01-mir-engine-port.md
@@ -2,7 +2,9 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 7
-- **Status:** backlog
+- **Status:** done (2026-06-19 — `IntentScorer` + `MIRRouter` + `RoutedArtifactGenerator`
+  in RuntimeCore; deterministic, model-free; drives the Phase-6 engine. See
+  [evidence-01](./evidence-story-01.md).)
 - **Depends on:** HSM-6-01
 - **Unblocks:** HSM-7-02, HSM-7-03, HSM-7-04
 - **Owner:** unassigned

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-02-five-profiles.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-02-five-profiles.md
@@ -2,7 +2,9 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 7
-- **Status:** backlog
+- **Status:** done (2026-06-19 — five profiles with distinct per-profile artifact
+  emphasis over MIR-01's intent set; each differs from Balanced. See
+  [evidence-02](./evidence-story-02.md).)
 - **Depends on:** HSM-7-01
 - **Unblocks:** HSM-7-04
 - **Owner:** unassigned

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-03-profile-selection-seam.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-03-profile-selection-seam.md
@@ -2,7 +2,9 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 7
-- **Status:** backlog
+- **Status:** done (2026-06-19 — profile rides on `Meeting.mirProfile` (Phase-0
+  contract) + `routingProfile` helper (defaults `.balanced`); round-trip proven. See
+  [evidence-03](./evidence-story-03.md).)
 - **Depends on:** HSM-7-01, HSM-0-01
 - **Unblocks:** HSM-8-04, HSM-9-02
 - **Owner:** unassigned

--- a/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-04-profile-effect-closeout.md
+++ b/pm/roadmap/holdspeak-mobile/phase-7-mir-port/story-04-profile-effect-closeout.md
@@ -2,7 +2,9 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 7
-- **Status:** backlog
+- **Status:** done (2026-06-19 — **Track-H gate PASSED**: same transcript,
+  balanced vs architect → artifact-type delta `{action_items, dependency_map,
+  risk_register}`. See [evidence-04](./evidence-story-04.md).)
 - **Depends on:** HSM-7-01, HSM-7-02, HSM-7-03
 - **Owner:** unassigned
 


### PR DESCRIPTION
## Phase 7 — MIR port (closes the phase; bundles HSM-7-01..04)

Ports the desktop MIR routing **decision** into the mobile Runtime Core so the
active profile measurably shapes what Phase-6 extracts. Pure Swift, host-proven,
no device needed.

### What's in
- **`IntentScorer`** — deterministic lexical scoring of MIR-01's five intents
  (architecture / delivery / product / incident / comms).
- **`MIRRouter`** — per-profile base emphasis + score-driven off-profile additions
  → an ordered `ArtifactType` chain. Deterministic (MIR-F-006).
- **`RoutedArtifactGenerator`** — scores → routes → drives the Phase-6 engine.
- **Profile seam** on the Phase-0 contract (`Meeting.mirProfile` + `routingProfile`).
- **Five profiles**, each with distinct emphasis.

### Track-H gate — PASSED
Same transcript, everything constant except the profile:
```
balanced  → {action_items, adr, customer_signals, decisions, incident_timeline, requirements, risk_register}
architect → {adr, customer_signals, decisions, dependency_map, incident_timeline, requirements}
delta     → {action_items, dependency_map, risk_register}
```
Switching the profile measurably changes the artifact set.

`swift test` **69 / 6 skipped (opt-in) / 0 failures** (7 new MIR tests). Model-free
+ deterministic so the gate is reproducible. Desktop windows/hysteresis/synthesis/
lineage + per-window override parked (Decisions deferred).

Bundled phase-close per `.tmp/BUNDLE-OK.md` (the gate exercises all four stories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)