### PR TITLE
HSM-5-02: Mode A on-device run proven on real metal (Qwen3 on the iPad)

### DIFF
--- a/apple/App/Local-Info.plist
+++ b/apple/App/Local-Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>HoldSpeakMobile</string>
+    <key>CFBundleDisplayName</key>
+    <string>HoldSpeak Local</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.holdspeak.mobile</string>
+    <key>CFBundleExecutable</key>
+    <string>HoldSpeakMobile</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>MinimumOSVersion</key>
+    <string>17.0</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <!-- Mode A is fully on-device; no networking is required or used. The egress
+         badge in-app reads "on-device, nothing leaves" — and means it. -->
+</dict>
+</plist>

--- a/apple/App/Local.entitlements
+++ b/apple/App/Local.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- HSM-5-02: hosting a real GGUF on the device needs more than the default
+         per-app memory ceiling. This entitlement raises it toward the device's
+         physical RAM, so a 4B/7B model isn't jetsam-killed on an 8GB iPad. -->
+    <key>com.apple.developer.kernel.increased-memory-limit</key>
+    <true/>
+</dict>
+</plist>

--- a/apple/App/LocalHarnessApp.swift
+++ b/apple/App/LocalHarnessApp.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+
+// HSM-5-02 (real-metal) — the FULLY-LOCAL (charter Mode A) device harness. Loads a
+// GGUF from the app's Documents (push it with scripts/push-model-device.sh) and turns
+// a meeting transcript into artifacts with **no network** — llama.cpp via LLM.swift
+// (LlamaProvider) on the device's Metal. This is the airplane-mode paradigm: host
+// the model on the iPad itself. Unlike the Mode-C harness, this app LINKS the native
+// engine (InferenceLlama + the LLM package).
+//
+// Compiled as ONE module with the Contracts/Providers/RuntimeCore/InferenceLlama
+// sources (gen-local-harness.rb), so it imports no package modules.
+
+@main
+struct LocalHarnessApp: App {
+    var body: some Scene {
+        WindowGroup { LocalView().preferredColorScheme(.dark) }
+    }
+}
+
+// MARK: - Signal palette
+
+private enum Sig {
+    static let bg = Color(hex: 0x0E0F13)
+    static let s1 = Color(hex: 0x15171D)
+    static let s2 = Color(hex: 0x1C1F27)
+    static let s3 = Color(hex: 0x242833)
+    static let line = Color.white.opacity(0.07)
+    static let text = Color(hex: 0xF2F3F5)
+    static let muted = Color(hex: 0x9BA2B0)
+    static let faint = Color(hex: 0x767E8D)
+    static let accent = Color(hex: 0xFF6B35)
+    static let ok = Color(hex: 0x3ECF8E)
+    static let bad = Color(hex: 0xE5544B)
+
+    static func style(for type: String) -> (Color, String) {
+        switch type {
+        case "decisions":    return (Color(hex: 0x5B8DEF), "checkmark.seal.fill")
+        case "action_items": return (ok, "arrow.right.circle.fill")
+        case "requirements": return (Color(hex: 0xF2A33C), "list.bullet.rectangle.fill")
+        default:             return (accent, "sparkles")
+        }
+    }
+}
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(.sRGB,
+                  red: Double((hex >> 16) & 0xFF) / 255,
+                  green: Double((hex >> 8) & 0xFF) / 255,
+                  blue: Double(hex & 0xFF) / 255, opacity: 1)
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class LocalModel: ObservableObject {
+    @Published var running = false
+    @Published var status = "Fully on-device — no network."
+    @Published var modelName = ""
+    @Published var modelPath: String?
+    @Published var elapsed = ""
+    @Published var results: [ArtifactResult] = []
+
+    struct ArtifactResult: Identifiable {
+        let id = UUID(); let type: String; let ok: Bool; let title: String; let body: String
+    }
+
+    var autoRun: Bool { ProcessInfo.processInfo.environment["HS_AUTORUN"] == "1" }
+
+    init() { locateModel() }
+
+    /// Find a `.gguf` in the app's Documents (pushed via push-model-device.sh).
+    func locateModel() {
+        guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            status = "No Documents directory."; return
+        }
+        let ggufs = ((try? FileManager.default.contentsOfDirectory(at: docs, includingPropertiesForKeys: nil)) ?? [])
+            .filter { $0.pathExtension.lowercased() == "gguf" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        if let first = ggufs.first {
+            modelPath = first.path; modelName = first.lastPathComponent
+            status = "Model ready — tap Run to generate, fully on device."
+        } else {
+            modelPath = nil; modelName = ""
+            status = "No .gguf in Documents. Push one: scripts/push-model-device.sh <model>.gguf"
+        }
+    }
+
+    func run() {
+        guard !running, let path = modelPath else { return }
+        running = true; results = []; elapsed = ""; status = "Loading the model on device…"
+        Task { @MainActor in
+            let start = Date()
+            do {
+                let provider = try LlamaProvider(modelPath: path)
+                status = "Generating artifacts — fully on device…"
+                let engine = ArtifactGenerationEngine(provider: provider)
+                let types: [ArtifactType] = [.decisions, .actionItems, .requirements]
+                let outcomes = await engine.generate(types: types, from: sampleTranscript())
+                for (type, result) in outcomes {
+                    switch result {
+                    case .success(let a):
+                        results.append(.init(type: type.rawValue, ok: true, title: a.title, body: a.bodyMarkdown))
+                    case .failure(let e):
+                        results.append(.init(type: type.rawValue, ok: false, title: "Couldn't generate", body: "\(e)"))
+                    }
+                }
+                let secs = String(format: "%.1f", Date().timeIntervalSince(start))
+                status = "\(results.filter(\.ok).count)/\(results.count) artifacts, fully on device"
+                elapsed = "\(secs)s"
+            } catch {
+                status = "Error: \(error)"
+            }
+            running = false
+        }
+    }
+
+    private func sampleTranscript() -> Transcript {
+        let lines: [(String, String)] = [
+            ("Alice", "Let's lock the plan. I propose we ship the iPad able to host its own model, fully offline."),
+            ("Bob", "Agreed. We decided Mode A runs llama.cpp on the device with no endpoint."),
+            ("Alice", "Bob, can you push a 4B GGUF and run the airplane-mode test by Friday?"),
+            ("Bob", "Yes, I'll own the on-device run and have it ready Friday."),
+            ("Alice", "One risk: a 12B model could thermally throttle on battery, so keep the default at 4B."),
+        ]
+        var t = 0.0
+        let segments = lines.map { pair -> Segment in
+            defer { t += 5 }
+            return Segment(text: pair.1, speaker: pair.0, startTime: t, endTime: t + 5)
+        }
+        return Transcript(meetingId: "ipad_local_001", segments: segments, transcriptHash: "ipad-local-hash")
+    }
+}
+
+// MARK: - View
+
+struct LocalView: View {
+    @StateObject private var m = LocalModel()
+
+    var body: some View {
+        ZStack {
+            Sig.bg.ignoresSafeArea()
+            RadialGradient(colors: [Sig.accent.opacity(0.16), .clear],
+                           center: .topTrailing, startRadius: 0, endRadius: 520).ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    header
+                    modelCard
+                    runButton
+                    statusLine
+                    if m.running && m.results.isEmpty { generating }
+                    ForEach(m.results) { card($0) }
+                    egressBadge
+                    Spacer(minLength: 16)
+                }
+                .padding(22).frame(maxWidth: 720).frame(maxWidth: .infinity)
+            }
+        }
+        .onAppear { if m.autoRun { m.run() } }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(LinearGradient(colors: [Sig.accent, Color(hex: 0xEC5A28)], startPoint: .topLeading, endPoint: .bottomTrailing))
+                    .frame(width: 30, height: 30)
+                    .overlay(Image(systemName: "cpu.fill").font(.system(size: 14, weight: .bold)).foregroundStyle(Sig.bg))
+                Text("HoldSpeak").font(.system(size: 19, weight: .bold)).foregroundStyle(Sig.text)
+                Text("Mobile").font(.system(size: 19)).foregroundStyle(Sig.faint)
+                Spacer()
+                Text("Mode A · local")
+                    .font(.system(size: 12, weight: .semibold)).foregroundStyle(Sig.accent)
+                    .padding(.horizontal, 10).padding(.vertical, 5)
+                    .background(Sig.accent.opacity(0.12), in: Capsule())
+            }
+            Text("Hosted on the iPad").font(.system(size: 29, weight: .bold)).foregroundStyle(Sig.text)
+            Text("A meeting, turned into decisions by a model running on this device — airplane-mode, no endpoint.")
+                .font(.system(size: 15)).foregroundStyle(Sig.muted).fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var modelCard: some View {
+        let has = m.modelPath != nil
+        return HStack(spacing: 12) {
+            Image(systemName: has ? "shippingbox.fill" : "shippingbox")
+                .font(.system(size: 22)).foregroundStyle(has ? Sig.ok : Sig.faint)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(has ? m.modelName : "No model on device").font(.system(size: 15, weight: .semibold).monospaced()).foregroundStyle(Sig.text)
+                Text(has ? "GGUF in Documents · loads with llama.cpp" : "Push one: scripts/push-model-device.sh <model>.gguf")
+                    .font(.caption).foregroundStyle(Sig.faint)
+            }
+            Spacer()
+            Button { m.locateModel() } label: { Image(systemName: "arrow.clockwise").foregroundStyle(Sig.muted) }
+        }
+        .padding(16).frame(maxWidth: .infinity, alignment: .leading)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(Sig.line, lineWidth: 1))
+    }
+
+    private var runButton: some View {
+        Button { m.run() } label: {
+            HStack {
+                if m.running { ProgressView().tint(.black) } else { Image(systemName: "play.fill").foregroundStyle(.black) }
+                Text(m.running ? "Working…" : "Run on device").font(.headline).foregroundStyle(.black)
+            }
+            .frame(maxWidth: .infinity).padding(.vertical, 13)
+            .background(Sig.accent, in: RoundedRectangle(cornerRadius: 12))
+        }
+        .disabled(m.running || m.modelPath == nil)
+        .opacity(m.modelPath == nil ? 0.5 : 1)
+    }
+
+    private var statusLine: some View {
+        HStack {
+            Text(m.status).font(.subheadline).foregroundStyle(Sig.muted)
+            Spacer()
+            if !m.elapsed.isEmpty { Text(m.elapsed).font(.subheadline.monospaced()).foregroundStyle(Sig.accent) }
+        }
+    }
+
+    private var generating: some View {
+        HStack(spacing: 10) {
+            ProgressView().tint(Sig.accent)
+            Text("The model is thinking, on the device…").font(.subheadline).foregroundStyle(Sig.faint)
+        }
+        .padding(16).frame(maxWidth: .infinity, alignment: .leading)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func card(_ r: LocalModel.ArtifactResult) -> some View {
+        let (color, glyph) = Sig.style(for: r.type)
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 9) {
+                Image(systemName: r.ok ? glyph : "exclamationmark.triangle.fill").foregroundStyle(r.ok ? color : Sig.bad)
+                Text(r.type.replacingOccurrences(of: "_", with: " ").capitalized)
+                    .font(.system(size: 13, weight: .bold)).tracking(0.5).foregroundStyle(r.ok ? color : Sig.bad)
+                Spacer()
+            }
+            Text(r.title).font(.system(size: 16, weight: .semibold)).foregroundStyle(Sig.text)
+            Text(r.body).font(.system(size: 14).monospaced()).foregroundStyle(Sig.muted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(16).frame(maxWidth: .infinity, alignment: .leading)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(Sig.line, lineWidth: 1))
+    }
+
+    private var egressBadge: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "lock.fill").foregroundStyle(Sig.ok)
+            Text("on-device · nothing leaves").font(.caption.monospaced()).foregroundStyle(Sig.muted)
+        }
+        .padding(.horizontal, 10).padding(.vertical, 8)
+        .background(Sig.s3, in: RoundedRectangle(cornerRadius: 9))
+        .overlay(RoundedRectangle(cornerRadius: 9).stroke(Sig.line, lineWidth: 1))
+    }
+}

--- a/apple/scripts/gen-local-harness.rb
+++ b/apple/scripts/gen-local-harness.rb
@@ -1,0 +1,94 @@
+#!/usr/bin/env ruby
+# HSM-5-02 fully-local (Mode A) device harness generator. Like gen-inference-harness,
+# it stages the package sources into ONE app module (SwiftPM can't emit a signed iOS
+# .app) — but it ALSO stages Sources/InferenceLlama (the llama.cpp adapter) and adds a
+# Swift Package dependency on LLM.swift so `import LLM` resolves and the native engine
+# links. The result runs a GGUF entirely on the device (no network). Output:
+# build/HoldSpeakLocalHarness.xcodeproj
+#
+# Usage: ruby apple/scripts/gen-local-harness.rb
+require 'xcodeproj'
+require 'fileutils'
+
+ROOT  = File.expand_path('..', __dir__)            # apple/
+BUILD = File.join(ROOT, 'build')
+STAGE = File.join(BUILD, 'local-harness-sources')
+PROJ_PATH = File.join(BUILD, 'HoldSpeakLocalHarness.xcodeproj')
+TEAM = ENV.fetch('HS_TEAM', 'M84954HNL6')
+BUNDLE_ID = 'dev.holdspeak.mobile'
+DEPLOY = '17.0'
+
+# Mode A needs the engine adapter too. KEEP `import LLM` (the external package);
+# strip only the intra-package imports (everything merges into one module).
+LAYER_DIRS = %w[Sources/Contracts Sources/Providers Sources/RuntimeCore Sources/InferenceLlama]
+INTRA_IMPORT = /^import\s+(Contracts|Providers|RuntimeCore|InferenceLlama)\s*$/
+
+FileUtils.rm_rf(STAGE)
+FileUtils.mkdir_p(STAGE)
+
+staged = []
+seen = {}
+LAYER_DIRS.each do |dir|
+  Dir[File.join(ROOT, dir, '**', '*.swift')].sort.each do |src|
+    base = File.basename(src)
+    raise "name collision staging #{base} (#{src} vs #{seen[base]})" if seen[base]
+    seen[base] = src
+    text = File.read(src).gsub(INTRA_IMPORT, '')
+    out = File.join(STAGE, base)
+    File.write(out, text)
+    staged << out
+  end
+end
+app = File.join(ROOT, 'App/LocalHarnessApp.swift')
+FileUtils.cp(app, File.join(STAGE, 'LocalHarnessApp.swift'))
+staged << File.join(STAGE, 'LocalHarnessApp.swift')
+
+FileUtils.rm_rf(PROJ_PATH)
+project = Xcodeproj::Project.new(PROJ_PATH)
+target = project.new_target(:application, 'HoldSpeakMobile', :ios, DEPLOY)
+
+group = project.new_group('Sources', STAGE)
+staged.each { |p| target.add_file_references([group.new_reference(p)]) }
+
+# --- Swift Package dependency: LLM.swift (the llama.cpp engine) ---
+pkg = project.new(Xcodeproj::Project::Object::XCRemoteSwiftPackageReference)
+pkg.repositoryURL = 'https://github.com/eastriverlee/LLM.swift'
+pkg.requirement = { 'kind' => 'upToNextMajorVersion', 'minimumVersion' => '2.1.0' }
+project.root_object.package_references << pkg
+
+dep = project.new(Xcodeproj::Project::Object::XCSwiftPackageProductDependency)
+dep.package = pkg
+dep.product_name = 'LLM'
+target.package_product_dependencies << dep
+
+build_file = project.new(Xcodeproj::Project::Object::PBXBuildFile)
+build_file.product_ref = dep
+target.frameworks_build_phase.files << build_file
+
+info_plist = File.join(ROOT, 'App/Local-Info.plist')
+target.build_configurations.each do |config|
+  s = config.build_settings
+  s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
+  s['PRODUCT_NAME'] = 'HoldSpeakMobile'
+  s['MARKETING_VERSION'] = '0.1.0'
+  s['CURRENT_PROJECT_VERSION'] = '1'
+  s['GENERATE_INFOPLIST_FILE'] = 'NO'
+  s['INFOPLIST_FILE'] = info_plist
+  s['TARGETED_DEVICE_FAMILY'] = '1,2'
+  s['IPHONEOS_DEPLOYMENT_TARGET'] = DEPLOY
+  s['SWIFT_VERSION'] = '6.0'
+  s['CODE_SIGN_STYLE'] = 'Automatic'
+  s['DEVELOPMENT_TEAM'] = TEAM
+  s['CODE_SIGN_IDENTITY'] = 'Apple Development'
+  s['SDKROOT'] = 'iphoneos'
+  # NOTE: com.apple.developer.kernel.increased-memory-limit (App/Local.entitlements)
+  # would raise the per-app RAM ceiling, but automatic dev signing can't add it —
+  # the App ID needs the "Increased Memory Limit" capability enabled in the developer
+  # portal first. Until then we run within the default ceiling, so keep the model at
+  # ~4B Q4 on an 8GB iPad. Re-enable CODE_SIGN_ENTITLEMENTS once the capability is on.
+end
+
+project.save
+puts "generated #{PROJ_PATH}"
+puts "  staged #{staged.size} sources from #{LAYER_DIRS.join(', ')} + the local-harness app"
+puts "  package=LLM.swift>=2.1.0 (product LLM) team=#{TEAM} bundle=#{BUNDLE_ID}"

--- a/apple/scripts/local-harness-device.sh
+++ b/apple/scripts/local-harness-device.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# HSM-5-02: build + sign the FULLY-LOCAL (Mode A) harness and install/launch it on a
+# physical iPad, so a meeting transcript is turned into artifacts by a GGUF running on
+# the device's Metal — no network. Push a model first with push-model-device.sh.
+#
+# Usage: apple/scripts/local-harness-device.sh [device-udid]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ruby scripts/gen-local-harness.rb
+
+DEVID="${1:-}"
+if [ -z "$DEVID" ]; then
+  UUID_RE='[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+  LIST="$(xcrun devicectl list devices 2>/dev/null || true)"
+  DEVID="$(printf '%s\n' "$LIST" | grep -i 'iPad' | grep -oE "$UUID_RE" | head -1 || true)"
+  [ -z "$DEVID" ] && DEVID="$(printf '%s\n' "$LIST" | grep -iE 'iPad|iPhone' | grep -oE "$UUID_RE" | head -1 || true)"
+fi
+echo "== target device: ${DEVID:-<none found>} =="
+
+# Build for a generic iOS destination (does not require a live device tunnel — more
+# reliable than pinning the device id when the build-time connection is flaky), then
+# install via devicectl which talks to the connected device directly.
+#
+# NOTE: do NOT flatten CONFIGURATION_BUILD_DIR here — LLM.swift pulls swift-syntax
+# (macros), and a flat product dir makes "Multiple commands produce …" collisions for
+# those package targets. Use -derivedDataPath (standard per-target layout) instead.
+# -skipMacroValidation enables the LLM macro plugin without the interactive trust gate.
+echo "== build + sign (generic/platform=iOS) =="
+xcodebuild -project build/HoldSpeakLocalHarness.xcodeproj -scheme HoldSpeakMobile \
+  -configuration Debug \
+  -destination 'generic/platform=iOS' \
+  -allowProvisioningUpdates \
+  -skipMacroValidation \
+  -clonedSourcePackagesDirPath build/spm-local \
+  -derivedDataPath build/dd-local \
+  build
+
+APP="$PWD/build/dd-local/Build/Products/Debug-iphoneos/HoldSpeakMobile.app"
+echo "== install $APP =="
+xcrun devicectl device install app --device "$DEVID" "$APP"
+
+echo "== launch =="
+xcrun devicectl device process launch --device "$DEVID" dev.holdspeak.mobile
+
+echo "== HSM-5-02 local harness launched on $DEVID =="
+echo "(on the iPad: it loads the .gguf you pushed to Documents, tap 'Run on device')"

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/current-phase-status.md
@@ -14,8 +14,19 @@ that lights up Mode A (Fully Local): it delivers the on-device `ILLMProvider`
 It also resolves the Phase-0 deferred decision — which inference engine the mobile
 runtime stands on.
 
-**Last updated:** 2026-06-19 (**HSM-5-03 — model packaging: both delivery paths
-host-proven.** A `ModelCatalog` pins the per-tier GGUFs (4B Llama-3.2-3B / 8B
+**Last updated:** 2026-06-20 (**HSM-5-02 DONE — Mode A proven on REAL METAL.** A GGUF
+is hosted entirely on the iPad Air M4 and turns a meeting transcript into artifacts
+with no network — the owner witnessed the artifact cards render on the device. Model:
+**Qwen3-4B-Instruct-2507 Q6_K** (3.08 GB), pushed via `push-model-device.sh`; app =
+the first iOS build that links the native llama.cpp engine (`gen-local-harness.rb`
+stages InferenceLlama + the LLM.swift SPM package). The process stayed alive with the
+3 GB model resident, so Q6 fits the 8 GB ceiling without the increased-memory
+entitlement (which would unlock Qwen3-8B once the App-ID capability is enabled). Build
+snags cleared for the next device build: `-skipMacroValidation` (the LLM macro plugin)
++ `-derivedDataPath` rather than a flat `CONFIGURATION_BUILD_DIR` (swift-syntax object
+collisions). See [`evidence-story-02.md`](./evidence-story-02.md).
+Earlier: **HSM-5-03 — model packaging: both delivery paths host-proven.** A
+`ModelCatalog` pins the per-tier GGUFs (4B Llama-3.2-3B / 8B
 Llama-3.1-8B / 12B+ Mistral-Nemo, all Q4_K_M; HF URLs verified live), a Foundation
 `ModelStore` is the model manager (list / **Files-sideload import** / delete /
 per-device `resolveActive`), and a Foundation `ModelDownloader` does the **Hugging

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/evidence-story-02.md
@@ -1,0 +1,57 @@
+# Evidence — HSM-5-02 (Mode A on-device run) — REAL METAL, owner-witnessed
+
+**Date:** 2026-06-20
+**Story:** [story-02-llm-provider-impl.md](./story-02-llm-provider-impl.md)
+**Result:** **DONE on real metal.** A GGUF model is hosted **entirely on the iPad
+Air M4** and turns a meeting transcript into artifacts with **no network** (charter
+Mode A). The owner watched the artifacts render on the device. This discharges the
+long-pending "iPad airplane-mode run" that was blocked behind the device lock.
+
+## What ran on the device
+
+- **App:** the fully-local Mode-A harness (`App/LocalHarnessApp.swift`) — the first
+  iOS build that LINKS the native engine (`InferenceLlama` / `LlamaProvider` =
+  llama.cpp via LLM.swift) and loads a GGUF from the app's Documents.
+- **Model:** **Qwen3-4B-Instruct-2507, Q6_K** (3.08 GB) — the July refresh, pushed
+  into the app container with `push-model-device.sh`.
+- **Device:** iPad Air 11-inch (M4), 8 GB, `6B2F424D-…` (devicectl `connected`).
+- **Path:** transcript → `LlamaProvider` (Metal, no network) →
+  `ArtifactGenerationEngine` → decisions / action_items / requirements cards.
+
+## Proof
+
+- **Owner observation (authoritative):** "I was sitting at the iPad and I saw the
+  results … the local model is working." The artifact cards rendered on-device.
+- **No OOM:** after auto-run, `xcrun devicectl device info processes` showed
+  `HoldSpeakMobile` (PID 1463) alive with the 3.08 GB model resident — i.e. Q6_K
+  fits the 8 GB Air's default memory ceiling without a jetsam kill.
+- Headless device-log capture was **not** achieved (`log stream` cannot target a
+  connected device; no `idevicescreenshot` installed) — the evidence is the owner's
+  direct observation plus the live process.
+
+## How it was built (snags cleared — keep for the next device build)
+
+- `gen-local-harness.rb` stages Contracts/Providers/RuntimeCore/**InferenceLlama**
+  into one module and adds an SPM dependency on **LLM.swift ≥ 2.1.0** (product `LLM`).
+- **`-skipMacroValidation`** — LLM.swift ships a macro plugin; xcodebuild blocks it
+  behind an interactive trust gate otherwise.
+- **Do not flatten `CONFIGURATION_BUILD_DIR`** — LLM.swift pulls swift-syntax, and a
+  flat product dir causes "Multiple commands produce …" collisions. Use
+  `-derivedDataPath` (standard per-target layout). Both encoded in
+  `local-harness-device.sh`.
+- Build for `generic/platform=iOS`, then `devicectl device install` — more reliable
+  than pinning the device id when the build-time tunnel is flaky.
+
+## Known constraint (the next-level lever)
+
+Without the **Increased Memory Limit** entitlement (rejected by automatic signing —
+the App ID needs the capability enabled in the developer portal first), ~3 GB is the
+safe app budget, so **4B Q-quant is the ceiling**. Enabling that capability unlocks
+Qwen3-8B (~5 GB) on the 8 GB iPad. `App/Local.entitlements` is staged and ready;
+re-enable `CODE_SIGN_ENTITLEMENTS` in the generator once the capability is on.
+
+## Remaining for Phase 5
+
+- Explicit radios-off airplane-mode toggle + the 30-min meeting (Gate 4 / HSM-5-05)
+  — the run was fully-local (no endpoint, no network calls) by construction, but the
+  formal airplane-mode + duration gate is still its own closeout.

--- a/pm/roadmap/holdspeak-mobile/phase-5-local-inference/story-02-llm-provider-impl.md
+++ b/pm/roadmap/holdspeak-mobile/phase-5-local-inference/story-02-llm-provider-impl.md
@@ -2,7 +2,10 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 5
-- **Status:** in-progress
+- **Status:** done (2026-06-20 — **Mode A proven on real metal**: Qwen3-4B-Instruct-2507
+  Q6_K hosted fully on the iPad Air M4, transcript → on-device artifacts, no network,
+  owner-witnessed. First iOS build linking the llama.cpp engine. See
+  [evidence-story-02.md](./evidence-story-02.md).)
 - **Depends on:** HSM-5-01
 - **Unblocks:** HSM-5-04, HSM-5-05, HSM-6-01
 - **Owner:** unassigned


### PR DESCRIPTION
**A Qwen3 model is hosted entirely on the iPad Air M4, turning a meeting into artifacts with no network** (charter Mode A). The owner witnessed the artifact cards render on the device — the airplane-mode paradigm working, and the on-device run that was blocked behind the device lock.

## What shipped
- **`App/LocalHarnessApp.swift`** — the first iOS build that **links the native llama.cpp engine** (`InferenceLlama`/`LlamaProvider` via LLM.swift) and loads a GGUF from the app's Documents, running transcript → `ArtifactGenerationEngine` fully local.
- **`scripts/gen-local-harness.rb`** — stages Contracts/Providers/RuntimeCore/InferenceLlama into one app module **+ adds the LLM.swift SPM dependency**.
- **`scripts/local-harness-device.sh`** — build (`generic/platform=iOS`) + `devicectl` install + launch. Encodes two snags cleared: **`-skipMacroValidation`** (LLM macro plugin) and **`-derivedDataPath`** not a flat `CONFIGURATION_BUILD_DIR` (swift-syntax object collisions).

## Proof
Model: **Qwen3-4B-Instruct-2507 Q6_K** (3.08 GB), pushed via `push-model-device.sh`. Owner-witnessed generation on-device; process stayed alive with the 3 GB model resident → Q6 fits the 8 GB ceiling. Evidence: `phase-5-local-inference/evidence-story-02.md`. HSM-5-02 → **done**.

## Note
`App/Local.entitlements` (increased-memory-limit) is staged but not signed — it needs the App-ID capability enabled in the developer portal, which then unlocks Qwen3-8B on the 8 GB iPad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuGkRn3BzV6v8EXgZDFind