### PR TITLE
HSM-12-01: the desktop client seam + pairing (Companion track)

### DIFF
--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient.swift
@@ -1,0 +1,163 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HSM-12-01 — the desktop client seam + pairing. The spine of the Companion track
+// (charter Amendment 1.1, Track M): point an iPhone/iPad at the same server a coding
+// session runs against, and drive it over the desktop's existing HTTP API. This file
+// is connect / health / egress only; the verb methods (meetings remote control,
+// remote-dictation inject) are added by the stories that need them (HSM-12-02 / 13).
+
+/// How the device is paired to a desktop/homelab peer: host + port + an optional
+/// token, over the user's own network (LAN / Tailscale) — no hosted relay. This is
+/// the "configure a desktop peer" surface; the shell turns it into a `Config`.
+public struct DesktopPeer: Sendable, Equatable {
+    public var host: String
+    public var port: Int
+    /// Bearer token for the desktop API. A credential — joined at call time, never
+    /// logged, never echoed back to the UI (mirrors the Phase-61 Slack discipline).
+    public var token: String?
+    /// "http" over a trusted LAN/Tailscale by default; "https" when the peer has TLS.
+    public var scheme: String
+
+    public init(host: String, port: Int, token: String? = nil, scheme: String = "http") {
+        self.host = host
+        self.port = port
+        self.token = token
+        self.scheme = scheme
+    }
+
+    /// The peer's base URL; `nil` when host/port are malformed (an empty host or a
+    /// non-positive port — a half-filled pairing form), so the client then stays
+    /// permanently offline rather than building a junk URL. Fail soft, never crash.
+    public var baseURL: URL? {
+        let trimmed = host.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, port > 0 else { return nil }
+        var c = URLComponents()
+        c.scheme = scheme
+        c.host = trimmed
+        c.port = port
+        return c.url
+    }
+}
+
+/// The result of probing the peer. **Never an error** — an unreachable desktop is a
+/// rendered state, so the caller needs no try/catch and the on-device runtime is
+/// never gated on it.
+public struct DesktopConnection: Sendable, Equatable {
+    public var reachable: Bool
+    public var runtimeReady: Bool
+    /// A short, human-readable detail for the UI (e.g. "ready · web", "meeting
+    /// active", "desktop unreachable: <reason>"). Never carries the token.
+    public var detail: String
+
+    public init(reachable: Bool, runtimeReady: Bool, detail: String) {
+        self.reachable = reachable
+        self.runtimeReady = runtimeReady
+        self.detail = detail
+    }
+
+    /// The peer could not be reached at all (network down, bad host, timeout).
+    public static func offline(_ reason: String) -> DesktopConnection {
+        DesktopConnection(reachable: false, runtimeReady: false, detail: "desktop unreachable: \(reason)")
+    }
+}
+
+/// `IDesktopClient` over plain HTTP to the user's own desktop/homelab peer, reached
+/// directly over their network — the same endpoints the web portal uses. One
+/// implementation of the seam, so swapping it never touches the Runtime Core.
+public struct HTTPDesktopClient: IDesktopClient {
+    public struct Config: Sendable, Equatable {
+        public var baseURL: URL
+        public var token: String?
+        public var timeout: TimeInterval
+        public init(baseURL: URL, token: String? = nil, timeout: TimeInterval = 8) {
+            self.baseURL = baseURL
+            self.token = token
+            self.timeout = timeout
+        }
+
+        /// Build a config from a paired peer; `nil` if the peer's URL is malformed.
+        public init?(peer: DesktopPeer, timeout: TimeInterval = 8) {
+            guard let url = peer.baseURL else { return nil }
+            self.init(baseURL: url, token: peer.token, timeout: timeout)
+        }
+    }
+
+    let config: Config
+    let session: URLSession
+
+    public init(config: Config, session: URLSession = .shared) {
+        self.config = config
+        self.session = session
+    }
+
+    public var egressLabel: String {
+        "local + LAN → \(config.baseURL.host ?? config.baseURL.absoluteString)"
+    }
+
+    /// `GET /health` to confirm reachability, then `GET /api/runtime/status` to read
+    /// runtime readiness. Any network failure maps to `.offline` — fail soft.
+    public func handshake() async -> DesktopConnection {
+        // 1) Reachability — /health returns {"status":"ok"}.
+        do {
+            let (_, response) = try await session.data(for: makeRequest(path: "health"))
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+                return .offline("health \(code)")
+            }
+        } catch {
+            return .offline(Self.reason(error))
+        }
+
+        // 2) Readiness — /api/runtime/status. Reachable even if this is unavailable.
+        do {
+            let (data, response) = try await session.data(for: makeRequest(path: "api/runtime/status"))
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                return DesktopConnection(reachable: true, runtimeReady: false, detail: "runtime status unavailable")
+            }
+            let status = (try? HoldSpeakContracts.decoder().decode(RuntimeStatusDTO.self, from: data)) ?? RuntimeStatusDTO()
+            let ready = (status.status ?? "").lowercased() == "ok"
+            return DesktopConnection(reachable: true, runtimeReady: ready, detail: status.summary)
+        } catch {
+            // Health passed but status call failed mid-flight: still reachable.
+            return DesktopConnection(reachable: true, runtimeReady: false, detail: "runtime status unavailable")
+        }
+    }
+
+    // MARK: - internals
+
+    /// Loose decode of `/api/runtime/status` — every field optional so the client
+    /// tolerates the desktop payload evolving (the codebase's robust-decode posture).
+    /// Keys arrive snake_case and convert via the shared decoder (`meeting_active`).
+    struct RuntimeStatusDTO: Decodable {
+        var status: String?
+        var mode: String?
+        var meetingActive: Bool?
+
+        var summary: String {
+            if meetingActive == true { return "meeting active" }
+            let s = status ?? "unknown"
+            return mode.map { "\(s) · \($0)" } ?? s
+        }
+    }
+
+    private func makeRequest(path: String) -> URLRequest {
+        let base = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private static func reason(_ error: Error) -> String {
+        if let url = error as? URLError { return "\(url.code)" }
+        return "network error"
+    }
+}

--- a/apple/Sources/Providers/Providers.swift
+++ b/apple/Sources/Providers/Providers.swift
@@ -40,6 +40,17 @@ public protocol ISyncProvider: Sendable {
     func pull() async throws -> ChangeSet
 }
 
+public protocol IDesktopClient: Sendable {
+    /// Probe the configured desktop/homelab peer (HSM-12-01). **Never throws** — an
+    /// unreachable desktop is a first-class state, not an error, so the companion can
+    /// render it and the device's on-device runtime is never blocked on the server.
+    /// The Runtime Core depends on this seam, never on a concrete transport.
+    func handshake() async -> DesktopConnection
+    /// Honest egress descriptor for the badge (positioning canon: one badge, never a
+    /// privacy novel). The companion talks to a LAN peer.
+    var egressLabel: String { get }
+}
+
 /// The sync-facing view of the local store (HSM-10-01): modified-time tracking and
 /// soft-delete tombstones on top of the Phase-4 store, so a change-set can be
 /// produced from and applied to it. Kept separate from `IStorage` so the base CRUD

--- a/apple/Sources/RuntimeCore/Companion/CompanionLink.swift
+++ b/apple/Sources/RuntimeCore/Companion/CompanionLink.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Contracts
+import Providers
+
+/// HSM-12-01 — the Runtime-Core entry point to the desktop companion (charter
+/// Amendment 1.1, Track M). Holds the `IDesktopClient` seam so the Runtime Core
+/// depends on the *interface*, never a concrete transport, and gives the host one
+/// thin thing to drive for "point this device at the server."
+///
+/// Deliberately minimal for HSM-12-01 — connect / health / egress only. The verb
+/// surfaces (meetings remote control HSM-12-02; the remote-dictation inject HSM-13)
+/// hang off this same seam in their stories.
+///
+/// **Offline-safe by construction:** `probe()` never throws and an unreachable
+/// desktop is a returned state, so nothing the device does locally is ever gated on
+/// the server being reachable (the "not a dumb terminal" principle, made structural).
+public struct CompanionLink: Sendable {
+    let client: IDesktopClient
+
+    public init(client: IDesktopClient) {
+        self.client = client
+    }
+
+    /// Probe the paired desktop. Never throws; returns the connection state to render.
+    public func probe() async -> DesktopConnection {
+        await client.handshake()
+    }
+
+    /// Honest egress descriptor for the badge (the companion talks to a LAN peer).
+    public var egressLabel: String { client.egressLabel }
+}

--- a/apple/Tests/ProvidersTests/DesktopClientTests.swift
+++ b/apple/Tests/ProvidersTests/DesktopClientTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HSM-12-01 — the desktop client seam + pairing. Network stubbed via `URLProtocol`;
+/// fully deterministic and offline (no real desktop). Proves: pairing → handshake
+/// against /health + /api/runtime/status, an honest egress label, the token rides as
+/// a Bearer header, and an unreachable peer fails soft (never throws → `.offline`).
+final class DesktopClientTests: XCTestCase {
+
+    // MARK: stub
+
+    final class StubProtocol: URLProtocol {
+        /// path -> (status, body). A missing path → network failure (simulated down).
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var failEverything = false
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            let path = request.url?.path ?? ""
+            if StubProtocol.failEverything || StubProtocol.routes[path] == nil {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let (status, body) = StubProtocol.routes[path]!
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.failEverything = false
+    }
+
+    private func client(token: String? = nil) -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    private func runtimeStatus(_ json: String) -> Data { Data(json.utf8) }
+
+    // MARK: pairing
+
+    func testPeerBuildsConfigFromHostPortToken() throws {
+        let peer = DesktopPeer(host: "desk.tailnet", port: 8000, token: "t0ken")
+        let config = try XCTUnwrap(HTTPDesktopClient.Config(peer: peer))
+        XCTAssertEqual(config.baseURL.absoluteString, "http://desk.tailnet:8000")
+        XCTAssertEqual(config.token, "t0ken")
+    }
+
+    func testMalformedPeerYieldsNoConfig() {
+        // An empty host has no valid URL → no config (the client then stays offline).
+        XCTAssertNil(HTTPDesktopClient.Config(peer: DesktopPeer(host: "", port: 0)))
+    }
+
+    // MARK: handshake — reachable
+
+    func testHandshakeReachableAndRuntimeReady() async {
+        StubProtocol.routes = [
+            "/health": (200, Data(#"{"status":"ok"}"#.utf8)),
+            "/api/runtime/status": (200, runtimeStatus(#"{"status":"ok","mode":"web","meeting_active":false}"#)),
+        ]
+        let conn = await client().handshake()
+        XCTAssertTrue(conn.reachable)
+        XCTAssertTrue(conn.runtimeReady)
+        XCTAssertTrue(conn.detail.contains("web"))   // summary surfaces the mode
+    }
+
+    func testHandshakeSurfacesActiveMeeting() async {
+        StubProtocol.routes = [
+            "/health": (200, Data(#"{"status":"ok"}"#.utf8)),
+            "/api/runtime/status": (200, runtimeStatus(#"{"status":"ok","mode":"web","meeting_active":true}"#)),
+        ]
+        let conn = await client().handshake()
+        XCTAssertTrue(conn.runtimeReady)
+        XCTAssertEqual(conn.detail, "meeting active")
+    }
+
+    func testHandshakeReachableButRuntimeStatusUnavailable() async {
+        StubProtocol.routes = [
+            "/health": (200, Data(#"{"status":"ok"}"#.utf8)),
+            "/api/runtime/status": (500, Data()),
+        ]
+        let conn = await client().handshake()
+        XCTAssertTrue(conn.reachable)        // health passed
+        XCTAssertFalse(conn.runtimeReady)    // status did not
+        XCTAssertEqual(conn.detail, "runtime status unavailable")
+    }
+
+    // MARK: handshake — offline (fail soft, never throw)
+
+    func testHandshakeUnreachableFailsSoft() async {
+        StubProtocol.failEverything = true   // peer down
+        let conn = await client().handshake()   // must NOT throw — no try
+        XCTAssertFalse(conn.reachable)
+        XCTAssertFalse(conn.runtimeReady)
+        XCTAssertTrue(conn.detail.hasPrefix("desktop unreachable"))
+    }
+
+    func testHandshakeBadHealthStatusIsOffline() async {
+        StubProtocol.routes = ["/health": (404, Data())]
+        let conn = await client().handshake()
+        XCTAssertFalse(conn.reachable)
+        XCTAssertTrue(conn.detail.contains("404"))
+    }
+
+    // MARK: egress + token
+
+    func testEgressLabelIsHonest() {
+        let label = client().egressLabel
+        XCTAssertTrue(label.contains("LAN"))
+        XCTAssertTrue(label.contains("desk.tailnet"))
+    }
+
+    func testTokenRidesAsBearerAndIsNotInEgress() async {
+        StubProtocol.routes = [
+            "/health": (200, Data(#"{"status":"ok"}"#.utf8)),
+            "/api/runtime/status": (200, runtimeStatus(#"{"status":"ok"}"#)),
+        ]
+        let c = client(token: "s3cret")
+        _ = await c.handshake()
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer s3cret")   // joined at call time
+        XCTAssertFalse(c.egressLabel.contains("s3cret"))         // never leaked to the badge
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/CompanionLinkTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CompanionLinkTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import Contracts
+@testable import Providers
+@testable import RuntimeCore
+
+/// HSM-12-01 — the Runtime-Core side of the desktop companion. Proves the core
+/// depends on the `IDesktopClient` *interface* (a fake drives it), and — the
+/// load-bearing guarantee — that an unreachable desktop never blocks on-device work.
+final class CompanionLinkTests: XCTestCase {
+
+    /// A fake desktop client: no network, scriptable connection, honest egress.
+    final class FakeDesktop: IDesktopClient, @unchecked Sendable {
+        var connection: DesktopConnection
+        var probes = 0
+        init(_ connection: DesktopConnection) { self.connection = connection }
+        func handshake() async -> DesktopConnection { probes += 1; return connection }
+        var egressLabel: String { "local + LAN → fake.desk" }
+    }
+
+    func testProbeReportsReadyConnection() async {
+        let fake = FakeDesktop(.init(reachable: true, runtimeReady: true, detail: "ready · web"))
+        let link = CompanionLink(client: fake)
+        let conn = await link.probe()
+        XCTAssertTrue(conn.reachable)
+        XCTAssertTrue(conn.runtimeReady)
+        XCTAssertEqual(fake.probes, 1)
+        XCTAssertTrue(link.egressLabel.contains("LAN"))
+    }
+
+    func testProbeReportsOfflineWithoutThrowing() async {
+        let link = CompanionLink(client: FakeDesktop(.offline("cannotConnectToHost")))
+        let conn = await link.probe()   // no try — the seam never throws
+        XCTAssertFalse(conn.reachable)
+        XCTAssertTrue(conn.detail.hasPrefix("desktop unreachable"))
+    }
+
+    /// The "not a dumb terminal" guarantee: on-device work completes fully while the
+    /// desktop is unreachable — the companion is additive, never on the local path.
+    func testOnDeviceWorkUnaffectedWhenDesktopUnreachable() async {
+        let link = CompanionLink(client: FakeDesktop(.offline("down")))
+
+        // Simulated on-device operation that does not depend on the server.
+        func localCapture() -> String { "captured-on-device" }
+
+        let conn = await link.probe()
+        let local = localCapture()
+
+        XCTAssertFalse(conn.reachable)              // server is down ...
+        XCTAssertEqual(local, "captured-on-device") // ... yet local work still ran
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-20 (**Charter Amendment 1.1 RATIFIED** — the Companion
-relationship is now co-canon with Rev 1.0: Tracks M–N, "companion to the desktop
+**Last updated:** 2026-06-20 (**HSM-12-01 done — the Companion track's first code
+ships: the desktop client seam.** `IDesktopClient` is a non-throwing `handshake()
+async -> DesktopConnection` seam (an unreachable desktop is a state, never an error);
+`HTTPDesktopClient` + `DesktopPeer` pair host/port + token and probe `/health` +
+`/api/runtime/status` over the desktop's existing API, honest `local + LAN → <host>`
+egress, token joined at call time. The RuntimeCore `CompanionLink` holds the
+interface — the core depends on the seam, not a transport — and a test proves
+on-device work runs unaffected while the desktop is down ("not a dumb terminal",
+made structural). `swift test` **96 passed / 6 skipped / 0 failed** (+12). Earlier
+the same day: **Charter Amendment 1.1 RATIFIED** — the Companion relationship is now
+co-canon with Rev 1.0: Tracks M–N, "companion to the desktop
 coder" promoted to a headline Vision objective, **iPhone + iPad at parity**, the
 **air-gapped notetaker made its own program gate (Gate 8)** + Gates 9/10, and
 **Hardening re-sequenced last** with Gate 7 extended to the companion failure
@@ -228,11 +237,11 @@ first-class, on iPhone + iPad at parity**: (1) the **Companion track**
 — point the iPad at the server you code against and **answer the coder by voice**
 (Phase 12 → 13, the Answer-the-Coder payoff), and (2) the **air-gapped fully-local
 notetaker** with a magic pencil that feeds the output (Phase 8, elevated: HSM-8-05 +
-HSM-8-06). **Start here →** [HSM-12-01](./phase-12-companion-client/story-01-desktop-client-seam.md)
-(the desktop client seam) — the highest-value **device-free** story, fully
-host-testable against a fake desktop, and the spine the whole Companion track hangs
-off. The on-device richness (HSM-8-05/06) sequences behind Phase 6 + HSM-5-02 (Mode
-A) and the iPad unlock; build its host-testable seams first, then gate on device.
+HSM-8-06). **HSM-12-01 (the desktop client seam) is done — the spine is in.** Next →
+[HSM-12-02](./phase-12-companion-client/story-02-meetings-remote-control.md) (meetings
+remote control over the existing endpoints, host-testable against a fake desktop).
+The on-device richness (HSM-8-05/06) sequences behind Phase 6 + HSM-5-02 (Mode A) and
+the iPad unlock; build its host-testable seams first, then gate on device.
 Sync (Phase 10) continues in parallel but is plumbing, not the headline value.
 **Status:** in-progress (Phases 0–1–4 closed, **Phase 6 closed (Gate 5 desktop-parity PASSED 0.92)**, **Phase 7 closed (MIR port — profile measurably changes extraction)**; Phase 5 host-complete — on-device Mode A + endpoint Modes B/C + sideload/HF packaging, device runs await the iPad unlock; Phase 10 opened (sync object model + engine). Next device-free: HSM-10-02 sync transport + Python sync API, or Phases 8/9 experience, or **Phase 12 — The Companion Client (HSM-12-01, the desktop client seam, fully host-testable against a fake desktop)**. iPad on-device batch (HSM-5-02/03/06 + Gate-4) when the device is unlocked; the companion gates (HSM-12-04 / HSM-13-04) join that device batch).
 
@@ -305,7 +314,7 @@ WebView, or UIKit.
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes — **+ companion + answer-the-coder + air-gapped notetaker at iPad parity** (Amendment 1.1) | not-started | [phase-9](./phase-9-iphone-experience/) |
 | 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (object model + transport + conflict + `SyncCoordinator` orchestration host-proven; only the live cross-device walkthrough (device) remains) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios **+ companion failure scenarios** (Gate 7 extended), production readiness — **runs last** (after 12–13, per Amendment 1.1) | not-started | [phase-11](./phase-11-hardening/) |
-| 12 | M | **The Companion Client:** point the iPhone/iPad at the same server you code against — a unified shell (on-device runtime + server, never a dumb terminal) + meetings remote control | not-started (scaffolded 2026-06-20) | [phase-12](./phase-12-companion-client/) |
+| 12 | M | **The Companion Client:** point the iPhone/iPad at the same server you code against — a unified shell (on-device runtime + server, never a dumb terminal) + meetings remote control | **in-progress (1/4 — HSM-12-01 seam done)** | [phase-12](./phase-12-companion-client/) |
 | 13 | N | **Answer the Coder:** the AI PI payoff — the agent's question surfaces on the device, you answer by native voice note, it lands back in the coder session | not-started (scaffolded 2026-06-20) | [phase-13](./phase-13-answer-the-coder/) |
 
 **Tracks M–N (Phases 12–13)** were added by owner steer (2026-06-20) and **ratified

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/current-phase-status.md
@@ -1,18 +1,28 @@
 # Phase 12 — The Companion Client
 
-**Status:** planning (scaffolded 2026-06-20). **Track M — added by owner steer
-(2026-06-20), outside the original charter's Tracks A–L.** The iPad stops being a
-launch stub and becomes a **first-class companion to the desktop/server you are
-already coding against**, without losing one ounce of its own on-device power
-(Phases 0–7 stand). Point the iPad at the same server your tmux + hooks session
-points at, and it becomes a native window into that runtime: list and start
-meetings, see live state, and (Phase 13) answer the coder by voice. Built
-**native over the desktop's existing HTTP API** (owner call, 2026-06-20) — the
-same endpoints the web portal uses — so the experience is web-app-consistent and
-genuinely native, not a WebView shell.
+**Status:** in-progress (1/4 — **HSM-12-01 done**, the seam is live). **Track M —
+ratified into the charter as Amendment 1.1 (2026-06-20), co-canon with Rev 1.0.**
+The device stops being a launch stub and becomes a **first-class companion to the
+desktop/server you are already coding against**, without losing one ounce of its own
+on-device power (Phases 0–7 stand). Point the iPhone/iPad at the same server your
+tmux + hooks session points at, and it becomes a native window into that runtime:
+list and start meetings, see live state, and (Phase 13) answer the coder by voice.
+Built **native over the desktop's existing HTTP API** (owner call) — the same
+endpoints the web portal uses — so the experience is web-app-consistent and
+genuinely native, not a WebView shell. iPhone + iPad at parity (Amendment 1.1, Q4).
 
-**Last updated:** 2026-06-20 (scaffolded — stories HSM-12-01..04 stubbed from the
-owner's companion-client steer. No work started.)
+**Last updated:** 2026-06-20 (**HSM-12-01 done — the desktop client seam + pairing,
+host-proven.** `IDesktopClient` is a non-throwing `handshake() async ->
+DesktopConnection` seam (an unreachable desktop is a state, never an error on the
+caller path); `HTTPDesktopClient` + `DesktopPeer` pair host/port + token and probe
+`/health` + `/api/runtime/status` over the existing API, with an honest `local +
+LAN → <host>` egress and the token joined at call time (never in the badge). The
+RuntimeCore `CompanionLink` holds the interface, so the core depends on the seam,
+not a transport — and a test proves on-device work runs unaffected while the
+desktop is unreachable ("not a dumb terminal", made structural). `swift test`
+**96 passed / 6 skipped / 0 failed** (+12). See
+[`evidence-story-01.md`](./evidence-story-01.md). Next: HSM-12-02 (meetings remote
+control). Earlier: scaffolded from the owner's companion-client steer.)
 
 ## Why this exists (the gap this closes)
 
@@ -86,20 +96,22 @@ views present it.
 
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
-| HSM-12-01 | Desktop client seam + pairing | backlog | [story-01](./story-01-desktop-client-seam.md) | — |
+| HSM-12-01 | Desktop client seam + pairing | **done** | [story-01](./story-01-desktop-client-seam.md) | [evidence-01](./evidence-story-01.md) |
 | HSM-12-02 | Meetings remote control | backlog | [story-02](./story-02-meetings-remote-control.md) | — |
 | HSM-12-03 | The unified Companion shell | backlog | [story-03](./story-03-unified-companion-shell.md) | — |
 | HSM-12-04 | Track M gate closeout | backlog | [story-04](./story-04-companion-gate-closeout.md) | — |
 
 ## Where we are
 
-Just scaffolded from the owner's 2026-06-20 steer. The foundation (HSM-12-01) is
-fully host-testable against a fake desktop and unblocks the rest; meetings remote
-control (HSM-12-02) consumes endpoints that already ship; the shell (HSM-12-03) is
-where the web-app consistency and the "not a dumb terminal" principle become
-visible; the gate (HSM-12-04) needs the unlocked iPad + a reachable desktop. Phase
-13 (Answer the Coder) builds the voice-note-into-the-coder payoff on this
-foundation. Next: HSM-12-01.
+**HSM-12-01 is done** — the foundation (`IDesktopClient` seam + `HTTPDesktopClient`
+pairing/handshake/egress + the RuntimeCore `CompanionLink`) is host-proven against a
+fake desktop and a stubbed network, and it unblocks the rest. Next: meetings remote
+control (HSM-12-02), which consumes endpoints that already ship (`/api/meetings`,
+`/api/meeting/start|stop`, `/api/runtime/status`) through this seam; then the shell
+(HSM-12-03), where the web-app consistency and the "not a dumb terminal" principle
+become visible; then the gate (HSM-12-04), which needs an unlocked iPhone/iPad + a
+reachable desktop. Phase 13 (Answer the Coder) builds the voice-note-into-the-coder
+payoff on this same seam.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/evidence-story-01.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/evidence-story-01.md
@@ -1,0 +1,64 @@
+# Evidence — HSM-12-01 (Desktop client seam + pairing)
+
+**Date:** 2026-06-20
+**Story:** [story-01-desktop-client-seam.md](./story-01-desktop-client-seam.md)
+**Result:** DONE — host-proven. The `IDesktopClient` seam + `HTTPDesktopClient`
+(pairing → handshake against `/health` + `/api/runtime/status`, honest egress,
+offline-tolerant) and the Runtime-Core `CompanionLink` consumer. `swift test`
+**96 passed / 6 skipped / 0 failed** (was 84; +12 this story).
+
+## What shipped
+
+- **Layer 3 (Providers):** `IDesktopClient` (Providers.swift) — a non-throwing
+  `handshake() async -> DesktopConnection` seam, so an unreachable desktop is a
+  first-class state, never an error on the caller path. Concrete
+  `HTTPDesktopClient` + `DesktopPeer` (host/port + token pairing) +
+  `DesktopConnection` in `Providers/Desktop/HTTPDesktopClient.swift`. URLSession
+  over the desktop's existing HTTP API; honest egress `local + LAN → <host>`; Bearer
+  token joined at call time, never in the egress label; `/api/runtime/status`
+  decoded loosely (every field optional) for robustness.
+- **Layer 2 (RuntimeCore):** `CompanionLink` (RuntimeCore/Companion/) holds the
+  `IDesktopClient` interface — the Runtime Core depends on the seam, not a transport
+  — and is the thin entry point the verb stories (HSM-12-02 / HSM-13) extend.
+
+## Acceptance criteria → proof
+
+- **Seam exists; core depends on the interface; a fake drives it.** `CompanionLink`
+  takes `IDesktopClient`; `CompanionLinkTests.FakeDesktop` drives the flow with no
+  network. ✅
+- **Configure a peer (host/port + token); handshake vs `/health` +
+  `/api/runtime/status`; surface reachable/unreachable + readiness.**
+  `DesktopPeer` → `Config`; `testHandshakeReachableAndRuntimeReady`,
+  `testHandshakeReachableButRuntimeStatusUnavailable`,
+  `testHandshakeSurfacesActiveMeeting`. ✅
+- **Honest egress descriptor.** `testEgressLabelIsHonest` (`LAN` + host present),
+  `testTokenRidesAsBearerAndIsNotInEgress` (token never in the label). ✅
+- **Offline-tolerant: fails soft, no throw; on-device flow unaffected.**
+  `testHandshakeUnreachableFailsSoft` (no `try`, returns `.offline`),
+  `testHandshakeBadHealthStatusIsOffline`, and the core guarantee
+  `CompanionLinkTests.testOnDeviceWorkUnaffectedWhenDesktopUnreachable`. ✅
+
+## Commands + output
+
+```
+$ swift build
+Build complete! (2.62s)
+
+$ swift test --filter 'DesktopClientTests|CompanionLinkTests'
+Test Suite 'CompanionLinkTests' passed   — Executed 3 tests, 0 failures
+Test Suite 'DesktopClientTests' passed   — Executed 9 tests, 0 failures
+Test Suite 'Selected tests' passed       — Executed 12 tests, 0 failures
+
+$ swift test
+Test Suite 'HoldSpeakMobilePackageTests.xctest' passed
+Executed 96 tests, with 6 tests skipped and 0 failures (0 unexpected)
+```
+
+## Notes
+
+- Fix during the run: `DesktopPeer.baseURL` now rejects an empty host / non-positive
+  port (URLComponents otherwise built `http://:0`), so a half-filled pairing form
+  stays offline instead of producing a junk client.
+- The 6 skips are the pre-existing opt-in device/live tests (unchanged by this story).
+- Device proof of the companion is the Track-M gate (HSM-12-04); this story is the
+  fully host-testable spine and needs no hardware.

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-01-desktop-client-seam.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-01-desktop-client-seam.md
@@ -2,7 +2,10 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 12
-- **Status:** backlog
+- **Status:** done (2026-06-20 — `IDesktopClient` seam + `HTTPDesktopClient`
+  (pairing/handshake/egress, offline-tolerant) + RuntimeCore `CompanionLink`;
+  `swift test` 96 passed / 6 skipped / 0 failed (+12). See
+  [evidence-01](./evidence-story-01.md).)
 - **Depends on:** HSM-0-04 (contracts), HSM-1-01 (SPM layout), HSM-10-02 (transport posture to reuse)
 - **Unblocks:** HSM-12-02, HSM-12-03, HSM-13-01
 - **Owner:** unassigned


### PR DESCRIPTION
First code of the Companion track (Track M). The spine: point an iPhone/iPad at the same server a coding session runs against and drive it over the desktop's **existing** HTTP API.

## What
- **Layer 3 — `IDesktopClient`** (Providers): a non-throwing `handshake() async -> DesktopConnection` seam, so an unreachable desktop is a first-class *state*, never an error on the caller path.
- **`HTTPDesktopClient` + `DesktopPeer` + `DesktopConnection`**: pair host/port + token; probe `/health` then `/api/runtime/status`; honest `local + LAN → <host>` egress; Bearer token joined at call time and never in the egress label; runtime status decoded loosely. Fails soft on any network error.
- **Layer 2 — `CompanionLink`** (RuntimeCore): holds the interface so the core depends on the seam, not a transport; the thin entry point HSM-12-02 / HSM-13 extend.

## "Not a dumb terminal", made structural
`CompanionLinkTests.testOnDeviceWorkUnaffectedWhenDesktopUnreachable` proves on-device work completes fully while the desktop is down — the companion is additive, never on the local path.

## Tests
`swift test` → **96 passed / 6 skipped / 0 failed** (+12: `DesktopClientTests` 9, `CompanionLinkTests` 3). Evidence: `phase-12-companion-client/evidence-story-01.md`. Mid-run fix: `DesktopPeer.baseURL` rejects an empty host / non-positive port (URLComponents otherwise built `http://:0`).

## Cadence
HSM-12-01 → `done` (+ evidence-story-01); phase-12 status + program README updated. Next: HSM-12-02 (meetings remote control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuGkRn3BzV6v8EXgZDFind