### PR TITLE
HSM-13-02: native voice-note composer (capture → transcribe → review → deliver)

### DIFF
--- a/apple/Sources/RuntimeCore/Companion/VoiceNoteComposer.swift
+++ b/apple/Sources/RuntimeCore/Companion/VoiceNoteComposer.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Contracts
+import Providers
+
+/// Composing a voice-note answer to the coder (HSM-13-02): record on the iPad,
+/// transcribe **on-device**, review/edit the recognized text, then deliver it
+/// through the HSM-13-01 inject path. The iPad "stands its own ground" here — the
+/// capture and transcription are the device's; only the resulting dictation payload
+/// leaves, to the paired server.
+///
+/// The one rule the owner drew a hard line on: **nothing is delivered before an
+/// explicit `send()`**. `stopAndTranscribe()` always lands in `.review`; it never
+/// auto-sends from recognition. The rich-pipeline transform happens server-side
+/// (HSM-13-01) — this stays thin: capture → recognize → review → post.
+public enum VoiceNoteState: Sendable, Equatable {
+    case idle
+    case recording
+    case transcribing
+    /// Recognized (and freely editable) text, awaiting an explicit send.
+    case review(text: String)
+    case delivering(text: String)
+    case delivered(RemoteDictationResult)
+    case failed(stage: VoiceNoteStage, reason: String)
+}
+
+/// Which leg failed, so the UI can say something honest ("couldn't reach the
+/// desktop" vs "transcription failed") rather than a generic error.
+public enum VoiceNoteStage: Sendable, Equatable { case capture, transcribe, deliver }
+
+public final class VoiceNoteComposer: @unchecked Sendable {
+    private let capture: IAudioCapture
+    private let client: IDesktopClient
+    /// Build an on-device transcriber bound to the captured audio. A factory (not a
+    /// pre-built `ITranscriber`) because `ITranscriber.transcribe()` reads audio it
+    /// was constructed with — the live path hands it the accumulated chunks; the
+    /// MLX/Whisper single-executor-thread discipline lives inside that transcriber,
+    /// not here (we never spin a second transcription path).
+    private let makeTranscriber: @Sendable ([AudioChunk]) -> ITranscriber
+
+    private let lock = NSLock()
+    private var chunks: [AudioChunk] = []
+    private var _state: VoiceNoteState = .idle
+
+    public init(capture: IAudioCapture,
+                client: IDesktopClient,
+                makeTranscriber: @escaping @Sendable ([AudioChunk]) -> ITranscriber) {
+        self.capture = capture
+        self.client = client
+        self.makeTranscriber = makeTranscriber
+    }
+
+    /// The current composition state. Safe to read from any thread.
+    public var state: VoiceNoteState { locked { _state } }
+
+    /// Honest egress for the badge: capture stays on-device; only the dictation
+    /// payload travels to the paired server (positioning canon — one badge, no
+    /// privacy novel). Mirrors the desktop client's label.
+    public var egressLabel: String { client.egressLabel }
+
+    /// Begin capture. Audio accumulates on-device; nothing leaves yet.
+    public func startRecording() {
+        locked { chunks.removeAll(); _state = .recording }
+        do {
+            try capture.start { [weak self] chunk in
+                guard let self else { return }
+                self.locked { self.chunks.append(chunk) }
+            }
+        } catch {
+            setState(.failed(stage: .capture, reason: String(describing: error)))
+        }
+    }
+
+    /// Stop capture and transcribe the captured audio on-device. Always lands in
+    /// `.review` (or `.failed`) — it **never** delivers.
+    public func stopAndTranscribe() async {
+        guard case .recording = state else { return }
+        do { try capture.stop() }
+        catch {
+            setState(.failed(stage: .capture, reason: String(describing: error)))
+            return
+        }
+        setState(.transcribing)
+        let captured = locked { chunks }
+        do {
+            let segments = try await makeTranscriber(captured).transcribe()
+            let text = segments.map(\.text).joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            setState(.review(text: text))
+        } catch {
+            setState(.failed(stage: .transcribe, reason: String(describing: error)))
+        }
+    }
+
+    /// Edit the recognized text before sending. A no-op outside `.review` (you can
+    /// only edit something that's been recognized and is awaiting send).
+    public func editText(_ text: String) {
+        locked { if case .review = _state { _state = .review(text: text) } }
+    }
+
+    /// Deliver the reviewed text through the HSM-13-01 inject path. The user pressed
+    /// send — deliver-on-command, never autonomous. A no-op unless in `.review`.
+    @discardableResult
+    public func send() async -> VoiceNoteState {
+        guard case .review(let text) = state else { return state }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            setState(.failed(stage: .deliver, reason: "nothing to send"))
+            return state
+        }
+        setState(.delivering(text: trimmed))
+        do {
+            setState(.delivered(try await client.sendRemoteDictation(text: trimmed)))
+        } catch {
+            setState(.failed(stage: .deliver, reason: String(describing: error)))
+        }
+        return state
+    }
+
+    // MARK: - internals
+
+    private func setState(_ s: VoiceNoteState) { locked { _state = s } }
+
+    private func locked<T>(_ body: () -> T) -> T {
+        lock.lock(); defer { lock.unlock() }
+        return body()
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/CompanionMeetingsTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CompanionMeetingsTests.swift
@@ -16,6 +16,7 @@ final class CompanionMeetingsTests: XCTestCase {
         var reachable: Bool
         var started: [String?] = []
         var stopped = 0
+        var remoteSent: [String] = []
         init(meetings: [MeetingSummary] = [], state: RuntimeState = RuntimeState(status: "ok"), reachable: Bool = true) {
             self.meetings = meetings; self.state = state; self.reachable = reachable
         }
@@ -33,6 +34,7 @@ final class CompanionMeetingsTests: XCTestCase {
         }
         func sendRemoteDictation(text: String) async throws -> RemoteDictationResult {
             if !reachable { throw Down() }
+            remoteSent.append(text)
             return RemoteDictationResult(success: true, finalText: text, delivered: true)
         }
     }

--- a/apple/Tests/RuntimeCoreTests/VoiceNoteComposerTests.swift
+++ b/apple/Tests/RuntimeCoreTests/VoiceNoteComposerTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+import Contracts
+@testable import Providers
+@testable import RuntimeCore
+
+/// HSM-13-02 — the native voice-note composer at the Runtime-Core layer. Fake
+/// capture / transcriber / desktop seams drive the state machine with no device:
+/// capture → transcribe → review → deliver. The load-bearing assertion is the
+/// owner's hard line — **nothing is delivered before an explicit `send()`**.
+final class VoiceNoteComposerTests: XCTestCase {
+
+    // A capture seam that emits canned chunks synchronously on start.
+    final class EmittingCapture: IAudioCapture, @unchecked Sendable {
+        let chunks: [AudioChunk]
+        var started = 0
+        var stopped = 0
+        var throwOnStart = false
+        init(_ chunks: [AudioChunk]) { self.chunks = chunks }
+        func start(onChunk: @escaping @Sendable (AudioChunk) -> Void) throws {
+            if throwOnStart { throw NSError(domain: "mic", code: 1) }
+            started += 1
+            for c in chunks { onChunk(c) }
+        }
+        func stop() throws { stopped += 1 }
+    }
+
+    // A transcriber that returns canned segments (or throws). Records the chunk count
+    // it was built with, so we can prove the captured audio reached it.
+    final class CannedTranscriber: ITranscriber, @unchecked Sendable {
+        let segments: [Segment]
+        let fail: Bool
+        init(segments: [Segment], fail: Bool = false) { self.segments = segments; self.fail = fail }
+        func transcribe() async throws -> [Segment] {
+            if fail { throw NSError(domain: "whisper", code: 2) }
+            return segments
+        }
+    }
+
+    final class ChunkBox: @unchecked Sendable { var received: [AudioChunk] = [] }
+
+    private func seg(_ text: String, _ s: Double, _ e: Double) -> Segment {
+        TranscribedSegment(text: text, startTime: s, endTime: e).asContractSegment()
+    }
+
+    private func chunk(_ n: Int) -> AudioChunk { AudioChunk(samples: Array(repeating: 0, count: 8), sequence: n) }
+
+    /// Build a composer wired to fakes; returns the composer + the fakes for asserts.
+    private func make(
+        chunks: [AudioChunk] = [],
+        segments: [Segment] = [],
+        transcribeFails: Bool = false,
+        reachable: Bool = true
+    ) -> (VoiceNoteComposer, EmittingCapture, CompanionMeetingsTests.FakeDesktop, ChunkBox) {
+        let capture = EmittingCapture(chunks)
+        let desktop = CompanionMeetingsTests.FakeDesktop(reachable: reachable)
+        let box = ChunkBox()
+        let composer = VoiceNoteComposer(
+            capture: capture,
+            client: desktop,
+            makeTranscriber: { received in
+                box.received = received
+                return CannedTranscriber(segments: segments, fail: transcribeFails)
+            }
+        )
+        return (composer, capture, desktop, box)
+    }
+
+    func testHappyPath_captureTranscribeReviewDeliver() async {
+        let (composer, capture, desktop, box) = make(
+            chunks: [chunk(0), chunk(1), chunk(2)],
+            segments: [seg("ship it", 0, 1), seg("on friday", 1, 2)]
+        )
+        XCTAssertEqual(composer.state, .idle)
+
+        composer.startRecording()
+        XCTAssertEqual(composer.state, .recording)
+        XCTAssertEqual(capture.started, 1)
+
+        await composer.stopAndTranscribe()
+        XCTAssertEqual(capture.stopped, 1)
+        XCTAssertEqual(box.received.count, 3, "the captured chunks reached the transcriber")
+        XCTAssertEqual(composer.state, .review(text: "ship it on friday"))
+        XCTAssertTrue(desktop.remoteSent.isEmpty, "nothing delivered before send")
+
+        let final = await composer.send()
+        XCTAssertEqual(desktop.remoteSent, ["ship it on friday"])
+        XCTAssertEqual(final, .delivered(RemoteDictationResult(success: true, finalText: "ship it on friday", delivered: true)))
+        XCTAssertEqual(composer.state, final)
+    }
+
+    func testTranscriptionNeverAutoSends() async {
+        let (composer, _, desktop, _) = make(chunks: [chunk(0)], segments: [seg("hello", 0, 1)])
+        composer.startRecording()
+        await composer.stopAndTranscribe()
+        // Recognition landed in review and delivered NOTHING on its own.
+        XCTAssertEqual(composer.state, .review(text: "hello"))
+        XCTAssertTrue(desktop.remoteSent.isEmpty)
+    }
+
+    func testEditChangesTheDeliveredPayload() async {
+        let (composer, _, desktop, _) = make(chunks: [chunk(0)], segments: [seg("raw recognition", 0, 1)])
+        composer.startRecording()
+        await composer.stopAndTranscribe()
+        composer.editText("the corrected answer")
+        XCTAssertEqual(composer.state, .review(text: "the corrected answer"))
+        await composer.send()
+        XCTAssertEqual(desktop.remoteSent, ["the corrected answer"], "the edited text is what ships")
+    }
+
+    func testEditOutsideReviewIsNoOp() async {
+        let (composer, _, _, _) = make()
+        composer.editText("nope")           // still idle
+        XCTAssertEqual(composer.state, .idle)
+    }
+
+    func testTranscribeFailure_failsAndDeliversNothing() async {
+        let (composer, _, desktop, _) = make(chunks: [chunk(0)], transcribeFails: true)
+        composer.startRecording()
+        await composer.stopAndTranscribe()
+        if case .failed(let stage, _) = composer.state { XCTAssertEqual(stage, .transcribe) } else { XCTFail("expected transcribe failure") }
+        XCTAssertTrue(desktop.remoteSent.isEmpty)
+    }
+
+    func testCaptureStartFailure_failsAtCapture() async {
+        let (composer, capture, _, _) = make()
+        capture.throwOnStart = true
+        composer.startRecording()
+        if case .failed(let stage, _) = composer.state { XCTAssertEqual(stage, .capture) } else { XCTFail("expected capture failure") }
+    }
+
+    func testDeliveryFailure_unreachableDesktop_failsAtDeliver() async {
+        let (composer, _, _, _) = make(chunks: [chunk(0)], segments: [seg("answer", 0, 1)], reachable: false)
+        composer.startRecording()
+        await composer.stopAndTranscribe()
+        XCTAssertEqual(composer.state, .review(text: "answer"))   // transcription is on-device, still works
+        await composer.send()
+        if case .failed(let stage, _) = composer.state { XCTAssertEqual(stage, .deliver) } else { XCTFail("expected deliver failure") }
+    }
+
+    func testEmptyRecognition_guardsTheSend() async {
+        let (composer, _, desktop, _) = make(chunks: [chunk(0)], segments: [seg("   ", 0, 1)])
+        composer.startRecording()
+        await composer.stopAndTranscribe()
+        XCTAssertEqual(composer.state, .review(text: ""))
+        await composer.send()
+        if case .failed(let stage, _) = composer.state { XCTAssertEqual(stage, .deliver) } else { XCTFail("expected guarded send") }
+        XCTAssertTrue(desktop.remoteSent.isEmpty, "an empty note never reaches the coder")
+    }
+
+    func testSendFromIdleIsNoOp() async {
+        let (composer, _, desktop, _) = make()
+        let result = await composer.send()
+        XCTAssertEqual(result, .idle)
+        XCTAssertTrue(desktop.remoteSent.isEmpty)
+    }
+
+    func testEgressLabelMirrorsTheClient() {
+        let (composer, _, _, _) = make()
+        XCTAssertEqual(composer.egressLabel, "local + LAN → fake.desk")
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-20 (**HSM-13-01 done — the remote-dictation inject path,
-LAN-proven (Phase 13 opened, 1/4).** The desktop's first answer-the-coder surface:
+**Last updated:** 2026-06-20 (**HSM-13-02 done — the native voice-note composer
+(Phase 13 now 2/4).** `VoiceNoteComposer` (RuntimeCore) is a state machine —
+record → transcribe on-device → review/edit → deliver — over three seams it does not
+own: the Phase-2 `IAudioCapture`, a `([AudioChunk]) -> ITranscriber` factory (built
+over the captured audio; no second transcription path, MLX discipline stays inside the
+transcriber), and the HSM-13-01 `sendRemoteDictation`. The owner's hard line is
+structural: `stopAndTranscribe()` always lands in `.review` and `send()` is separate —
+**nothing is delivered before an explicit send**; an empty note is guarded. `swift
+test` 117/6-skip/0-fail (+10 over fake seams); the live on-device walkthrough folds
+into HSM-13-04. Next: HSM-13-03 (the Companion board). Earlier: **HSM-13-01 done — the
+remote-dictation inject path, LAN-proven (Phase 13 opened, 1/4).** The desktop's first answer-the-coder surface:
 `POST /api/dictation/remote` runs a client-dictated answer through the **same rich
 pipeline** as the browser dry-run (corrections/blocks/plugins) and hands the
 *processed* text to a new `on_remote_dictation` host hook (no hook → process-only;
@@ -250,7 +259,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); Phase 13 1/4 (HSM-13-01 remote-dictation inject, LAN-proven on a physical iPad).**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); Phase 13 2/4 (HSM-13-01 remote-dictation inject LAN-proven on a physical iPad; HSM-13-02 native voice-note composer, host-tested).**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
@@ -1,7 +1,8 @@
 # Phase 13 — Answer the Coder
 
-**Status:** in-progress (1/4 — **HSM-13-01 done**: the remote-dictation inject path
-ships and the Companion seam carrying it is proven on real metal). **Track N — added by owner steer
+**Status:** in-progress (2/4 — **HSM-13-01 + HSM-13-02 done**: the remote-dictation
+inject path is proven on real metal, and the native voice-note composer
+(capture→transcribe→review→deliver) is host-tested over its seams). **Track N — added by owner steer
 (2026-06-20), outside the original charter's Tracks A–L.** This is the payoff of
 the companion track and the scenario the owner painted in his own words:
 
@@ -19,7 +20,18 @@ That is the AI PI ("AI Pie") companion loop, driven from the iPad for the first
 time. Built native over the desktop HTTP API (owner call), on the Phase-12 client
 foundation.
 
-**Last updated:** 2026-06-20 (**HSM-13-01 done — the remote-dictation inject path,
+**Last updated:** 2026-06-20 (**HSM-13-02 done — the native voice-note composer.**
+`VoiceNoteComposer` (RuntimeCore) is a state machine — idle → recording →
+transcribing → review → delivering → delivered/failed — over three seams it does not
+own: the Phase-2 `IAudioCapture`, a `([AudioChunk]) -> ITranscriber` **factory** (built
+over the captured audio; no second transcription path, MLX discipline stays inside the
+transcriber), and the HSM-13-01 `sendRemoteDictation`. The owner's hard line is
+structural: `stopAndTranscribe()` always lands in `.review`, `send()` is separate and
+a no-op outside review — **nothing is delivered before an explicit send**; an empty
+note is guarded. `swift test` **117/6-skip/0-fail** (+10 `VoiceNoteComposerTests` over
+fake seams). The live on-device walkthrough folds into HSM-13-04. See
+[`evidence-story-02`](./evidence-story-02.md). Next: HSM-13-03 (the Companion board)
+or HSM-13-04 (the gate). Earlier: **HSM-13-01 done — the remote-dictation inject path,
 LAN-proven.** Desktop `POST /api/dictation/remote` runs a client-dictated answer
 through the **same rich pipeline** as the browser dry-run
 (`_run_dictation_dry_run_text` — corrections/blocks/plugins) and delivers the
@@ -76,8 +88,10 @@ explicit send.
       through the dictation runtime's rich pipeline (plugins/blocks/corrections),
       not as raw text; the client posts to it through the Phase-12 seam; both ends
       tested (HSM-13-01). *(LAN-proven on a physical iPad — evidence-story-01.)*
-- [ ] The iPad captures a native voice note (on-device capture + Whisper) and turns
+- [x] The iPad captures a native voice note (on-device capture + Whisper) and turns
       it into pipeline-processed dictation text ready to deliver (HSM-13-02).
+      *(`VoiceNoteComposer` view-model + seams, host-tested; live on-device run folds
+      into HSM-13-04.)*
 - [ ] The iPad surfaces the AI PI companion state (waiting sessions, selected
       target, confidence, blockers) from `/api/companion/status` and can pick the
       target session via `select`/`dismiss`/`pin` (HSM-13-03).
@@ -92,23 +106,25 @@ explicit send.
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
 | HSM-13-01 | Remote-dictation inject path (desktop + client) | done | [story-01](./story-01-remote-dictation-inject.md) | [evidence](./evidence-story-01.md) |
-| HSM-13-02 | Native voice-note capture → dictation | backlog | [story-02](./story-02-voice-note-capture.md) | — |
+| HSM-13-02 | Native voice-note capture → dictation | done | [story-02](./story-02-voice-note-capture.md) | [evidence](./evidence-story-02.md) |
 | HSM-13-03 | The Companion board (the agent's question on the iPad) | backlog | [story-03](./story-03-companion-board.md) | — |
 | HSM-13-04 | Answer-the-coder gate closeout | backlog | [story-04](./story-04-answer-the-coder-closeout.md) | — |
 
 ## Where we are
 
-The inject path (HSM-13-01) is **done** — the one genuinely new desktop-side surface
-(precedent: the mobile program already added Python routes in Phase 10 —
-`holdspeak/web/routes/sync.py`) now accepts a client-dictated answer, runs it through
-the rich pipeline, and hands the processed text to a host delivery hook; the Swift
-seam posts it; and a physical iPad reached the desktop over the LAN to prove the
-carrying seam on real metal. What remains is the iPad-side payoff: voice-note capture
-(HSM-13-02, reuses the proven on-device capture + Whisper), the Companion board
-(HSM-13-03, consumes `/api/companion/*` that already ships), and the end-to-end gate
-(HSM-13-04) — wiring the `on_remote_dictation` hook into a live coder session and
-proving the owner's scenario on real hardware. Next: HSM-13-02 (native voice-note
-capture).
+Both halves of the answer path now exist. The inject path (HSM-13-01) is **done** —
+the one genuinely new desktop-side surface accepts a client-dictated answer, runs it
+through the rich pipeline, and hands the processed text to a host delivery hook; the
+Swift seam posts it; a physical iPad reached the desktop over the LAN to prove the
+carrying seam on real metal. The native voice-note composer (HSM-13-02) is **done** —
+a RuntimeCore state machine that records, transcribes on-device, lets you review/edit,
+and delivers on an explicit send (never before), host-tested over its capture /
+transcriber / desktop seams. What remains is the surfacing + the proof: the Companion
+board (HSM-13-03, consumes `/api/companion/*` that already ships) to show *which*
+waiting coder the answer targets, and the end-to-end gate (HSM-13-04) — wiring the
+`on_remote_dictation` hook into a live coder session and proving the owner's scenario
+on real hardware with a real spoken note. Next: HSM-13-03 (the Companion board), then
+the gate.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/evidence-story-02.md
@@ -1,0 +1,50 @@
+# Evidence — HSM-13-02 (Native voice-note capture → dictation)
+
+**Date:** 2026-06-20 · **Status:** done
+
+The iPad's native voice-note answer path, as a Runtime-Core view-model:
+record → transcribe on-device → review/edit → deliver via the HSM-13-01 inject path.
+The owner's hard line holds structurally — **nothing is delivered before an explicit
+`send()`**.
+
+## What shipped
+
+- `apple/Sources/RuntimeCore/Companion/VoiceNoteComposer.swift` — a state machine
+  (`VoiceNoteState`: idle → recording → transcribing → review → delivering →
+  delivered / failed) over three seams it does **not** own:
+  - **capture:** the Phase-2 `IAudioCapture` (press-to-talk; chunks accumulate
+    on-device under a lock).
+  - **transcribe:** a `@Sendable ([AudioChunk]) -> ITranscriber` **factory** — built
+    over the captured audio because `ITranscriber.transcribe()` reads the audio it was
+    constructed with. No second transcription path is introduced; the MLX
+    single-executor-thread discipline stays inside the transcriber.
+  - **deliver:** the HSM-13-01 `IDesktopClient.sendRemoteDictation(text:)`.
+- `editText(_:)` allows a quick review/edit; `send()` is deliver-on-command and a
+  no-op outside `.review`; an empty note is guarded and never reaches the coder.
+- `egressLabel` mirrors the client's honest `local + LAN → <host>` (capture stays
+  local; only the payload travels).
+
+## Tests (ran)
+
+`swift test` → **117 passed / 6 skipped / 0 failed** (+10). New
+`VoiceNoteComposerTests` (fake capture / transcriber / desktop seams):
+
+- `testHappyPath_captureTranscribeReviewDeliver` — full flow; the captured chunks
+  reach the transcriber; the reviewed text is what ships.
+- `testTranscriptionNeverAutoSends` — recognition lands in `.review` and delivers
+  nothing on its own (`remoteSent` empty).
+- `testEditChangesTheDeliveredPayload` — the edited text is what ships, not the raw
+  recognition.
+- `testTranscribeFailure_*` / `testCaptureStartFailure_*` /
+  `testDeliveryFailure_unreachableDesktop_*` — each leg fails to its own stage and
+  delivers nothing.
+- `testEmptyRecognition_guardsTheSend`, `testSendFromIdleIsNoOp`,
+  `testEditOutsideReviewIsNoOp`, `testEgressLabelMirrorsTheClient`.
+
+## Deferred (by design)
+
+The **live on-device walkthrough** — speak a real voice note on the iPad, confirm
+on-device Whisper recognition, review, and deliver into a live coder session — folds
+into **HSM-13-04** (the Track N gate), exactly as this story's test plan states. The
+view-model + seam wiring are ready for it; the SwiftUI surface lands with the
+Companion shell (HSM-12-03) / the gate.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-02-voice-note-capture.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-02-voice-note-capture.md
@@ -2,7 +2,9 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 13
-- **Status:** backlog
+- **Status:** done (2026-06-20 — the `VoiceNoteComposer` capture→transcribe→review→
+  deliver view-model ships, host-tested over fake seams; live on-device run folds
+  into HSM-13-04. See [evidence-story-02](./evidence-story-02.md))
 - **Depends on:** HSM-13-01, HSM-2-01 (capture), HSM-3-01 (Whisper)
 - **Unblocks:** HSM-13-04
 - **Owner:** unassigned
@@ -31,16 +33,25 @@ server's.
 
 ## Acceptance criteria
 
-- [ ] Press-to-talk captures a voice note on the iPad via the Phase-2 capture seam
+- [x] Press-to-talk captures a voice note on the iPad via the Phase-2 capture seam
       and transcribes it with the Phase-3 Whisper transcriber, fully on-device.
-- [ ] The recognized text is shown for a quick review/edit before anything is sent
-      (never auto-sent from recognition).
-- [ ] On send, the text is delivered through the HSM-13-01 client method; the
+      *(`VoiceNoteComposer` drives `IAudioCapture` → an `ITranscriber` built over the
+      captured `AudioChunk`s; host-tested that the captured chunks reach the
+      transcriber. The live on-device capture+Whisper run folds into HSM-13-04, per
+      this story's test plan.)*
+- [x] The recognized text is shown for a quick review/edit before anything is sent
+      (never auto-sent from recognition). *(`stopAndTranscribe()` always lands in
+      `.review`; `editText(_:)` mutates it; `send()` is separate —
+      `testTranscriptionNeverAutoSends` / `testEditChangesTheDeliveredPayload`.)*
+- [x] On send, the text is delivered through the HSM-13-01 client method; the
       egress label is honest (capture stays local; the dictation payload goes to the
-      paired server).
-- [ ] The capture path reuses the on-device seams (no new transcription/capture
+      paired server). *(`send()` calls `IDesktopClient.sendRemoteDictation`;
+      `egressLabel` mirrors the client's `local + LAN → <host>`.)*
+- [x] The capture path reuses the on-device seams (no new transcription/capture
       engine); a view-model drives capture → transcribe → review → deliver without
-      UIKit.
+      UIKit. *(Pure RuntimeCore; a transcriber **factory** over the existing
+      `ITranscriber` — no second transcription path; the MLX single-executor-thread
+      discipline stays inside the transcriber.)*
 
 ## Test plan
 


### PR DESCRIPTION
## HSM-13-02 — the iPad's native answer path (Phase 13 now 2/4)

The voice-note half of answer-the-coder, as a RuntimeCore view-model.

### What ships
`VoiceNoteComposer` (`apple/Sources/RuntimeCore/Companion/VoiceNoteComposer.swift`) —
a state machine (`idle → recording → transcribing → review → delivering →
delivered/failed`) over three seams it does **not** own:
- **capture:** the Phase-2 `IAudioCapture` (press-to-talk; chunks accumulate on-device).
- **transcribe:** a `@Sendable ([AudioChunk]) -> ITranscriber` **factory** — built over
  the captured audio (since `transcribe()` reads the audio it was constructed with). No
  second transcription path; the MLX single-executor-thread discipline stays inside the
  transcriber.
- **deliver:** the HSM-13-01 `IDesktopClient.sendRemoteDictation`.

### The owner's hard line, made structural
`stopAndTranscribe()` always lands in `.review`; `send()` is separate and a no-op
outside review — **nothing is delivered before an explicit send**. An empty note is
guarded; `egressLabel` mirrors the client's honest `local + LAN → <host>`.

### Tests
`swift test` **117 passed / 6 skipped / 0 failed** (+10 `VoiceNoteComposerTests` over
fake capture/transcriber/desktop seams): happy path, never-auto-sends,
edit-changes-payload, per-stage failures (capture/transcribe/deliver), guarded/idle
sends, egress label.

### Deferred (by design)
The **live on-device walkthrough** (speak a real note on the iPad → on-device Whisper →
review → deliver into a live coder session) folds into **HSM-13-04** (the Track N
gate), per this story's test plan. The SwiftUI surface lands with the Companion shell
(HSM-12-03) / the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)