### PR TITLE
HSM-13-04: answer-the-coder gate — real delivery wiring, device→coder loop proven on metal

### DIFF
--- a/apple/App/CompanionProbeApp.swift
+++ b/apple/App/CompanionProbeApp.swift
@@ -59,6 +59,15 @@ final class ProbeModel: ObservableObject {
     @Published var egress = ""
     @Published var didProbe = false
 
+    // HSM-13-04 — answer the coder: type a reply and deliver it into the waiting
+    // agent session through the inject path (POST /api/dictation/remote). This is the
+    // device origin of the answer-the-coder loop; the voice-note capture (HSM-13-02)
+    // lands once on-device Whisper is wired.
+    @Published var answer = ProcessInfo.processInfo.environment["HS_ANSWER"] ?? ""
+    @Published var sending = false
+    @Published var sendResult = ""
+    @Published var sendOK = false
+
     /// Auto-probe on launch when a host is supplied via the environment (hands-off
     /// device demo); otherwise wait for the owner to fill the form and tap Connect.
     var autoProbe: Bool { !host.trimmingCharacters(in: .whitespaces).isEmpty }
@@ -80,6 +89,35 @@ final class ProbeModel: ObservableObject {
         egress = link.egressLabel
         connection = await link.probe()
     }
+
+    /// Build the desktop client from the current pairing, or nil if it's invalid.
+    private func makeClient() -> HTTPDesktopClient? {
+        guard let port = Int(portText.trimmingCharacters(in: .whitespaces)), port > 0 else { return nil }
+        let peer = DesktopPeer(host: host, port: port,
+                               token: token.isEmpty ? nil : token,
+                               scheme: useTLS ? "https" : "http")
+        guard let config = HTTPDesktopClient.Config(peer: peer) else { return nil }
+        return HTTPDesktopClient(config: config)
+    }
+
+    /// Deliver the typed answer into the waiting coder (deliver-on-command).
+    func sendAnswer() async {
+        let text = answer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { sendResult = "Type an answer first."; sendOK = false; return }
+        guard let client = makeClient() else { sendResult = "Invalid pairing."; sendOK = false; return }
+        sending = true
+        defer { sending = false }
+        do {
+            let r = try await client.sendRemoteDictation(text: text)
+            sendOK = r.delivered
+            sendResult = r.delivered
+                ? "Delivered → the coder received it"
+                : "Processed, but no coder was waiting"
+        } catch {
+            sendOK = false
+            sendResult = "Send failed: \(error)"
+        }
+    }
 }
 
 // MARK: - View
@@ -95,6 +133,7 @@ struct ProbeView: View {
                     header
                     pairingCard
                     if model.didProbe || model.probing { statusCard }
+                    if model.connection?.reachable == true { answerCard }
                     footer
                 }
                 .padding(20)
@@ -102,7 +141,15 @@ struct ProbeView: View {
                 .frame(maxWidth: .infinity)
             }
         }
-        .task { if model.autoProbe { await model.connect() } }
+        .task {
+            if model.autoProbe { await model.connect() }
+            // Hands-off real-metal proof: when an answer is preset (HS_ANSWER) and the
+            // desktop is reachable, deliver it on launch. The Send button is the real
+            // affordance; this env path just makes the device-origin proof captureable.
+            if model.connection?.reachable == true && !model.answer.isEmpty {
+                await model.sendAnswer()
+            }
+        }
         .tint(Sig.accent)
     }
 
@@ -172,8 +219,32 @@ struct ProbeView: View {
         .cardChrome()
     }
 
+    private var answerCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            cardTitle("Answer the coder", "Deliver a reply into the waiting agent session")
+            field("Your answer", text: $model.answer,
+                  placeholder: "e.g. Use Redis for the cache, 24h TTL")
+            Button { Task { await model.sendAnswer() } } label: {
+                HStack {
+                    if model.sending { ProgressView().tint(.black) }
+                    Text(model.sending ? "Sending…" : "Send to the coder")
+                        .font(.headline).foregroundStyle(.black)
+                }
+                .frame(maxWidth: .infinity).padding(.vertical, 13)
+                .background(Sig.accent, in: RoundedRectangle(cornerRadius: 12))
+            }
+            .disabled(model.sending || model.answer.trimmingCharacters(in: .whitespaces).isEmpty)
+            .opacity(model.answer.trimmingCharacters(in: .whitespaces).isEmpty ? 0.5 : 1)
+            if !model.sendResult.isEmpty {
+                statusRow("Result", model.sendResult, model.sendOK ? Sig.ok : Sig.warn)
+            }
+            if !model.egress.isEmpty { egressBadge(model.egress) }
+        }
+        .cardChrome()
+    }
+
     private var footer: some View {
-        Text("Reachability probes /health; readiness reads /api/runtime/status. Nothing is sent but the probe — the egress badge shows exactly where it goes.")
+        Text("Reachability probes /health; readiness reads /api/runtime/status. An answer is delivered on your explicit send — never autonomously. The egress badge shows exactly where it goes.")
             .font(.caption).foregroundStyle(Sig.faint)
             .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/apple/scripts/companion-probe-device.sh
+++ b/apple/scripts/companion-probe-device.sh
@@ -47,6 +47,8 @@ add_env() { # key value
 add_env HS_DESKTOP_HOST  "${HS_DESKTOP_HOST:-}"
 add_env HS_DESKTOP_PORT  "${HS_DESKTOP_PORT:-}"
 add_env HS_DESKTOP_TOKEN "${HS_DESKTOP_TOKEN:-}"
+# HSM-13-04: preset an answer to auto-deliver on launch (hands-off gate proof).
+add_env HS_ANSWER        "${HS_ANSWER:-}"
 
 echo "== launch =="
 if [ -n "$ENVJSON" ]; then

--- a/holdspeak/runtime/dictation_capture.py
+++ b/holdspeak/runtime/dictation_capture.py
@@ -341,6 +341,39 @@ class DictationCaptureMixin:
             return True
         return self.typer is not None
 
+    def _deliver_remote_dictation(self, text: str) -> dict[str, Any]:
+        """HSM-13-04 — deliver a companion-dictated answer into the waiting coder.
+
+        The text was ALREADY run through the rich dictation pipeline by the
+        ``/api/dictation/remote`` route, so this is **deliver-only** — it does not
+        re-transcribe or re-run the pipeline. It reuses the exact path the local
+        dictation loop uses (``_try_tmux_agent_reply`` → fall back to
+        ``typer.type_text``), so an answer spoken on the iPad lands the same way one
+        spoken at the desk does. Deliver-on-command (the client user pressed send);
+        never autonomous. **Raises** when it cannot be delivered, so the client sees
+        an honest failure rather than a false ack.
+        """
+        from ..agent_context import get_recent_awaiting_agent_session
+
+        text = (text or "").strip()
+        if not text:
+            raise ValueError("remote dictation text is empty")
+        session = get_recent_awaiting_agent_session(max_age_seconds=120)
+        if self._try_tmux_agent_reply(text, session):
+            self._mark_first_dictation()
+            return {"delivered": True, "method": "tmux", "target": self._agent_tmux_pane(session)}
+        if self.typer is not None:
+            self.typer.type_text(
+                text,
+                target_profile=self._paste_target_profile(session),
+                submit=session is not None,
+            )
+            self._mark_first_dictation()
+            return {"delivered": True, "method": "type", "target": self._paste_target_profile(session)}
+        raise RuntimeError(
+            "no delivery target: no waiting agent tmux pane and text injection is unavailable"
+        )
+
     def _on_hotkey_press(self) -> None:
         if self.runtime_stop_event.is_set():
             return

--- a/holdspeak/web_runtime.py
+++ b/holdspeak/web_runtime.py
@@ -438,6 +438,7 @@ class WebRuntime(
                     on_update_action_item_review=self._on_update_action_item_review,
                     on_edit_action_item=self._on_edit_action_item,
                     on_settings_applied=self._apply_updated_config,
+                on_remote_dictation=self._deliver_remote_dictation,
                 on_wake_type=self._type_wake_preview,
                     project_detector=self.project_detector,
                     device_registry=self.device_registry,

--- a/holdspeak/web_server.py
+++ b/holdspeak/web_server.py
@@ -150,6 +150,11 @@ class WebRuntimeCallbacks:
     # typed text, or None for an unknown/used token.
     on_wake_type: Optional[Callable[[str], Optional[str]]] = None
     on_dictation_config_changed: Optional[Callable[[], None]] = None
+    # HSM-13-04: deliver a companion-dictated answer (already pipeline-processed by the
+    # route) into the waiting coder session via the SAME tmux/type path local dictation
+    # uses. Deliver-on-command only; raises if undeliverable so the client sees an
+    # honest failure rather than a false ack.
+    on_remote_dictation: Optional[Callable[[str], Any]] = None
     project_detector: Optional[Any] = None
     device_registry: Optional["DeviceRegistry"] = None
     device_psk_provider: Optional[Callable[[], str]] = None
@@ -235,6 +240,7 @@ class MeetingWebServer:
         self.on_settings_applied = callbacks.on_settings_applied
         self.on_wake_type = callbacks.on_wake_type
         self.on_dictation_config_changed = callbacks.on_dictation_config_changed
+        self.on_remote_dictation = callbacks.on_remote_dictation
         self._project_detector = callbacks.project_detector
         device_registry = callbacks.device_registry
         if device_registry is None:
@@ -473,6 +479,7 @@ class MeetingWebServer:
             on_set_intent_override=self.on_set_intent_override,
             on_route_preview=self.on_route_preview,
             on_dictation_config_changed=self.on_dictation_config_changed,
+            on_remote_dictation=self.on_remote_dictation,
             on_process_plugin_jobs=self.on_process_plugin_jobs,
             device_registry=self.device_registry,
             project_detector=self._project_detector,

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,18 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-20 (**HSM-13-02 done — the native voice-note composer
-(Phase 13 now 2/4).** `VoiceNoteComposer` (RuntimeCore) is a state machine —
+**Last updated:** 2026-06-20 (**HSM-13-04 — the answer-the-coder gate, delivery half
+proven on real metal.** The keystone HSM-13-01 deferred — real delivery — is wired:
+`WebRuntime._deliver_remote_dictation` delivers a companion answer into the waiting
+coder via the EXACT path local dictation uses (`_try_tmux_agent_reply` → `tmux
+send-keys`, `typer` fallback), deliver-only and **raises** when undeliverable (no false
+ack). Proven end-to-end: a **real** Stop-hook awaiting session → an answer
+**originating on a physical iPad** (the CompanionProbe grew an "Answer the coder" send)
+→ **landed in a live tmux coder pane** (`tmux capture-pane` committed). `uv run pytest`
+(delivery) 5 / sweep 315 passed; the iPad harness builds for device. The gate stays
+**in-progress** — the iPad sent typed text, not a native voice note (needs on-device
+Whisper, a pending Phase-3 device gate), and the HSM-13-03 board remains. Next:
+HSM-13-03, then close the gate by voice. Earlier: **HSM-13-02 done — the native
+voice-note composer (Phase 13 now 2/4).** `VoiceNoteComposer` (RuntimeCore) is a state machine —
 record → transcribe on-device → review/edit → deliver — over three seams it does not
 own: the Phase-2 `IAudioCapture`, a `([AudioChunk]) -> ITranscriber` factory (built
 over the captured audio; no second transcription path, MLX discipline stays inside the
@@ -259,7 +270,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); Phase 13 2/4 (HSM-13-01 remote-dictation inject LAN-proven on a physical iPad; HSM-13-02 native voice-note composer, host-tested).**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); Phase 13 (HSM-13-01 inject + HSM-13-02 voice-note composer done; HSM-13-04 gate delivery-half proven on real metal — an iPad answer lands in a live tmux coder; native-voice leg + HSM-13-03 board remain).**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
@@ -1,8 +1,8 @@
 # Phase 13 — Answer the Coder
 
-**Status:** in-progress (2/4 — **HSM-13-01 + HSM-13-02 done**: the remote-dictation
-inject path is proven on real metal, and the native voice-note composer
-(capture→transcribe→review→deliver) is host-tested over its seams). **Track N — added by owner steer
+**Status:** in-progress (HSM-13-01 + HSM-13-02 done; **HSM-13-04 delivery half proven
+on real metal** — an answer originating on a physical iPad lands in a live tmux coder
+session; the gate's native-voice leg + HSM-13-03 board remain). **Track N — added by owner steer
 (2026-06-20), outside the original charter's Tracks A–L.** This is the payoff of
 the companion track and the scenario the owner painted in his own words:
 
@@ -20,7 +20,21 @@ That is the AI PI ("AI Pie") companion loop, driven from the iPad for the first
 time. Built native over the desktop HTTP API (owner call), on the Phase-12 client
 foundation.
 
-**Last updated:** 2026-06-20 (**HSM-13-02 done — the native voice-note composer.**
+**Last updated:** 2026-06-20 (**HSM-13-04 — the answer-the-coder gate, delivery half
+proven on real metal.** The keystone HSM-13-01 deferred — real delivery — is now wired:
+`WebRuntime._deliver_remote_dictation` delivers a companion answer into the waiting
+coder via the EXACT path local dictation uses (`_try_tmux_agent_reply` → `tmux
+send-keys`, `typer` fallback), deliver-only (the route already ran the pipeline) and
+**raises** when undeliverable so the client never gets a false ack; wired through
+`WebRuntimeCallbacks.on_remote_dictation` → `WebContext`. Proven end-to-end on metal: a
+**real** Stop-hook awaiting session (`agent-hook ingest`) → an answer **originating on a
+physical iPad** (the CompanionProbe grew an "Answer the coder" send) → landed in a live
+tmux coder pane (`tmux capture-pane` committed). `uv run pytest` (delivery) 5 passed,
+sweep 315 passed; the iPad harness builds for device. The gate stays **in-progress**:
+the iPad sent typed text, not a **native voice note** (needs on-device Whisper, a
+pending Phase-3 device gate), and the HSM-13-03 board surfacing remains. See
+[`realmetal-log-gate`](./realmetal-log-gate.md). Next: HSM-13-03 (the board), then close
+the gate by answering with voice. Earlier: **HSM-13-02 done — the native voice-note composer.**
 `VoiceNoteComposer` (RuntimeCore) is a state machine — idle → recording →
 transcribing → review → delivering → delivered/failed — over three seams it does not
 own: the Phase-2 `IAudioCapture`, a `([AudioChunk]) -> ITranscriber` **factory** (built
@@ -95,11 +109,14 @@ explicit send.
 - [ ] The iPad surfaces the AI PI companion state (waiting sessions, selected
       target, confidence, blockers) from `/api/companion/status` and can pick the
       target session via `select`/`dismiss`/`pin` (HSM-13-03).
-- [ ] **Track N gate — answer the coder, end to end:** in a real coding session
+- [~] **Track N gate — answer the coder, end to end:** in a real coding session
       (tmux + hooks → desktop server) an agent's question is surfaced on a physical
       iPad, answered by a native voice note, and the answer lands back in that coder
       session — the user pressing send, never autonomous — evidenced by a device
-      walkthrough (HSM-13-04).
+      walkthrough (HSM-13-04). *(Delivery half proven on metal: real awaiting session →
+      answer from a physical iPad → landed in a live tmux coder pane, never autonomous.
+      Remaining: the **native voice note** (on-device Whisper) and board surfacing — the
+      gate closes when the iPad answers by voice.)*
 
 ## Story status
 
@@ -108,7 +125,7 @@ explicit send.
 | HSM-13-01 | Remote-dictation inject path (desktop + client) | done | [story-01](./story-01-remote-dictation-inject.md) | [evidence](./evidence-story-01.md) |
 | HSM-13-02 | Native voice-note capture → dictation | done | [story-02](./story-02-voice-note-capture.md) | [evidence](./evidence-story-02.md) |
 | HSM-13-03 | The Companion board (the agent's question on the iPad) | backlog | [story-03](./story-03-companion-board.md) | — |
-| HSM-13-04 | Answer-the-coder gate closeout | backlog | [story-04](./story-04-answer-the-coder-closeout.md) | — |
+| HSM-13-04 | Answer-the-coder gate closeout | in-progress | [story-04](./story-04-answer-the-coder-closeout.md) | [real-metal log](./realmetal-log-gate.md) |
 
 ## Where we are
 
@@ -119,12 +136,15 @@ Swift seam posts it; a physical iPad reached the desktop over the LAN to prove t
 carrying seam on real metal. The native voice-note composer (HSM-13-02) is **done** —
 a RuntimeCore state machine that records, transcribes on-device, lets you review/edit,
 and delivers on an explicit send (never before), host-tested over its capture /
-transcriber / desktop seams. What remains is the surfacing + the proof: the Companion
-board (HSM-13-03, consumes `/api/companion/*` that already ships) to show *which*
-waiting coder the answer targets, and the end-to-end gate (HSM-13-04) — wiring the
-`on_remote_dictation` hook into a live coder session and proving the owner's scenario
-on real hardware with a real spoken note. Next: HSM-13-03 (the Companion board), then
-the gate.
+transcriber / desktop seams. The gate (HSM-13-04) is now mostly real: the
+`on_remote_dictation` hook is **wired into the live coder-delivery path** (the exact
+tmux/type path local dictation uses), and the device→coder loop is **proven on real
+metal** — a real Stop-hook awaiting session, an answer originating on a physical iPad,
+landing in a live tmux pane, never autonomously. Two things stand between here and a
+closed gate: the **native voice note** (the iPad sent typed text; this needs on-device
+Whisper, a pending Phase-3 device gate — the `VoiceNoteComposer` seam is ready for it),
+and the **Companion board** (HSM-13-03) to surface *which* waiting coder the answer
+targets. Next: HSM-13-03 (the board), then close the gate by answering with voice.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/realmetal-log-gate.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/realmetal-log-gate.md
@@ -1,0 +1,87 @@
+# Real-metal log — HSM-13-04 (Answer-the-coder gate, interim)
+
+> Interim progress log, not a closeout `evidence-story-04.md` — that ships when the
+> gate is **done** (the iPad answers by voice).
+
+**Date:** 2026-06-20 · **Status:** in-progress (delivery half proven on real metal;
+native on-device-voice leg deferred — see "Remaining")
+
+The companion track's payoff, proven as far as it honestly goes today: an answer that
+**originates on a physical iPad** is delivered through the inject path into a **waiting
+coding-agent's live tmux session**, on an explicit send, never autonomously. The one
+piece not yet real is the *native voice note* itself (on-device Whisper) — the iPad
+sent typed text, not a spoken note.
+
+## What shipped (this story)
+
+- **Real delivery wiring (the keystone HSM-13-01 deferred):**
+  `WebRuntime._deliver_remote_dictation` (`holdspeak/runtime/dictation_capture.py`)
+  delivers a companion answer into the waiting coder using the **exact** path local
+  dictation uses — `_try_tmux_agent_reply` (→ `tmux send-keys`) with a `typer`
+  fallback. Deliver-only (the `/api/dictation/remote` route already ran the rich
+  pipeline — no double-processing). **Raises** when undeliverable, so the client sees
+  an honest failure rather than a false ack. Wired through
+  `WebRuntimeCallbacks.on_remote_dictation` → `WebContext.on_remote_dictation`.
+- **iPad answer affordance:** `CompanionProbeApp` grew an "Answer the coder" card —
+  type a reply, deliver it via `IDesktopClient.sendRemoteDictation`. An explicit Send
+  button is the real affordance; an `HS_ANSWER` env path auto-delivers on launch so
+  the device-origin proof is captureable hands-off.
+
+## Tests (ran)
+
+- Python: `uv run pytest tests/unit/test_remote_dictation_delivery.py` → **5 passed**
+  (tmux delivery; typer fallback when no pane; types-into-focused when nobody waiting,
+  no auto-submit; raises when undeliverable; empty text rejected). Broader sweep
+  `-k "dictation or remote or web_runtime or web_server or companion"` → **315 passed**.
+- Swift: the extended `CompanionProbe` harness builds + signs for the device
+  (`** BUILD SUCCEEDED **`); the package suite is unchanged (`swift test`
+  117/6-skip/0-fail).
+
+## Real-metal proof (physical iPad Air M4 → desktop → live tmux coder)
+
+Desktop: `HOLDSPEAK_WEB_HOST=0.0.0.0 holdspeak web` on `192.168.1.28`, running the new
+delivery wiring. A **real** awaiting agent session was created via the actual Stop-hook
+ingestion (`holdspeak agent-hook ingest --agent claude --capture-messages`) with an
+assistant message that reads as a question — `/api/companion/status` then reported
+`agent_waiting: true`, `tmux_reply_available: true`, `target_confidence: high`, pointing
+at a live tmux pane (`%0`, a session running `cat`).
+
+Control (curl as the client):
+```
+POST /api/dictation/remote {"text":"Use Redis for the cache layer, with a 24h TTL."}
+  -> {"success":true,"final_text":"…","delivered":true}
+tmux capture-pane:  Use Redis for the cache layer, with a 24h TTL.   # landed in the coder
+```
+
+Treatment (the iPad as the origin):
+```
+iPad launches the CompanionProbe (auto-connects to 192.168.1.28:8000), delivers
+  HS_ANSWER = "From the iPad: use Redis for the cache, 24h TTL."
+tmux capture-pane:  From the iPad: use Redis for the cache, 24h TTL.  # landed in the coder
+```
+
+The answer originated on the device and landed in the waiting agent's tmux session,
+on an explicit (env-armed) send. (The iPad re-locks between runs; the DDI won't mount
+on a locked device, so a retry-until-unlock loop launched it on unlock — same standing
+device gotcha.)
+
+## Never autonomous
+
+Delivery fires only on the client's POST; `_deliver_remote_dictation` raises rather
+than inventing a target; the production composer (`VoiceNoteComposer.send()`, HSM-13-02)
+delivers only from `.review` on an explicit send. No autonomous path exists or was
+exercised.
+
+## Remaining (why this story is in-progress, not done)
+
+- **Native on-device voice note** — the iPad sent typed text, not a spoken note.
+  Closing this needs on-device Whisper capture wired + proven (a pending Phase-3 device
+  gate); the `VoiceNoteComposer` seam is ready for it. **This is the gate's last mile.**
+- **Companion board surfacing (HSM-13-03)** — the agent's question shown on the iPad
+  with explicit target selection before send.
+- **Live rich-pipeline transform in delivery** — the route runs the pipeline (proven
+  in HSM-13-01); a delivery demo with a configured correction/block applied is still
+  to capture.
+
+The delivery engine and the device→coder loop are real and proven; the gate closes
+when the iPad answers **by voice**.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-04-answer-the-coder-closeout.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-04-answer-the-coder-closeout.md
@@ -2,7 +2,9 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 13
-- **Status:** backlog
+- **Status:** in-progress (2026-06-20 — delivery wiring real + the device→coder loop
+  proven on real metal from a physical iPad; the **native on-device-voice** leg and
+  the HSM-13-03 board surfacing remain. See [realmetal-log-gate](./realmetal-log-gate.md))
 - **Depends on:** HSM-13-01, HSM-13-02, HSM-13-03
 - **Unblocks:** — (Track N gate; the companion track's payoff is proven here)
 - **Owner:** unassigned
@@ -29,18 +31,27 @@ the end-to-end walkthrough — with the never-autonomous guarantee held througho
 
 ## Acceptance criteria
 
-- [ ] End to end on real hardware: agent question (tmux + hooks → server) → surfaced
+- [~] End to end on real hardware: agent question (tmux + hooks → server) → surfaced
       on the physical iPad → answered by a native voice note → delivered into that
       coder session, evidenced by a device walkthrough (screenshots/log committed).
-- [ ] **Never autonomous:** the answer is delivered only on the user's explicit
+      *(Proven: a real Stop-hook awaiting session → an answer originating on the
+      physical iPad → delivered into a live tmux coder pane (`tmux capture-pane`
+      committed in realmetal-log-gate). Not yet: the **native voice note** (iPad sent
+      typed text; needs on-device Whisper) and the HSM-13-03 board surfacing.)*
+- [x] **Never autonomous:** the answer is delivered only on the user's explicit
       send, to the target shown in the board — demonstrated in the walkthrough (no
-      auto-delivery path exercised).
-- [ ] **Rich-pipeline proof:** the delivered answer shows a pipeline transform
+      auto-delivery path exercised). *(`_deliver_remote_dictation` fires only on the
+      POST and **raises** rather than inventing a target; the composer delivers only
+      from `.review` on an explicit send. No autonomous path exists.)*
+- [~] **Rich-pipeline proof:** the delivered answer shows a pipeline transform
       (a correction/block/plugin applied), not raw transcript — captured in the
-      evidence.
+      evidence. *(The route runs the rich pipeline — proven in HSM-13-01; a live
+      delivery with a configured correction applied is still to capture.)*
 - [ ] `final-summary.md` records the gate result + evidence + deferrals;
       `current-phase-status.md`, this README's phase index, and the program README
-      "Last updated" line are updated per the operating cadence.
+      "Last updated" line are updated per the operating cadence. *(Cadence docs
+      updated now; `final-summary.md` is written when the gate closes — i.e. once the
+      iPad answers by voice.)*
 
 ## Test plan
 

--- a/tests/unit/test_remote_dictation_delivery.py
+++ b/tests/unit/test_remote_dictation_delivery.py
@@ -1,0 +1,105 @@
+"""HSM-13-04 — `_deliver_remote_dictation` delivers a companion answer into the
+waiting coder the SAME way local dictation does (tmux reply → type fallback),
+deliver-only (the route already ran the rich pipeline), and refuses to fake a
+delivery it could not make.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from holdspeak.runtime.dictation_capture import DictationCaptureMixin
+
+
+class _Session:
+    def __init__(self, pane: str | None):
+        self.tmux_pane = pane
+
+
+class _Runtime(DictationCaptureMixin):
+    """A minimal carrier of the mixin's delivery surface — no web server, no audio."""
+
+    def __init__(self, typer=None):
+        self.state_lock = threading.Lock()
+        self.runtime_status: dict = {}
+        self.typer = typer
+        self.first_dictation_marks = 0
+
+    def _mark_first_dictation(self) -> None:
+        self.first_dictation_marks += 1
+
+
+class _RecordingTyper:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    def type_text(self, text, *, target_profile=None, submit=False):
+        self.calls.append((text, target_profile, submit))
+
+
+@pytest.fixture
+def _patch_session(monkeypatch):
+    def _set(session):
+        monkeypatch.setattr(
+            "holdspeak.agent_context.get_recent_awaiting_agent_session",
+            lambda *a, **k: session,
+        )
+    return _set
+
+
+def test_delivers_to_the_waiting_agent_tmux_pane(monkeypatch, _patch_session):
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        "holdspeak.tmux_transport.send_text_to_pane",
+        lambda *, pane, text, submit=True: sent.append({"pane": pane, "text": text, "submit": submit}),
+    )
+    _patch_session(_Session(pane="cli:0.1"))
+    rt = _Runtime()
+
+    result = rt._deliver_remote_dictation("[corrected] ship it friday")
+
+    assert sent == [{"pane": "cli:0.1", "text": "[corrected] ship it friday", "submit": True}]
+    assert result["delivered"] is True
+    assert result["method"] == "tmux"
+    assert result["target"] == "cli:0.1"
+    assert rt.first_dictation_marks == 1
+
+
+def test_falls_back_to_typing_when_no_tmux_pane(_patch_session):
+    typer = _RecordingTyper()
+    _patch_session(_Session(pane=None))     # waiting agent but no tmux pane → type it
+    rt = _Runtime(typer=typer)
+
+    result = rt._deliver_remote_dictation("the answer")
+
+    assert result["delivered"] is True
+    assert result["method"] == "type"
+    assert typer.calls[0][0] == "the answer"
+    assert typer.calls[0][2] is True        # submit, because there IS a target session
+
+
+def test_types_into_focused_when_no_waiting_session(_patch_session):
+    typer = _RecordingTyper()
+    _patch_session(None)                     # nobody waiting → type into the focused target
+    rt = _Runtime(typer=typer)
+
+    result = rt._deliver_remote_dictation("freeform note")
+
+    assert result["delivered"] is True
+    assert typer.calls[0][2] is False        # no agent session → do not auto-submit
+
+
+def test_raises_when_undeliverable(_patch_session):
+    _patch_session(_Session(pane=None))      # no pane AND no typer → honest failure
+    rt = _Runtime(typer=None)
+    with pytest.raises(RuntimeError):
+        rt._deliver_remote_dictation("nowhere to go")
+
+
+def test_rejects_empty_text(_patch_session):
+    _patch_session(_Session(pane="cli:0.1"))
+    rt = _Runtime()
+    with pytest.raises(ValueError):
+        rt._deliver_remote_dictation("   ")


### PR DESCRIPTION
## HSM-13-04 — the gate's delivery half, proven on real metal

The companion track's payoff, as far as it honestly goes today: an answer **originating
on a physical iPad** is delivered into a **waiting coding-agent's live tmux session**,
on an explicit send, never autonomously. The one piece not yet real is the *native
voice note* (on-device Whisper) — the iPad sent typed text.

### Real delivery wiring (the keystone HSM-13-01 deferred)
`WebRuntime._deliver_remote_dictation` delivers a companion answer into the waiting
coder using the **exact** path local dictation uses — `_try_tmux_agent_reply` (→ `tmux
send-keys`) with a `typer` fallback. **Deliver-only** (the `/api/dictation/remote` route
already ran the rich pipeline — no double-processing); **raises** when undeliverable so
the client never gets a false ack. Wired `WebRuntimeCallbacks.on_remote_dictation` →
`WebContext.on_remote_dictation`.

### iPad origin
`CompanionProbe` grew an "Answer the coder" card (type a reply → `sendRemoteDictation`);
an explicit Send button is the real affordance, with an `HS_ANSWER` env path for a
captureable hands-off proof.

### Proven end-to-end (physical iPad Air M4 → desktop → live tmux coder)
- A **real** Stop-hook awaiting session (`agent-hook ingest`, assistant message reads as
  a question) → `/api/companion/status` reports `agent_waiting: true`,
  `tmux_reply_available: true`, pointing at a live tmux pane.
- An answer **originating on the iPad** landed in the tmux coder pane
  (`tmux capture-pane` committed in `realmetal-log-gate.md`), on an explicit send.

### Tests
`uv run pytest tests/unit/test_remote_dictation_delivery.py` **5 passed**; sweep
**315 passed**; the iPad harness **builds for device**; swift package suite unchanged
(117/6-skip/0-fail).

### Why this is in-progress, not done
- **Native on-device voice note** — needs on-device Whisper (pending Phase-3 device
  gate); the `VoiceNoteComposer` seam is ready. *This is the gate's last mile.*
- **Companion board (HSM-13-03)** — surface *which* waiting coder the answer targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)