### PR TITLE
holdspeak-mobile: Phase 10 — HSM-10-02 (PR-A) Swift sync transport + offline queue

### DIFF
--- a/apple/Sources/Providers/Sync/HTTPSyncProvider.swift
+++ b/apple/Sources/Providers/Sync/HTTPSyncProvider.swift
@@ -1,0 +1,74 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+/// HSM-10-02 — the sync transport: an `ISyncProvider` over plain HTTP to the user's
+/// own peer (HoldSpeak Desktop / homelab), reached directly over their network
+/// (e.g. Tailscale) — no hosted relay. `push` POSTs a change-set; `pull` GETs the
+/// peer's. One implementation of the seam, so swapping it never touches the Runtime
+/// Core. Offline tolerance is the queue's job (`SyncQueue`); this type just does the
+/// round-trip and fails honestly when the peer is unreachable.
+public struct HTTPSyncProvider: ISyncProvider {
+    public struct Config: Sendable, Equatable {
+        public var baseURL: URL
+        public var apiKey: String?
+        public var timeout: TimeInterval
+        public init(baseURL: URL, apiKey: String? = nil, timeout: TimeInterval = 30) {
+            self.baseURL = baseURL
+            self.apiKey = apiKey
+            self.timeout = timeout
+        }
+    }
+
+    public enum SyncTransportError: Error, Equatable {
+        case http(status: Int)
+        case malformedResponse
+    }
+
+    let config: Config
+    let session: URLSession
+
+    public init(config: Config, session: URLSession = .shared) {
+        self.config = config
+        self.session = session
+    }
+
+    /// Honest egress descriptor for the badge: sync leaves the device for a LAN peer.
+    public var egressLabel: String { "local + LAN → \(config.baseURL.host ?? config.baseURL.absoluteString)" }
+
+    public func push(_ changeSet: ChangeSet) async throws {
+        var request = makeRequest(path: "api/sync/push", method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try HoldSpeakContracts.encoder().encode(changeSet)
+        let (_, response) = try await session.data(for: request)
+        try check(response)
+    }
+
+    public func pull() async throws -> ChangeSet {
+        let request = makeRequest(path: "api/sync/pull", method: "GET")
+        let (data, response) = try await session.data(for: request)
+        try check(response)
+        do { return try HoldSpeakContracts.decoder().decode(ChangeSet.self, from: data) }
+        catch { throw SyncTransportError.malformedResponse }
+    }
+
+    private func makeRequest(path: String, method: String) -> URLRequest {
+        let base = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
+        request.httpMethod = method
+        request.timeoutInterval = config.timeout
+        if let apiKey = config.apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private func check(_ response: URLResponse) throws {
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw SyncTransportError.http(status: http.statusCode)
+        }
+    }
+}

--- a/apple/Sources/Providers/Sync/SyncQueue.swift
+++ b/apple/Sources/Providers/Sync/SyncQueue.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Contracts
+
+/// HSM-10-02 — offline tolerance for sync. A disk-backed FIFO of change-sets the
+/// app records locally; flushing pushes them to a peer and drops each on success.
+/// Sync is **never on the capture/review path**: you record a change-set instantly
+/// (a local file write), and `flush` resumes opportunistically when a peer is
+/// reachable. If the peer is down, the queue is left intact and the app is
+/// unaffected — `flush` swallows transport errors rather than propagating them.
+public struct SyncQueue: Sendable {
+    public let directory: URL
+
+    public init(directory: URL) { self.directory = directory }
+
+    public static func defaultDirectory() throws -> URL {
+        let base = try FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        let dir = base.appendingPathComponent("HoldSpeak/sync-queue", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func ensure() throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    /// Record a change-set to the queue. `seq` is a zero-padded monotonic ordinal so
+    /// the lexical filename order is FIFO order (caller supplies it — e.g. a counter
+    /// or a timestamp — keeping this type free of clock/RNG).
+    @discardableResult
+    public func enqueue(_ changeSet: ChangeSet, seq: Int) throws -> URL {
+        try ensure()
+        let name = String(format: "%012d.json", seq)
+        let url = directory.appendingPathComponent(name)
+        try HoldSpeakContracts.encoder().encode(changeSet).write(to: url)
+        return url
+    }
+
+    /// Queued change-sets in FIFO order.
+    public func pending() throws -> [URL] {
+        try ensure()
+        return try FileManager.default
+            .contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    public func count() throws -> Int { try pending().count }
+
+    /// Push every queued change-set to the peer, dropping each on success. On the
+    /// first transport failure it **stops and leaves the rest queued** (offline →
+    /// resume later) and does NOT throw. Returns how many were flushed.
+    @discardableResult
+    public func flush(through provider: ISyncProvider) async -> Int {
+        guard let urls = try? pending() else { return 0 }
+        var flushed = 0
+        for url in urls {
+            guard
+                let data = try? Data(contentsOf: url),
+                let changeSet = try? HoldSpeakContracts.decoder().decode(ChangeSet.self, from: data)
+            else {
+                try? FileManager.default.removeItem(at: url)   // unreadable/corrupt → drop, keep going
+                continue
+            }
+            do {
+                try await provider.push(changeSet)
+                try? FileManager.default.removeItem(at: url)
+                flushed += 1
+            } catch {
+                break   // peer unreachable — stop, keep the rest, resume later
+            }
+        }
+        return flushed
+    }
+}

--- a/apple/Tests/ProvidersTests/SyncTransportTests.swift
+++ b/apple/Tests/ProvidersTests/SyncTransportTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HSM-10-02 — the HTTP sync transport + offline queue. Network stubbed via
+/// `URLProtocol`; the queue uses temp dirs. All offline + deterministic.
+final class SyncTransportTests: XCTestCase {
+
+    // MARK: stubs
+
+    final class SyncStubProtocol: URLProtocol {
+        nonisolated(unsafe) static var handler: ((URLRequest) -> (Int, Data))?
+        nonisolated(unsafe) static var lastMethod: String?
+        nonisolated(unsafe) static var lastURL: URL?
+        nonisolated(unsafe) static var lastBody: Data?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            SyncStubProtocol.lastMethod = request.httpMethod
+            SyncStubProtocol.lastURL = request.url
+            SyncStubProtocol.lastBody = request.httpBody ?? request.httpBodyStream.map { s in
+                s.open(); defer { s.close() }
+                var d = Data(); var buf = [UInt8](repeating: 0, count: 4096)
+                while s.hasBytesAvailable { let n = s.read(&buf, maxLength: 4096); if n <= 0 { break }; d.append(buf, count: n) }
+                return d
+            }
+            let (status, body) = SyncStubProtocol.handler?(request) ?? (500, Data())
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [SyncStubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    private func provider(_ session: URLSession) -> HTTPSyncProvider {
+        HTTPSyncProvider(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!), session: session)
+    }
+
+    private func sampleChangeSet() -> ChangeSet {
+        ChangeSet(meetings: [.tombstone(id: "m1", kind: .meeting, at: Date(timeIntervalSince1970: 1))])
+    }
+
+    // Fake providers for queue tests.
+    final class OKProvider: ISyncProvider, @unchecked Sendable {
+        var pushed = 0
+        func push(_ changeSet: ChangeSet) async throws { pushed += 1 }
+        func pull() async throws -> ChangeSet { ChangeSet() }
+    }
+    final class UnreachableProvider: ISyncProvider, @unchecked Sendable {
+        struct Down: Error {}
+        func push(_ changeSet: ChangeSet) async throws { throw Down() }
+        func pull() async throws -> ChangeSet { throw Down() }
+    }
+    final class FailAfterProvider: ISyncProvider, @unchecked Sendable {
+        struct Down: Error {}
+        let limit: Int; var pushed = 0
+        init(limit: Int) { self.limit = limit }
+        func push(_ changeSet: ChangeSet) async throws {
+            if pushed >= limit { throw Down() }; pushed += 1
+        }
+        func pull() async throws -> ChangeSet { ChangeSet() }
+    }
+
+    // MARK: HTTPSyncProvider
+
+    func testPushPostsChangeSetToSyncEndpoint() async throws {
+        SyncStubProtocol.handler = { _ in (200, Data()) }
+        try await provider(stubbedSession()).push(sampleChangeSet())
+        XCTAssertEqual(SyncStubProtocol.lastMethod, "POST")
+        XCTAssertEqual(SyncStubProtocol.lastURL?.absoluteString, "http://desk.tailnet:8000/api/sync/push")
+        let body = try XCTUnwrap(SyncStubProtocol.lastBody)
+        let decoded = try HoldSpeakContracts.decoder().decode(ChangeSet.self, from: body)
+        XCTAssertEqual(decoded.meetings.first?.meta.id, "m1")
+        XCTAssertTrue(decoded.meetings.first?.meta.deleted == true)
+    }
+
+    func testPullDecodesChangeSet() async throws {
+        SyncStubProtocol.handler = { _ in
+            (200, try! HoldSpeakContracts.encoder().encode(
+                ChangeSet(artifacts: [.tombstone(id: "a1", kind: .artifact, at: Date(timeIntervalSince1970: 2))])))
+        }
+        let cs = try await provider(stubbedSession()).pull()
+        XCTAssertEqual(SyncStubProtocol.lastURL?.absoluteString, "http://desk.tailnet:8000/api/sync/pull")
+        XCTAssertEqual(cs.artifacts.first?.meta.id, "a1")
+    }
+
+    func testPushNon2xxThrows() async {
+        SyncStubProtocol.handler = { _ in (503, Data()) }
+        do { try await provider(stubbedSession()).push(sampleChangeSet()); XCTFail("expected error") }
+        catch HTTPSyncProvider.SyncTransportError.http(let s) { XCTAssertEqual(s, 503) }
+        catch { XCTFail("wrong error: \(error)") }
+    }
+
+    func testEgressLabelIsHonest() {
+        XCTAssertTrue(provider(stubbedSession()).egressLabel.contains("LAN"))
+        XCTAssertTrue(provider(stubbedSession()).egressLabel.contains("desk.tailnet"))
+    }
+
+    // MARK: SyncQueue offline tolerance
+
+    private func tempQueue() -> SyncQueue {
+        SyncQueue(directory: URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hsm-q-\(UUID().uuidString)", isDirectory: true))
+    }
+
+    func testEnqueuePreservesFIFOOrder() throws {
+        let q = tempQueue()
+        try q.enqueue(sampleChangeSet(), seq: 0)
+        try q.enqueue(sampleChangeSet(), seq: 1)
+        try q.enqueue(sampleChangeSet(), seq: 2)
+        XCTAssertEqual(try q.pending().map(\.lastPathComponent),
+                       ["000000000000.json", "000000000001.json", "000000000002.json"])
+    }
+
+    func testFlushDrainsWhenPeerReachable() async throws {
+        let q = tempQueue()
+        for i in 0..<3 { try q.enqueue(sampleChangeSet(), seq: i) }
+        let ok = OKProvider()
+        let n = await q.flush(through: ok)
+        XCTAssertEqual(n, 3)
+        XCTAssertEqual(ok.pushed, 3)
+        XCTAssertEqual(try q.count(), 0)
+    }
+
+    func testFlushKeepsQueueWhenPeerUnreachable() async throws {
+        let q = tempQueue()
+        for i in 0..<3 { try q.enqueue(sampleChangeSet(), seq: i) }
+        let n = await q.flush(through: UnreachableProvider())   // must not throw
+        XCTAssertEqual(n, 0)
+        XCTAssertEqual(try q.count(), 3)   // intact → resume later
+    }
+
+    func testFlushIsPartialAndResumable() async throws {
+        let q = tempQueue()
+        for i in 0..<3 { try q.enqueue(sampleChangeSet(), seq: i) }
+        let n = await q.flush(through: FailAfterProvider(limit: 2))
+        XCTAssertEqual(n, 2)
+        XCTAssertEqual(try q.count(), 1)   // the rest stays queued
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,13 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Phase 7 CLOSED ✅ — the MIR port, host-proven.** The
+**Last updated:** 2026-06-19 (**HSM-10-02 (sync transport) — the Swift HTTP transport
++ offline queue, host-proven (PR-A).** `HTTPSyncProvider` (`ISyncProvider` over
+`POST /api/sync/push` + `GET /api/sync/pull`, direct to the peer, honest egress
+label) + `SyncQueue` (disk FIFO; `flush` keeps the queue + never throws when the peer
+is down — offline tolerated, sync off the capture path). `swift test` **77/77**
+(6 opt-in skips) incl. 8 transport tests. Next (PR-B): the desktop **Python sync
+receiver** (`holdspeak/web/routes/sync.py`). Earlier: **Phase 7 CLOSED ✅ — the MIR
+port, host-proven.** The
 profile-driven routing decision lives in RuntimeCore: `IntentScorer` (deterministic
 lexical scoring of MIR-01's five intents) → `MIRRouter` (per-profile emphasis +
 score-driven additions → ordered `ArtifactType` chain) → `RoutedArtifactGenerator`
@@ -226,7 +233,7 @@ WebView, or UIKit.
 | 7 | H | MIR port: 5 profiles measurably alter extraction | **done (4/4) ✅** | [phase-7](./phase-7-mir-port/) |
 | 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes | not-started | [phase-9](./phase-9-iphone-experience/) |
-| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (1/4; HSM-10-01 object model + engine host-proven) | [phase-10](./phase-10-sync/) |
+| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (HSM-10-01 done; HSM-10-02 Swift transport+queue host-proven, Python receiver next) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios, production readiness | not-started | [phase-11](./phase-11-hardening/) |
 
 Phases are sequenced as the charter lists the tracks. The contract layer (Phase

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
@@ -1,7 +1,8 @@
 # Phase 10 — Sync
 
-**Status:** in-progress (HSM-10-01 done 2026-06-19 — the sync object model + engine
-are host-proven; transport/conflict/gate remain). Track K of the Council
+**Status:** in-progress (HSM-10-01 done; **HSM-10-02 underway — the Swift HTTP
+transport + offline queue are host-proven (PR-A); the desktop Python sync receiver
+is PR-B**; conflict/gate remain). Track K of the Council
 Implementation Charter. The `ISyncProvider` (Layer 3): cross-device continuity so
 a meeting captured on the phone shows up on the desktop, and edits round-trip —
 over the user's own network (desktop / homelab / Tailscale), local-first and
@@ -61,7 +62,7 @@ local-first; it never acts autonomously.
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
 | HSM-10-01 | Sync provider + object model | done | [story-01](./story-01-sync-provider-object-model.md) | [evidence-01](./evidence-story-01.md) |
-| HSM-10-02 | Transport targets | backlog | [story-02](./story-02-transport-targets.md) | — |
+| HSM-10-02 | Transport targets | in-progress (Swift transport+queue done; Python receiver PR-B) | [story-02](./story-02-transport-targets.md) | in story (PR-A) |
 | HSM-10-03 | Conflict + round-trip | backlog | [story-03](./story-03-conflict-and-roundtrip.md) | — |
 | HSM-10-04 | Continuity closeout (Gate 6) | backlog | [story-04](./story-04-continuity-closeout.md) | — |
 

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/story-02-transport-targets.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/story-02-transport-targets.md
@@ -7,6 +7,23 @@
 - **Unblocks:** HSM-10-04
 - **Owner:** unassigned
 
+## Progress (2026-06-19) — the Swift transport + offline queue (PR-A)
+
+Shipped in two PRs; this is the mobile half. The desktop **Python sync receiver**
+is PR-B (`holdspeak/web/routes/sync.py`).
+
+- `HTTPSyncProvider` (`apple/Sources/Providers/Sync/HTTPSyncProvider.swift`) — an
+  `ISyncProvider` over HTTP: `push` → `POST {base}/api/sync/push`, `pull` →
+  `GET {base}/api/sync/pull` (URLSession, Foundation; optional bearer; honest
+  `egressLabel` "local + LAN → host"). Direct to the peer, no relay.
+- `SyncQueue` (`apple/Sources/Providers/Sync/SyncQueue.swift`) — disk-backed FIFO;
+  `flush(through:)` drains to a reachable peer and **leaves the queue intact +
+  doesn't throw when the peer is down** (offline tolerated, resume later; sync never
+  on the capture/review path).
+- Proof: `swift test` **77/77** (6 opt-in skips) incl. 8 transport tests (push
+  shape, pull decode, non-2xx error, egress label, FIFO order, drain-when-reachable,
+  keep-when-unreachable, partial-resume).
+
 ## Problem
 
 The sync object model needs a wire. The charter's targets are the user's own
@@ -25,14 +42,15 @@ peers, opportunistically and offline-tolerant.
 
 ## Acceptance criteria
 
-- [ ] Change-sets push and pull between the phone and a desktop/homelab endpoint
-      over a Tailscale network.
-- [ ] Offline is tolerated: with no peer reachable the app fully works and sync
-      resumes when a peer returns (sync is never on the capture/review path).
-- [ ] The transport is one implementation of `ISyncProvider`; swapping it would
-      not touch the Runtime Core.
-- [ ] Sync egress is represented honestly (local + LAN target) per the egress-badge
-      convention where surfaced.
+- [~] Change-sets push and pull between the phone and a desktop/homelab endpoint —
+      the Swift transport (`HTTPSyncProvider`) is done + host-proven against a stub;
+      the live desktop receiver is PR-B (Python sync API).
+- [x] Offline is tolerated: `SyncQueue.flush` keeps the queue + never throws when
+      the peer is unreachable; the app is unaffected (sync off the capture path).
+- [x] The transport is one implementation of `ISyncProvider`; swapping it would not
+      touch the Runtime Core.
+- [x] Sync egress is represented honestly (`egressLabel` = "local + LAN → host");
+      the badge wiring is the host UI's (Phases 8–9).
 
 ## Test plan
 


### PR DESCRIPTION
## HSM-10-02 (PR-A) — the Swift sync transport + offline queue

The mobile half of the sync transport. The desktop **Python sync receiver** is PR-B.

- **`HTTPSyncProvider`** — `ISyncProvider` over HTTP: `push` → `POST /api/sync/push`,
  `pull` → `GET /api/sync/pull` (URLSession, Foundation; optional bearer; direct to
  the peer, no relay; honest `egressLabel` "local + LAN → host").
- **`SyncQueue`** — disk-backed FIFO; `flush(through:)` drains to a reachable peer
  and **leaves the queue intact + never throws when the peer is down** (offline
  tolerated, resume later; sync never on the capture/review path).

`swift test` **77 / 6 skipped (opt-in) / 0 failures**; 8 transport tests (push
shape, pull decode, non-2xx, egress, FIFO, drain, offline-keep, partial-resume).

HSM-10-02 stays in-progress (PR-B = the desktop sync receiver). Conflict/merge is HSM-10-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)