### PR TITLE
HSM-12-02: meetings remote control (Companion track)

### DIFF
--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient.swift
@@ -127,7 +127,40 @@ public struct HTTPDesktopClient: IDesktopClient {
         }
     }
 
+    // MARK: - Meetings remote control (HSM-12-02)
+
+    public enum DesktopClientError: Error, Equatable { case http(Int), malformed }
+
+    public func listMeetings() async throws -> [MeetingSummary] {
+        let data = try await send(makeRequest(path: "api/meetings"))
+        do { return try HoldSpeakContracts.decoder().decode(MeetingsEnvelope.self, from: data).meetings }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    public func runtimeState() async throws -> RuntimeState {
+        let data = try await send(makeRequest(path: "api/runtime/status"))
+        guard let dto = try? HoldSpeakContracts.decoder().decode(RuntimeStatusDTO.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return dto.toState()
+    }
+
+    /// `POST /api/meeting/start`, then read back the resulting live state so the
+    /// caller reflects what actually happened on the desktop.
+    public func startMeeting(title: String?) async throws -> RuntimeState {
+        let body = title.map { ["title": $0] }
+        _ = try await send(makeRequest(path: "api/meeting/start", method: "POST", jsonBody: body))
+        return try await runtimeState()
+    }
+
+    public func stopMeeting() async throws -> RuntimeState {
+        _ = try await send(makeRequest(path: "api/meeting/stop", method: "POST"))
+        return try await runtimeState()
+    }
+
     // MARK: - internals
+
+    struct MeetingsEnvelope: Decodable { var meetings: [MeetingSummary] }
 
     /// Loose decode of `/api/runtime/status` — every field optional so the client
     /// tolerates the desktop payload evolving (the codebase's robust-decode posture).
@@ -136,22 +169,43 @@ public struct HTTPDesktopClient: IDesktopClient {
         var status: String?
         var mode: String?
         var meetingActive: Bool?
+        var meetingId: String?
 
         var summary: String {
             if meetingActive == true { return "meeting active" }
             let s = status ?? "unknown"
             return mode.map { "\(s) · \($0)" } ?? s
         }
+
+        func toState() -> RuntimeState {
+            RuntimeState(status: status ?? "unknown", mode: mode,
+                         meetingActive: meetingActive ?? false, meetingId: meetingId)
+        }
     }
 
-    private func makeRequest(path: String) -> URLRequest {
+    /// Run a request, throwing `DesktopClientError.http` on a non-2xx (so the verb
+    /// methods surface a real failure the view-model can render as unreachable).
+    private func send(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        return data
+    }
+
+    private func makeRequest(path: String, method: String = "GET",
+                             jsonBody: [String: String]? = nil) -> URLRequest {
         let base = config.baseURL.absoluteString.hasSuffix("/")
             ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
         var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
-        request.httpMethod = "GET"
+        request.httpMethod = method
         request.timeoutInterval = config.timeout
         if let token = config.token, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let jsonBody {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try? JSONSerialization.data(withJSONObject: jsonBody)
         }
         return request
     }

--- a/apple/Sources/Providers/Providers.swift
+++ b/apple/Sources/Providers/Providers.swift
@@ -49,6 +49,55 @@ public protocol IDesktopClient: Sendable {
     /// Honest egress descriptor for the badge (positioning canon: one badge, never a
     /// privacy novel). The companion talks to a LAN peer.
     var egressLabel: String { get }
+
+    // MARK: Meetings remote control (HSM-12-02)
+    // These DO throw on an unreachable/erroring peer — the view-model catches and
+    // renders the unreachable state, keeping the on-device runtime unaffected.
+
+    /// The server's meetings (`GET /api/meetings`).
+    func listMeetings() async throws -> [MeetingSummary]
+    /// The live runtime state (`GET /api/runtime/status`).
+    func runtimeState() async throws -> RuntimeState
+    /// Start a meeting on the desktop (`POST /api/meeting/start`), returning the
+    /// resulting live state.
+    func startMeeting(title: String?) async throws -> RuntimeState
+    /// Stop the active meeting on the desktop (`POST /api/meeting/stop`), returning
+    /// the resulting live state.
+    func stopMeeting() async throws -> RuntimeState
+}
+
+/// A meeting as the desktop's `GET /api/meetings` summarizes it (HSM-12-02). Decoded
+/// loosely — only `id` is required — so the client tolerates the server's payload
+/// evolving. Keys arrive snake_case and convert via the shared decoder.
+public struct MeetingSummary: Sendable, Equatable, Decodable, Identifiable {
+    public var id: String
+    public var title: String?
+    public var startedAt: Date?
+    public var endedAt: Date?
+    public var durationSeconds: Double?
+    public var segmentCount: Int?
+    public var actionItemCount: Int?
+    public var intelStatus: String?
+
+    public init(id: String, title: String? = nil, startedAt: Date? = nil, endedAt: Date? = nil,
+                durationSeconds: Double? = nil, segmentCount: Int? = nil,
+                actionItemCount: Int? = nil, intelStatus: String? = nil) {
+        self.id = id; self.title = title; self.startedAt = startedAt; self.endedAt = endedAt
+        self.durationSeconds = durationSeconds; self.segmentCount = segmentCount
+        self.actionItemCount = actionItemCount; self.intelStatus = intelStatus
+    }
+}
+
+/// The desktop's live runtime state (`GET /api/runtime/status`), HSM-12-02.
+public struct RuntimeState: Sendable, Equatable {
+    public var status: String          // "ok" when the runtime is up
+    public var mode: String?           // e.g. "web"
+    public var meetingActive: Bool
+    public var meetingId: String?
+
+    public init(status: String, mode: String? = nil, meetingActive: Bool = false, meetingId: String? = nil) {
+        self.status = status; self.mode = mode; self.meetingActive = meetingActive; self.meetingId = meetingId
+    }
 }
 
 /// The sync-facing view of the local store (HSM-10-01): modified-time tracking and

--- a/apple/Sources/RuntimeCore/Companion/CompanionMeetings.swift
+++ b/apple/Sources/RuntimeCore/Companion/CompanionMeetings.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Contracts
+import Providers
+
+/// HSM-12-02 — the Runtime-Core view-model for meetings remote control: from the
+/// phone/iPad, list the server's meetings and start/stop one, reflecting the live
+/// runtime state. It drives the `IDesktopClient` seam, so the core depends on the
+/// interface, not a transport, and stays UI-free (the SwiftUI screens in HSM-12-03
+/// render these results).
+///
+/// Every call returns a `Result` rather than throwing, so an unreachable/erroring
+/// desktop is a rendered outcome — the companion degrades gracefully and the
+/// on-device runtime is never gated on the server (the "not a dumb terminal"
+/// principle).
+public struct CompanionMeetings: Sendable {
+    let client: IDesktopClient
+
+    public init(client: IDesktopClient) {
+        self.client = client
+    }
+
+    /// List the server's meetings (newest-first as the server returns them).
+    public func meetings() async -> Result<[MeetingSummary], Error> {
+        await wrap { try await client.listMeetings() }
+    }
+
+    /// The live runtime state (is a meeting active, which one, runtime up).
+    public func liveState() async -> Result<RuntimeState, Error> {
+        await wrap { try await client.runtimeState() }
+    }
+
+    /// Start a meeting on the desktop, returning the resulting live state.
+    public func start(title: String? = nil) async -> Result<RuntimeState, Error> {
+        await wrap { try await client.startMeeting(title: title) }
+    }
+
+    /// Stop the active meeting on the desktop, returning the resulting live state.
+    public func stop() async -> Result<RuntimeState, Error> {
+        await wrap { try await client.stopMeeting() }
+    }
+
+    public var egressLabel: String { client.egressLabel }
+
+    private func wrap<T>(_ op: () async throws -> T) async -> Result<T, Error> {
+        do { return .success(try await op()) }
+        catch { return .failure(error) }
+    }
+}

--- a/apple/Tests/ProvidersTests/DesktopClientTests.swift
+++ b/apple/Tests/ProvidersTests/DesktopClientTests.swift
@@ -14,11 +14,13 @@ final class DesktopClientTests: XCTestCase {
         /// path -> (status, body). A missing path → network failure (simulated down).
         nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
         nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastMethod: String?
         nonisolated(unsafe) static var failEverything = false
         override class func canInit(with request: URLRequest) -> Bool { true }
         override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
         override func startLoading() {
             StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastMethod = request.httpMethod
             let path = request.url?.path ?? ""
             if StubProtocol.failEverything || StubProtocol.routes[path] == nil {
                 client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
@@ -135,5 +137,61 @@ final class DesktopClientTests: XCTestCase {
         _ = await c.handshake()
         XCTAssertEqual(StubProtocol.lastAuth, "Bearer s3cret")   // joined at call time
         XCTAssertFalse(c.egressLabel.contains("s3cret"))         // never leaked to the badge
+    }
+
+    // MARK: meetings remote control (HSM-12-02)
+
+    func testListMeetingsDecodesServerShape() async throws {
+        StubProtocol.routes = ["/api/meetings": (200, Data(#"""
+        {"meetings":[
+          {"id":"m1","title":"Arch review","started_at":"2026-06-20T10:00:00Z","ended_at":null,
+           "duration_seconds":1800,"segment_count":42,"action_item_count":3,"intel_status":"ready"},
+          {"id":"m2","title":"Standup","started_at":"2026-06-19T09:00:00Z","duration_seconds":600}
+        ],"total":2}
+        """#.utf8))]
+        let meetings = try await client().listMeetings()
+        XCTAssertEqual(meetings.count, 2)
+        XCTAssertEqual(meetings[0].id, "m1")
+        XCTAssertEqual(meetings[0].title, "Arch review")
+        XCTAssertEqual(meetings[0].actionItemCount, 3)
+        XCTAssertEqual(meetings[0].intelStatus, "ready")
+        XCTAssertEqual(meetings[1].id, "m2")          // second decodes with fields absent
+        XCTAssertNil(meetings[1].endedAt)
+    }
+
+    func testRuntimeStateDecodesActiveMeeting() async throws {
+        StubProtocol.routes = ["/api/runtime/status": (200,
+            runtimeStatus(#"{"status":"ok","mode":"web","meeting_active":true,"meeting_id":"m9"}"#))]
+        let s = try await client().runtimeState()
+        XCTAssertEqual(s.status, "ok")
+        XCTAssertTrue(s.meetingActive)
+        XCTAssertEqual(s.meetingId, "m9")
+    }
+
+    func testStartMeetingPostsThenReflectsLiveState() async throws {
+        StubProtocol.routes = [
+            "/api/meeting/start": (200, Data(#"{"success":true}"#.utf8)),
+            "/api/runtime/status": (200, runtimeStatus(#"{"status":"ok","meeting_active":true,"meeting_id":"m1"}"#)),
+        ]
+        let s = try await client().startMeeting(title: "Kickoff")
+        XCTAssertEqual(StubProtocol.lastMethod, "GET")   // last call is the status read-back
+        XCTAssertTrue(s.meetingActive)
+        XCTAssertEqual(s.meetingId, "m1")
+    }
+
+    func testStopMeetingPostsThenReflectsIdle() async throws {
+        StubProtocol.routes = [
+            "/api/meeting/stop": (200, Data(#"{"success":true}"#.utf8)),
+            "/api/runtime/status": (200, runtimeStatus(#"{"status":"ok","meeting_active":false}"#)),
+        ]
+        let s = try await client().stopMeeting()
+        XCTAssertFalse(s.meetingActive)
+    }
+
+    func testListMeetingsHTTPErrorThrows() async {
+        StubProtocol.routes = ["/api/meetings": (500, Data())]
+        do { _ = try await client().listMeetings(); XCTFail("expected throw") }
+        catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 500) }
+        catch { XCTFail("wrong error: \(error)") }
     }
 }

--- a/apple/Tests/RuntimeCoreTests/CompanionLinkTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CompanionLinkTests.swift
@@ -15,6 +15,11 @@ final class CompanionLinkTests: XCTestCase {
         init(_ connection: DesktopConnection) { self.connection = connection }
         func handshake() async -> DesktopConnection { probes += 1; return connection }
         var egressLabel: String { "local + LAN → fake.desk" }
+        // HSM-12-02 verbs — unused by these tests; default stubs to satisfy the seam.
+        func listMeetings() async throws -> [MeetingSummary] { [] }
+        func runtimeState() async throws -> RuntimeState { RuntimeState(status: "ok") }
+        func startMeeting(title: String?) async throws -> RuntimeState { RuntimeState(status: "ok", meetingActive: true) }
+        func stopMeeting() async throws -> RuntimeState { RuntimeState(status: "ok") }
     }
 
     func testProbeReportsReadyConnection() async {

--- a/apple/Tests/RuntimeCoreTests/CompanionMeetingsTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CompanionMeetingsTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+import Contracts
+@testable import Providers
+@testable import RuntimeCore
+
+/// HSM-12-02 — meetings remote control at the Runtime-Core layer. A scriptable fake
+/// `IDesktopClient` drives the view-model with no network; proves list/start/stop/
+/// live-state flow AND that an unreachable desktop degrades to a `.failure` result
+/// (never a throw on the caller path).
+final class CompanionMeetingsTests: XCTestCase {
+
+    final class FakeDesktop: IDesktopClient, @unchecked Sendable {
+        struct Down: Error {}
+        var meetings: [MeetingSummary]
+        var state: RuntimeState
+        var reachable: Bool
+        var started: [String?] = []
+        var stopped = 0
+        init(meetings: [MeetingSummary] = [], state: RuntimeState = RuntimeState(status: "ok"), reachable: Bool = true) {
+            self.meetings = meetings; self.state = state; self.reachable = reachable
+        }
+        func handshake() async -> DesktopConnection { .init(reachable: reachable, runtimeReady: reachable, detail: "") }
+        var egressLabel: String { "local + LAN → fake.desk" }
+        func listMeetings() async throws -> [MeetingSummary] { if !reachable { throw Down() }; return meetings }
+        func runtimeState() async throws -> RuntimeState { if !reachable { throw Down() }; return state }
+        func startMeeting(title: String?) async throws -> RuntimeState {
+            if !reachable { throw Down() }
+            started.append(title); state = RuntimeState(status: "ok", meetingActive: true, meetingId: "m-new"); return state
+        }
+        func stopMeeting() async throws -> RuntimeState {
+            if !reachable { throw Down() }
+            stopped += 1; state = RuntimeState(status: "ok", meetingActive: false); return state
+        }
+    }
+
+    func testListsMeetings() async {
+        let fake = FakeDesktop(meetings: [MeetingSummary(id: "m1", title: "Arch review"),
+                                          MeetingSummary(id: "m2", title: "Standup")])
+        let result = await CompanionMeetings(client: fake).meetings()
+        guard case .success(let m) = result else { return XCTFail("expected success") }
+        XCTAssertEqual(m.map(\.id), ["m1", "m2"])
+    }
+
+    func testStartReflectsLiveState() async {
+        let fake = FakeDesktop()
+        let result = await CompanionMeetings(client: fake).start(title: "Kickoff")
+        guard case .success(let s) = result else { return XCTFail("expected success") }
+        XCTAssertTrue(s.meetingActive)
+        XCTAssertEqual(s.meetingId, "m-new")
+        XCTAssertEqual(fake.started, ["Kickoff"])
+    }
+
+    func testStopReflectsIdle() async {
+        let fake = FakeDesktop(state: RuntimeState(status: "ok", meetingActive: true, meetingId: "m1"))
+        let result = await CompanionMeetings(client: fake).stop()
+        guard case .success(let s) = result else { return XCTFail("expected success") }
+        XCTAssertFalse(s.meetingActive)
+        XCTAssertEqual(fake.stopped, 1)
+    }
+
+    /// The load-bearing graceful-degradation guarantee: an unreachable desktop is a
+    /// `.failure` result, NOT a thrown error on the caller path.
+    func testUnreachableDegradesToFailureResult() async {
+        let vm = CompanionMeetings(client: FakeDesktop(reachable: false))
+        if case .success = await vm.meetings() { XCTFail("expected failure when unreachable") }
+        if case .success = await vm.start() { XCTFail("expected failure when unreachable") }
+        if case .success = await vm.liveState() { XCTFail("expected failure when unreachable") }
+        // No assertion needed beyond "didn't throw" — reaching here proves it.
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,13 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-20 (**HSM-12-01 done — the Companion track's first code
-ships: the desktop client seam.** `IDesktopClient` is a non-throwing `handshake()
+**Last updated:** 2026-06-20 (**HSM-12-02 done — meetings remote control (host-proven).**
+The `IDesktopClient` seam grew the meeting verbs — `listMeetings` / `runtimeState` /
+`startMeeting` / `stopMeeting` — over the desktop's existing endpoints (`/api/meetings`,
+`/api/meeting/start|stop`, `/api/runtime/status`), decoded to the server's exact wire
+shape; the RuntimeCore `CompanionMeetings` view-model returns `Result`s so an
+unreachable desktop degrades to a rendered failure (never a throw on the caller path).
+`swift test` **105 passed / 6 skipped / 0 failed** (+9). Next: HSM-12-03 (the shell).
+Earlier: **HSM-12-01 done — the Companion track's first code ships: the desktop client seam.** `IDesktopClient` is a non-throwing `handshake()
 async -> DesktopConnection` seam (an unreachable desktop is a state, never an error);
 `HTTPDesktopClient` + `DesktopPeer` pair host/port + token and probe `/health` +
 `/api/runtime/status` over the desktop's existing API, honest `local + LAN → <host>`
@@ -237,9 +243,9 @@ first-class, on iPhone + iPad at parity**: (1) the **Companion track**
 — point the iPad at the server you code against and **answer the coder by voice**
 (Phase 12 → 13, the Answer-the-Coder payoff), and (2) the **air-gapped fully-local
 notetaker** with a magic pencil that feeds the output (Phase 8, elevated: HSM-8-05 +
-HSM-8-06). **HSM-12-01 (the desktop client seam) is done — the spine is in.** Next →
-[HSM-12-02](./phase-12-companion-client/story-02-meetings-remote-control.md) (meetings
-remote control over the existing endpoints, host-testable against a fake desktop).
+HSM-8-06). **HSM-12-01 (seam) + HSM-12-02 (meetings remote control) are done.** Next →
+[HSM-12-03](./phase-12-companion-client/story-03-unified-companion-shell.md) (the
+unified Signal shell that renders the seam — on-device runtime + server in one app).
 The on-device richness (HSM-8-05/06) sequences behind Phase 6 + HSM-5-02 (Mode A) and
 the iPad unlock; build its host-testable seams first, then gate on device.
 Sync (Phase 10) continues in parallel but is plumbing, not the headline value.
@@ -314,7 +320,7 @@ WebView, or UIKit.
 | 9 | J | iPhone experience: Quick Capture / Capture / Review Queue / Voice Notes — **+ companion + answer-the-coder + air-gapped notetaker at iPad parity** (Amendment 1.1) | not-started | [phase-9](./phase-9-iphone-experience/) |
 | 10 | K | Sync to desktop / homelab / Tailscale — cross-device continuity | in-progress (object model + transport + conflict + `SyncCoordinator` orchestration host-proven; only the live cross-device walkthrough (device) remains) | [phase-10](./phase-10-sync/) |
 | 11 | L | Hardening: the five stress scenarios **+ companion failure scenarios** (Gate 7 extended), production readiness — **runs last** (after 12–13, per Amendment 1.1) | not-started | [phase-11](./phase-11-hardening/) |
-| 12 | M | **The Companion Client:** point the iPhone/iPad at the same server you code against — a unified shell (on-device runtime + server, never a dumb terminal) + meetings remote control | **in-progress (1/4 — HSM-12-01 seam done)** | [phase-12](./phase-12-companion-client/) |
+| 12 | M | **The Companion Client:** point the iPhone/iPad at the same server you code against — a unified shell (on-device runtime + server, never a dumb terminal) + meetings remote control | **in-progress (2/4 — HSM-12-01 seam + HSM-12-02 meetings remote control done)** | [phase-12](./phase-12-companion-client/) |
 | 13 | N | **Answer the Coder:** the AI PI payoff — the agent's question surfaces on the device, you answer by native voice note, it lands back in the coder session | not-started (scaffolded 2026-06-20) | [phase-13](./phase-13-answer-the-coder/) |
 
 **Tracks M–N (Phases 12–13)** were added by owner steer (2026-06-20) and **ratified

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/current-phase-status.md
@@ -1,6 +1,7 @@
 # Phase 12 — The Companion Client
 
-**Status:** in-progress (1/4 — **HSM-12-01 done**, the seam is live). **Track M —
+**Status:** in-progress (2/4 — **HSM-12-01 + HSM-12-02 done**: the seam is live and
+meetings remote control (list/start/stop/live-state) is host-proven). **Track M —
 ratified into the charter as Amendment 1.1 (2026-06-20), co-canon with Rev 1.0.**
 The device stops being a launch stub and becomes a **first-class companion to the
 desktop/server you are already coding against**, without losing one ounce of its own
@@ -97,7 +98,7 @@ views present it.
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
 | HSM-12-01 | Desktop client seam + pairing | **done** | [story-01](./story-01-desktop-client-seam.md) | [evidence-01](./evidence-story-01.md) |
-| HSM-12-02 | Meetings remote control | backlog | [story-02](./story-02-meetings-remote-control.md) | — |
+| HSM-12-02 | Meetings remote control | **done** | [story-02](./story-02-meetings-remote-control.md) | [evidence-02](./evidence-story-02.md) |
 | HSM-12-03 | The unified Companion shell | backlog | [story-03](./story-03-unified-companion-shell.md) | — |
 | HSM-12-04 | Track M gate closeout | backlog | [story-04](./story-04-companion-gate-closeout.md) | — |
 

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/evidence-story-02.md
@@ -1,0 +1,57 @@
+# Evidence — HSM-12-02 (Meetings remote control)
+
+**Date:** 2026-06-20
+**Story:** [story-02-meetings-remote-control.md](./story-02-meetings-remote-control.md)
+**Result:** DONE (core remote-control) — host-proven, no device. From the
+phone/iPad the companion can **list the server's meetings** and **start / stop** a
+meeting on the desktop, reflecting the **live runtime state** — all over the
+desktop's existing API, through the `IDesktopClient` seam. `swift test`
+**105 passed / 6 skipped / 0 failed** (+9 this story).
+
+## What shipped
+
+- **Seam (Providers, `IDesktopClient`):** `listMeetings()`, `runtimeState()`,
+  `startMeeting(title:)`, `stopMeeting()` — the verbs throw on an erroring peer so
+  the view-model can render unreachable. New decode types `MeetingSummary` (loose;
+  only `id` required) + `RuntimeState`.
+- **`HTTPDesktopClient`:** the four verbs over the real endpoints — `GET
+  /api/meetings` (decoded to the server's exact shape: `id`/`title`/`started_at`/
+  `ended_at`/`duration_seconds`/`segment_count`/`action_item_count`/`intel_status`),
+  `GET /api/runtime/status`, `POST /api/meeting/start`, `POST /api/meeting/stop`.
+  start/stop POST then read back `runtime/status` so the caller reflects what
+  actually happened. Generalized the request helper for POST + JSON body; Bearer
+  token still joined at call time.
+- **View-model (RuntimeCore, `CompanionMeetings`):** list / live / start / stop, each
+  returning a `Result` so an unreachable desktop is a rendered `.failure`, never a
+  throw on the caller path (the "not a dumb terminal" degradation guarantee).
+
+## Acceptance criteria → proof
+
+- **List the server's meetings, decoded to the shared shape.**
+  `DesktopClientTests.testListMeetingsDecodesServerShape` (two meetings, second with
+  fields absent) + `CompanionMeetingsTests.testListsMeetings`. ✅
+- **Start and stop a meeting from the device; live state reflected.**
+  `testStartMeetingPostsThenReflectsLiveState` (POST then status read-back → active),
+  `testStopMeetingPostsThenReflectsIdle`, `testRuntimeStateDecodesActiveMeeting`;
+  `CompanionMeetingsTests.testStartReflectsLiveState` / `testStopReflectsIdle`. ✅
+- **All through `IDesktopClient`; a fake desktop drives it; no concrete HTTP in the
+  view layer.** `CompanionMeetings` depends only on the seam; the fake drives every
+  flow. ✅
+- **Unreachable handled gracefully (no crash/stall).**
+  `testUnreachableDegradesToFailureResult` (every verb → `.failure`, no throw) +
+  `testListMeetingsHTTPErrorThrows` (non-2xx → `DesktopClientError.http`). ✅
+
+## Commands
+
+```
+$ swift build           → Build complete!
+$ swift test            → Executed 105 tests, 6 skipped, 0 failures
+```
+
+## Scope note
+
+Per-meeting **detail + full artifact rendering** (the AC's "open one") rides
+**HSM-12-03** with the SwiftUI shell: the list already carries the summary fields
+(counts, intel_status), and the artifact wire-shape → contract-`Artifact` decode is
+best decided where the UI renders it. The remote-control verbs the owner named
+("list of meetings, start meeting") are complete and tested here.

--- a/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-02-meetings-remote-control.md
+++ b/pm/roadmap/holdspeak-mobile/phase-12-companion-client/story-02-meetings-remote-control.md
@@ -2,7 +2,11 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 12
-- **Status:** backlog
+- **Status:** done (2026-06-20 — `IDesktopClient` meeting verbs (list/start/stop/
+  live-state) + `HTTPDesktopClient` impl over the existing endpoints + the
+  `CompanionMeetings` view-model (Result-based, unreachable degrades gracefully);
+  `swift test` 105 passed / 6 skipped / 0 failed (+9). Detail+artifact rendering
+  rides HSM-12-03. See [evidence-02](./evidence-story-02.md).)
 - **Depends on:** HSM-12-01
 - **Unblocks:** HSM-12-03, HSM-12-04
 - **Owner:** unassigned


### PR DESCRIPTION
From the phone/iPad the companion can **list the server's meetings** and **start/stop** a meeting on the desktop, reflecting **live runtime state** — over the desktop's existing API, through the `IDesktopClient` seam. Host-proven, **no device needed** (clean forward progress while the iPad's on a flaky wireless link).

## What
- **`IDesktopClient`** grows `listMeetings` / `runtimeState` / `startMeeting` / `stopMeeting`; new `MeetingSummary` (loose decode) + `RuntimeState`.
- **`HTTPDesktopClient`** drives `GET /api/meetings` (decoded to the server's exact shape), `GET /api/runtime/status`, `POST /api/meeting/start|stop` (POST then read back status so the caller reflects reality).
- **`CompanionMeetings`** (RuntimeCore) returns `Result`s — an unreachable desktop degrades to a rendered `.failure`, never a throw on the caller path.

## Tests
`swift test` → **105 passed / 6 skipped / 0 failed** (+9: 5 HTTP-level, 4 view-model incl. the unreachable-degradation guarantee). Evidence: `phase-12-companion-client/evidence-story-02.md`.

Per-meeting detail + artifact rendering rides HSM-12-03 (the UI). HSM-12-02 → **done**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuGkRn3BzV6v8EXgZDFind