### PR TITLE
holdspeak-mobile: Phase 10 — HSM-10-03 sync conflict policy + idempotent round-trip

### DIFF
--- a/apple/Sources/RuntimeCore/Sync/SyncEngine.swift
+++ b/apple/Sources/RuntimeCore/Sync/SyncEngine.swift
@@ -2,24 +2,45 @@ import Foundation
 import Contracts
 import Providers
 
-/// HSM-10-01 — the sync engine (Runtime Core, Layer 2).
+/// HSM-10-01/03 — the sync engine (Runtime Core, Layer 2).
 ///
-/// Produces a `ChangeSet` from the local store and applies a `ChangeSet` back to
-/// it, both expressed in Phase-0 contract entities. It depends only on the
-/// `ISyncStore` + `ISyncProvider` seams — never a concrete transport — so the same
-/// engine drives desktop / homelab / Tailscale once those land (HSM-10-02).
+/// Produces a `ChangeSet` from the local store and applies one back, both in
+/// Phase-0 contract entities, over the `ISyncStore` + `ISyncProvider` seams (never
+/// a concrete transport). `apply` validates every payload against the contract
+/// before any write, and resolves conflicts (HSM-10-03).
 ///
-/// Conflict resolution (idempotent round-trip, last-writer policy) is HSM-10-03;
-/// this story establishes the object model and the produce/apply machinery. `apply`
-/// validates every payload against the Phase-0 contract (encode→decode through the
-/// shared coder, which is the schema) **before** it touches the store.
+/// ## Conflict policy (HSM-10-03)
+/// Per record, comparing the incoming `last_modified` to the local one:
+/// - **incoming newer** → apply it (a live record upserts; a tombstone deletes).
+///   This also handles tombstone-vs-live by recency: a newer tombstone deletes; a
+///   newer live record resurrects, but an **older** live record never resurrects a
+///   newer tombstone (no zombie re-creates).
+/// - **incoming older** → skip (keep the newer local edit).
+/// - **same timestamp, same content (or both tombstones)** → no-op → the round-trip
+///   is **idempotent**.
+/// - **same timestamp, divergent** (both live but different, or delete-vs-edit) →
+///   a genuine concurrent conflict: keep the local copy and **surface it in the
+///   report** rather than silently dropping either side (non-destructive). The host
+///   resolves surfaced conflicts; nothing is lost silently.
 public struct SyncEngine: Sendable {
 
     public init() {}
 
     public enum SyncError: Error, Equatable {
-        case tombstoneMissingMetadata
         case liveRecordMissingPayload(kind: SyncKind, id: String)
+    }
+
+    /// One surfaced concurrent conflict (kept local; incoming not silently dropped).
+    public struct Conflict: Sendable, Equatable {
+        public let kind: SyncKind
+        public let id: String
+    }
+
+    public struct ApplyReport: Sendable, Equatable {
+        public var applied: Int = 0
+        public var skipped: Int = 0
+        public var conflicts: [Conflict] = []
+        public var changed: Bool { applied > 0 }
     }
 
     /// The full local state as a change-set: live entities + tombstones.
@@ -31,18 +52,30 @@ public struct SyncEngine: Sendable {
             Synced<Artifact>.live($0.artifact, id: $0.artifact.id, kind: .artifact, modifiedAt: $0.modifiedAt)
         }
         let tombs = try store.tombstones()
-        let meetingTombs = tombs.filter { $0.kind == .meeting }
-            .map { Synced<Meeting>(meta: $0, value: nil) }
-        let artifactTombs = tombs.filter { $0.kind == .artifact }
-            .map { Synced<Artifact>(meta: $0, value: nil) }
+        let meetingTombs = tombs.filter { $0.kind == .meeting }.map { Synced<Meeting>(meta: $0, value: nil) }
+        let artifactTombs = tombs.filter { $0.kind == .artifact }.map { Synced<Artifact>(meta: $0, value: nil) }
         return ChangeSet(meetings: meetings + meetingTombs, artifacts: artifacts + artifactTombs)
     }
 
-    /// Apply a change-set to the store: live records upserted with their carried
-    /// `lastModified`; tombstones soft-deleted. Every live payload is validated
-    /// against the Phase-0 contract before any write.
-    public func apply(_ changeSet: ChangeSet, to store: ISyncStore) throws {
-        // Validate first — nothing touches the store until every payload is schema-valid.
+    private enum Action { case apply, skip, conflict }
+
+    /// The conflict decision for one record against its local counterpart.
+    private func decide(incomingTime: Date, incomingDeleted: Bool,
+                        localTime: Date?, localDeleted: Bool, contentEqual: Bool) -> Action {
+        guard let localTime else { return .apply }            // brand new
+        if incomingTime > localTime { return .apply }         // newer wins (incl. resurrect / delete)
+        if incomingTime < localTime { return .skip }          // local is newer
+        if incomingDeleted == localDeleted {                  // same timestamp…
+            return incomingDeleted ? .skip : (contentEqual ? .skip : .conflict)
+        }
+        return .conflict                                      // delete-vs-edit at the same time
+    }
+
+    /// Apply a change-set with the conflict policy above. Validates every live
+    /// payload against the contract before any write; returns a report (applied /
+    /// skipped / surfaced conflicts).
+    @discardableResult
+    public func apply(_ changeSet: ChangeSet, to store: ISyncStore) throws -> ApplyReport {
         for rec in changeSet.meetings where !rec.meta.deleted {
             guard let v = rec.value else { throw SyncError.liveRecordMissingPayload(kind: .meeting, id: rec.meta.id) }
             try validate(v)
@@ -52,27 +85,59 @@ public struct SyncEngine: Sendable {
             try validate(v)
         }
 
+        var report = ApplyReport()
+
+        let liveMeetings = Dictionary(uniqueKeysWithValues: try store.allMeetings().map { ($0.meeting.id, $0) })
+        let liveArtifacts = Dictionary(uniqueKeysWithValues: try store.allArtifacts().map { ($0.artifact.id, $0) })
+        let tombs = try store.tombstones()
+        let meetingTombs = Dictionary(uniqueKeysWithValues: tombs.filter { $0.kind == .meeting }.map { ($0.id, $0.lastModified) })
+        let artifactTombs = Dictionary(uniqueKeysWithValues: tombs.filter { $0.kind == .artifact }.map { ($0.id, $0.lastModified) })
+
         for rec in changeSet.meetings {
-            if rec.meta.deleted { try store.deleteMeeting(id: rec.meta.id, at: rec.meta.lastModified) }
-            else { try store.saveMeeting(rec.value!, modifiedAt: rec.meta.lastModified) }
+            let live = liveMeetings[rec.meta.id]
+            let localTime = live?.modifiedAt ?? meetingTombs[rec.meta.id]
+            let localDeleted = live == nil && meetingTombs[rec.meta.id] != nil
+            let contentEqual = (live != nil && rec.value != nil) ? (live!.meeting == rec.value!) : false
+            switch decide(incomingTime: rec.meta.lastModified, incomingDeleted: rec.meta.deleted,
+                          localTime: localTime, localDeleted: localDeleted, contentEqual: contentEqual) {
+            case .apply:
+                if rec.meta.deleted { try store.deleteMeeting(id: rec.meta.id, at: rec.meta.lastModified) }
+                else { try store.saveMeeting(rec.value!, modifiedAt: rec.meta.lastModified) }
+                report.applied += 1
+            case .skip: report.skipped += 1
+            case .conflict: report.conflicts.append(.init(kind: .meeting, id: rec.meta.id))
+            }
         }
+
         for rec in changeSet.artifacts {
-            if rec.meta.deleted { try store.deleteArtifact(id: rec.meta.id, at: rec.meta.lastModified) }
-            else { try store.saveArtifact(rec.value!, modifiedAt: rec.meta.lastModified) }
+            let live = liveArtifacts[rec.meta.id]
+            let localTime = live?.modifiedAt ?? artifactTombs[rec.meta.id]
+            let localDeleted = live == nil && artifactTombs[rec.meta.id] != nil
+            let contentEqual = (live != nil && rec.value != nil) ? (live!.artifact == rec.value!) : false
+            switch decide(incomingTime: rec.meta.lastModified, incomingDeleted: rec.meta.deleted,
+                          localTime: localTime, localDeleted: localDeleted, contentEqual: contentEqual) {
+            case .apply:
+                if rec.meta.deleted { try store.deleteArtifact(id: rec.meta.id, at: rec.meta.lastModified) }
+                else { try store.saveArtifact(rec.value!, modifiedAt: rec.meta.lastModified) }
+                report.applied += 1
+            case .skip: report.skipped += 1
+            case .conflict: report.conflicts.append(.init(kind: .artifact, id: rec.meta.id))
+            }
         }
+
+        return report
     }
 
     /// Drive one round-trip through a provider: push the local snapshot, pull the
-    /// peer's change-set, and apply it locally. (Bidirectional conflict policy is
-    /// HSM-10-03; here the pulled set is applied as-is.)
-    public func sync(local store: ISyncStore, via provider: ISyncProvider) async throws {
+    /// peer's change-set, and apply it locally (conflict-resolved).
+    @discardableResult
+    public func sync(local store: ISyncStore, via provider: ISyncProvider) async throws -> ApplyReport {
         try await provider.push(snapshot(of: store))
         let incoming = try await provider.pull()
-        try apply(incoming, to: store)
+        return try apply(incoming, to: store)
     }
 
-    /// Schema validation: round-trip the value through the contract coder. A value
-    /// the contract can't hold throws here, before the store is touched.
+    /// Schema validation: round-trip the value through the contract coder.
     private func validate<T: Codable>(_ value: T) throws {
         let data = try HoldSpeakContracts.encoder().encode(value)
         _ = try HoldSpeakContracts.decoder().decode(T.self, from: data)

--- a/apple/Tests/RuntimeCoreTests/SyncConflictTests.swift
+++ b/apple/Tests/RuntimeCoreTests/SyncConflictTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-10-03 — the conflict policy + idempotent round-trip, over a real SQLite
+/// store. Host-testable + deterministic (fixed whole-second timestamps).
+final class SyncConflictTests: XCTestCase {
+
+    struct Sample: Codable { let meeting: Meeting; let artifact: Artifact }
+    private func fixture() throws -> Sample {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<4 { url.deleteLastPathComponent() }
+        url.appendPathComponent("pm/roadmap/holdspeak-mobile/contracts/fixtures/meeting-sample.json")
+        return try HoldSpeakContracts.decoder().decode(Sample.self, from: Data(contentsOf: url))
+    }
+    private func tempStore() throws -> SQLiteStorage {
+        try SQLiteStorage(path: NSTemporaryDirectory() + "hsm-cf-\(UUID().uuidString).sqlite")
+    }
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+    private var t1: Date { t0.addingTimeInterval(60) }
+    private var t2: Date { t0.addingTimeInterval(120) }
+
+    private func meeting(_ title: String) throws -> Meeting {
+        var m = try fixture().meeting
+        m.title = title
+        return m
+    }
+    private func live(_ m: Meeting, at t: Date) -> ChangeSet {
+        ChangeSet(meetings: [.live(m, id: m.id, kind: .meeting, modifiedAt: t)])
+    }
+
+    func testRoundTripIsIdempotent() throws {
+        let s = try fixture()
+        let a = try tempStore(); defer { a.close() }
+        let b = try tempStore(); defer { b.close() }
+        try a.saveMeeting(s.meeting, modifiedAt: t0)
+        try a.saveArtifact(s.artifact, modifiedAt: t0)
+        let engine = SyncEngine()
+        let cs = try engine.snapshot(of: a)
+
+        let first = try engine.apply(cs, to: b)
+        XCTAssertEqual(first.applied, 2)
+
+        let second = try engine.apply(cs, to: b)        // sync twice → no change
+        XCTAssertEqual(second.applied, 0)
+        XCTAssertFalse(second.changed)
+        XCTAssertEqual(second.skipped, 2)
+        XCTAssertEqual(try b.allMeetings().count, 1)
+    }
+
+    func testNewerWinsAndOlderIsSkipped() throws {
+        let b = try tempStore(); defer { b.close() }
+        let engine = SyncEngine()
+        let m = try meeting("X")
+        try b.saveMeeting(m, modifiedAt: t1)
+
+        var newer = m; newer.title = "Y"
+        XCTAssertEqual(try engine.apply(live(newer, at: t2), to: b).applied, 1)   // newer wins
+        XCTAssertEqual(try b.loadMeeting(id: m.id)?.title, "Y")
+
+        var older = m; older.title = "Z"
+        let r = try engine.apply(live(older, at: t0), to: b)                      // older skipped
+        XCTAssertEqual(r.skipped, 1)
+        XCTAssertEqual(try b.loadMeeting(id: m.id)?.title, "Y")
+    }
+
+    func testConcurrentDivergenceSurfacedNonDestructively() throws {
+        let b = try tempStore(); defer { b.close() }
+        let engine = SyncEngine()
+        let local = try meeting("LOCAL")
+        try b.saveMeeting(local, modifiedAt: t0)
+
+        var incoming = local; incoming.title = "REMOTE"        // same id + time, diverged
+        let r = try engine.apply(live(incoming, at: t0), to: b)
+
+        XCTAssertEqual(r.conflicts, [.init(kind: .meeting, id: local.id)])   // surfaced, not silent
+        XCTAssertEqual(r.applied, 0)
+        XCTAssertEqual(try b.loadMeeting(id: local.id)?.title, "LOCAL")      // local kept
+    }
+
+    func testTombstoneDoesNotResurrectOlderEdit() throws {
+        let b = try tempStore(); defer { b.close() }
+        let engine = SyncEngine()
+        let m = try meeting("X")
+        try b.saveMeeting(m, modifiedAt: t0)
+        try b.deleteMeeting(id: m.id, at: t1)                  // tombstone at t1
+        XCTAssertNil(try b.loadMeeting(id: m.id))
+
+        // An older live re-create must NOT resurrect over a newer tombstone.
+        let skip = try engine.apply(live(m, at: t0), to: b)
+        XCTAssertEqual(skip.skipped, 1)
+        XCTAssertNil(try b.loadMeeting(id: m.id))
+
+        // A newer live re-create does resurrect.
+        var revived = m; revived.title = "BACK"
+        XCTAssertEqual(try engine.apply(live(revived, at: t2), to: b).applied, 1)
+        XCTAssertEqual(try b.loadMeeting(id: m.id)?.title, "BACK")
+    }
+}

--- a/holdspeak/web/routes/sync.py
+++ b/holdspeak/web/routes/sync.py
@@ -35,6 +35,21 @@ def _iso(value: Any) -> Any:
     return value.isoformat() if hasattr(value, "isoformat") else str(value)
 
 
+def _records_valid(records: Any) -> bool:
+    """Every record is a `synced<T>` with a well-formed `meta` (id + known kind)."""
+    if not isinstance(records, list):
+        return False
+    for rec in records:
+        if not isinstance(rec, dict):
+            return False
+        meta = rec.get("meta")
+        if not isinstance(meta, dict):
+            return False
+        if not meta.get("id") or meta.get("kind") not in ("meeting", "artifact"):
+            return False
+    return True
+
+
 def _artifact_value(artifact: Any) -> dict[str, Any]:
     """An `ArtifactSummary` → the Phase-0 `Artifact` contract dict."""
     return {
@@ -99,6 +114,14 @@ def build_sync_router(ctx: WebContext) -> APIRouter:
         if not isinstance(body, dict) or ("meetings" not in body and "artifacts" not in body):
             return JSONResponse(
                 {"success": False, "error": "expected a change_set with meetings/artifacts"},
+                status_code=422,
+            )
+
+        # HSM-10-03 — validate the envelope on this end too: every record needs a
+        # well-formed sync header (id + a known kind). Malformed → 422, never stored.
+        if not _records_valid(body.get("meetings") or []) or not _records_valid(body.get("artifacts") or []):
+            return JSONResponse(
+                {"success": False, "error": "malformed sync record (need meta.id + meta.kind)"},
                 status_code=422,
             )
 

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,14 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**HSM-10-02 (sync transport) DONE — both sides of the
+**Last updated:** 2026-06-19 (**HSM-10-03 (sync conflict + round-trip) DONE.**
+`SyncEngine.apply` is now conflict-aware: LWW by `last_modified`, **same-time
+divergence surfaced non-destructively** (kept local + reported, never silently
+dropped), tombstone no-resurrect, and **idempotent** (sync twice → no change) — all
+over the Phase-0 fixture; plus desktop-end push validation (malformed record → 422).
+Both ends validate against the contract. `swift test` 81/81; `uv run pytest
+tests/unit/test_web_routes_sync.py` 4 passed. Phase 10 now 3/4 — only the live
+cross-device gate (HSM-10-04, needs the iPad) remains. Earlier: **HSM-10-02 (sync
+transport) DONE — both sides of the
 wire.** The desktop **Python sync receiver** landed (PR-B): `holdspeak/web/routes/sync.py`
 serves the desktop's meetings/artifacts as a contract change-set on
 `GET /api/sync/pull` and receives a pushed change-set into a durable inbox on
@@ -242,7 +250,7 @@ WebView, or UIKit.
 | 7 | H | MIR port: 5 profiles measurably alter extraction | **done (4/4) ✅** | [phase-7](./phase-7-mir-port/) |
 | 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes | not-started | [phase-9](./phase-9-iphone-experience/) |
-| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (2/4; HSM-10-01 object model + HSM-10-02 transport both sides done; conflict + live gate remain) | [phase-10](./phase-10-sync/) |
+| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (3/4; object model + transport + conflict policy host-proven; only the live cross-device gate (device) remains) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios, production readiness | not-started | [phase-11](./phase-11-hardening/) |
 
 Phases are sequenced as the charter lists the tracks. The contract layer (Phase

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
@@ -1,9 +1,10 @@
 # Phase 10 — Sync
 
-**Status:** in-progress (HSM-10-01 + **HSM-10-02 done** — the sync object model +
-engine + the transport (both sides: Swift `HTTPSyncProvider`/`SyncQueue` + the
-desktop Python sync receiver) are host-proven; conflict (HSM-10-03) + the
-continuity gate (HSM-10-04, live cross-device) remain). Track K of the Council
+**Status:** in-progress (HSM-10-01 + HSM-10-02 + **HSM-10-03 done** — object model,
+engine, transport (both sides), and the conflict policy (LWW + non-destructive
+concurrent-divergence + tombstone-no-resurrect + idempotent, both-ends validated)
+are all host-proven; only the continuity gate (HSM-10-04, live cross-device) remains,
+and it needs the iPad). Track K of the Council
 Implementation Charter. The `ISyncProvider` (Layer 3): cross-device continuity so
 a meeting captured on the phone shows up on the desktop, and edits round-trip —
 over the user's own network (desktop / homelab / Tailscale), local-first and
@@ -64,7 +65,7 @@ local-first; it never acts autonomously.
 |---|---|---|---|---|
 | HSM-10-01 | Sync provider + object model | done | [story-01](./story-01-sync-provider-object-model.md) | [evidence-01](./evidence-story-01.md) |
 | HSM-10-02 | Transport targets | done (both sides) | [story-02](./story-02-transport-targets.md) | [evidence-02](./evidence-story-02.md) |
-| HSM-10-03 | Conflict + round-trip | backlog | [story-03](./story-03-conflict-and-roundtrip.md) | — |
+| HSM-10-03 | Conflict + round-trip | done | [story-03](./story-03-conflict-and-roundtrip.md) | [evidence-03](./evidence-story-03.md) |
 | HSM-10-04 | Continuity closeout (Gate 6) | backlog | [story-04](./story-04-continuity-closeout.md) | — |
 
 ## Where we are

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/evidence-story-03.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/evidence-story-03.md
@@ -1,0 +1,50 @@
+# Evidence — HSM-10-03 — Conflict + round-trip
+
+- **Shipped:** 2026-06-19 · **Branch:** `holdspeak-mobile/phase-10-conflict`
+
+## The conflict policy (documented)
+
+`SyncEngine.apply` resolves each record by comparing the incoming `last_modified`
+to the local one:
+
+- **incoming newer** → apply (live upserts; tombstone deletes; an older live record
+  never resurrects a newer tombstone — no zombie re-creates).
+- **incoming older** → skip (keep the newer local edit).
+- **same timestamp + same content (or both tombstones)** → no-op → **idempotent**.
+- **same timestamp + divergent** (both live but different, or delete-vs-edit) → a
+  genuine concurrent conflict: keep local and **surface it in the `ApplyReport`**
+  rather than silently dropping either side (non-destructive — the host resolves
+  surfaced conflicts).
+
+`apply` returns an `ApplyReport { applied, skipped, conflicts }`.
+
+## Files
+- `apple/Sources/RuntimeCore/Sync/SyncEngine.swift` — conflict-aware `apply`
+  (+ `ApplyReport`, `Conflict`); validates every live payload against the contract
+  before any write (the mobile end of "both ends").
+- `holdspeak/web/routes/sync.py` — the desktop **push** now validates each record's
+  `meta` (id + known kind); malformed → 422, never stored (the desktop end).
+
+## Verification — all over the Phase-0 fixture
+- Swift (`SyncConflictTests`): `testRoundTripIsIdempotent` (apply twice → applied=0,
+  skipped=2, store unchanged); `testNewerWinsAndOlderIsSkipped` (LWW by time);
+  `testConcurrentDivergenceSurfacedNonDestructively` (same-time divergence → conflict
+  reported, local kept); `testTombstoneDoesNotResurrectOlderEdit` (older re-create
+  skipped; newer resurrects). `swift test` **81/81** (6 opt-in skips).
+- Python (`test_web_routes_sync.py`): `test_push_rejects_malformed_record`
+  (no `meta` → 422, nothing written). `uv run pytest` → **4 passed**.
+
+## Acceptance criteria — re-checked
+- [x] Syncing the same state twice changes nothing (idempotent) — over the fixture.
+- [x] A divergent edit resolves non-destructively (no edit silently lost): clear
+      timestamp ordering = LWW; concurrent (same-time) divergence is surfaced in the
+      report, local retained. Policy documented above; divergent case is a test.
+- [x] Deletes propagate via tombstones without resurrecting on the next sync.
+- [x] Every object crossing the wire validates against the contract on both ends
+      (Swift decode/encode round-trip; desktop push record validation).
+
+## Notes
+- Whole-entity LWW for clearly-ordered edits (Meeting/Artifact are opaque to the
+  engine); only genuinely-concurrent edits surface as conflicts. A field-level merge
+  / conflict-copy store is a future enhancement if usage demands it.
+- This is the policy; the **live cross-device run** is HSM-10-04 (needs the iPad).

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/story-03-conflict-and-roundtrip.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/story-03-conflict-and-roundtrip.md
@@ -2,7 +2,10 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 10
-- **Status:** backlog
+- **Status:** done (2026-06-19 — conflict-aware `SyncEngine.apply` (LWW by
+  `last_modified`; same-time divergence surfaced non-destructively; tombstone
+  no-resurrect; idempotent) + desktop-end push validation. See
+  [evidence-03](./evidence-story-03.md).)
 - **Depends on:** HSM-10-01, HSM-10-02
 - **Unblocks:** HSM-10-04
 - **Owner:** unassigned

--- a/tests/unit/test_web_routes_sync.py
+++ b/tests/unit/test_web_routes_sync.py
@@ -108,3 +108,13 @@ def test_push_rejects_non_changeset(monkeypatch, tmp_path):
     monkeypatch.setattr(hsdb, "get_database", lambda *a, **k: _fake_db(tmp_path))
     resp = _client().post("/api/sync/push", json={"nope": 1})
     assert resp.status_code == 422
+
+
+def test_push_rejects_malformed_record(monkeypatch, tmp_path):
+    # HSM-10-03 both-ends validation: a record without a well-formed meta is rejected
+    # and never reaches the inbox.
+    monkeypatch.setattr(hsdb, "get_database", lambda *a, **k: _fake_db(tmp_path))
+    bad = {"meetings": [{"value": {"id": "m1"}}], "artifacts": []}  # no meta
+    resp = _client().post("/api/sync/push", json=bad)
+    assert resp.status_code == 422
+    assert not (tmp_path / "sync_inbox").exists()


### PR DESCRIPTION
## HSM-10-03 — conflict policy + idempotent round-trip (the no-data-loss story)

Makes `SyncEngine.apply` conflict-aware. Host-proven over the Phase-0 fixture;
cross-runtime (Swift policy + desktop-end validation). No live-store mutation — that
(the desktop applying pushed records to its live meetings) is HSM-10-04 / device.

### Policy (documented)
Per record, comparing incoming vs local `last_modified`:
- **newer wins** (live upserts; tombstone deletes; an older live record never
  resurrects a newer tombstone → no zombie re-creates);
- **older skips** (keep the newer local edit);
- **same time + same content / both tombstones** → no-op → **idempotent**;
- **same time + divergent** → genuine concurrent conflict: keep local + **surface in
  `ApplyReport`** (non-destructive — never silently dropped).

### Both ends validate
- Swift: `apply` validates every live payload against the contract before any write.
- Desktop: `POST /api/sync/push` now validates each record's `meta` (id + kind) →
  malformed → 422, never stored.

### Proof
- `swift test` **81/81** (6 opt-in skips) — `SyncConflictTests`: idempotent,
  newer-wins/older-skip, concurrent-divergence-surfaced, tombstone-no-resurrect.
- `uv run pytest tests/unit/test_web_routes_sync.py` → **4 passed**.

Phase 10 → **3/4**; only the live cross-device gate (HSM-10-04, needs the iPad) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)