### PR TITLE
holdspeak-mobile: Phase 10 — SyncCoordinator (one-call "sync now"), toward HSM-10-04

### DIFF
--- a/apple/Sources/Providers/Sync/SyncQueue.swift
+++ b/apple/Sources/Providers/Sync/SyncQueue.swift
@@ -36,6 +36,15 @@ public struct SyncQueue: Sendable {
         return url
     }
 
+    /// Enqueue with a monotonic seq derived from the current contents
+    /// (max-existing + 1) — stays clock/RNG-free and keeps FIFO order even across
+    /// partial flushes (a removed-then-readded item never reuses a live index).
+    @discardableResult
+    public func enqueueNext(_ changeSet: ChangeSet) throws -> URL {
+        let next = (try pending().compactMap { Int($0.deletingPathExtension().lastPathComponent) }.max() ?? -1) + 1
+        return try enqueue(changeSet, seq: next)
+    }
+
     /// Queued change-sets in FIFO order.
     public func pending() throws -> [URL] {
         try ensure()

--- a/apple/Sources/RuntimeCore/Sync/SyncCoordinator.swift
+++ b/apple/Sources/RuntimeCore/Sync/SyncCoordinator.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Contracts
+import Providers
+
+/// HSM-10 — the one-call sync operation the host UI drives ("Sync now").
+///
+/// Ties the pieces together: snapshot the local store, durably **record** the
+/// outbound change-set to the offline queue, **flush** the queue to the peer, then
+/// **pull + apply** the peer's change-set (conflict-resolved). It is offline-safe by
+/// construction — `syncNow` never throws on an unreachable peer; it reports
+/// `reachedPeer = false` with the snapshot safely queued for the next attempt, so
+/// sync is never on the capture/review path.
+///
+/// This is the mobile-side orchestration the continuity gate (HSM-10-04) exercises
+/// live on hardware; here it's host-proven against a fake peer.
+public struct SyncCoordinator: Sendable {
+    let store: ISyncStore
+    let provider: ISyncProvider
+    let queue: SyncQueue
+    let engine: SyncEngine
+
+    public init(store: ISyncStore, provider: ISyncProvider, queue: SyncQueue,
+                engine: SyncEngine = SyncEngine()) {
+        self.store = store
+        self.provider = provider
+        self.queue = queue
+        self.engine = engine
+    }
+
+    public struct Outcome: Sendable, Equatable {
+        /// Queued change-sets successfully pushed this pass.
+        public var pushed: Int
+        /// Change-sets still queued afterward (peer was down for some/all).
+        public var pendingAfter: Int
+        /// Records applied from the peer's pull.
+        public var applied: Int
+        /// Concurrent conflicts surfaced on apply (kept local; never silently dropped).
+        public var conflicts: [SyncEngine.Conflict]
+        /// Whether the peer answered the pull this pass.
+        public var reachedPeer: Bool
+    }
+
+    /// Run one sync pass. Durable-first: the local snapshot is queued before any
+    /// network, so nothing is lost if the peer is down or the app dies mid-sync.
+    @discardableResult
+    public func syncNow() async throws -> Outcome {
+        // 1. Record the outbound snapshot durably (offline-safe).
+        try queue.enqueueNext(try engine.snapshot(of: store))
+
+        // 2. Flush the queue to the peer (never throws; leaves the rest if down).
+        let pushed = await queue.flush(through: provider)
+        let pendingAfter = (try? queue.count()) ?? 0
+
+        // 3. Pull + apply if the peer is reachable.
+        do {
+            let incoming = try await provider.pull()
+            let report = try engine.apply(incoming, to: store)
+            return Outcome(pushed: pushed, pendingAfter: pendingAfter,
+                           applied: report.applied, conflicts: report.conflicts, reachedPeer: true)
+        } catch {
+            // Peer unreachable on pull — the snapshot is safely queued for later.
+            return Outcome(pushed: pushed, pendingAfter: pendingAfter,
+                           applied: 0, conflicts: [], reachedPeer: false)
+        }
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/SyncCoordinatorTests.swift
+++ b/apple/Tests/RuntimeCoreTests/SyncCoordinatorTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-10 — the one-call sync orchestration. Host-tested against a toggleable fake
+/// peer + a real SQLite store + a temp queue. Deterministic, offline-safe.
+final class SyncCoordinatorTests: XCTestCase {
+
+    struct Sample: Codable { let meeting: Meeting; let artifact: Artifact }
+    private func fixture() throws -> Sample {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<4 { url.deleteLastPathComponent() }
+        url.appendPathComponent("pm/roadmap/holdspeak-mobile/contracts/fixtures/meeting-sample.json")
+        return try HoldSpeakContracts.decoder().decode(Sample.self, from: Data(contentsOf: url))
+    }
+    private func tempStore() throws -> SQLiteStorage {
+        try SQLiteStorage(path: NSTemporaryDirectory() + "hsm-co-\(UUID().uuidString).sqlite")
+    }
+    private func tempQueue() -> SyncQueue {
+        SyncQueue(directory: URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hsm-coq-\(UUID().uuidString)", isDirectory: true))
+    }
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// A peer that can be toggled down, records pushes, and serves a configured pull.
+    final class FakePeer: ISyncProvider, @unchecked Sendable {
+        struct Down: Error {}
+        var up: Bool = true
+        var received: [ChangeSet] = []
+        var pullResult = ChangeSet()
+        func push(_ changeSet: ChangeSet) async throws {
+            if !up { throw Down() }
+            received.append(changeSet)
+        }
+        func pull() async throws -> ChangeSet {
+            if !up { throw Down() }
+            return pullResult
+        }
+    }
+
+    func testSyncNowPushesAndAppliesWhenReachable() async throws {
+        let s = try fixture()
+        let store = try tempStore(); defer { store.close() }
+        try store.saveMeeting(s.meeting, modifiedAt: t0)
+
+        let peer = FakePeer()
+        // The peer offers a fresh artifact to pull back.
+        peer.pullResult = ChangeSet(artifacts: [.live(s.artifact, id: s.artifact.id, kind: .artifact, modifiedAt: t0)])
+
+        let coord = SyncCoordinator(store: store, provider: peer, queue: tempQueue())
+        let outcome = try await coord.syncNow()
+
+        XCTAssertTrue(outcome.reachedPeer)
+        XCTAssertEqual(outcome.pushed, 1)               // the local snapshot flushed
+        XCTAssertEqual(outcome.pendingAfter, 0)         // queue drained
+        XCTAssertEqual(outcome.applied, 1)              // pulled artifact applied
+        XCTAssertFalse(peer.received.isEmpty)           // peer got our snapshot
+        XCTAssertEqual(try store.loadArtifacts(meetingId: s.artifact.meetingId), [s.artifact])
+    }
+
+    func testSyncNowIsOfflineSafe() async throws {
+        let s = try fixture()
+        let store = try tempStore(); defer { store.close() }
+        try store.saveMeeting(s.meeting, modifiedAt: t0)
+
+        let peer = FakePeer(); peer.up = false
+        let coord = SyncCoordinator(store: store, provider: peer, queue: tempQueue())
+
+        let outcome = try await coord.syncNow()         // must not throw
+        XCTAssertFalse(outcome.reachedPeer)
+        XCTAssertEqual(outcome.pushed, 0)
+        XCTAssertEqual(outcome.pendingAfter, 1)         // snapshot safely queued
+        XCTAssertEqual(outcome.applied, 0)
+    }
+
+    func testQueuedSnapshotsResumeWhenPeerReturns() async throws {
+        let s = try fixture()
+        let store = try tempStore(); defer { store.close() }
+        try store.saveMeeting(s.meeting, modifiedAt: t0)
+
+        let peer = FakePeer(); peer.up = false
+        let queue = tempQueue()
+        let coord = SyncCoordinator(store: store, provider: peer, queue: queue)
+
+        _ = try await coord.syncNow()                   // offline → queued
+        _ = try await coord.syncNow()                   // offline again → 2 queued
+        XCTAssertEqual(try queue.count(), 2)
+
+        peer.up = true
+        let outcome = try await coord.syncNow()         // back online → flush all (incl. this pass's)
+        XCTAssertTrue(outcome.reachedPeer)
+        XCTAssertEqual(outcome.pendingAfter, 0)
+        XCTAssertEqual(peer.received.count, 3)          // all three snapshots delivered
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,14 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**HSM-10-03 (sync conflict + round-trip) DONE.**
+**Last updated:** 2026-06-19 (**Sync "do it now" orchestration — `SyncCoordinator`,
+host-proven.** The one-call sync the host UI drives: `syncNow()` snapshots the store →
+durably queues the outbound change-set → flushes to the peer → pulls + applies
+(conflict-resolved), **offline-safe by construction** (never throws on an unreachable
+peer; the snapshot is queued for the next pass). `SyncQueue.enqueueNext` (clock-free)
+backs the durable-first record. `swift test` **84/84** incl. `SyncCoordinatorTests`
+(reachable / offline / resume). This is the mobile side of the continuity gate
+(HSM-10-04 → in-progress); only the live on-device walkthrough remains. Earlier:
+**HSM-10-03 (sync conflict + round-trip) DONE.**
 `SyncEngine.apply` is now conflict-aware: LWW by `last_modified`, **same-time
 divergence surfaced non-destructively** (kept local + reported, never silently
 dropped), tombstone no-resurrect, and **idempotent** (sync twice → no change) — all
@@ -254,7 +262,7 @@ WebView, or UIKit.
 | 7 | H | MIR port: 5 profiles measurably alter extraction | **done (4/4) ✅** | [phase-7](./phase-7-mir-port/) |
 | 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes | not-started | [phase-9](./phase-9-iphone-experience/) |
-| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (3/4; object model + transport + conflict policy host-proven; only the live cross-device gate (device) remains) | [phase-10](./phase-10-sync/) |
+| 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (object model + transport + conflict + `SyncCoordinator` orchestration host-proven; only the live cross-device walkthrough (device) remains) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios, production readiness | not-started | [phase-11](./phase-11-hardening/) |
 
 Phases are sequenced as the charter lists the tracks. The contract layer (Phase

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/current-phase-status.md
@@ -66,7 +66,7 @@ local-first; it never acts autonomously.
 | HSM-10-01 | Sync provider + object model | done | [story-01](./story-01-sync-provider-object-model.md) | [evidence-01](./evidence-story-01.md) |
 | HSM-10-02 | Transport targets | done (both sides) | [story-02](./story-02-transport-targets.md) | [evidence-02](./evidence-story-02.md) |
 | HSM-10-03 | Conflict + round-trip | done | [story-03](./story-03-conflict-and-roundtrip.md) | [evidence-03](./evidence-story-03.md) |
-| HSM-10-04 | Continuity closeout (Gate 6) | backlog | [story-04](./story-04-continuity-closeout.md) | — |
+| HSM-10-04 | Continuity closeout (Gate 6) | in-progress (SyncCoordinator orchestration host-proven; live device walkthrough pending) | [story-04](./story-04-continuity-closeout.md) | in story |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-10-sync/story-04-continuity-closeout.md
+++ b/pm/roadmap/holdspeak-mobile/phase-10-sync/story-04-continuity-closeout.md
@@ -2,9 +2,29 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 10
-- **Status:** backlog
+- **Status:** in-progress (the mobile-side orchestration is built + host-proven; the
+  live cross-device walkthrough is gated on the iPad unlock)
 - **Depends on:** HSM-10-01, HSM-10-02, HSM-10-03
 - **Owner:** unassigned
+
+## Progress (2026-06-19) — the "Sync now" orchestration is ready
+
+The one-call sync operation the host UI drives is built + host-proven; only the
+live, on-hardware walkthrough remains.
+
+- `SyncCoordinator` (`apple/Sources/RuntimeCore/Sync/SyncCoordinator.swift`):
+  `syncNow()` snapshots the store → durably records the outbound change-set to the
+  queue → flushes to the peer → pulls + applies (conflict-resolved). **Offline-safe
+  by construction** — never throws on an unreachable peer; reports
+  `reachedPeer=false` with the snapshot queued for the next pass.
+- `SyncQueue.enqueueNext` (clock-free monotonic seq) backs the durable-first record.
+- Host tests (`SyncCoordinatorTests`): reachable (push + drain + apply), offline
+  (queued, no throw), and resume (all queued snapshots delivered when the peer
+  returns). `swift test` 84/84.
+
+**Remaining for the gate:** the live phone↔desktop walkthrough over Tailscale on real
+devices (needs the iPad unlock + a running desktop receiver, which shipped in
+HSM-10-02 PR-B). On pass, write `evidence-story-04.md` + `final-summary.md`.
 
 ## Problem
 


### PR DESCRIPTION
## `SyncCoordinator` — the one-call sync the host UI drives

The mobile-side orchestration that ties the sync pieces together. Host-proven; the
live cross-device walkthrough (HSM-10-04 gate) is the only remaining piece (device).

- **`syncNow()`** snapshots the store → durably **records** the outbound change-set
  to the queue → **flushes** to the peer → **pulls + applies** (conflict-resolved).
- **Offline-safe by construction:** never throws on an unreachable peer; returns
  `Outcome{pushed, pendingAfter, applied, conflicts, reachedPeer}` with the snapshot
  queued for the next pass. Sync stays off the capture/review path.
- `SyncQueue.enqueueNext` — clock-free monotonic seq (max-existing + 1).

`swift test` **84/84** incl. `SyncCoordinatorTests`: reachable (push + drain +
apply), offline (queued, no throw), resume (all queued snapshots delivered when the
peer returns).

HSM-10-04 → in-progress (orchestration ready); the live phone↔desktop run needs the
iPad unlock + the desktop receiver (shipped in HSM-10-02 PR-B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)