### PR TITLE
holdspeak-mobile: Companion Client track (Phases 12–13) + air-gapped on-device elevation (Phase 8)

### DIFF
--- a/pm/roadmap/holdspeak-mobile/PROGRAM-RISKS.md
+++ b/pm/roadmap/holdspeak-mobile/PROGRAM-RISKS.md
@@ -4,7 +4,7 @@
 each phase's `current-phase-status.md`). Every risk names a **stop signal** — the
 concrete observation that triggers "halt this approach and regroup."
 
-**Last updated:** 2026-06-18 (seeded at Phase-0 close).
+**Last updated:** 2026-06-20 (added P8–P10 for the Companion track, Phases 12–13).
 
 | # | Risk | Phase(s) | Likelihood | Mitigation | Stop signal |
 |---|---|---|---|---|---|
@@ -15,6 +15,9 @@ concrete observation that triggers "halt this approach and regroup."
 | P5 | **Hardware-gated closeouts** — gates 2/3/4/6/7 need real Tier-1/Tier-2 devices; only simulators available | 2, 3, 5, 10, 11 | medium | Treat device gates as hardware-only by nature; secure the devices before the closeout stories | A gate is closed on simulator-only evidence — reject; it does not meet the charter gate |
 | P6 | **iOS deployment-floor coupling** — if Core ML wins (HSM-5-01), `MLState` KV cache forces an iOS-18+ floor set after Phase 1 chose a target | 1, 5 | low | Carry the dependency explicitly from HSM-5-01 back to Phase 1's minimum-deployment-target decision | Phase 1 ships a floor below iOS 18 and Core ML wins — re-baseline the floor |
 | P7 | **Charter scope is large** (~26 weeks, 12 phases) and a late phase surfaces an early-phase design flaw | all | medium | Phase gates are evidence-bound; hardening (Phase 11) findings route back to the owning phase, not patched in place | A Phase-11 scenario fails for a reason rooted in an earlier phase — file it back to that phase, don't hack the hardening layer |
+| P8 | **The iPad is reduced to a dumb terminal** — the companion track quietly neuters the on-device runtime the owner forbade neutering | 12, 13 | high | The unified shell (HSM-12-03) presents the on-device runtime as a first-class peer of the server; both gates (HSM-12-04 / HSM-13-04) re-prove on-device capability; the companion is additive, never on the local path | A paired iPad hides/disables on-device meetings or inference — restore them; the device must stand its own ground |
+| P9 | **The remote-dictation inject endpoint becomes an unauthenticated write into the dev machine**, or injects without the user's explicit send | 13 | high | Tokened behind the Phase-12 client handshake; deliver-on-command only (never autonomous); credential joined at call time, never echoed (Phase-61 Slack discipline); mirrors the actuator Propose→Approve lifecycle | The endpoint accepts an untokened write, or any path delivers without an explicit send — halt and gate it |
+| P10 | **Tracks M–N drift from the charter** — the companion track lives outside the charter's Tracks A–L and the two specs disagree | 12, 13 | medium | The addition is recorded in the README + each phase's "Decisions made" as an owner steer (2026-06-20); flagged for an owner-blessed charter amendment, not silently rewritten | A phase doc and `CHARTER.md` give conflicting direction for the iPad's identity — get the owner's amendment before building deeper |
 
 ## Retired
 

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,29 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-19 (**Sync "do it now" orchestration — `SyncCoordinator`,
-host-proven.** The one-call sync the host UI drives: `syncNow()` snapshots the store →
+**Last updated:** 2026-06-20 (**Companion track scaffolded — Phases 12–13 (Tracks
+M–N), by owner steer.** The program was chartered as a standalone on-device runtime
+and never planned the iPad as a **first-class companion to the desktop coder** — the
+one iPad-UI phase (8) is a PencilKit notebook, and the iPad app today is a Gate-1
+launch stub plus a demo harness. Two new phases close that gap without neutering the
+device: **Phase 12 — The Companion Client** (point the iPad at the same server you
+code against; a unified shell presenting both its own on-device runtime *and* the
+server; meetings remote control — list / start / stop / live state over the existing
+HTTP API), and **Phase 13 — Answer the Coder** (the AI PI payoff: the agent's
+question surfaces on the iPad, you answer with a native voice note through the rich
+dictation pipeline, it lands back in the coder session — never autonomous). Built
+native over the desktop's existing API (owner call); the desktop already serves what
+the client consumes (`/api/meetings`, `/api/meeting/start|stop`, `/api/dictation/*`,
+`/api/companion/*`), the one new desktop surface being the remote-dictation inject
+endpoint (HSM-13-01). Phase 8 + the on-device runtime stand untouched. Ten new story
+files scaffolded; no implementation started. **Also: Phase 8 (the on-device iPad
+experience) elevated to the owner's richness bar** — the **air-gapped fully-local
+notetaker** (iPad at a meeting, zero connectivity, Mode A on-device) is now a
+first-class scenario with its own gate (HSM-8-05), and the **magic pencil is
+genuinely involved** (HSM-8-06: on-device handwriting recognition, notes/marks
+promoted to artifacts, marked moments weighting MIR) rather than a parallel
+scratchpad; the notebook/linking stories raised to match. The standalone on-device
+paradigm and the companion track are now both first-class, in both directions.
+Earlier: **Sync "do it now" orchestration — `SyncCoordinator`, host-proven.** The one-call sync the host UI drives: `syncNow()` snapshots the store →
 durably queues the outbound change-set → flushes to the peer → pulls + applies
 (conflict-resolved), **offline-safe by construction** (never throws on an unreachable
 peer; the snapshot is queued for the next pass). `SyncQueue.enqueueNext` (clock-free)
@@ -193,8 +215,20 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred.
-**Status:** in-progress (Phases 0–1–4 closed, **Phase 6 closed (Gate 5 desktop-parity PASSED 0.92)**, **Phase 7 closed (MIR port — profile measurably changes extraction)**; Phase 5 host-complete — on-device Mode A + endpoint Modes B/C + sideload/HF packaging, device runs await the iPad unlock; Phase 10 opened (sync object model + engine). Next device-free: HSM-10-02 sync transport + Python sync API, or Phases 8/9 experience. iPad on-device batch (HSM-5-02/03/06 + Gate-4) when the device is unlocked).
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) scaffolded 2026-06-20 by owner steer; no work started.**
+
+**Highest-value direction (owner steer, 2026-06-20).** The program's value now
+concentrates on the **two iPad faces, both first-class**: (1) the **Companion track**
+— point the iPad at the server you code against and **answer the coder by voice**
+(Phase 12 → 13, the Answer-the-Coder payoff), and (2) the **air-gapped fully-local
+notetaker** with a magic pencil that feeds the output (Phase 8, elevated: HSM-8-05 +
+HSM-8-06). **Start here →** [HSM-12-01](./phase-12-companion-client/story-01-desktop-client-seam.md)
+(the desktop client seam) — the highest-value **device-free** story, fully
+host-testable against a fake desktop, and the spine the whole Companion track hangs
+off. The on-device richness (HSM-8-05/06) sequences behind Phase 6 + HSM-5-02 (Mode
+A) and the iPad unlock; build its host-testable seams first, then gate on device.
+Sync (Phase 10) continues in parallel but is plumbing, not the headline value.
+**Status:** in-progress (Phases 0–1–4 closed, **Phase 6 closed (Gate 5 desktop-parity PASSED 0.92)**, **Phase 7 closed (MIR port — profile measurably changes extraction)**; Phase 5 host-complete — on-device Mode A + endpoint Modes B/C + sideload/HF packaging, device runs await the iPad unlock; Phase 10 opened (sync object model + engine). Next device-free: HSM-10-02 sync transport + Python sync API, or Phases 8/9 experience, or **Phase 12 — The Companion Client (HSM-12-01, the desktop client seam, fully host-testable against a fake desktop)**. iPad on-device batch (HSM-5-02/03/06 + Gate-4) when the device is unlocked; the companion gates (HSM-12-04 / HSM-13-04) join that device batch).
 
 ## Vision
 
@@ -260,10 +294,21 @@ WebView, or UIKit.
 | 5 | F | Local inference (4B/8B) — a 30-min meeting processed on-device | in-progress (engine pick + structured-output + model policy done; HSM-5-06 endpoint Modes B/C; **HSM-5-02 LlamaProvider/Mode A host-proven on Metal**; **HSM-5-03 packaging — sideload + HF download host-proven**; iPad runs + HSM-5-05 gate device) | [phase-5](./phase-5-local-inference/) |
 | 6 | G | Meeting intelligence: structured-JSON artifacts at desktop parity | **Gate 5 PASSED ✅ (5/6; 6-06 deferred)** | [phase-6](./phase-6-meeting-intelligence/) |
 | 7 | H | MIR port: 5 profiles measurably alter extraction | **done (4/4) ✅** | [phase-7](./phase-7-mir-port/) |
-| 8 | I | iPad experience: PencilKit notebook + transcript linking + review | not-started | [phase-8](./phase-8-ipad-experience/) |
+| 8 | I | iPad experience: the **air-gapped fully-local notetaker** (rich, zero-connectivity, Mode A) + a **magic pencil that feeds the output** (PencilKit notebook, marked moments, ink → artifacts) + review | not-started (elevated 2026-06-20: +HSM-8-05 air-gapped gate, +HSM-8-06 ink-into-intelligence) | [phase-8](./phase-8-ipad-experience/) |
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes | not-started | [phase-9](./phase-9-iphone-experience/) |
 | 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (object model + transport + conflict + `SyncCoordinator` orchestration host-proven; only the live cross-device walkthrough (device) remains) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios, production readiness | not-started | [phase-11](./phase-11-hardening/) |
+| 12 | M | **The Companion Client:** point the iPad at the same server you code against — a unified shell (on-device runtime + server, never a dumb terminal) + meetings remote control | not-started (scaffolded 2026-06-20) | [phase-12](./phase-12-companion-client/) |
+| 13 | N | **Answer the Coder:** the AI PI payoff — the agent's question surfaces on the iPad, you answer by native voice note, it lands back in the coder session | not-started (scaffolded 2026-06-20) | [phase-13](./phase-13-answer-the-coder/) |
+
+**Tracks M–N (Phases 12–13)** were added by owner steer (2026-06-20), outside the
+original charter's Tracks A–L. They close a gap the owner named directly: there was
+no phase for the iPad as a **first-class companion to the desktop coder**. The iPad
+keeps every on-device power (Phases 0–7 stand — "not a dumb terminal"); the
+companion track *adds* a server-aware face, built native over the desktop's
+existing HTTP API. Phase 8 (the PencilKit notebook) stays the on-device iPad
+flagship, untouched. The charter (Tracks A–L) may want an owner-blessed amendment
+to record M–N; this is flagged, not silently rewritten.
 
 Phases are sequenced as the charter lists the tracks. The contract layer (Phase
 0) and runtime-core seams gate everything above them; the two experience phases

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/current-phase-status.md
@@ -1,0 +1,141 @@
+# Phase 12 — The Companion Client
+
+**Status:** planning (scaffolded 2026-06-20). **Track M — added by owner steer
+(2026-06-20), outside the original charter's Tracks A–L.** The iPad stops being a
+launch stub and becomes a **first-class companion to the desktop/server you are
+already coding against**, without losing one ounce of its own on-device power
+(Phases 0–7 stand). Point the iPad at the same server your tmux + hooks session
+points at, and it becomes a native window into that runtime: list and start
+meetings, see live state, and (Phase 13) answer the coder by voice. Built
+**native over the desktop's existing HTTP API** (owner call, 2026-06-20) — the
+same endpoints the web portal uses — so the experience is web-app-consistent and
+genuinely native, not a WebView shell.
+
+**Last updated:** 2026-06-20 (scaffolded — stories HSM-12-01..04 stubbed from the
+owner's companion-client steer. No work started.)
+
+## Why this exists (the gap this closes)
+
+The program was chartered as "the first mobile runtime" — a standalone on-device
+app. That work is real and stays. But it left a hole the owner named directly:
+there was **no phase for the iPad as a rich client to the desktop coder**. The
+only iPad-UI phase (Phase 8) is a PencilKit meeting notebook; the iPad app today
+is a Gate-1 launch stub plus a one-off inference demo harness. Nothing let you
+point the iPad at your dev machine and drive it. This track closes that — and the
+desktop is ready to be driven: it already exposes `/api/meetings`,
+`/api/meeting/start|stop`, `/api/runtime/status`, `/api/dictation/*`, and the AI PI
+`/api/companion/*` surface. A client mostly consumes what already ships.
+
+## The principle (owner, 2026-06-20): not a dumb terminal
+
+> "It doesn't mean the iPad becomes a dumb terminal device. It can act in that
+> capacity, but it should also stand its own ground."
+
+The iPad keeps every on-device capability (capture, Whisper, local inference,
+meeting intelligence, MIR). The companion shell **adds** a server-aware face; it
+never replaces the local runtime. The unified shell presents both at once — what
+runs here and what is happening on the server — so the device is enriched, never
+reduced.
+
+## Goal
+
+Build the native SwiftUI Companion Client over a Runtime-Core desktop-client seam:
+configure/point the iPad at a desktop or homelab server, browse and start/stop
+meetings on that server from the iPad, see live runtime state, and present it all
+in a web-app-consistent Signal shell that also surfaces the iPad's own on-device
+runtime. The phase passes when the iPad is a first-class companion to a real
+desktop on real hardware (the Track M gate), with the on-device runtime provably
+still intact. The host stays thin — the client seam lives in the Runtime Core; the
+views present it.
+
+## Scope
+
+- **In:** the `IDesktopClient` Runtime-Core seam + pairing/handshake against the
+  desktop HTTP API (HSM-12-01); meetings remote control — list / open /
+  start / stop / live status over the existing endpoints (HSM-12-02); the unified
+  Companion shell (web-app-consistent Signal; on-device runtime + server view in
+  one app, the iPad never neutered) (HSM-12-03); the Track M gate device closeout
+  (HSM-12-04).
+- **Out:** answering the coder / the AI PI loop / remote dictation inject (Phase 13
+  — Track N). The PencilKit notebook (Phase 8, untouched). The on-device engines
+  themselves (Phases 2–7 — this client presents them, it does not rebuild them).
+  Cross-device data sync (Phase 10 — a different mechanism; the client drives the
+  live server, sync reconciles stores). A hosted cloud service (this is the user's
+  own server over LAN/Tailscale). Hardening (Phase 11).
+
+## Exit criteria (evidence required)
+
+- [ ] An `IDesktopClient` seam exists; the Runtime Core depends on the interface,
+      not a concrete transport; the iPad can be pointed at a desktop/homelab server
+      (host/port/token over LAN/Tailscale), handshakes against `/health` +
+      `/api/runtime/status`, carries an honest egress label, and is offline-tolerant
+      (the app never stalls when the server is unreachable) (HSM-12-01).
+- [ ] From the iPad you can list the server's meetings, open one, and **start and
+      stop a meeting on the desktop**, with live runtime state reflected — all over
+      the existing endpoints, driven through the seam (HSM-12-02).
+- [ ] The Companion shell is web-app-consistent (Signal language, the portal's
+      Meetings / Dictate / Companion navigation) and presents the iPad's **own
+      on-device runtime alongside** the server view — the device is not reduced to a
+      remote (HSM-12-03).
+- [ ] **Track M gate — first-class companion, proven:** on a physical iPad against a
+      real desktop, point the iPad at the server, list + start/stop a meeting from
+      the iPad, and confirm the on-device runtime still fully works (capture/local
+      intelligence not neutered), evidenced by a device walkthrough (HSM-12-04).
+
+## Story status
+
+| ID | Story | Status | Story file | Evidence |
+|---|---|---|---|---|
+| HSM-12-01 | Desktop client seam + pairing | backlog | [story-01](./story-01-desktop-client-seam.md) | — |
+| HSM-12-02 | Meetings remote control | backlog | [story-02](./story-02-meetings-remote-control.md) | — |
+| HSM-12-03 | The unified Companion shell | backlog | [story-03](./story-03-unified-companion-shell.md) | — |
+| HSM-12-04 | Track M gate closeout | backlog | [story-04](./story-04-companion-gate-closeout.md) | — |
+
+## Where we are
+
+Just scaffolded from the owner's 2026-06-20 steer. The foundation (HSM-12-01) is
+fully host-testable against a fake desktop and unblocks the rest; meetings remote
+control (HSM-12-02) consumes endpoints that already ship; the shell (HSM-12-03) is
+where the web-app consistency and the "not a dumb terminal" principle become
+visible; the gate (HSM-12-04) needs the unlocked iPad + a reachable desktop. Phase
+13 (Answer the Coder) builds the voice-note-into-the-coder payoff on this
+foundation. Next: HSM-12-01.
+
+## Active risks
+
+| Risk | Likelihood | Mitigation | Stop signal |
+|---|---|---|---|
+| The client stalls the app when the server is unreachable (companion blocks the on-device runtime) | high | The seam is offline-tolerant by construction; on-device features never depend on the server being reachable; the shell shows a clear "server unreachable" state and keeps working locally | An on-device action (capture, local meeting) blocks because the desktop is down — decouple; the companion is additive, never on the local path |
+| The iPad is quietly reduced to a remote (the "dumb terminal" failure the owner forbade) | high | HSM-12-03 presents the on-device runtime as a first-class peer of the server view; the gate (HSM-12-04) explicitly re-proves on-device capability | The shell hides or disables on-device meetings/inference when paired — restore them; the device stands its own ground |
+| Business logic leaks into SwiftUI views, breaking the charter's layer rule | medium | The client logic lives in the `IDesktopClient` seam + view-models in the Runtime Core; views present only | A view holds HTTP/client state or business logic — pull it into the core |
+| The mobile↔desktop API drifts and the client breaks silently | medium | The client speaks the same contracts the web portal does; validate decoded payloads against the Phase-0 schemas where they overlap; pin the endpoints the client depends on | A server response fails to decode/validate — reconcile the contract before shipping |
+| Pairing/auth to the desktop is unclear over LAN/Tailscale | medium | Reuse the Phase-10 transport posture (direct to the peer over the user's own network, honest egress); a simple host/port + token handshake, no third-party relay | The client needs a hosted relay or a cloud account to reach the desktop — out of scope; keep it the user's own network |
+
+## Decisions made (this phase)
+
+- 2026-06-20 — **Owner steer:** the iPad must be a first-class companion to the
+  desktop server in addition to its standalone on-device runtime — not a dumb
+  terminal, not neutered. This adds Track M (this phase) + Track N (Phase 13)
+  outside the original charter Tracks A–L; the charter may want an owner-blessed
+  amendment to record the new tracks (flagged, not silently rewritten).
+- 2026-06-20 — **Owner call:** the client is **native SwiftUI over the desktop's
+  existing HTTP API** (the same endpoints the web portal uses), not a WebView
+  wrapper — native richness + web-app consistency. New desktop endpoints are added
+  only where the existing surface has no equivalent (the remote-dictation inject
+  path lands in Phase 13).
+- 2026-06-20 — **Owner call:** Phase 8 (the PencilKit notebook) stays the iPad
+  flagship as-is; the companion client is this separate, later track, not a
+  re-scope of Phase 8.
+
+## Decisions deferred
+
+- Pairing/discovery UX (manual host:port + token vs. Bonjour/Tailscale discovery) —
+  trigger: HSM-12-01 — default: manual host:port + token first (simplest, no
+  dependency), discovery parked as polish.
+- Whether the companion shell and the Phase-8 notebook are one app or two targets —
+  trigger: HSM-12-03 — default: one app, the companion as a mode/tab alongside the
+  on-device surfaces, so the device is unified, not split.
+- How live runtime state reaches the iPad (poll `/api/runtime/status` vs. an
+  event/stream transport) — trigger: HSM-12-02 — default: poll first; an
+  event/push transport is a later optimization (and is also what Phase 13's
+  companion board would benefit from).

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-01-desktop-client-seam.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-01-desktop-client-seam.md
@@ -1,0 +1,64 @@
+# HSM-12-01 — Desktop client seam + pairing
+
+- **Project:** holdspeak-mobile
+- **Phase:** 12
+- **Status:** backlog
+- **Depends on:** HSM-0-04 (contracts), HSM-1-01 (SPM layout), HSM-10-02 (transport posture to reuse)
+- **Unblocks:** HSM-12-02, HSM-12-03, HSM-13-01
+- **Owner:** unassigned
+
+## Problem
+
+The iPad cannot act as a companion until it can point at, reach, and trust a
+desktop/homelab server — the same server your tmux + hooks coding session points
+at. That connection must be a clean Runtime-Core seam (so views and business logic
+never hold a raw HTTP client), and it must be offline-tolerant: the iPad's own
+on-device runtime can never stall because a server is unreachable. This is the
+spine the whole track hangs off.
+
+## Scope
+
+- **In:** an `IDesktopClient` abstraction (Layer 3) the Runtime Core depends on;
+  configuration of a desktop peer (host/port + token over the user's own LAN /
+  Tailscale, reusing the Phase-10 transport posture — direct to the peer, no
+  third-party relay); a handshake/health check against the desktop's `/health` +
+  `/api/runtime/status`; an honest egress descriptor for the connection (positioning
+  canon: one badge, never a privacy novel); offline tolerance (every call fails
+  soft and never blocks the on-device path).
+- **Out:** the meeting/dictation/companion calls themselves (HSM-12-02, Phase 13).
+  The shell/UI (HSM-12-03). Any on-device feature change (the local runtime is
+  untouched). Discovery/Bonjour (parked; manual host:port + token first).
+
+## Acceptance criteria
+
+- [ ] `IDesktopClient` exists; the Runtime Core depends on the interface, and a
+      fake client drives the connection flow in tests (no concrete HTTP in the
+      core's callers).
+- [ ] The iPad can be configured with a desktop peer (host/port + token) and a
+      handshake succeeds against a server presenting `/health` + `/api/runtime/status`,
+      surfacing reachable/unreachable + runtime readiness.
+- [ ] The connection carries an honest egress descriptor (e.g. `local + LAN →
+      <host>`); no privacy-novel prose.
+- [ ] Every client call is offline-tolerant: when the peer is down the call fails
+      soft (no throw on the capture/UI path), and a test proves the on-device flow
+      is unaffected by an unreachable peer.
+
+## Test plan
+
+- Unit: drive the connect/handshake/health flow against a fake desktop (reachable,
+  unreachable, not-ready) → correct state transitions; egress descriptor correct;
+  unreachable peer never throws on the caller path.
+- Unit: a Runtime-Core flow that uses the on-device runtime while the desktop is
+  unreachable completes unaffected (the "not blocked by the server" guarantee).
+- Manual / device: deferred to HSM-12-04 (real desktop on the LAN).
+
+## Notes / open questions
+
+- Reuse the Phase-10 `HTTPSyncProvider`/`SyncQueue` posture for transport hygiene
+  (direct to the peer, honest egress, never-throw-when-down) — but this is the
+  *live* client, distinct from the store-reconciling sync provider; do not conflate
+  the two seams.
+- The token is a credential: join it at call time, never log it, never put it in a
+  payload echoed back to the UI (mirror the Phase-61 Slack-URL discipline).
+- Keep the seam minimal here — just connect/health/egress. The verb methods (list
+  meetings, start meeting, post dictation) are added by the stories that need them.

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-02-meetings-remote-control.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-02-meetings-remote-control.md
@@ -1,0 +1,61 @@
+# HSM-12-02 — Meetings remote control
+
+- **Project:** holdspeak-mobile
+- **Phase:** 12
+- **Status:** backlog
+- **Depends on:** HSM-12-01
+- **Unblocks:** HSM-12-03, HSM-12-04
+- **Owner:** unassigned
+
+## Problem
+
+The owner named it directly: "start meeting, list of meetings." When the iPad is
+pointed at the same server you are coding against, you should be able to see the
+server's meetings and start or stop one from the iPad — the remote-control half of
+the companion. The desktop already serves these endpoints; this story makes the
+client drive them through the seam.
+
+## Scope
+
+- **In:** client methods + Runtime-Core view-models over the existing desktop
+  endpoints — list the server's meetings (`GET /api/meetings`, with
+  `/api/meetings/facets` available for filtering), open one
+  (`GET /api/meetings/{id}` + `/artifacts`), **start a meeting on the desktop**
+  (`POST /api/meeting/start`), **stop it** (`POST /api/meeting/stop`), and reflect
+  live runtime state (`GET /api/runtime/status`). All through `IDesktopClient`; the
+  view-models expose list/detail/start/stop/live-state without UIKit.
+- **Out:** the SwiftUI screens themselves (HSM-12-03 renders these view-models).
+  Dictation / answering the coder (Phase 13). Meeting *import* and faceted search
+  depth (desktop Phase 55 — the client reads what the server returns, it does not
+  re-implement faceting). Editing/deleting server meetings from the iPad (parked).
+
+## Acceptance criteria
+
+- [ ] A view-model lists the server's meetings from `/api/meetings` and opens one
+      (detail + artifacts) — decoded into the shared contract types, validated where
+      the Phase-0 schemas overlap.
+- [ ] From the iPad, `start` and `stop` a meeting on the desktop via
+      `/api/meeting/start` + `/api/meeting/stop`, and the resulting live state is
+      reflected from `/api/runtime/status`.
+- [ ] All of it runs through `IDesktopClient`; a fake desktop drives the flow in
+      tests; no concrete HTTP in the view layer or the view-models' callers.
+- [ ] Unreachable/again-reachable transitions are handled gracefully (the list and
+      controls show a clear unreachable state and recover; no crash, no stall).
+
+## Test plan
+
+- Unit: against a fake desktop, list → open → start → stop → live-state transitions
+  produce the expected view-model state; payloads decode/validate; start/stop are
+  driven through the seam.
+- Unit: a `/api/runtime/status` poll reflects an in-progress meeting and returns to
+  idle on stop.
+- Manual / device: deferred to HSM-12-04 (real desktop, real meeting).
+
+## Notes / open questions
+
+- Live state: poll `/api/runtime/status` first (the phase default); an event/stream
+  transport is a later optimization that Phase 13's companion board also wants —
+  flag it, don't build it here.
+- Respect the server's own state machine — the iPad requests start/stop; the
+  desktop owns whether a meeting can start (mic, readiness). Surface the server's
+  refusal honestly rather than second-guessing it on the client.

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-03-unified-companion-shell.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-03-unified-companion-shell.md
@@ -1,0 +1,67 @@
+# HSM-12-03 — The unified Companion shell
+
+- **Project:** holdspeak-mobile
+- **Phase:** 12
+- **Status:** backlog
+- **Depends on:** HSM-12-01, HSM-12-02
+- **Unblocks:** HSM-12-04
+- **Owner:** unassigned
+
+## Problem
+
+This is where the "not a dumb terminal" principle becomes visible or gets
+violated. The iPad must present, in one native app, **both** its own on-device
+runtime **and** the server it is pointed at — web-app-consistent so it feels like
+the HoldSpeak you already know, and rich enough that the device clearly stands its
+own ground. A shell that hides the local runtime when paired, or that looks
+nothing like the portal, fails the owner's brief.
+
+## Scope
+
+- **In:** the SwiftUI Companion shell — navigation consistent with the web portal's
+  surfaces (Meetings / Dictate / Companion), dressed in the Signal design language
+  (reuse the harness palette: near-black surfaces, one orange signal for the
+  live/primary moment, real depth, per-type cards); a connect-to-desktop onboarding
+  (point at the server — host/port + token from HSM-12-01); the meetings
+  remote-control screens over the HSM-12-02 view-models; and a clear, calm
+  "server unreachable" state that never blocks the app. Crucially, the shell
+  presents the iPad's **own on-device runtime as a first-class peer** of the server
+  view (local meetings / local inference remain reachable and obviously alive when
+  paired).
+- **Out:** answering the coder / the companion board / voice-note dictation (Phase
+  13 — the "Companion" tab's deep content lands there; this story stands up the
+  navigation slot and the meetings/local surfaces). The PencilKit notebook (Phase
+  8). Any business logic in the views (it stays in the Runtime-Core view-models).
+
+## Acceptance criteria
+
+- [ ] The shell is web-app-consistent: the portal's Meetings / Dictate / Companion
+      navigation, rendered in the Signal language (not stock SwiftUI), to a high UI
+      standard (real depth, affordances, no flat/basic placeholder cards).
+- [ ] Connect-to-desktop onboarding points the iPad at a server (HSM-12-01) and the
+      meetings remote-control surfaces (HSM-12-02) are reachable from the shell.
+- [ ] The iPad's **on-device runtime is presented alongside** the server view — a
+      paired iPad still shows its local meetings/inference as first-class; the device
+      is not reduced to a remote (proven in the screenshot/walkthrough).
+- [ ] A "server unreachable" state is clear and calm and never blocks on-device use;
+      the views hold no business logic (Runtime-Core view-models only).
+
+## Test plan
+
+- Unit: the shell's view-models (composed from HSM-12-01/02) drive
+  connected/unreachable/local-only states without UIKit.
+- Screenshot / device: the shell on an iPad showing (a) the portal-consistent
+  navigation in Signal, (b) the on-device runtime present while paired, (c) the
+  unreachable state — screenshot-verified (a class in the bundle is not proof it
+  renders; capture the actual screen).
+- Manual / device: folded into HSM-12-04.
+
+## Notes / open questions
+
+- Reuse the `InferenceHarnessApp` Signal palette/components as the seed, but this is
+  the real shell, not the demo harness — retire harness-only scaffolding.
+- One app, not two: default to the companion living as a mode/tab alongside the
+  on-device surfaces (Decisions deferred, phase status) so the device stays unified.
+- High UI bar applies (repo standing rule): add affordances, check overflow on the
+  iPad's large canvas, offer copy/preview where it helps; flat placeholder cards are
+  rejected.

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-04-companion-gate-closeout.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-04-companion-gate-closeout.md
@@ -1,0 +1,57 @@
+# HSM-12-04 — Track M gate closeout
+
+- **Project:** holdspeak-mobile
+- **Phase:** 12
+- **Status:** backlog
+- **Depends on:** HSM-12-01, HSM-12-02, HSM-12-03
+- **Unblocks:** Phase 13 (Answer the Coder) runs on this proven foundation
+- **Owner:** unassigned
+
+## Problem
+
+The companion is only real when it is proven on the metal the owner described: an
+iPad in hand, pointed at the same server a coding session runs against. This story
+is the Track M gate — the end-to-end device walkthrough — and it carries the
+non-negotiable counter-proof that the iPad was **not** neutered in the process.
+
+## Scope
+
+- **In:** a real-hardware walkthrough on the physical iPad Air M4 against a real
+  desktop/homelab server over the LAN/Tailscale: point the iPad at the server,
+  list the server's meetings, start and stop a meeting from the iPad, and watch
+  live state track it — then confirm the iPad's on-device runtime still fully works
+  (start a local capture / local intelligence) to prove it stands its own ground.
+  Evidence captured (screenshots/log) and the `final-summary.md` written.
+- **Out:** answering the coder / voice notes / the companion board (Phase 13). Any
+  new feature work (this is the closeout of 12-01..03). Hardening scenarios (Phase
+  11).
+
+## Acceptance criteria
+
+- [ ] On a physical iPad against a real desktop: point-at-server → list meetings →
+      **start and stop a meeting on the desktop from the iPad** → live state tracks
+      it, evidenced by a device walkthrough (screenshots/log committed).
+- [ ] **Not-a-dumb-terminal counter-proof:** with the iPad paired, an on-device
+      action (local capture or local meeting intelligence) still runs fully — the
+      device is enriched, not reduced — and this is shown in the same walkthrough.
+- [ ] The server-unreachable path is exercised once on device (kill/restore the
+      server) and the app keeps working locally without stalling.
+- [ ] `final-summary.md` records the gate result, evidence, and any deferrals;
+      `current-phase-status.md`, this README's phase index, and the program README
+      "Last updated" line are updated per the operating cadence.
+
+## Test plan
+
+- Device: the full walkthrough above on the unlocked iPad + a reachable desktop;
+  capture screenshots and a short log as evidence (a build/type-check is not
+  validation — behavior on device is).
+- Regression: `swift test` green (the host slice + seam tests from 12-01..03).
+
+## Notes / open questions
+
+- Device-gated like the other on-device gates — needs the iPad unlock (tracked
+  across Phase 5/6 device follow-ups) and a desktop reachable on the LAN.
+- If the live device run is blocked, host-prove every seam against a fake desktop
+  and stage the device walkthrough with a ready script (mirror how HSM-5-06 / the
+  Phase-56 macOS click were handled) — but the gate is not "done" until the real
+  walkthrough lands.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
@@ -1,0 +1,130 @@
+# Phase 13 — Answer the Coder
+
+**Status:** planning (scaffolded 2026-06-20). **Track N — added by owner steer
+(2026-06-20), outside the original charter's Tracks A–L.** This is the payoff of
+the companion track and the scenario the owner painted in his own words:
+
+> "We're coding away in our tmux session ... we happen to have installed our hooks,
+> we're pointing to the server. On the other hand, our iPad is pointed to the same
+> server. Boom. The agent has a question. Well, guess what? Now we know it on the
+> iPad, and we can use our native functionality to send back a voice note around
+> this — and use all the rich plugins."
+
+The agent (in your tmux + hooks session, talking to the desktop server) raises a
+question. The iPad — pointed at the same server — **surfaces it**, and you answer
+with a **native voice note** that runs through HoldSpeak's rich dictation pipeline
+(plugins, blocks, corrections) and is **delivered back into the coder session**.
+That is the AI PI ("AI Pie") companion loop, driven from the iPad for the first
+time. Built native over the desktop HTTP API (owner call), on the Phase-12 client
+foundation.
+
+**Last updated:** 2026-06-20 (scaffolded — stories HSM-13-01..04 stubbed from the
+owner's answer-the-coder steer. No work started.)
+
+## What "AI PI" is (so this is grounded, not invented)
+
+AI PI is the desktop's already-shipped agent companion loop (desktop Phase 24):
+when a coding agent is waiting on a reply, HoldSpeak knows about it and can deliver
+a spoken/typed answer into that session. The desktop already serves it at
+`/api/companion/status` (waiting sessions, selected target, delivery confidence,
+blockers) with `select` / `dismiss` / `pin` controls, and a read-only `/companion`
+portal page. This phase gives that loop an iPad face and a native-voice answer
+path — it does not reinvent the loop.
+
+## Goal
+
+Make the iPad a first-class way to answer a waiting coder: surface the AI PI
+companion state on the iPad, capture a native voice note (reusing the on-device
+capture + Whisper + the rich dictation pipeline), and deliver the result into the
+selected coder session via a desktop inject endpoint. The phase passes when, on
+real hardware, an agent's question raised in a real coding session is answered by
+voice from the iPad and lands back in that session (the Track N gate). The Propose
+→ Review → Approve discipline holds: the iPad never injects without the user's
+explicit send.
+
+## Scope
+
+- **In:** the remote-dictation **inject path** — a new desktop endpoint that accepts
+  a dictated payload from the client and routes it through the dictation runtime's
+  rich pipeline (plugins/blocks/corrections), plus the client side that posts it
+  (HSM-13-01); native **voice-note capture → dictation** on the iPad (reuse Phase 2
+  capture + Phase 3 Whisper → the pipeline) (HSM-13-02); the **Companion board** on
+  the iPad surfacing AI PI state + target selection (`/api/companion/*`)
+  (HSM-13-03); and the end-to-end **answer-the-coder** gate closeout (HSM-13-04).
+- **Out:** the connection/seam + meetings remote control + shell (Phase 12 — this
+  builds on them). Autonomous delivery (the user always presses send; never
+  auto-injected). New AI PI *intelligence* (the loop exists on the desktop; this
+  surfaces and feeds it). The PencilKit notebook (Phase 8). Hardening (Phase 11).
+
+## Exit criteria (evidence required)
+
+- [ ] A desktop endpoint accepts a dictated payload from the client and routes it
+      through the dictation runtime's rich pipeline (plugins/blocks/corrections),
+      not as raw text; the client posts to it through the Phase-12 seam; both ends
+      tested (HSM-13-01).
+- [ ] The iPad captures a native voice note (on-device capture + Whisper) and turns
+      it into pipeline-processed dictation text ready to deliver (HSM-13-02).
+- [ ] The iPad surfaces the AI PI companion state (waiting sessions, selected
+      target, confidence, blockers) from `/api/companion/status` and can pick the
+      target session via `select`/`dismiss`/`pin` (HSM-13-03).
+- [ ] **Track N gate — answer the coder, end to end:** in a real coding session
+      (tmux + hooks → desktop server) an agent's question is surfaced on a physical
+      iPad, answered by a native voice note, and the answer lands back in that coder
+      session — the user pressing send, never autonomous — evidenced by a device
+      walkthrough (HSM-13-04).
+
+## Story status
+
+| ID | Story | Status | Story file | Evidence |
+|---|---|---|---|---|
+| HSM-13-01 | Remote-dictation inject path (desktop + client) | backlog | [story-01](./story-01-remote-dictation-inject.md) | — |
+| HSM-13-02 | Native voice-note capture → dictation | backlog | [story-02](./story-02-voice-note-capture.md) | — |
+| HSM-13-03 | The Companion board (the agent's question on the iPad) | backlog | [story-03](./story-03-companion-board.md) | — |
+| HSM-13-04 | Answer-the-coder gate closeout | backlog | [story-04](./story-04-answer-the-coder-closeout.md) | — |
+
+## Where we are
+
+Just scaffolded from the owner's 2026-06-20 steer, on top of Phase 12's client
+foundation. The inject path (HSM-13-01) is the one genuinely new desktop-side
+surface (precedent: the mobile program already added Python routes in Phase 10 —
+`holdspeak/web/routes/sync.py`); voice-note capture (HSM-13-02) reuses the proven
+on-device capture + Whisper; the Companion board (HSM-13-03) consumes endpoints
+that already ship; the gate (HSM-13-04) is the real-metal proof of the owner's
+scenario. Next: HSM-13-01, once Phase 12's seam exists.
+
+## Active risks
+
+| Risk | Likelihood | Mitigation | Stop signal |
+|---|---|---|---|
+| The iPad injects into a coder session without the user's explicit approval (the unforgivable agent-companion bug) | high | Delivery is always user-pressed-send; the inject endpoint is a propose/deliver-on-command path, never autonomous; mirror the actuator Propose→Approve discipline | Any code path injects without an explicit send — halt; the companion never acts on its own |
+| The voice note is delivered as raw transcript, bypassing the rich pipeline the owner asked for | high | HSM-13-01 routes through the dictation runtime's plugins/blocks/corrections; a test asserts a known correction/plugin transform is applied to a delivered payload | A delivered answer is verbatim Whisper output with no pipeline applied — wire it through the pipeline, that richness is the point |
+| Delivery targets the wrong agent session (answer lands in the wrong coder) | medium | The Companion board makes the selected target explicit and visible before send; reuse the desktop's existing target-selection (`select`/`pin`); show the target in the send confirmation | The send UI does not show which session will receive the answer — make the target unmistakable before any send |
+| The inject endpoint becomes an unauthenticated write into the dev machine | medium | The endpoint requires the Phase-12 client token; honest egress label on the iPad; the credential is joined at call time, never echoed (mirror the Phase-61 Slack discipline) | The endpoint accepts an untokened write — gate it behind the client handshake |
+| Latency/availability of the companion state makes the board feel dead | low | Poll first (Phase-12 default); flag an event/push transport as the optimization that makes "boom, the agent has a question" feel instant; do not block send on it | The board only updates on manual refresh and misses live questions — schedule the event-transport follow-up |
+
+## Decisions made (this phase)
+
+- 2026-06-20 — **Owner steer:** the centerpiece is answering a waiting coder by
+  native voice from the iPad — the agent asks (tmux + hooks → server), the iPad
+  (pointed at the same server) surfaces it, you answer by voice note through the
+  rich pipeline, it lands back in the session. This is Track N.
+- 2026-06-20 — Delivery is never autonomous: the user always presses send. The
+  inject path is propose/deliver-on-command, consistent with the program's
+  "the mobile runtime never acts autonomously" principle and the desktop actuator
+  Propose→Approve→Execute lifecycle.
+- 2026-06-20 — The answer runs through the **rich** dictation pipeline
+  (plugins/blocks/corrections), not as raw transcript — the owner asked for "all
+  the rich plugins," and that richness is the differentiator over a dumb text box.
+
+## Decisions deferred
+
+- The exact inject mechanism on the desktop (route into the AI PI delivery path vs.
+  type into the focused dictation target vs. queue to the dictation runner) —
+  trigger: HSM-13-01 — default: route through the dictation runtime so the existing
+  AI PI delivery + pipeline both apply; reuse, do not fork.
+- Live "the agent has a question" push vs. poll on the iPad — trigger: HSM-13-03 —
+  default: poll `/api/companion/status` first (Phase-12 default); an event/push
+  transport is the follow-on that makes it feel instant.
+- Whether the iPad can compose a typed answer too (not only voice) — trigger:
+  HSM-13-02 — default: voice-note first (the named scenario); a typed fallback is
+  cheap to add once the inject path exists.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-01-remote-dictation-inject.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-01-remote-dictation-inject.md
@@ -1,0 +1,65 @@
+# HSM-13-01 — Remote-dictation inject path (desktop + client)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 13
+- **Status:** backlog
+- **Depends on:** HSM-12-01 (the desktop client seam + token)
+- **Unblocks:** HSM-13-02, HSM-13-04
+- **Owner:** unassigned
+
+## Problem
+
+Today the desktop dictates locally (mic → the focused target / the AI PI delivery
+path). For the iPad to answer a coder, the desktop needs to accept a dictated
+payload **from the client** and route it through the same rich dictation runtime —
+plugins, blocks, corrections — so an answer sent from the iPad is as smart as one
+spoken at the desk. This is the one genuinely new desktop-side surface in the
+track. (Precedent: the mobile program already added Python routes in Phase 10 —
+`holdspeak/web/routes/sync.py`.)
+
+## Scope
+
+- **In (desktop, Python):** a new authenticated endpoint (e.g.
+  `POST /api/dictation/remote`) in `holdspeak/web/routes/dictation` that accepts a
+  dictated payload (text + optional target/session id) from the client and routes
+  it through the dictation runtime's rich pipeline (the existing
+  plugins/blocks/corrections path used by `dictation_runner`), delivering it to the
+  selected destination (the AI PI delivery path / the focused dictation target).
+  Tokened behind the Phase-12 client handshake; never autonomous (deliver-on-command
+  only). **In (client, Swift):** the `IDesktopClient` method that posts to it.
+- **Out:** capturing the voice note (HSM-13-02 produces the text). The Companion
+  board / target selection UI (HSM-13-03). Any change to how the desktop dictates
+  locally (this is additive — a remote entry point into the same pipeline).
+
+## Acceptance criteria
+
+- [ ] `POST /api/dictation/remote` accepts a dictated payload and routes it through
+      the dictation runtime's rich pipeline — a test asserts a known
+      correction/block/plugin transform is applied (the delivered text is **not**
+      raw input).
+- [ ] The endpoint requires the Phase-12 client token; an untokened request is
+      refused; the token is never echoed in a response/log.
+- [ ] Delivery is deliver-on-command (the payload carries an explicit intent to
+      send); there is no autonomous/background injection path.
+- [ ] The Swift `IDesktopClient` posts a payload through the seam and surfaces the
+      desktop's accept/refuse result; a fake desktop drives the client test.
+
+## Test plan
+
+- Unit (Python): `uv run pytest` over the new route — pipeline transform applied,
+  token required, malformed/untokened refused, target honored; add it to the route
+  preflight sweep so it cannot ship dead-on-arrival.
+- Unit (Swift): the client method posts + decodes accept/refuse against a fake
+  desktop; token joined at call time, never in the echoed result.
+- Manual / device: deferred to HSM-13-04 (real session delivery).
+
+## Notes / open questions
+
+- Reuse, do not fork: route into the existing dictation runtime so the AI PI
+  delivery path + the rich pipeline both apply (Decisions deferred, phase status).
+  Do not build a second, thinner dictation path that skips the plugins.
+- This story spans both roadmaps' code (a `holdspeak` Python route + the `apple`
+  client). Keep the desktop route minimal and contract-clean; the richness comes
+  from the pipeline it delegates to, not from this endpoint.
+- Mirror the Phase-61 Slack-credential discipline for the token; mirror the
+  actuator Propose→Approve posture for "never autonomous."

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-02-voice-note-capture.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-02-voice-note-capture.md
@@ -1,0 +1,61 @@
+# HSM-13-02 — Native voice-note capture → dictation
+
+- **Project:** holdspeak-mobile
+- **Phase:** 13
+- **Status:** backlog
+- **Depends on:** HSM-13-01, HSM-2-01 (capture), HSM-3-01 (Whisper)
+- **Unblocks:** HSM-13-04
+- **Owner:** unassigned
+
+## Problem
+
+The owner's words: "use our **native functionality** to send back a voice note."
+The answer to the coder should be spoken on the iPad and captured with the device's
+own capability — not typed into a box. This story is the native voice-note path:
+press to speak, capture on-device, transcribe with Whisper, and hand the text to
+the inject path. It is where the iPad "standing its own ground" pays off in the
+companion flow — the capture and transcription are the iPad's, the delivery is the
+server's.
+
+## Scope
+
+- **In:** a native voice-note capture on the iPad — press-to-talk capture (reuse
+  the Phase-2 `IAudioCapture`), on-device Whisper transcription (reuse the Phase-3
+  transcriber), a quick review/edit of the recognized text, then deliver via the
+  HSM-13-01 client method. The capture is on-device; only the resulting dictation
+  payload leaves (honest egress label).
+- **Out:** the inject endpoint itself (HSM-13-01). The Companion board / which
+  session it targets (HSM-13-03 supplies the target). On-device meeting capture
+  (Phase 8 — this is a short voice note, not a meeting). A typed-answer fallback
+  (deferred; voice-note first).
+
+## Acceptance criteria
+
+- [ ] Press-to-talk captures a voice note on the iPad via the Phase-2 capture seam
+      and transcribes it with the Phase-3 Whisper transcriber, fully on-device.
+- [ ] The recognized text is shown for a quick review/edit before anything is sent
+      (never auto-sent from recognition).
+- [ ] On send, the text is delivered through the HSM-13-01 client method; the
+      egress label is honest (capture stays local; the dictation payload goes to the
+      paired server).
+- [ ] The capture path reuses the on-device seams (no new transcription/capture
+      engine); a view-model drives capture → transcribe → review → deliver without
+      UIKit.
+
+## Test plan
+
+- Unit: the capture → transcribe → review → deliver view-model over fake
+  capture/transcribe/client seams → correct state flow; nothing is delivered before
+  an explicit send.
+- Device (folded into HSM-13-04): speak a real voice note on the iPad, confirm
+  on-device recognition, review, and deliver.
+
+## Notes / open questions
+
+- MLX threading rule still applies on-device: all MLX/Whisper work stays pinned to
+  the single executor thread (the standing `_MlxTranscriber` discipline) — do not
+  introduce a second transcription path here.
+- The rich-pipeline transform happens server-side (HSM-13-01); the iPad sends clean
+  recognized text. Keep the client thin — capture + recognize + review + post.
+- Voice-note first per the owner's scenario; a typed fallback is cheap to add later
+  once the inject path exists (Decisions deferred, phase status).

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-03-companion-board.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-03-companion-board.md
@@ -1,0 +1,59 @@
+# HSM-13-03 — The Companion board (the agent's question on the iPad)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 13
+- **Status:** backlog
+- **Depends on:** HSM-12-01 (seam), HSM-12-03 (the Companion nav slot)
+- **Unblocks:** HSM-13-04
+- **Owner:** unassigned
+
+## Problem
+
+"Boom. The agent has a question. Now we know it on the iPad." For that to be true,
+the iPad must surface the AI PI companion state — which agent sessions are waiting,
+which one is selected, how confident delivery is, what is blocking it — and let you
+pick the target you are about to answer. The desktop already computes and serves
+this; this story gives it an iPad face and makes the answer target unmistakable
+before any send.
+
+## Scope
+
+- **In:** the Companion board screen (the deep content of the Phase-12 "Companion"
+  nav slot) over `GET /api/companion/status` — waiting agent sessions, the selected
+  reply target, delivery confidence, transport, freshness, and blockers — plus
+  target selection via `POST /api/companion/select` / `dismiss` / `pin`. The board
+  hands the chosen target to the voice-note flow (HSM-13-02 → HSM-13-01) and shows
+  that target in the send confirmation.
+- **Out:** capturing/sending the answer (HSM-13-02 / HSM-13-01). The AI PI loop's
+  intelligence (desktop-owned; this surfaces it). A live push transport (poll
+  first; the event transport is the deferred optimization).
+
+## Acceptance criteria
+
+- [ ] The board renders the AI PI state from `/api/companion/status` (waiting
+      sessions, selected target, confidence, transport, freshness, blockers) in the
+      Signal language, to a high UI standard.
+- [ ] The user can select / dismiss / pin a target via the existing companion
+      endpoints, and the selected target is unmistakable before any answer is sent.
+- [ ] The board hands the chosen target to the answer flow so HSM-13-02's send
+      delivers to that session (no silent default target).
+- [ ] Unreachable/stale state is shown honestly (freshness/blockers), never faked as
+      "nothing waiting."
+
+## Test plan
+
+- Unit: the board view-model over a fake desktop — waiting sessions render, select/
+  dismiss/pin update the selected target, the chosen target is exposed to the answer
+  flow; stale/unreachable surfaced honestly.
+- Screenshot / device: the board on the iPad showing a real waiting session and the
+  selected target (folded into HSM-13-04).
+
+## Notes / open questions
+
+- This mirrors the desktop's read-only `/companion` page (desktop Phase 24) but adds
+  the iPad-native selection + the bridge to the voice-note answer — reuse the
+  desktop's selection endpoints, do not invent parallel state.
+- Poll `/api/companion/status` first (Phase-12 default); flag the event/push
+  transport as the follow-on that makes "the agent has a question" feel instant.
+- Honesty rule (positioning canon): at zero waiting sessions, say so plainly; never
+  manufacture a target.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-04-answer-the-coder-closeout.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-04-answer-the-coder-closeout.md
@@ -1,0 +1,63 @@
+# HSM-13-04 — Answer-the-coder gate closeout
+
+- **Project:** holdspeak-mobile
+- **Phase:** 13
+- **Status:** backlog
+- **Depends on:** HSM-13-01, HSM-13-02, HSM-13-03
+- **Unblocks:** — (Track N gate; the companion track's payoff is proven here)
+- **Owner:** unassigned
+
+## Problem
+
+The whole track exists for one moment, and it has to be proven on the metal the
+owner described: a real coding session, a real agent question, answered by voice
+from a real iPad, landing back in that session. This story is the Track N gate —
+the end-to-end walkthrough — with the never-autonomous guarantee held throughout.
+
+## Scope
+
+- **In:** a real-hardware walkthrough — a coding agent running in a tmux session
+  with HoldSpeak hooks installed, pointing at the desktop server; a physical iPad
+  Air M4 pointed at the **same** server; the agent raises a question; the iPad's
+  Companion board surfaces it (HSM-13-03); the user answers with a native voice note
+  (HSM-13-02); the answer is delivered through the inject path (HSM-13-01) into that
+  coder session, on an explicit send. Evidence captured and `final-summary.md`
+  written; Phase 13 closed (or the device step explicitly deferred with a ready
+  script if the iPad is locked).
+- **Out:** new feature work (this is the closeout of 13-01..03). Hardening scenarios
+  (Phase 11). Multi-user / multi-session orchestration beyond picking one target.
+
+## Acceptance criteria
+
+- [ ] End to end on real hardware: agent question (tmux + hooks → server) → surfaced
+      on the physical iPad → answered by a native voice note → delivered into that
+      coder session, evidenced by a device walkthrough (screenshots/log committed).
+- [ ] **Never autonomous:** the answer is delivered only on the user's explicit
+      send, to the target shown in the board — demonstrated in the walkthrough (no
+      auto-delivery path exercised).
+- [ ] **Rich-pipeline proof:** the delivered answer shows a pipeline transform
+      (a correction/block/plugin applied), not raw transcript — captured in the
+      evidence.
+- [ ] `final-summary.md` records the gate result + evidence + deferrals;
+      `current-phase-status.md`, this README's phase index, and the program README
+      "Last updated" line are updated per the operating cadence.
+
+## Test plan
+
+- Device: the full walkthrough above on the unlocked iPad + a real desktop running a
+  real waiting agent session (the `.43` homelab or a dev Mac, per the standing
+  real-metal posture); capture screenshots and a short log (a build is not
+  validation — the agent receiving the answer is).
+- Regression: `swift test` green; the Python route tests (HSM-13-01) green.
+
+## Notes / open questions
+
+- Real-metal posture (standing rule): prove on a real endpoint/session, not a
+  no-LLM plumbing pass — a plumbing-only run can hide a silently-broken delivery.
+  Control-vs-treatment if the delivery's effect is in doubt.
+- Device-gated: needs the iPad unlock + a reachable desktop with a live agent
+  session. If blocked, host-prove every seam and stage the device step with a ready
+  script (mirror HSM-5-06 / the Phase-56 macOS click) — but the gate is not "done"
+  until the agent actually receives an iPad-spoken answer.
+- This is the emotional close of the companion track; write the `final-summary` to
+  show the owner's scenario working, not just tests passing.

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
@@ -6,8 +6,30 @@ turns the runtime into the charter's flagship experience — record a meeting, t
 PencilKit notes, link them to the transcript, and review the artifacts, all on an
 iPad Air/Pro M4.
 
-**Last updated:** 2026-06-18 (scaffolded — stories HSM-8-01..04 stubbed from
-charter Track I; no work started).
+**Last updated:** 2026-06-20 (**elevated to the owner's richness bar.** Two stories
+added and the existing notebook/linking stories raised: HSM-8-05 makes the
+**air-gapped, fully-local notetaker** (iPad at a meeting, zero connectivity, Mode A
+on-device) a first-class scenario with its own gate, and HSM-8-06 makes the **magic
+pencil genuinely involved** — handwriting recognized on-device, notes/marks promoted
+to artifacts, marked moments weighting MIR extraction — so ink shapes the meeting
+output instead of sitting parallel to it. Owner steer: "the air-gapped scenario is
+paradigm and has to be rich; the magic pencil has to be involved." Earlier:
+scaffolded — stories HSM-8-01..04 stubbed from charter Track I; no work started.)
+
+## The paradigm (owner, 2026-06-20)
+
+> "Hosting a local model and doing local inference on the iPad in the scenario where
+> it can't connect to a desktop is the paradigm — an air-gapped meeting. We bring
+> the iPad to a meeting, zero connectivity, and let it do the notetaker job. That
+> has to be rich. And there has to be a way to create notes with the magic pencil,
+> real notes, and have that somehow involved."
+
+This phase is the home of that experience. The fully-local engine (Mode A) lives in
+Phase 5; the intelligence in Phase 6; MIR in Phase 7. Phase 8 is where they become
+a **rich, first-class, offline notetaker with a magic pencil that feeds the
+output** — the standalone counterpart to the Companion track (Phases 12–13). The
+iPad stands its own ground with zero connectivity; that is not a fallback, it is the
+point.
 
 ## Goal
 
@@ -21,9 +43,12 @@ the Runtime Core, it does not own business logic.
 ## Scope
 
 - **In:** the iPad app shell + meeting-capture screen over the Runtime Core
-  (HSM-8-01); PencilKit handwritten notes + notebook mode (HSM-8-02); transcript
-  linking — note ↔ `Segment`/timestamp (HSM-8-03); artifact review + the
-  notebook-workflow gate closeout (HSM-8-04).
+  (HSM-8-01); a rich PencilKit notebook (pages, tools, ink + typed) (HSM-8-02);
+  transcript linking + one-gesture marked moments — note ↔ `Segment`/timestamp
+  (HSM-8-03); artifact review + the notebook-workflow gate closeout (HSM-8-04); the
+  **air-gapped fully-local notetaker** scenario + gate (HSM-8-05); and **ink into
+  intelligence** — handwriting recognized on-device, notes/marks promoted to
+  artifacts, marks weighting MIR extraction (HSM-8-06).
 - **Out:** the iPhone experience (Phase 9). Sync across devices (Phase 10). The
   audio/transcription/inference/intelligence engines themselves (Phases 2–7 — this
   host consumes them). Any business logic in the view layer (it stays in the
@@ -41,6 +66,14 @@ the Runtime Core, it does not own business logic.
 - [ ] **Track I gate — the meeting-notebook workflow is complete:** record →
       transcript → notebook notes → linked moments → artifact review, end to end
       on a real iPad, evidenced by a device walkthrough (HSM-8-04).
+- [ ] **Air-gapped gate — the fully-local notetaker:** the whole workflow runs in
+      real airplane mode (no desktop / LAN / endpoint) with Mode-A on-device
+      inference, rich (not a degraded fallback), honest local egress, proven on a
+      physical iPad (HSM-8-05).
+- [ ] **The magic pencil is involved:** handwriting is recognized on-device, a
+      note/marked moment can be promoted to a contract artifact (propose-and-confirm),
+      and a marked moment measurably shapes MIR extraction — ink feeds the output,
+      it is not a parallel scratchpad (HSM-8-06).
 
 ## Story status
 
@@ -50,15 +83,23 @@ the Runtime Core, it does not own business logic.
 | HSM-8-02 | PencilKit notebook | backlog | [story-02](./story-02-pencilkit-notebook.md) | — |
 | HSM-8-03 | Transcript linking | backlog | [story-03](./story-03-transcript-linking.md) | — |
 | HSM-8-04 | Artifact review + notebook closeout | backlog | [story-04](./story-04-artifact-review-closeout.md) | — |
+| HSM-8-05 | The air-gapped notetaker (fully-local, zero-connectivity) | backlog | [story-05](./story-05-air-gapped-notetaker.md) | — |
+| HSM-8-06 | Ink into intelligence (the magic pencil, involved) | backlog | [story-06](./story-06-ink-into-intelligence.md) | — |
 
 ## Where we are
 
-Just scaffolded. This is the first real product surface and it sits on top of the
-whole stack: it needs Phase 2 (audio), Phase 3 (transcript), and — for the review
-to show real artifacts — Phases 5–7. The four stories follow Track I's feature
-list (capture, PencilKit notebook, transcript linking, artifact review) and end
-on the notebook-workflow gate. Next: HSM-8-01 once Phases 2–3 give a recordable,
-transcribing runtime; the artifact-review depth (HSM-8-04) wants Phase 6.
+Scaffolded and now elevated to the owner's richness bar (2026-06-20). This is the
+first real on-device product surface and it sits on top of the whole stack: it
+needs Phase 2 (audio), Phase 3 (transcript), and — for the review + the air-gapped
+loop + ink-into-intelligence — Phases 5–7 (Mode-A on-device inference, the artifact
+engine, the MIR seam). The six stories: capture (8-01), the rich PencilKit notebook
+(8-02), transcript linking + marked moments (8-03), artifact review + the Track I
+gate (8-04), the **air-gapped fully-local notetaker + gate (8-05)**, and **ink into
+intelligence (8-06)**. The phase now closes on two things being true at once: the
+notebook workflow is complete *and* it is rich with zero connectivity, with the
+magic pencil feeding the output. Next: HSM-8-01 once Phases 2–3 give a recordable,
+transcribing runtime; 8-05/8-06 sequence after Phase 6 (artifacts) + HSM-5-02
+(Mode A) so the offline richness is real, not stubbed.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-02-pencilkit-notebook.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-02-pencilkit-notebook.md
@@ -15,16 +15,23 @@ Notes have to live alongside the live transcript and persist with the meeting.
 
 ## Scope
 
-- **In:** a PencilKit notebook surface in the meeting screen (handwritten notes,
-  notebook mode), with the drawing persisted and associated with the meeting via
-  the Phase-4 store.
+- **In:** a **first-class** PencilKit notebook surface in the meeting screen — not
+  a bare canvas: multiple pages, real pen tools (pen / highlighter / eraser,
+  PencilKit's tool picker), ink mixed with typed text, and the Signal design
+  language — with the drawing persisted and associated with the meeting via the
+  Phase-4 store. The notebook is a flagship surface (the owner's "magic pencil,"
+  rich), the thing a laptop can't do in a meeting.
 - **Out:** linking a note to a transcript moment (HSM-8-03). Handwriting-to-text
-  recognition. Artifact review (HSM-8-04). Any business logic in the view.
+  recognition + ink-into-intelligence (HSM-8-06). Artifact review (HSM-8-04). Any
+  business logic in the view.
 
 ## Acceptance criteria
 
 - [ ] A PencilKit canvas captures handwritten notes during/after a meeting in a
       notebook mode.
+- [ ] The notebook is a **rich** surface, not a blank box: multiple pages, the
+      pen/highlighter/eraser tool set, and ink mixed with typed text, to a high UI
+      standard (Signal language) verified by screenshot.
 - [ ] The notebook persists with the meeting and reloads intact (strokes
       preserved).
 - [ ] The notebook coexists with the live transcript view without dropping Pencil

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-03-transcript-linking.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-03-transcript-linking.md
@@ -27,7 +27,12 @@ identity, not on rendered text that re-flows.
 
 - [ ] Making a note records the transcript moment (a Phase-0 `Segment` identity /
       timestamp), stored as a structured link anchor.
-- [ ] Tapping a linked note navigates to that transcript moment.
+- [ ] Tapping a linked note navigates to that transcript moment, and the link is
+      **bidirectional** — from a transcript moment you can reach the note(s) taken
+      there.
+- [ ] A one-gesture "mark this moment" (a pen tap/star) creates a linked anchor
+      without writing a full note, so a live meeting can be flagged at speed (these
+      marks are the raw material HSM-8-06 weaves into the intelligence).
 - [ ] The link survives reload and re-render of the transcript (anchored on the
       `Segment` contract, not on text offsets).
 - [ ] A note made when no transcript exists yet degrades gracefully (no crash, no

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-05-air-gapped-notetaker.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-05-air-gapped-notetaker.md
@@ -1,0 +1,75 @@
+# HSM-8-05 — The air-gapped notetaker (fully-local, zero-connectivity)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 8
+- **Status:** backlog
+- **Depends on:** HSM-8-01, HSM-8-02, HSM-8-03, HSM-8-04, HSM-5-02 (Mode A on-device), HSM-6-02 (intelligence), HSM-7-03 (MIR seam)
+- **Unblocks:** HSM-8-06
+- **Owner:** unassigned
+
+## Problem
+
+This is the paradigm the whole on-device runtime exists for, and it had no
+first-class home (owner steer, 2026-06-20): **you bring the iPad to a meeting with
+zero connectivity** — airplane mode, no desktop, no LAN, no endpoint — and it does
+the full notetaker job entirely on-device. Record → local Whisper transcription →
+local (Mode A) meeting intelligence → handwritten notebook → linked moments →
+artifact review, all offline, and it has to be *rich*, not a degraded fallback.
+Phase 8 named the workflow but never named the air-gapped condition or proved the
+experience under it; Phase 5 carries the engine's airplane-mode checkbox, not the
+experience. This story makes the air-gapped notetaker an explicit, first-class
+scenario with its own gate.
+
+## Scope
+
+- **In:** the fully-local notetaker experience and its proof — the Phase-8 workflow
+  (capture → live transcript → notebook → linked moments → artifact review) running
+  end to end with **Mode A** (on-device GGUF, HSM-5-02) and the on-device Whisper
+  (Phase 3), under **real airplane mode** (no desktop / LAN / endpoint reachable);
+  an honest "fully on-device" egress state (the egress badge reads local / nothing
+  leaves); graceful behavior when no model is resident (clear guidance, never a
+  dead end); and the air-gapped gate walkthrough on a physical iPad.
+- **Out:** the companion/server features (Phases 12–13 — explicitly *not* needed
+  here; their absence must not degrade this). Ink-into-intelligence (HSM-8-06 —
+  this story proves the offline loop; 8-06 deepens the pencil's role on top).
+  Engine performance tuning (Phase 5 / Phase 11). Sync (Phase 10).
+
+## Acceptance criteria
+
+- [ ] In real airplane mode on a physical iPad (no desktop, no LAN, no endpoint),
+      the full notetaker loop runs: record → on-device transcript → **Mode A**
+      on-device intelligence → notebook + linked moments → artifact review — with no
+      network access at any step (proven, e.g., with the radios off).
+- [ ] The experience is rich, not a degraded fallback: the artifacts are real and
+      profile-shaped (MIR via HSM-7-03), the notebook is the full HSM-8-02 surface,
+      and the UI is Signal-grade — the offline meeting feels first-class.
+- [ ] The egress state is honest and calm — "on-device · nothing leaves" — with no
+      privacy-novel prose (positioning canon).
+- [ ] No-model-resident is handled gracefully: clear, actionable guidance to get a
+      model on-device (HSM-5-03 paths), never a crash or a silent dead end.
+- [ ] **Air-gapped gate:** the offline walkthrough is evidenced by a device
+      recording/screens with the network provably off; `evidence-story-05.md`
+      written.
+
+## Test plan
+
+- Device: the airplane-mode walkthrough above on the unlocked iPad with a resident
+  Mode-A model — record a short real meeting offline, get real local artifacts,
+  take pencil notes, review; capture the radios-off proof. A no-LLM plumbing pass
+  is not sufficient — the local model must actually produce the artifacts
+  (real-metal posture).
+- Unit: the runtime composes capture + Mode-A inference + store with every
+  network/companion seam absent → the loop still completes (no hidden dependency on
+  a reachable peer).
+
+## Notes / open questions
+
+- This is the counterpart to the companion track's P8 ("not a dumb terminal"): there
+  the iPad must not lose its server face; here it must not lose its **standalone**
+  face. The device is first-class in both directions.
+- Device-gated (iPad unlock + a resident Mode-A model). If blocked, host-prove the
+  no-network composition and stage the airplane-mode device run with a ready script
+  (mirror HSM-5-02's pending airplane-mode run) — but the gate is not "done" until
+  a real offline meeting yields real local artifacts on device.
+- Reuses HSM-5-02 (Mode A) + the HSM-5-05 30-min local gate; this story is the
+  *experience* gate over that engine, not a re-proof of the engine.

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-06-ink-into-intelligence.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-06-ink-into-intelligence.md
@@ -1,0 +1,71 @@
+# HSM-8-06 — Ink into intelligence (the magic pencil, involved)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 8
+- **Status:** backlog
+- **Depends on:** HSM-8-02 (notebook), HSM-8-03 (linking + marked moments), HSM-8-04 (artifact review), HSM-6-02 (artifacts), HSM-7-03 (MIR seam)
+- **Unblocks:** —
+- **Owner:** unassigned
+
+## Problem
+
+The owner's words: the magic pencil notes must be "somehow involved" — not a
+parallel scratchpad. Today HSM-8-02 stores ink and HSM-8-03 links it to a moment,
+but the handwriting never touches the meeting intelligence. This story makes the
+pencil a first-class input to the meeting record: what you write and mark by hand
+shapes and attaches to the artifacts, on-device. This is the difference between a
+notebook that sits next to the transcript and a notebook that is *part of* the
+meeting's output.
+
+## Scope
+
+- **In:** weaving ink into the Phase-6/7 intelligence, fully on-device —
+  (1) **handwriting-to-text** on a written note (PencilKit Scribble / on-device
+  Vision recognition), so a scribbled note can be promoted to text;
+  (2) **promote a note to an artifact**: a written/marked note becomes (or attaches
+  to) an action item / decision / note on a `Segment`, through the contract types;
+  (3) **marked moments feed extraction**: the HSM-8-03 one-gesture marks are passed
+  as emphasis hints into the MIR seam (HSM-7-03) so what the user flagged by hand is
+  weighted in what the model extracts; (4) the ink↔artifact links surface in the
+  HSM-8-04 review so the user sees their handwriting reflected in the output.
+- **Out:** cloud handwriting recognition (must be on-device — the air-gapped
+  scenario HSM-8-05 forbids network). Full OCR of arbitrary documents. Autonomous
+  creation of artifacts from ink without the user's confirmation (propose, never
+  auto-commit). Rebuilding the artifact engine (Phase 6) or MIR (Phase 7).
+
+## Acceptance criteria
+
+- [ ] A handwritten note can be recognized to text on-device (Scribble / Vision),
+      with the user able to accept/correct the recognition before it is used.
+- [ ] The user can **promote a note or marked moment to an artifact** — an action
+      item / decision / a note attached to a `Segment` — expressed in the Phase-0
+      contract types and shown in the HSM-8-04 review (propose-and-confirm, never
+      auto-committed).
+- [ ] **Marked moments (HSM-8-03) influence extraction:** they are passed as
+      emphasis hints through the HSM-7-03 MIR seam, and a test shows a marked moment
+      measurably changes what is extracted vs. the same transcript unmarked.
+- [ ] The review surface shows the link between a handwritten note/mark and the
+      artifact it shaped (the pencil is visibly *involved*, not parallel).
+- [ ] All of it works fully on-device (no network), so HSM-8-05's air-gapped loop
+      keeps this richness with zero connectivity.
+
+## Test plan
+
+- Unit: handwriting-to-text over a fixture stroke set → recognized text (or the
+  accept/correct path) without network; promote-to-artifact produces a schema-valid
+  contract object; a marked-moment emphasis hint changes the MIR routing/extraction
+  vs. unmarked (deterministic, model-free where possible).
+- Device: write a to-do by hand in a real (offline) meeting, recognize it, promote
+  it to an action item, and see it in review linked back to the ink (folded into
+  the HSM-8-05 air-gapped walkthrough where practical).
+
+## Notes / open questions
+
+- Recognition is on-device only (PencilKit Scribble / Vision `VNRecognizeText`); the
+  air-gapped gate (HSM-8-05) is the hard constraint — no cloud handwriting path.
+- "Emphasis hints" reuse the desktop's selection-pin → grounding idea (desktop
+  Phase 53): a user-flagged moment grounds/weights the extraction. Keep the hint a
+  contract-level signal so it can ride sync (Phase 10) and stay compatible with the
+  desktop.
+- Propose-and-confirm only — promoting ink to an artifact is the user's call, never
+  automatic (charter non-goal: the runtime never acts autonomously).


### PR DESCRIPTION
## What

Planning/scaffold only — no implementation (every new story is `backlog`). Closes the gap the owner named: the mobile program was chartered as a standalone on-device runtime and never planned the iPad as a **first-class companion to the desktop coder**, and its on-device iPad experience (Phase 8) was a thin notebook rather than the rich air-gapped notetaker the paradigm calls for.

### New track — the two iPad faces, both first-class
- **Phase 12 — The Companion Client (Track M):** point the iPad at the same server you code against. An `IDesktopClient` seam + pairing, meetings remote control (list/start/stop/live over the **existing** desktop HTTP API), and a unified Signal shell presenting **both** the on-device runtime **and** the server — never a dumb terminal.
- **Phase 13 — Answer the Coder (Track N):** the AI PI payoff — the agent's question (tmux + hooks → server) surfaces on the iPad, you answer with a **native voice note** through the rich dictation pipeline, it lands back in the coder session. **Never autonomous** (user always presses send). One new desktop endpoint: `POST /api/dictation/remote`.

Built **native over the existing HTTP API** (owner call), not a WebView.

### Phase 8 elevated to the richness bar (kept as the on-device flagship)
- **HSM-8-05 — the air-gapped fully-local notetaker** (iPad at a meeting, zero connectivity, Mode A on-device) as a first-class scenario with its own airplane-mode gate.
- **HSM-8-06 — ink into intelligence:** on-device handwriting recognition, promote a note/marked-moment → contract artifact (propose-and-confirm), marked moments weight MIR extraction. The magic pencil **feeds the output**, not a parallel scratchpad.
- Notebook/linking stories raised (rich surface; bidirectional links + one-gesture marked moments).

## Why
Direct owner steer (2026-06-20): the iPad must stand its own ground (rich air-gapped notetaker) **and** be a first-class companion to the desktop coder — neither neutering the other.

## Scope / safety
- Roadmap markdown only — no code, no test surface.
- Tracks M–N sit outside the charter's A–L; **flagged for an owner-blessed charter amendment**, not silently rewritten.
- Program risks **P8–P10** added (dumb-terminal both directions, unauth/autonomous inject, charter drift).
- PMO pointers retuned to the highest-value direction; device-free start = **HSM-12-01**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuGkRn3BzV6v8EXgZDFind