### PR TITLE
holdspeak-mobile: Phase 10 — HSM-10-02 (PR-B) desktop Python sync receiver

### DIFF
--- a/holdspeak/web/routes/__init__.py
+++ b/holdspeak/web/routes/__init__.py
@@ -18,6 +18,7 @@ from .meetings import build_meetings_router
 from .pages import build_pages_router
 from .projects import build_projects_router
 from .setup import build_setup_router
+from .sync import build_sync_router
 from .system import build_system_router
 
 __all__ = [
@@ -29,5 +30,6 @@ __all__ = [
     "build_pages_router",
     "build_projects_router",
     "build_setup_router",
+    "build_sync_router",
     "build_system_router",
 ]

--- a/holdspeak/web/routes/sync.py
+++ b/holdspeak/web/routes/sync.py
@@ -1,0 +1,120 @@
+"""HSM-10-02 — the desktop sync receiver (mobile ⇄ desktop continuity).
+
+The Python side of the mobile sync transport (`HTTPSyncProvider` in the Apple
+runtime). Two routes on the user's own server:
+
+- ``GET /api/sync/pull`` — serialize the desktop's meetings + artifacts as a
+  contract change-set (the HSM-10-01 envelope: ``{meetings, artifacts}`` of
+  ``{meta:{id, kind, last_modified, deleted}, value}``). Read-only.
+- ``POST /api/sync/push`` — receive a pushed change-set into a durable inbox
+  (``<db_dir>/sync_inbox/``). It accepts + persists; **merging pushed records into
+  the live store (with conflict resolution) is HSM-10-03**, not this story.
+
+The wire is snake_case, matching the contract coder on the mobile side
+(SERIALIZATION-CONTRACT §11). No new DB schema — the inbox is plain JSON files —
+so this is purely additive to the shipped desktop product.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from ...logging_config import get_logger
+from ..context import WebContext
+
+log = get_logger("web.routes.sync")
+
+
+def _iso(value: Any) -> Any:
+    if value is None:
+        return None
+    return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+
+def _artifact_value(artifact: Any) -> dict[str, Any]:
+    """An `ArtifactSummary` → the Phase-0 `Artifact` contract dict."""
+    return {
+        "id": artifact.id,
+        "meeting_id": artifact.meeting_id,
+        "artifact_type": artifact.artifact_type,
+        "title": artifact.title,
+        "body_markdown": artifact.body_markdown,
+        "structured_json": artifact.structured_json,
+        "confidence": artifact.confidence,
+        "status": artifact.status,
+        "plugin_id": artifact.plugin_id,
+        "plugin_version": artifact.plugin_version,
+        "sources": artifact.sources,
+    }
+
+
+def build_sync_router(ctx: WebContext) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/api/sync/pull")
+    async def api_sync_pull(limit: int = 50) -> Any:
+        from ...db import get_database
+
+        db = get_database()
+        bounded = max(1, min(int(limit), 500))
+        meetings: list[dict[str, Any]] = []
+        artifacts: list[dict[str, Any]] = []
+
+        for summary in db.meetings.list_meetings(limit=bounded):
+            state = db.meetings.get_meeting(summary.id)
+            if state is None:
+                continue
+            meetings.append({
+                "meta": {
+                    "id": summary.id, "kind": "meeting",
+                    # NOTE: started_at as last_modified is a transport-grade stamp;
+                    # conflict-grade last-modified (updated_at) is HSM-10-03.
+                    "last_modified": _iso(summary.started_at), "deleted": False,
+                },
+                "value": state.to_dict(),
+            })
+            for art in db.plugins.list_artifacts(summary.id):
+                artifacts.append({
+                    "meta": {
+                        "id": art.id, "kind": "artifact",
+                        "last_modified": _iso(art.updated_at), "deleted": False,
+                    },
+                    "value": _artifact_value(art),
+                })
+
+        return JSONResponse({"meetings": meetings, "artifacts": artifacts})
+
+    @router.post("/api/sync/push")
+    async def api_sync_push(request: Request) -> Any:
+        from ...db import get_database
+
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"success": False, "error": "invalid JSON"}, status_code=400)
+        if not isinstance(body, dict) or ("meetings" not in body and "artifacts" not in body):
+            return JSONResponse(
+                {"success": False, "error": "expected a change_set with meetings/artifacts"},
+                status_code=422,
+            )
+
+        n_meetings = len(body.get("meetings") or [])
+        n_artifacts = len(body.get("artifacts") or [])
+
+        inbox = get_database().db_path.parent / "sync_inbox"
+        inbox.mkdir(parents=True, exist_ok=True)
+        # Lexically-ordered name from the existing count (no clock dependency).
+        idx = len(list(inbox.glob("inbox-*.json")))
+        dest = inbox / f"inbox-{idx:06d}.json"
+        dest.write_text(json.dumps(body), encoding="utf-8")
+
+        log.info(f"sync push received: meetings={n_meetings} artifacts={n_artifacts} -> {dest.name}")
+        return JSONResponse(
+            {"success": True, "received": {"meetings": n_meetings, "artifacts": n_artifacts}}
+        )
+
+    return router

--- a/holdspeak/web_server.py
+++ b/holdspeak/web_server.py
@@ -447,6 +447,7 @@ class MeetingWebServer:
             build_pages_router,
             build_projects_router,
             build_setup_router,
+            build_sync_router,
             build_system_router,
         )
 
@@ -493,6 +494,7 @@ class MeetingWebServer:
         app.include_router(build_system_router(web_ctx))
         app.include_router(build_projects_router(web_ctx))
         app.include_router(build_setup_router(web_ctx))
+        app.include_router(build_sync_router(web_ctx))
 
         @app.on_event("startup")
         async def _startup() -> None:

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,15 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**HSM-10-02 (sync transport) — the Swift HTTP transport
+**Last updated:** 2026-06-19 (**HSM-10-02 (sync transport) DONE — both sides of the
+wire.** The desktop **Python sync receiver** landed (PR-B): `holdspeak/web/routes/sync.py`
+serves the desktop's meetings/artifacts as a contract change-set on
+`GET /api/sync/pull` and receives a pushed change-set into a durable inbox on
+`POST /api/sync/push` (additive — no DB schema change), mounted in `web_server.py`.
+Paired with the Swift `HTTPSyncProvider` + `SyncQueue` (PR-A, #75), the phone can now
+push/pull change-sets to a desktop/homelab peer, offline-tolerant. `uv run pytest
+tests/unit/test_web_routes_sync.py` 3 passed (+ route preflight green); `swift test`
+77/77. Conflict/merge into the live store is HSM-10-03; the live cross-device run is
+HSM-10-04. Earlier: **HSM-10-02 (sync transport) — the Swift HTTP transport
 + offline queue, host-proven (PR-A).** `HTTPSyncProvider` (`ISyncProvider` over
 `POST /api/sync/push` + `GET /api/sync/pull`, direct to the peer, honest egress
 label) + `SyncQueue` (disk FIFO; `flush` keeps the queue + never throws when the peer
@@ -233,7 +242,7 @@ WebView, or UIKit.
 | 7 | H | MIR port: 5 profiles measurably alter extraction | **done (4/4) ✅** | [phase-7](./phase-7-mir-port/) |
 | 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes | not-started | [phase-9](./phase-9-iphone-experience/) |
-| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (HSM-10-01 done; HSM-10-02 Swift transport+queue host-proven, Python receiver next) | [phase-10](./phase-10-sync/) |
+| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (2/4; HSM-10-01 object model + HSM-10-02 transport both sides done; conflict + live gate remain) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios, production readiness | not-started | [phase-11](./phase-11-hardening/) |
 
 Phases are sequenced as the charter lists the tracks. The contract layer (Phase

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
@@ -1,8 +1,9 @@
 # Phase 10 — Sync
 
-**Status:** in-progress (HSM-10-01 done; **HSM-10-02 underway — the Swift HTTP
-transport + offline queue are host-proven (PR-A); the desktop Python sync receiver
-is PR-B**; conflict/gate remain). Track K of the Council
+**Status:** in-progress (HSM-10-01 + **HSM-10-02 done** — the sync object model +
+engine + the transport (both sides: Swift `HTTPSyncProvider`/`SyncQueue` + the
+desktop Python sync receiver) are host-proven; conflict (HSM-10-03) + the
+continuity gate (HSM-10-04, live cross-device) remain). Track K of the Council
 Implementation Charter. The `ISyncProvider` (Layer 3): cross-device continuity so
 a meeting captured on the phone shows up on the desktop, and edits round-trip —
 over the user's own network (desktop / homelab / Tailscale), local-first and
@@ -62,7 +63,7 @@ local-first; it never acts autonomously.
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
 | HSM-10-01 | Sync provider + object model | done | [story-01](./story-01-sync-provider-object-model.md) | [evidence-01](./evidence-story-01.md) |
-| HSM-10-02 | Transport targets | in-progress (Swift transport+queue done; Python receiver PR-B) | [story-02](./story-02-transport-targets.md) | in story (PR-A) |
+| HSM-10-02 | Transport targets | done (both sides) | [story-02](./story-02-transport-targets.md) | [evidence-02](./evidence-story-02.md) |
 | HSM-10-03 | Conflict + round-trip | backlog | [story-03](./story-03-conflict-and-roundtrip.md) | — |
 | HSM-10-04 | Continuity closeout (Gate 6) | backlog | [story-04](./story-04-continuity-closeout.md) | — |
 

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/evidence-story-02.md
@@ -1,0 +1,51 @@
+# Evidence — HSM-10-02 — Transport targets
+
+- **Shipped:** 2026-06-19 (two PRs: PR-A Swift transport, PR-B Python receiver)
+- **Owner:** unassigned
+
+## What shipped — both sides of the wire
+
+### Mobile (Swift, PR-A — merged #75)
+- `apple/Sources/Providers/Sync/HTTPSyncProvider.swift` — `ISyncProvider` over HTTP
+  (`push` → `POST /api/sync/push`, `pull` → `GET /api/sync/pull`; URLSession,
+  Foundation; optional bearer; direct to the peer, no relay; honest
+  `egressLabel` "local + LAN → host").
+- `apple/Sources/Providers/Sync/SyncQueue.swift` — disk-backed FIFO;
+  `flush(through:)` drains to a reachable peer and **leaves the queue intact +
+  never throws when the peer is down** (offline tolerated; sync off the
+  capture/review path).
+
+### Desktop (Python, PR-B)
+- `holdspeak/web/routes/sync.py` — `build_sync_router`: `GET /api/sync/pull`
+  serializes the desktop's meetings (`MeetingState.to_dict`) + artifacts
+  (`ArtifactSummary`) into the contract change-set envelope; `POST /api/sync/push`
+  receives a change-set into a durable inbox (`<db_dir>/sync_inbox/`, plain JSON —
+  no new DB schema). Mounted in `web_server.py`.
+
+The wire is snake_case both ways (SERIALIZATION-CONTRACT §11), so the Swift coder
+and the Python routes interoperate by shape.
+
+## Verification
+- Swift: `swift test` **77/77** (6 opt-in skips) — 8 transport tests (push shape,
+  pull decode, non-2xx, egress, FIFO, drain, offline-keep, partial-resume).
+- Python: `uv run pytest tests/unit/test_web_routes_sync.py` → **3 passed**
+  (pull serializes meetings+artifacts into the envelope; push writes the change-set
+  to the inbox + returns counts; non-change-set → 422). Route preflight + core
+  route tests green with the new router mounted (no import cycle).
+
+## Acceptance criteria — re-checked
+- [x] Change-sets push and pull between the phone and a desktop/homelab endpoint —
+      `HTTPSyncProvider` ⇄ the desktop sync routes; each side host-tested. The live
+      phone↔desktop-over-Tailscale run is the device confirmation (rides with
+      HSM-10-04 + the iPad unlock).
+- [x] Offline tolerated: `SyncQueue.flush` keeps the queue + never throws when the
+      peer is unreachable; the app is unaffected.
+- [x] One implementation of `ISyncProvider`; swapping it would not touch the Runtime Core.
+- [x] Sync egress represented honestly (`egressLabel` "local + LAN → host"); badge
+      wiring is the host UI's (Phases 8–9).
+
+## Deviations / follow-ups
+- The desktop **receives** pushed change-sets into a durable inbox; **merging them
+  into the live store with conflict resolution is HSM-10-03**. Pull is read-only.
+- Pull's `last_modified` for meetings is `started_at` (transport-grade);
+  conflict-grade `updated_at` semantics are HSM-10-03. Artifacts already carry `updated_at`.

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/story-02-transport-targets.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/story-02-transport-targets.md
@@ -2,7 +2,10 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 10
-- **Status:** backlog
+- **Status:** done (2026-06-19 — both sides of the wire: Swift `HTTPSyncProvider` +
+  `SyncQueue` (PR-A, #75) and the desktop Python sync receiver (PR-B). Each side
+  host-tested; live phone↔desktop run rides with HSM-10-04. See
+  [evidence-02](./evidence-story-02.md).)
 - **Depends on:** HSM-10-01
 - **Unblocks:** HSM-10-04
 - **Owner:** unassigned

--- a/tests/unit/test_web_routes_sync.py
+++ b/tests/unit/test_web_routes_sync.py
@@ -1,0 +1,110 @@
+"""HSM-10-02 (PR-B) — the desktop sync receiver routes.
+
+Fake-DB unit tests: no real DB seeding. The handlers do `from ...db import
+get_database` at call time, so we patch `holdspeak.db.get_database`.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from datetime import datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import holdspeak.db as hsdb
+from holdspeak.web.context import WebContext
+from holdspeak.web.routes import build_sync_router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(build_sync_router(WebContext(get_state=lambda: {})))
+    return TestClient(app)
+
+
+def _meeting_state(mid: str):
+    return types.SimpleNamespace(
+        id=mid,
+        to_dict=lambda: {
+            "id": mid, "started_at": "2026-01-01T00:00:00Z", "ended_at": None,
+            "duration": 0.0, "formatted_duration": "0:00", "title": "T", "tags": [],
+            "segments": [], "bookmarks": [], "intel": None,
+            "intel_status": {"state": "none", "detail": None,
+                             "requested_at": None, "completed_at": None},
+            "mic_label": "m", "remote_label": "r", "web_url": None, "devices": [],
+        },
+    )
+
+
+def _artifact(aid: str, mid: str):
+    return types.SimpleNamespace(
+        id=aid, meeting_id=mid, artifact_type="decisions", title="t",
+        body_markdown="b", structured_json={}, confidence=0.8, status="draft",
+        plugin_id="p", plugin_version="1", sources=[], updated_at=datetime(2026, 1, 2),
+    )
+
+
+def _fake_db(tmp_path, *, meetings=(), artifacts=None):
+    artifacts = artifacts or {}
+    summaries = [types.SimpleNamespace(id=m, started_at=datetime(2026, 1, 1)) for m in meetings]
+    states = {m: _meeting_state(m) for m in meetings}
+    return types.SimpleNamespace(
+        db_path=tmp_path / "hs.db",
+        meetings=types.SimpleNamespace(
+            list_meetings=lambda limit=50: summaries[:limit],
+            get_meeting=lambda mid: states.get(mid),
+        ),
+        plugins=types.SimpleNamespace(
+            list_artifacts=lambda mid: artifacts.get(mid, []),
+        ),
+    )
+
+
+def test_pull_serializes_meetings_and_artifacts(monkeypatch, tmp_path):
+    fake = _fake_db(tmp_path, meetings=["m1"], artifacts={"m1": [_artifact("a1", "m1")]})
+    monkeypatch.setattr(hsdb, "get_database", lambda *a, **k: fake)
+
+    resp = _client().get("/api/sync/pull")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert len(body["meetings"]) == 1
+    m = body["meetings"][0]
+    assert m["meta"] == {"id": "m1", "kind": "meeting",
+                         "last_modified": "2026-01-01T00:00:00", "deleted": False}
+    assert m["value"]["id"] == "m1"
+
+    assert len(body["artifacts"]) == 1
+    a = body["artifacts"][0]
+    assert a["meta"]["kind"] == "artifact" and a["meta"]["id"] == "a1"
+    assert a["value"]["artifact_type"] == "decisions"
+    assert a["value"]["meeting_id"] == "m1"
+
+
+def test_push_writes_changeset_to_inbox(monkeypatch, tmp_path):
+    fake = _fake_db(tmp_path)
+    monkeypatch.setattr(hsdb, "get_database", lambda *a, **k: fake)
+
+    changeset = {
+        "meetings": [{"meta": {"id": "m1", "kind": "meeting",
+                               "last_modified": "2026-01-01T00:00:00Z", "deleted": False},
+                      "value": {"id": "m1"}}],
+        "artifacts": [],
+    }
+    resp = _client().post("/api/sync/push", json=changeset)
+    assert resp.status_code == 200
+    assert resp.json() == {"success": True, "received": {"meetings": 1, "artifacts": 0}}
+
+    inbox = tmp_path / "sync_inbox"
+    files = list(inbox.glob("inbox-*.json"))
+    assert len(files) == 1
+    stored = json.loads(files[0].read_text())
+    assert stored["meetings"][0]["meta"]["id"] == "m1"
+
+
+def test_push_rejects_non_changeset(monkeypatch, tmp_path):
+    monkeypatch.setattr(hsdb, "get_database", lambda *a, **k: _fake_db(tmp_path))
+    resp = _client().post("/api/sync/push", json={"nope": 1})
+    assert resp.status_code == 422


### PR DESCRIPTION
## HSM-10-02 (PR-B) — the desktop Python sync receiver (completes HSM-10-02)

The Python side of the sync wire. **Additive** to the shipped desktop product —
new routes + a JSON inbox, no DB schema change.

- **`holdspeak/web/routes/sync.py`** (`build_sync_router`):
  - `GET /api/sync/pull` — serialize the desktop's meetings (`MeetingState.to_dict`)
    + artifacts (`ArtifactSummary`) into the contract change-set envelope
    (snake_case, SERIALIZATION-CONTRACT §11). Read-only.
  - `POST /api/sync/push` — receive a change-set into a durable inbox
    (`<db_dir>/sync_inbox/`) + return counts. (Merging into the live store with
    conflict resolution is HSM-10-03.)
- Mounted in `web_server.py`; exported from `web/routes/__init__.py`.

Paired with the Swift `HTTPSyncProvider` + `SyncQueue` (PR-A, #75), the phone can
now push/pull change-sets to a desktop/homelab peer. **HSM-10-02 → done**; the live
cross-device run is HSM-10-04.

`uv run pytest tests/unit/test_web_routes_sync.py` → **3 passed**; route preflight +
core route tests green with the new router mounted (no import cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)