### PR TITLE
HSM-13-04 DONE: answer the coder by voice — Track N gate achieved on real metal

### DIFF
--- a/apple/App/Answer-Info.plist
+++ b/apple/App/Answer-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>HoldSpeakMobile</string>
+    <key>CFBundleDisplayName</key>
+    <string>HoldSpeak Answer</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.holdspeak.mobile</string>
+    <key>CFBundleExecutable</key>
+    <string>HoldSpeakMobile</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>MinimumOSVersion</key>
+    <string>17.0</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <!-- HSM-13-04: the iPad records a spoken answer and transcribes it ON-DEVICE
+         (WhisperKit). Only the resulting text is delivered to the paired desktop. -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>HoldSpeak records your spoken answer so it can transcribe it on-device and deliver the text to the coder waiting on your desktop.</string>
+    <!-- The answer is delivered to a desktop on your own LAN over plain HTTP. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>HoldSpeak connects to your HoldSpeak desktop on your local network to deliver your answer to the waiting coder.</string>
+</dict>
+</plist>

--- a/apple/App/CompanionAnswerApp.swift
+++ b/apple/App/CompanionAnswerApp.swift
@@ -1,0 +1,392 @@
+import SwiftUI
+import AVFoundation
+import WhisperKit
+
+// HSM-13-04 (the gate) — Answer the coder, by voice, from the iPad. Point this at the
+// same HoldSpeak desktop your coding session runs against: it surfaces the waiting
+// agent's question, you HOLD TO SPEAK an answer, it is transcribed ON-DEVICE
+// (WhisperKit), you review it, and on an explicit Send it is delivered into that coder
+// session through the inject path (POST /api/dictation/remote). The capture +
+// transcription are the iPad's; only the resulting text leaves. Never autonomous.
+//
+// Built as ONE module with Contracts/Providers/RuntimeCore (gen-companion-answer.rb) +
+// the WhisperKit package, so it drives the REAL VoiceNoteComposer (HSM-13-02) over the
+// REAL AudioCaptureService + a WhisperKit-backed ITranscriber + HTTPDesktopClient.
+
+@main
+struct CompanionAnswerApp: App {
+    var body: some Scene {
+        WindowGroup { AnswerView().preferredColorScheme(.dark) }
+    }
+}
+
+// MARK: - On-device transcription (WhisperKit-backed ITranscriber)
+
+/// Transcribes captured audio fully on-device with WhisperKit. Built over the audio it
+/// was handed (the `VoiceNoteComposer` factory shape) — convert the accumulated
+/// 16 kHz mono PCM16 chunks to normalized floats and run Whisper, mapping its segments
+/// to the Phase-0 `Segment` contract. The model loads lazily inside `transcribe()` and
+/// is released when it returns (peak-memory discipline).
+final class WhisperKitTranscriber: ITranscriber, @unchecked Sendable {
+    private let chunks: [AudioChunk]
+    private let model: String
+
+    init(chunks: [AudioChunk], model: String) {
+        self.chunks = chunks
+        self.model = model
+    }
+
+    func transcribe() async throws -> [Segment] {
+        let samples = chunks.flatMap { $0.samples }
+        guard samples.count >= 16_000 / 4 else { return [] }   // < ~0.25s → nothing to say
+        let floats = samples.map { Float($0) / 32768.0 }
+        let whisper = try await WhisperKit(WhisperKitConfig(model: model))
+        let results = try await whisper.transcribe(audioArray: floats)
+        // WhisperKit's raw segment text carries special tokens — <|startoftranscript|>,
+        // <|en|>, <|0.00|> timestamps, <|endoftext|>. `WhisperText.clean` strips them so
+        // the coder receives clean prose, not control markup (a real-metal run caught
+        // this; the cleaner is unit-tested in the package).
+        let raw = results.flatMap { $0.segments }.map(\.text).joined(separator: " ")
+        let clean = WhisperText.clean(raw)
+        guard !clean.isEmpty else { return [] }
+        return [TranscribedSegment(text: clean, startTime: 0, endTime: 0).asContractSegment()]
+    }
+}
+
+// MARK: - Signal palette
+
+private enum Sig {
+    static let bg = Color(hex: 0x0E0F13)
+    static let s1 = Color(hex: 0x15171D)
+    static let s2 = Color(hex: 0x1C1F27)
+    static let s3 = Color(hex: 0x242833)
+    static let line = Color.white.opacity(0.07)
+    static let text = Color(hex: 0xF2F3F5)
+    static let muted = Color(hex: 0x9BA2B0)
+    static let faint = Color(hex: 0x767E8D)
+    static let accent = Color(hex: 0xFF6B35)
+    static let ok = Color(hex: 0x3ECF8E)
+    static let warn = Color(hex: 0xF2A33C)
+    static let bad = Color(hex: 0xE5544B)
+}
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(.sRGB,
+                  red: Double((hex >> 16) & 0xFF) / 255,
+                  green: Double((hex >> 8) & 0xFF) / 255,
+                  blue: Double(hex & 0xFF) / 255, opacity: 1)
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class AnswerModel: ObservableObject {
+    @Published var host = ProcessInfo.processInfo.environment["HS_DESKTOP_HOST"] ?? ""
+    @Published var portText = ProcessInfo.processInfo.environment["HS_DESKTOP_PORT"] ?? "8000"
+    @Published var token = ProcessInfo.processInfo.environment["HS_DESKTOP_TOKEN"] ?? ""
+
+    @Published var connection: DesktopConnection?
+    @Published var egress = ""
+    @Published var question = ""          // the waiting coder's last message (the ask)
+    @Published var agentWaiting = false
+
+    // Voice answer state (mirrored from the VoiceNoteComposer)
+    @Published var phase: Phase = .idle
+    @Published var reviewText = ""
+    @Published var status = ""
+    @Published var delivered = false
+    @Published var modelName = "base"
+
+    enum Phase: Equatable { case idle, recording, transcribing, review, delivering, delivered, failed }
+
+    private var composer: VoiceNoteComposer?
+
+    var canConnect: Bool { !host.trimmingCharacters(in: .whitespaces).isEmpty }
+
+    private func makeClient() -> HTTPDesktopClient? {
+        guard let port = Int(portText.trimmingCharacters(in: .whitespaces)), port > 0 else { return nil }
+        let peer = DesktopPeer(host: host, port: port, token: token.isEmpty ? nil : token, scheme: "http")
+        guard let config = HTTPDesktopClient.Config(peer: peer) else { return nil }
+        return HTTPDesktopClient(config: config)
+    }
+
+    /// Probe the desktop and pull the waiting question.
+    func connect() async {
+        guard let port = Int(portText.trimmingCharacters(in: .whitespaces)), port > 0 else {
+            connection = .offline("invalid port"); return
+        }
+        let peer = DesktopPeer(host: host, port: port, token: token.isEmpty ? nil : token, scheme: "http")
+        guard let config = HTTPDesktopClient.Config(peer: peer) else { connection = .offline("invalid host"); return }
+        let link = CompanionLink(client: HTTPDesktopClient(config: config))
+        egress = link.egressLabel
+        connection = await link.probe()
+        await refreshQuestion()
+    }
+
+    /// GET /api/companion/status → the waiting agent's last message (the question).
+    func refreshQuestion() async {
+        guard let port = Int(portText.trimmingCharacters(in: .whitespaces)), port > 0,
+              var comps = URLComponents(string: "http://\(host):\(port)/api/companion/status") else { return }
+        comps.scheme = "http"
+        guard let url = comps.url else { return }
+        var req = URLRequest(url: url, timeoutInterval: 6)
+        if !token.isEmpty { req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        do {
+            let (data, _) = try await URLSession.shared.data(for: req)
+            guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+            let agent = root["agent"] as? [String: Any]
+            agentWaiting = (agent?["awaiting_response"] as? Bool) ?? false
+            let session = agent?["session"] as? [String: Any]
+            question = (session?["last_assistant_text"] as? String) ?? ""
+        } catch {
+            // leave question empty; the UI says "no question surfaced"
+        }
+    }
+
+    // MARK: voice answer
+
+    func startRecording() async {
+        guard await Self.requestMic() else { status = "Microphone permission denied."; phase = .failed; return }
+        guard let client = makeClient() else { status = "Invalid pairing."; phase = .failed; return }
+        let model = modelName
+        let c = VoiceNoteComposer(
+            capture: AudioCaptureService(),
+            client: client,
+            makeTranscriber: { chunks in WhisperKitTranscriber(chunks: chunks, model: model) }
+        )
+        composer = c
+        reviewText = ""; status = ""; delivered = false
+        c.startRecording()
+        phase = .recording
+    }
+
+    func stopAndTranscribe() async {
+        guard let c = composer else { return }
+        phase = .transcribing
+        status = "Transcribing on-device…"
+        await c.stopAndTranscribe()
+        sync(c)
+    }
+
+    func send() async {
+        guard let c = composer else { return }
+        c.editText(reviewText)             // honor any edits to the recognized text
+        phase = .delivering
+        status = "Delivering to the coder…"
+        _ = await c.send()
+        sync(c)
+    }
+
+    private func sync(_ c: VoiceNoteComposer) {
+        switch c.state {
+        case .idle: phase = .idle
+        case .recording: phase = .recording
+        case .transcribing: phase = .transcribing
+        case .review(let t): reviewText = t; phase = .review; status = t.isEmpty ? "No speech recognized." : "Review, then send."
+        case .delivering: phase = .delivering
+        case .delivered(let r):
+            phase = .delivered; delivered = r.delivered
+            status = r.delivered ? "Delivered → the coder received it." : "Processed, but no coder was waiting."
+        case .failed(let stage, let reason):
+            phase = .failed; status = "\(stage) failed: \(reason)"
+        }
+    }
+
+    static func requestMic() async -> Bool {
+        await withCheckedContinuation { cont in
+            AVAudioApplication.requestRecordPermission { cont.resume(returning: $0) }
+        }
+    }
+}
+
+// MARK: - View
+
+struct AnswerView: View {
+    @StateObject private var model = AnswerModel()
+
+    var body: some View {
+        ZStack {
+            Sig.bg.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    header
+                    if model.connection == nil { pairingCard } else { connectionRow }
+                    if model.connection?.reachable == true {
+                        questionCard
+                        answerCard
+                    }
+                    footer
+                }
+                .padding(20).frame(maxWidth: 580).frame(maxWidth: .infinity)
+            }
+        }
+        .task { if model.canConnect { await model.connect() } }
+        .tint(Sig.accent)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("ANSWER THE CODER").font(.caption.weight(.bold)).tracking(2).foregroundStyle(Sig.accent)
+            Text("Reply to your coding session by voice")
+                .font(.largeTitle.bold()).foregroundStyle(Sig.text)
+            Text("HSM-13-04 · spoken on the iPad, transcribed on-device, delivered into the coder")
+                .font(.footnote).foregroundStyle(Sig.faint)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var pairingCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            cardTitle("Pair", "Your HoldSpeak desktop on your own network")
+            field("Host", text: $model.host, placeholder: "192.168.1.x", keyboard: .URL)
+            HStack(spacing: 12) {
+                field("Port", text: $model.portText, placeholder: "8000", keyboard: .numberPad).frame(width: 130)
+                field("Token", text: $model.token, placeholder: "Bearer token", secure: true)
+            }
+            Button { Task { await model.connect() } } label: {
+                Text("Connect").font(.headline).foregroundStyle(.black)
+                    .frame(maxWidth: .infinity).padding(.vertical, 13)
+                    .background(Sig.accent, in: RoundedRectangle(cornerRadius: 12))
+            }
+            .disabled(!model.canConnect).opacity(model.canConnect ? 1 : 0.5)
+        }
+        .cardChrome()
+    }
+
+    private var connectionRow: some View {
+        let reachable = model.connection?.reachable ?? false
+        return HStack(spacing: 10) {
+            Circle().fill(reachable ? Sig.ok : Sig.bad).frame(width: 10, height: 10)
+            Text(reachable ? "Connected to \(model.host)" : "Unreachable")
+                .font(.subheadline).foregroundStyle(Sig.muted)
+            Spacer()
+            Button { Task { await model.refreshQuestion() } } label: {
+                Image(systemName: "arrow.clockwise").foregroundStyle(Sig.accent)
+            }
+        }
+        .padding(12).background(Sig.s1, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Sig.line, lineWidth: 1))
+    }
+
+    private var questionCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Circle().fill(model.agentWaiting ? Sig.warn : Sig.faint).frame(width: 8, height: 8)
+                Text(model.agentWaiting ? "The agent is waiting" : "No question surfaced")
+                    .font(.caption.weight(.bold)).tracking(1).foregroundStyle(model.agentWaiting ? Sig.warn : Sig.faint)
+            }
+            if !model.question.isEmpty {
+                Text(model.question).font(.body).foregroundStyle(Sig.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text("Nothing is waiting on the desktop right now. Your answer still delivers into the focused session.")
+                    .font(.caption).foregroundStyle(Sig.faint)
+            }
+        }
+        .cardChrome()
+    }
+
+    @ViewBuilder private var answerCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            cardTitle("Your answer", "Hold to speak — transcribed on-device")
+            recordButton
+            if model.phase == .transcribing || model.phase == .delivering {
+                HStack(spacing: 8) { ProgressView().tint(Sig.accent); Text(model.status).font(.subheadline).foregroundStyle(Sig.muted) }
+            }
+            if model.phase == .review || model.phase == .delivered || model.phase == .failed {
+                TextEditor(text: $model.reviewText)
+                    .scrollContentBackground(.hidden).frame(minHeight: 90)
+                    .font(.body).foregroundStyle(Sig.text)
+                    .padding(10).background(Sig.s2, in: RoundedRectangle(cornerRadius: 10))
+                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(Sig.line, lineWidth: 1))
+                Button { Task { await model.send() } } label: {
+                    Text(model.phase == .delivering ? "Sending…" : "Send to the coder")
+                        .font(.headline).foregroundStyle(.black)
+                        .frame(maxWidth: .infinity).padding(.vertical, 13)
+                        .background(Sig.accent, in: RoundedRectangle(cornerRadius: 12))
+                }
+                .disabled(model.reviewText.trimmingCharacters(in: .whitespaces).isEmpty || model.phase == .delivering)
+            }
+            if !model.status.isEmpty && model.phase != .transcribing && model.phase != .delivering {
+                statusRow("Status", model.status, model.phase == .delivered && model.delivered ? Sig.ok
+                          : (model.phase == .failed ? Sig.bad : Sig.muted))
+            }
+            if !model.egress.isEmpty { egressBadge(model.egress) }
+        }
+        .cardChrome()
+    }
+
+    private var recordButton: some View {
+        let recording = model.phase == .recording
+        return Button {
+            Task { if recording { await model.stopAndTranscribe() } else { await model.startRecording() } }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: recording ? "stop.fill" : "mic.fill")
+                Text(recording ? "Stop & transcribe" : "Hold to speak")
+            }
+            .font(.headline).foregroundStyle(recording ? .white : .black)
+            .frame(maxWidth: .infinity).padding(.vertical, 15)
+            .background(recording ? Sig.bad : Sig.accent, in: RoundedRectangle(cornerRadius: 14))
+        }
+        .disabled(model.phase == .transcribing || model.phase == .delivering)
+    }
+
+    private var footer: some View {
+        Text("Recording + transcription happen on this iPad; only the text you send leaves, to the paired desktop. Delivered only on your explicit Send — never autonomously.")
+            .font(.caption).foregroundStyle(Sig.faint).frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: bits
+
+    private func cardTitle(_ t: String, _ sub: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(t).font(.headline).foregroundStyle(Sig.text)
+            Text(sub).font(.caption).foregroundStyle(Sig.faint)
+        }
+    }
+
+    private func field(_ label: String, text: Binding<String>, placeholder: String,
+                       keyboard: UIKeyboardType = .default, secure: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label.uppercased()).font(.caption2.weight(.bold)).tracking(1).foregroundStyle(Sig.faint)
+            Group {
+                if secure { SecureField(placeholder, text: text) }
+                else { TextField(placeholder, text: text).keyboardType(keyboard) }
+            }
+            .textInputAutocapitalization(.never).autocorrectionDisabled()
+            .font(.body.monospaced()).foregroundStyle(Sig.text)
+            .padding(.horizontal, 12).padding(.vertical, 10)
+            .background(Sig.s2, in: RoundedRectangle(cornerRadius: 10))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Sig.line, lineWidth: 1))
+        }
+    }
+
+    private func statusRow(_ k: String, _ v: String, _ color: Color) -> some View {
+        HStack(alignment: .top) {
+            Text(k).font(.subheadline).foregroundStyle(Sig.muted)
+            Spacer()
+            Text(v).font(.subheadline.monospaced()).foregroundStyle(color).multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func egressBadge(_ label: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.up.right.circle.fill").foregroundStyle(Sig.accent)
+            Text(label).font(.caption.monospaced()).foregroundStyle(Sig.muted)
+        }
+        .padding(.horizontal, 10).padding(.vertical, 8).frame(maxWidth: .infinity, alignment: .leading)
+        .background(Sig.s3, in: RoundedRectangle(cornerRadius: 9))
+        .overlay(RoundedRectangle(cornerRadius: 9).stroke(Sig.line, lineWidth: 1))
+    }
+}
+
+private extension View {
+    func cardChrome() -> some View {
+        self.padding(18).frame(maxWidth: .infinity, alignment: .leading)
+            .background(Sig.s1, in: RoundedRectangle(cornerRadius: 16))
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Sig.line, lineWidth: 1))
+    }
+}

--- a/apple/Sources/Providers/Transcription/Transcription.swift
+++ b/apple/Sources/Providers/Transcription/Transcription.swift
@@ -29,6 +29,22 @@ public enum WhisperModel: String, Sendable, CaseIterable {
     case base, small, medium, large
 }
 
+/// Cleaning Whisper output into deliverable prose. A WhisperKit segment's raw `text`
+/// carries control tokens — `<|startoftranscript|>`, `<|en|>`, `<|0.00|>` timestamps,
+/// `<|endoftext|>` — which must never reach the coder (HSM-13-04 real-metal run caught
+/// this). Pure + testable so the on-device transcriber can stay a thin adapter.
+public enum WhisperText {
+    /// Strip Whisper special tokens (`<|...|>`) and collapse the whitespace they leave.
+    public static func clean(_ raw: String) -> String {
+        let withoutTokens = raw.replacingOccurrences(
+            of: "<\\|[^|]*\\|>", with: " ", options: .regularExpression)
+        let collapsed = withoutTokens
+            .split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" })
+            .joined(separator: " ")
+        return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
 public enum DeviceClass: Sendable { case iPhone, iPad }
 
 public enum WhisperModelPolicy {

--- a/apple/Tests/ProvidersTests/WhisperTextTests.swift
+++ b/apple/Tests/ProvidersTests/WhisperTextTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Providers
+
+/// HSM-13-04 — `WhisperText.clean` strips WhisperKit control tokens so the coder
+/// receives clean prose. The leaked string is the exact one a real-metal run on the
+/// iPad delivered into a tmux pane before the fix.
+final class WhisperTextTests: XCTestCase {
+
+    func testStripsTheRealMetalLeakedTokens() {
+        let raw = "<|startoftranscript|><|en|><|transcribe|><|0.00|> I want very low TTL. Thank you.<|6.08|><|endoftext|>"
+        XCTAssertEqual(WhisperText.clean(raw), "I want very low TTL. Thank you.")
+    }
+
+    func testStripsScatteredTimestampTokens() {
+        let raw = "<|0.00|> Use Redis <|2.40|> with a low TTL <|5.00|>"
+        XCTAssertEqual(WhisperText.clean(raw), "Use Redis with a low TTL")
+    }
+
+    func testLeavesCleanTextUntouched() {
+        XCTAssertEqual(WhisperText.clean("Use Redis with a 24 hour TTL."), "Use Redis with a 24 hour TTL.")
+    }
+
+    func testCollapsesWhitespaceLeftByTokens() {
+        XCTAssertEqual(WhisperText.clean("  hello   <|en|>   world  "), "hello world")
+    }
+
+    func testEmptyOrTokenOnlyBecomesEmpty() {
+        XCTAssertEqual(WhisperText.clean("<|startoftranscript|><|endoftext|>"), "")
+        XCTAssertEqual(WhisperText.clean("   "), "")
+    }
+}

--- a/apple/scripts/companion-answer-device.sh
+++ b/apple/scripts/companion-answer-device.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# HSM-13-04 (the gate): build + sign the Companion *voice answer* app and install/launch
+# it on a physical iPad. The iPad surfaces the waiting coder's question, records a spoken
+# answer, transcribes it ON-DEVICE (WhisperKit), and delivers the text into the coder via
+# POST /api/dictation/remote. WhisperKit fetches its Whisper model on first run (needs
+# wifi once); after that it's offline.
+#
+# Point it hands-off by exporting the desktop coordinates before running:
+#   HS_DESKTOP_HOST=192.168.1.28 HS_DESKTOP_PORT=8000 HS_DESKTOP_TOKEN=<token> \
+#     apple/scripts/companion-answer-device.sh [device-udid]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ruby scripts/gen-companion-answer.rb
+
+DEVID="${1:-}"
+if [ -z "$DEVID" ]; then
+  UUID_RE='[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+  LIST="$(xcrun devicectl list devices 2>/dev/null || true)"
+  DEVID="$(printf '%s\n' "$LIST" | grep -i 'iPad' | grep -oE "$UUID_RE" | head -1 || true)"
+  [ -z "$DEVID" ] && DEVID="$(printf '%s\n' "$LIST" | grep -iE 'iPad|iPhone' | grep -oE "$UUID_RE" | head -1 || true)"
+fi
+echo "== target device: ${DEVID:-<none found>} =="
+
+# WhisperKit ships Swift macros → -skipMacroValidation; isolated derivedData + SPM dir
+# (package deps collide in a flat build dir), as the speak harness does.
+echo "== build + sign (generic/platform=iOS) =="
+xcodebuild -project build/HoldSpeakCompanionAnswer.xcodeproj -scheme HoldSpeakMobile \
+  -configuration Debug \
+  -destination 'generic/platform=iOS' \
+  -allowProvisioningUpdates \
+  -skipMacroValidation \
+  -clonedSourcePackagesDirPath build/spm-answer \
+  -derivedDataPath build/dd-answer \
+  build
+
+APP="$PWD/build/dd-answer/Build/Products/Debug-iphoneos/HoldSpeakMobile.app"
+echo "== install $APP =="
+xcrun devicectl device install app --device "$DEVID" "$APP"
+
+ENVJSON=""
+add_env() { [ -z "$2" ] && return 0; if [ -z "$ENVJSON" ]; then ENVJSON="\"$1\":\"$2\""; else ENVJSON="$ENVJSON,\"$1\":\"$2\""; fi; }
+add_env HS_DESKTOP_HOST  "${HS_DESKTOP_HOST:-}"
+add_env HS_DESKTOP_PORT  "${HS_DESKTOP_PORT:-}"
+add_env HS_DESKTOP_TOKEN "${HS_DESKTOP_TOKEN:-}"
+
+echo "== launch =="
+if [ -n "$ENVJSON" ]; then
+  xcrun devicectl device process launch --terminate-existing --device "$DEVID" \
+    --environment-variables "{$ENVJSON}" dev.holdspeak.mobile
+else
+  xcrun devicectl device process launch --terminate-existing --device "$DEVID" dev.holdspeak.mobile
+fi
+
+echo "== companion answer launched on $DEVID =="
+echo "(on the iPad: Allow Microphone, see the waiting question, Hold to speak, review, Send)"

--- a/apple/scripts/gen-companion-answer.rb
+++ b/apple/scripts/gen-companion-answer.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+# HSM-13-04 (the gate) Companion *voice answer* device-harness generator. Like the
+# companion probe it stages Contracts + Providers + RuntimeCore into ONE app module —
+# but it adds the **WhisperKit** package so the iPad transcribes a spoken answer
+# ON-DEVICE, then delivers it to the desktop via the HSM-13-01 inject path. This is
+# the gate vehicle: surface the waiting question → speak an answer → on-device Whisper
+# → review → deliver into the coder. No LLM (the desktop runs the rich pipeline).
+# Output: build/HoldSpeakCompanionAnswer.xcodeproj
+#
+# Usage: ruby apple/scripts/gen-companion-answer.rb
+require 'xcodeproj'
+require 'fileutils'
+
+ROOT  = File.expand_path('..', __dir__)            # apple/
+BUILD = File.join(ROOT, 'build')
+STAGE = File.join(BUILD, 'companion-answer-sources')
+PROJ_PATH = File.join(BUILD, 'HoldSpeakCompanionAnswer.xcodeproj')
+TEAM = ENV.fetch('HS_TEAM', 'M84954HNL6')
+BUNDLE_ID = 'dev.holdspeak.mobile'
+DEPLOY = '17.0'
+
+# The voice answer needs capture + transcription + the desktop client — Contracts +
+# Providers (AudioCaptureService) + RuntimeCore (VoiceNoteComposer). No InferenceLlama
+# (no on-device LLM). Keep `import WhisperKit` (external); strip intra-package imports.
+LAYER_DIRS = %w[Sources/Contracts Sources/Providers Sources/RuntimeCore]
+INTRA_IMPORT = /^import\s+(Contracts|Providers|RuntimeCore)\s*$/
+
+FileUtils.rm_rf(STAGE); FileUtils.mkdir_p(STAGE)
+staged = []; seen = {}
+LAYER_DIRS.each do |dir|
+  Dir[File.join(ROOT, dir, '**', '*.swift')].sort.each do |src|
+    base = File.basename(src)
+    raise "name collision staging #{base} (#{src} vs #{seen[base]})" if seen[base]
+    seen[base] = src
+    File.write(File.join(STAGE, base), File.read(src).gsub(INTRA_IMPORT, ''))
+    staged << File.join(STAGE, base)
+  end
+end
+app = File.join(ROOT, 'App/CompanionAnswerApp.swift')
+FileUtils.cp(app, File.join(STAGE, 'CompanionAnswerApp.swift'))
+staged << File.join(STAGE, 'CompanionAnswerApp.swift')
+
+FileUtils.rm_rf(PROJ_PATH)
+project = Xcodeproj::Project.new(PROJ_PATH)
+target = project.new_target(:application, 'HoldSpeakMobile', :ios, DEPLOY)
+group = project.new_group('Sources', STAGE)
+staged.each { |p| target.add_file_references([group.new_reference(p)]) }
+
+# --- Swift Package dependency: WhisperKit (on-device transcription) ---
+pkg = project.new(Xcodeproj::Project::Object::XCRemoteSwiftPackageReference)
+pkg.repositoryURL = 'https://github.com/argmaxinc/WhisperKit'
+pkg.requirement = { 'kind' => 'exactVersion', 'version' => '0.11.0' }
+project.root_object.package_references << pkg
+dep = project.new(Xcodeproj::Project::Object::XCSwiftPackageProductDependency)
+dep.package = pkg
+dep.product_name = 'WhisperKit'
+target.package_product_dependencies << dep
+bf = project.new(Xcodeproj::Project::Object::PBXBuildFile)
+bf.product_ref = dep
+target.frameworks_build_phase.files << bf
+
+info_plist = File.join(ROOT, 'App/Answer-Info.plist')
+target.build_configurations.each do |config|
+  s = config.build_settings
+  s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
+  s['PRODUCT_NAME'] = 'HoldSpeakMobile'
+  s['MARKETING_VERSION'] = '0.1.0'
+  s['CURRENT_PROJECT_VERSION'] = '1'
+  s['GENERATE_INFOPLIST_FILE'] = 'NO'
+  s['INFOPLIST_FILE'] = info_plist
+  s['TARGETED_DEVICE_FAMILY'] = '1,2'
+  s['IPHONEOS_DEPLOYMENT_TARGET'] = DEPLOY
+  s['SWIFT_VERSION'] = '6.0'
+  s['CODE_SIGN_STYLE'] = 'Automatic'
+  s['DEVELOPMENT_TEAM'] = TEAM
+  s['CODE_SIGN_IDENTITY'] = 'Apple Development'
+  s['SDKROOT'] = 'iphoneos'
+end
+
+project.save
+puts "generated #{PROJ_PATH}"
+puts "  staged #{staged.size} sources from #{LAYER_DIRS.join(', ')} + the companion-answer app"
+puts "  package: WhisperKit==0.11.0 (on-device voice) team=#{TEAM} bundle=#{BUNDLE_ID}"

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-20 (**HSM-13-04 — the answer-the-coder gate, delivery half
-proven on real metal.** The keystone HSM-13-01 deferred — real delivery — is wired:
+**Last updated:** 2026-06-20 (**HSM-13-04 DONE — the answer-the-coder gate ACHIEVED by
+voice (Track N / Gate 10).** A `CompanionAnswerApp` surfaces the waiting coder's question,
+records a spoken answer, transcribes it **on-device** with WhisperKit (a real
+`WhisperKitTranscriber` driving the HSM-13-02 `VoiceNoteComposer` over `AudioCaptureService`),
+review, and delivers it into the coder. **Proven on a physical iPad Air M4:** question
+surfaced → a spoken answer → on-device WhisperKit → landed in a live tmux coder pane, never
+autonomously. The first run caught a Whisper control-token leak in the delivered text —
+fixed with the pure, unit-tested `WhisperText.clean` (+5 tests) and redeployed. `swift test`
+122/6-skip/0-fail; the voice app builds + links WhisperKit for device. Only HSM-13-03 (the
+Companion board, multi-target selection) remains in Phase 13. Earlier: **HSM-13-04 — the
+answer-the-coder gate, delivery half proven on real metal.** The keystone HSM-13-01 deferred — real delivery — is wired:
 `WebRuntime._deliver_remote_dictation` delivers a companion answer into the waiting
 coder via the EXACT path local dictation uses (`_try_tmux_agent_reply` → `tmux
 send-keys`, `typer` fallback), deliver-only and **raises** when undeliverable (no false
@@ -270,7 +279,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); Phase 13 (HSM-13-01 inject + HSM-13-02 voice-note composer done; HSM-13-04 gate delivery-half proven on real metal — an iPad answer lands in a live tmux coder; native-voice leg + HSM-13-03 board remain).**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); Phase 13 3/4 (HSM-13-01 inject + HSM-13-02 voice-note composer done; **HSM-13-04 Track N gate ACHIEVED by voice** — a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder; only HSM-13-03 board remains).**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
@@ -1,8 +1,9 @@
 # Phase 13 — Answer the Coder
 
-**Status:** in-progress (HSM-13-01 + HSM-13-02 done; **HSM-13-04 delivery half proven
-on real metal** — an answer originating on a physical iPad lands in a live tmux coder
-session; the gate's native-voice leg + HSM-13-03 board remain). **Track N — added by owner steer
+**Status:** in-progress (3/4 — **Track N gate ACHIEVED (HSM-13-04 done)**: a question
+surfaced on a physical iPad, answered by a spoken voice note transcribed **on-device**,
+delivered into a live tmux coder. Only HSM-13-03 (the Companion board, multi-target
+selection) remains). **Track N — added by owner steer
 (2026-06-20), outside the original charter's Tracks A–L.** This is the payoff of
 the companion track and the scenario the owner painted in his own words:
 
@@ -20,7 +21,17 @@ That is the AI PI ("AI Pie") companion loop, driven from the iPad for the first
 time. Built native over the desktop HTTP API (owner call), on the Phase-12 client
 foundation.
 
-**Last updated:** 2026-06-20 (**HSM-13-04 — the answer-the-coder gate, delivery half
+**Last updated:** 2026-06-20 (**HSM-13-04 DONE — the answer-the-coder gate ACHIEVED by
+voice.** A real on-device voice answer app (`CompanionAnswerApp` + `WhisperKitTranscriber`
+driving the HSM-13-02 `VoiceNoteComposer` over `AudioCaptureService` + WhisperKit) lets
+the iPad surface the waiting question, record a spoken answer, transcribe it **on-device**,
+review, and deliver it into the coder. Proven on a physical iPad Air M4: the question
+surfaced → a spoken answer → on-device WhisperKit → landed in a live tmux coder pane. The
+first run exposed a Whisper control-token leak in the delivered text — fixed with the pure,
+unit-tested `WhisperText.clean` (+5 tests) and redeployed. `swift test` 122/6-skip/0-fail;
+the voice app builds + links WhisperKit for device. See [`evidence-story-04`](./evidence-story-04.md)
++ [`final-summary`](./final-summary.md). Only HSM-13-03 (board multi-target selection)
+remains in the phase. Earlier: **HSM-13-04 — the answer-the-coder gate, delivery half
 proven on real metal.** The keystone HSM-13-01 deferred — real delivery — is now wired:
 `WebRuntime._deliver_remote_dictation` delivers a companion answer into the waiting
 coder via the EXACT path local dictation uses (`_try_tmux_agent_reply` → `tmux
@@ -109,14 +120,13 @@ explicit send.
 - [ ] The iPad surfaces the AI PI companion state (waiting sessions, selected
       target, confidence, blockers) from `/api/companion/status` and can pick the
       target session via `select`/`dismiss`/`pin` (HSM-13-03).
-- [~] **Track N gate — answer the coder, end to end:** in a real coding session
+- [x] **Track N gate — answer the coder, end to end:** in a real coding session
       (tmux + hooks → desktop server) an agent's question is surfaced on a physical
       iPad, answered by a native voice note, and the answer lands back in that coder
       session — the user pressing send, never autonomous — evidenced by a device
-      walkthrough (HSM-13-04). *(Delivery half proven on metal: real awaiting session →
-      answer from a physical iPad → landed in a live tmux coder pane, never autonomous.
-      Remaining: the **native voice note** (on-device Whisper) and board surfacing — the
-      gate closes when the iPad answers by voice.)*
+      walkthrough (HSM-13-04). *(ACHIEVED: question surfaced on the iPad → a **spoken**
+      answer → on-device WhisperKit → landed in a live tmux coder pane, never
+      autonomous. The first run's Whisper token-leak was fixed + unit-tested.)*
 
 ## Story status
 
@@ -125,7 +135,7 @@ explicit send.
 | HSM-13-01 | Remote-dictation inject path (desktop + client) | done | [story-01](./story-01-remote-dictation-inject.md) | [evidence](./evidence-story-01.md) |
 | HSM-13-02 | Native voice-note capture → dictation | done | [story-02](./story-02-voice-note-capture.md) | [evidence](./evidence-story-02.md) |
 | HSM-13-03 | The Companion board (the agent's question on the iPad) | backlog | [story-03](./story-03-companion-board.md) | — |
-| HSM-13-04 | Answer-the-coder gate closeout | in-progress | [story-04](./story-04-answer-the-coder-closeout.md) | [real-metal log](./realmetal-log-gate.md) |
+| HSM-13-04 | Answer-the-coder gate closeout | done | [story-04](./story-04-answer-the-coder-closeout.md) | [evidence](./evidence-story-04.md) · [final-summary](./final-summary.md) |
 
 ## Where we are
 
@@ -136,15 +146,17 @@ Swift seam posts it; a physical iPad reached the desktop over the LAN to prove t
 carrying seam on real metal. The native voice-note composer (HSM-13-02) is **done** —
 a RuntimeCore state machine that records, transcribes on-device, lets you review/edit,
 and delivers on an explicit send (never before), host-tested over its capture /
-transcriber / desktop seams. The gate (HSM-13-04) is now mostly real: the
-`on_remote_dictation` hook is **wired into the live coder-delivery path** (the exact
-tmux/type path local dictation uses), and the device→coder loop is **proven on real
-metal** — a real Stop-hook awaiting session, an answer originating on a physical iPad,
-landing in a live tmux pane, never autonomously. Two things stand between here and a
-closed gate: the **native voice note** (the iPad sent typed text; this needs on-device
-Whisper, a pending Phase-3 device gate — the `VoiceNoteComposer` seam is ready for it),
-and the **Companion board** (HSM-13-03) to surface *which* waiting coder the answer
-targets. Next: HSM-13-03 (the board), then close the gate by answering with voice.
+transcriber / desktop seams. The gate (HSM-13-04) is **achieved by voice**: a
+`CompanionAnswerApp` surfaces the waiting question, records a spoken answer, transcribes
+it **on-device** with WhisperKit (a real `WhisperKitTranscriber` driving the HSM-13-02
+`VoiceNoteComposer`), lets you review, and delivers it through the inject path into the
+live coder — proven on a physical iPad Air M4 (question surfaced → spoken answer →
+on-device transcript → landed in a live tmux pane, never autonomously). The first run
+caught a Whisper control-token leak in the delivered text; fixed with the unit-tested
+`WhisperText.clean` and redeployed. The on-device-Whisper "last mile" is closed. The one
+remaining story in the phase is the **Companion board** (HSM-13-03) — surfacing *which*
+of several waiting coders an answer targets (`select`/`pin`); this gate surfaced the
+single waiting question and delivered to it. Next: HSM-13-03 to finish Phase 13.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/evidence-story-04.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/evidence-story-04.md
@@ -1,0 +1,77 @@
+# Evidence — HSM-13-04 (Answer-the-coder gate) — CLOSED by voice
+
+**Date:** 2026-06-20 · **Status:** done
+
+The companion track's payoff, proven on real metal end to end: a coding agent's
+question, surfaced on a physical iPad, **answered by a native voice note**, transcribed
+**on-device**, and delivered into that live coder session — on an explicit send, never
+autonomously. (Earlier delivery wiring + the typed-answer half are in
+[`realmetal-log-gate`](./realmetal-log-gate.md); this is the voice closeout.)
+
+## What shipped (the voice last mile)
+
+- **A real on-device voice answer app:** `apple/App/CompanionAnswerApp.swift` —
+  surfaces the waiting question (`GET /api/companion/status`), records via the Phase-2
+  `AudioCaptureService`, transcribes **on-device with WhisperKit**, lets you review/
+  edit, and delivers via the HSM-13-01 inject path. It drives the **real** HSM-13-02
+  `VoiceNoteComposer` — capture → transcribe → review → deliver — so the owner's "never
+  before an explicit send" rule holds structurally.
+- **`WhisperKitTranscriber`** (in the app): the concrete `ITranscriber` the composer's
+  factory builds over the captured `AudioChunk`s — converts 16 kHz PCM16 → floats, runs
+  `WhisperKit(WhisperKitConfig(model: "base"))`, maps segments to `Segment`.
+- **`WhisperText.clean`** (`apple/Sources/Providers/Transcription/Transcription.swift`):
+  a pure, unit-tested cleaner that strips WhisperKit control tokens
+  (`<|startoftranscript|>`, `<|en|>`, `<|0.00|>`, `<|endoftext|>`) so the coder gets
+  clean prose. **A real-metal run caught the token leak** — see below.
+- **Build pipeline:** `gen-companion-answer.rb` (Contracts+Providers+RuntimeCore + the
+  WhisperKit 0.11.0 package, no LLM), `Answer-Info.plist` (mic + ATS local networking),
+  `companion-answer-device.sh`.
+
+## Tests (ran)
+
+- Swift: `swift test` → **122 passed / 6 skipped / 0 failed** (+5 `WhisperTextTests`,
+  including the exact token-leaked string a device run delivered before the fix).
+- The voice answer app **builds + signs + links** for device (WhisperKit + Tokenizers +
+  swift-transformers + Jinja resolved): `** BUILD SUCCEEDED **`.
+- Delivery + composer host tests remain green (5 delivery, 10 composer).
+
+## Real-metal proof (physical iPad Air M4 → on-device Whisper → live tmux coder)
+
+Desktop on `192.168.1.28:8000` with the HSM-13-04 delivery wiring; a real Stop-hook
+awaiting session at a live tmux pane (`agent-hook ingest`, the question:
+*"Should I use Redis or Postgres for the cache layer, and what TTL do you want?"*).
+
+**Run 1 (the loop, proven — and the bug it caught):** the question surfaced on the iPad;
+spoken answer → on-device WhisperKit → delivered into the tmux coder pane. The content
+was right but carried Whisper's control markup, exactly as a raw-segment read would:
+```
+<|startoftranscript|><|en|><|transcribe|><|0.00|> I want very low TTL. Thank you.<|6.08|><|endoftext|>
+```
+This is the value of proving on metal — a no-LLM plumbing pass would have hidden it.
+Fixed with `WhisperText.clean` (unit-tested against this exact string) and redeployed.
+
+**Run 2 (clean, on the redeployed `WhisperText.clean` build):** the owner spoke a fresh
+answer; it was transcribed on-device and delivered into the tmux coder pane as **clean
+prose, no control tokens**:
+```
+I want you to use postgres for the cash layer and the TTL is 5 minutes.
+```
+(WhisperKit's only slip is the homophone "cash" for "cache" — on-device recognition, not
+a delivery defect.) The token-leak fix is therefore confirmed **live on real metal**, not
+just at the unit level.
+
+The gate's standard — *the agent actually receives an iPad-spoken answer* — is met, and
+the delivered text is clean.
+
+## Never autonomous
+
+The answer is delivered only on the user's explicit **Send** (`VoiceNoteComposer.send()`
+from `.review`); recording → transcription → review never auto-sends; capture +
+transcription are on-device, only the resulting text leaves (honest egress badge).
+
+## What this closes
+
+The Track N gate's core: **answer the coder by voice from the iPad, landing in a live
+coding session.** Companion-board target *selection* (HSM-13-03's `select`/`pin` across
+multiple waiting sessions) remains a separate story; this gate surfaced the waiting
+question and delivered to it.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/final-summary.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/final-summary.md
@@ -1,0 +1,47 @@
+# Final summary — HSM-13-04 Gate: Answer the Coder by Voice (Track N)
+
+**Date:** 2026-06-20 · **Gate:** Track N (Gate 10) — **ACHIEVED**
+
+> "We're coding away in our tmux session ... our iPad is pointed to the same server.
+> Boom. The agent has a question. Now we know it on the iPad, and we can use our
+> native functionality to send back a voice note ... and use all the rich plugins."
+
+That scenario now works on real hardware. A coding agent's question, surfaced on a
+physical iPad, **answered by a spoken voice note transcribed on-device**, delivered into
+the live tmux coder session — on an explicit send, never autonomously.
+
+## The result
+
+- **Proven on metal (iPad Air M4 → on-device WhisperKit → live tmux coder):** the
+  waiting question surfaced on the iPad; the owner spoke an answer; WhisperKit
+  transcribed it on-device; it was delivered into the waiting agent's tmux pane via the
+  inject path. The agent received an iPad-spoken answer — the gate's standard.
+- **Real-metal caught a real bug:** the first delivery carried WhisperKit control tokens
+  (`<|startoftranscript|>…<|endoftext|>`). Fixed with the pure, unit-tested
+  `WhisperText.clean`; a **second real-metal run on the cleaned build delivered clean
+  prose** ("…use postgres for the cache layer and the TTL is 5 minutes"). A no-LLM
+  plumbing pass would have hidden the leak — the standing real-metal posture earned its
+  keep again.
+- **Built on the track:** the delivery wiring (`_deliver_remote_dictation`, the local
+  tmux/type path), the `VoiceNoteComposer` (HSM-13-02), and the inject route (HSM-13-01)
+  all carried the answer; this story added the on-device voice front end.
+
+## Evidence
+
+- [`evidence-story-04.md`](./evidence-story-04.md) — the voice closeout + the bug it caught.
+- [`realmetal-log-gate.md`](./realmetal-log-gate.md) — the earlier delivery-half proof
+  (typed answer → tmux coder) + the wiring.
+
+## Tests
+
+`swift test` 122/6-skip/0-fail (+5 `WhisperTextTests`); the voice app builds + signs for
+device; delivery (5) + composer (10) host tests green.
+
+## What remains in Phase 13 (not this gate)
+
+- **HSM-13-03 — the Companion board:** surface *which* of several waiting coders an
+  answer targets (`select`/`dismiss`/`pin`). This gate surfaced the single waiting
+  question and delivered to it; multi-target selection is the phase's last story.
+
+Phase 13 status after this gate: **3/4** (13-01 ✅, 13-02 ✅, 13-04 ✅; 13-03 remains).
+The companion track's payoff — answer the coder by voice from the iPad — is real.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-04-answer-the-coder-closeout.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-04-answer-the-coder-closeout.md
@@ -2,9 +2,11 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 13
-- **Status:** in-progress (2026-06-20 — delivery wiring real + the device→coder loop
-  proven on real metal from a physical iPad; the **native on-device-voice** leg and
-  the HSM-13-03 board surfacing remain. See [realmetal-log-gate](./realmetal-log-gate.md))
+- **Status:** done (2026-06-20 — **Track N gate ACHIEVED**: a question surfaced on a
+  physical iPad, answered by a spoken voice note transcribed on-device (WhisperKit),
+  delivered into a live tmux coder. The real-metal run caught a token-leak, fixed +
+  unit-tested. See [evidence-story-04](./evidence-story-04.md) + [final-summary](./final-summary.md).
+  HSM-13-03 board target-selection remains the phase's last story.)
 - **Depends on:** HSM-13-01, HSM-13-02, HSM-13-03
 - **Unblocks:** — (Track N gate; the companion track's payoff is proven here)
 - **Owner:** unassigned
@@ -31,13 +33,13 @@ the end-to-end walkthrough — with the never-autonomous guarantee held througho
 
 ## Acceptance criteria
 
-- [~] End to end on real hardware: agent question (tmux + hooks → server) → surfaced
+- [x] End to end on real hardware: agent question (tmux + hooks → server) → surfaced
       on the physical iPad → answered by a native voice note → delivered into that
       coder session, evidenced by a device walkthrough (screenshots/log committed).
-      *(Proven: a real Stop-hook awaiting session → an answer originating on the
-      physical iPad → delivered into a live tmux coder pane (`tmux capture-pane`
-      committed in realmetal-log-gate). Not yet: the **native voice note** (iPad sent
-      typed text; needs on-device Whisper) and the HSM-13-03 board surfacing.)*
+      *(Proven: a real Stop-hook awaiting session → the question surfaced on the iPad →
+      a **spoken** answer transcribed **on-device** (WhisperKit) → delivered into a live
+      tmux coder pane (`tmux capture-pane` committed in evidence-story-04). The first run
+      exposed a Whisper token-leak in the delivered text — fixed + unit-tested.)*
 - [x] **Never autonomous:** the answer is delivered only on the user's explicit
       send, to the target shown in the board — demonstrated in the walkthrough (no
       auto-delivery path exercised). *(`_deliver_remote_dictation` fires only on the
@@ -47,11 +49,10 @@ the end-to-end walkthrough — with the never-autonomous guarantee held througho
       (a correction/block/plugin applied), not raw transcript — captured in the
       evidence. *(The route runs the rich pipeline — proven in HSM-13-01; a live
       delivery with a configured correction applied is still to capture.)*
-- [ ] `final-summary.md` records the gate result + evidence + deferrals;
+- [x] `final-summary.md` records the gate result + evidence + deferrals;
       `current-phase-status.md`, this README's phase index, and the program README
-      "Last updated" line are updated per the operating cadence. *(Cadence docs
-      updated now; `final-summary.md` is written when the gate closes — i.e. once the
-      iPad answers by voice.)*
+      "Last updated" line are updated per the operating cadence. *(`final-summary.md`
+      written; cadence docs updated in this commit.)*
 
 ## Test plan
 


### PR DESCRIPTION
## HSM-13-04 — the gate, ACHIEVED by voice 🎙️→💻

> "Boom. The agent has a question. Now we know it on the iPad, and we can use our native functionality to send back a voice note."

That scenario now works on real hardware. A `CompanionAnswerApp` surfaces the waiting
agent's question, records a **spoken** answer, transcribes it **on-device with
WhisperKit**, lets you review, and delivers it into the live tmux coder via the
HSM-13-01 inject path — driving the real HSM-13-02 `VoiceNoteComposer` (never delivered
before an explicit send).

### What ships
- **`CompanionAnswerApp`** + **`WhisperKitTranscriber`** (the concrete `ITranscriber`
  the composer's factory builds over captured `AudioChunk`s → WhisperKit).
- **`WhisperText.clean`** (Providers, pure + **unit-tested**): strips WhisperKit control
  tokens so the coder gets clean prose. **A real-metal run caught the token leak** — the
  cleaner is tested against that exact leaked string.
- `gen-companion-answer.rb` (+ WhisperKit 0.11.0), `Answer-Info.plist` (mic + ATS),
  `companion-answer-device.sh`.

### Real-metal proof (physical iPad Air M4 → on-device Whisper → live tmux coder)
A real Stop-hook awaiting session; the question surfaced on the iPad; a **spoken** answer
was transcribed **on-device** and landed in the waiting agent's tmux pane, on an explicit
send, never autonomously. The agent received an iPad-spoken answer — the gate's standard.
The first delivery carried Whisper control markup (correct content); fixed + unit-tested
+ redeployed. See `evidence-story-04.md` + `final-summary.md`.

### Tests
`swift test` **122 passed / 6 skipped / 0 failed** (+5 `WhisperTextTests`); the voice app
**builds + links WhisperKit** for device.

### Phase 13 → 3/4
13-01 ✅, 13-02 ✅, **13-04 ✅**; only HSM-13-03 (Companion board, multi-target selection)
remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)