### PR TITLE
HSM-13-03: the Companion board — Phase 13 (Answer the Coder) COMPLETE

### DIFF
--- a/apple/App/CompanionAnswerApp.swift
+++ b/apple/App/CompanionAnswerApp.swift
@@ -89,8 +89,7 @@ final class AnswerModel: ObservableObject {
 
     @Published var connection: DesktopConnection?
     @Published var egress = ""
-    @Published var question = ""          // the waiting coder's last message (the ask)
-    @Published var agentWaiting = false
+    @Published var board = CompanionBoardState()   // the waiting coders + the selected target (HSM-13-03)
 
     // Voice answer state (mirrored from the VoiceNoteComposer)
     @Published var phase: Phase = .idle
@@ -104,6 +103,8 @@ final class AnswerModel: ObservableObject {
     private var composer: VoiceNoteComposer?
 
     var canConnect: Bool { !host.trimmingCharacters(in: .whitespaces).isEmpty }
+    /// The target an answer would currently land in (the selected waiting coder).
+    var activeTarget: CompanionTarget? { board.activeTarget }
 
     private func makeClient() -> HTTPDesktopClient? {
         guard let port = Int(portText.trimmingCharacters(in: .whitespaces)), port > 0 else { return nil }
@@ -122,27 +123,25 @@ final class AnswerModel: ObservableObject {
         let link = CompanionLink(client: HTTPDesktopClient(config: config))
         egress = link.egressLabel
         connection = await link.probe()
-        await refreshQuestion()
+        await refreshBoard()
     }
 
-    /// GET /api/companion/status → the waiting agent's last message (the question).
-    func refreshQuestion() async {
-        guard let port = Int(portText.trimmingCharacters(in: .whitespaces)), port > 0,
-              var comps = URLComponents(string: "http://\(host):\(port)/api/companion/status") else { return }
-        comps.scheme = "http"
-        guard let url = comps.url else { return }
-        var req = URLRequest(url: url, timeoutInterval: 6)
-        if !token.isEmpty { req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
-        do {
-            let (data, _) = try await URLSession.shared.data(for: req)
-            guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-            let agent = root["agent"] as? [String: Any]
-            agentWaiting = (agent?["awaiting_response"] as? Bool) ?? false
-            let session = agent?["session"] as? [String: Any]
-            question = (session?["last_assistant_text"] as? String) ?? ""
-        } catch {
-            // leave question empty; the UI says "no question surfaced"
-        }
+    /// Load the Companion board (the waiting coders + the selected target) via the seam.
+    func refreshBoard() async {
+        guard let client = makeClient() else { return }
+        if case .success(let s) = await CompanionBoard(client: client).load() { board = s }
+    }
+
+    /// Make `target` the active reply target — the next answer delivers to it.
+    func select(_ target: CompanionTarget) async {
+        guard let client = makeClient() else { return }
+        if case .success(let s) = await CompanionBoard(client: client).select(target) { board = s }
+    }
+
+    /// Pin/unpin a waiting coder (sticky target).
+    func pin(_ target: CompanionTarget, _ pinned: Bool) async {
+        guard let client = makeClient() else { return }
+        if case .success(let s) = await CompanionBoard(client: client).pin(target, pinned: pinned) { board = s }
     }
 
     // MARK: voice answer
@@ -214,7 +213,7 @@ struct AnswerView: View {
                     header
                     if model.connection == nil { pairingCard } else { connectionRow }
                     if model.connection?.reachable == true {
-                        questionCard
+                        boardCard
                         answerCard
                     }
                     footer
@@ -262,7 +261,7 @@ struct AnswerView: View {
             Text(reachable ? "Connected to \(model.host)" : "Unreachable")
                 .font(.subheadline).foregroundStyle(Sig.muted)
             Spacer()
-            Button { Task { await model.refreshQuestion() } } label: {
+            Button { Task { await model.refreshBoard() } } label: {
                 Image(systemName: "arrow.clockwise").foregroundStyle(Sig.accent)
             }
         }
@@ -270,22 +269,59 @@ struct AnswerView: View {
         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Sig.line, lineWidth: 1))
     }
 
-    private var questionCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
+    /// The Companion board (HSM-13-03): the waiting coders, the selected target made
+    /// unmistakable. Tap a row to make it the target your answer will land in.
+    private var boardCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
-                Circle().fill(model.agentWaiting ? Sig.warn : Sig.faint).frame(width: 8, height: 8)
-                Text(model.agentWaiting ? "The agent is waiting" : "No question surfaced")
-                    .font(.caption.weight(.bold)).tracking(1).foregroundStyle(model.agentWaiting ? Sig.warn : Sig.faint)
+                Circle().fill(model.board.awaiting ? Sig.warn : Sig.faint).frame(width: 8, height: 8)
+                Text(model.board.awaiting ? "Waiting for you" : "No coder waiting")
+                    .font(.caption.weight(.bold)).tracking(1)
+                    .foregroundStyle(model.board.awaiting ? Sig.warn : Sig.faint)
+                Spacer()
+                if model.board.targets.count > 1 {
+                    Text("\(model.board.targets.count) sessions").font(.caption2).foregroundStyle(Sig.faint)
+                }
             }
-            if !model.question.isEmpty {
-                Text(model.question).font(.body).foregroundStyle(Sig.text)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            } else {
-                Text("Nothing is waiting on the desktop right now. Your answer still delivers into the focused session.")
+            if model.board.targets.isEmpty {
+                Text("Nothing is waiting on the desktop right now. An answer still delivers into the focused session.")
                     .font(.caption).foregroundStyle(Sig.faint)
+            } else {
+                ForEach(model.board.targets) { t in targetRow(t) }
             }
         }
         .cardChrome()
+    }
+
+    private func targetRow(_ t: CompanionTarget) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: t.selected ? "largecircle.fill.circle" : "circle")
+                    .foregroundStyle(t.selected ? Sig.accent : Sig.faint)
+                Text(t.project ?? t.agent).font(.subheadline.weight(.semibold)).foregroundStyle(Sig.text)
+                if t.pinned { Image(systemName: "pin.fill").font(.caption2).foregroundStyle(Sig.accent) }
+                if t.stale { Text("stale").font(.caption2).foregroundStyle(Sig.warn) }
+                Spacer()
+                Button { Task { await model.pin(t, !t.pinned) } } label: {
+                    Image(systemName: t.pinned ? "pin.slash" : "pin").font(.caption).foregroundStyle(Sig.muted)
+                }
+            }
+            if let q = t.question, !q.isEmpty {
+                Text(q).font(.callout).foregroundStyle(t.selected ? Sig.text : Sig.muted)
+                    .lineLimit(3).frame(maxWidth: .infinity, alignment: .leading)
+            }
+            if !t.selected {
+                Button { Task { await model.select(t) } } label: {
+                    Text("Answer this one").font(.caption.weight(.semibold)).foregroundStyle(Sig.accent)
+                }
+            } else {
+                Text("Your answer lands here").font(.caption2.weight(.bold)).tracking(1).foregroundStyle(Sig.accent)
+            }
+        }
+        .padding(12)
+        .background(t.selected ? Sig.s3 : Sig.s2, in: RoundedRectangle(cornerRadius: 11))
+        .overlay(RoundedRectangle(cornerRadius: 11)
+            .stroke(t.selected ? Sig.accent.opacity(0.5) : Sig.line, lineWidth: 1))
     }
 
     @ViewBuilder private var answerCard: some View {

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient.swift
@@ -167,9 +167,78 @@ public struct HTTPDesktopClient: IDesktopClient {
         catch { throw DesktopClientError.malformed }
     }
 
+    // MARK: - The Companion board (HSM-13-03)
+
+    public func companionStatus() async throws -> CompanionBoardState {
+        let data = try await send(makeRequest(path: "api/companion/status"))
+        guard let dto = try? HoldSpeakContracts.decoder().decode(CompanionStatusDTO.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return dto.toState()
+    }
+
+    public func selectCompanionTarget(agent: String, sessionID: String) async throws {
+        _ = try await send(makeJSONRequest(path: "api/companion/select",
+                                           body: ["agent": agent, "session_id": sessionID]))
+    }
+
+    public func dismissCompanionTarget(agent: String, sessionID: String) async throws {
+        _ = try await send(makeJSONRequest(path: "api/companion/dismiss",
+                                           body: ["agent": agent, "session_id": sessionID]))
+    }
+
+    public func pinCompanionTarget(agent: String, sessionID: String, pinned: Bool) async throws {
+        // `pinned` MUST ride as a JSON bool — the desktop does `bool(body.get("pinned"))`,
+        // and a string "false" would read truthy. makeJSONRequest keeps it a real bool.
+        _ = try await send(makeJSONRequest(path: "api/companion/pin",
+                                           body: ["agent": agent, "session_id": sessionID, "pinned": pinned]))
+    }
+
     // MARK: - internals
 
     struct MeetingsEnvelope: Decodable { var meetings: [MeetingSummary] }
+
+    /// Loose decode of `/api/companion/status` — only what the board needs, every
+    /// field optional so the client tolerates the rich payload evolving. Keys arrive
+    /// snake_case and convert via the shared decoder.
+    struct CompanionStatusDTO: Decodable {
+        var readyForAgentReply: Bool?
+        var blockers: [String]?
+        var agent: Agent?
+
+        struct Agent: Decodable {
+            var awaitingResponse: Bool?
+            var sessions: Sessions?
+            struct Sessions: Decodable { var items: [Item]? }
+            struct Item: Decodable {
+                var selected: Bool?
+                var pinned: Bool?
+                var stale: Bool?
+                var session: Session?
+                var identity: Identity?
+                struct Session: Decodable {
+                    var agent: String?
+                    var sessionId: String?
+                    var lastAssistantText: String?
+                    var projectName: String?
+                }
+                struct Identity: Decodable { var targetConfidence: String? }
+            }
+        }
+
+        func toState() -> CompanionBoardState {
+            let targets = (agent?.sessions?.items ?? []).compactMap { item -> CompanionTarget? in
+                guard let s = item.session, let a = s.agent, let sid = s.sessionId else { return nil }
+                return CompanionTarget(
+                    agent: a, sessionID: sid, question: s.lastAssistantText, project: s.projectName,
+                    selected: item.selected ?? false, pinned: item.pinned ?? false,
+                    stale: item.stale ?? false, confidence: item.identity?.targetConfidence)
+            }
+            return CompanionBoardState(
+                readyForReply: readyForAgentReply ?? false, blockers: blockers ?? [],
+                awaiting: agent?.awaitingResponse ?? false, targets: targets)
+        }
+    }
 
     /// Loose decode of `/api/runtime/status` — every field optional so the client
     /// tolerates the desktop payload evolving (the codebase's robust-decode posture).
@@ -216,6 +285,22 @@ public struct HTTPDesktopClient: IDesktopClient {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try? JSONSerialization.data(withJSONObject: jsonBody)
         }
+        return request
+    }
+
+    /// A POST with a heterogeneous JSON body (e.g. a real bool for `pinned`). Keeps
+    /// the raw snake_case keys the desktop's control routes read verbatim.
+    private func makeJSONRequest(path: String, body: [String: Any]) -> URLRequest {
+        let base = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         return request
     }
 

--- a/apple/Sources/Providers/Providers.swift
+++ b/apple/Sources/Providers/Providers.swift
@@ -72,6 +72,19 @@ public protocol IDesktopClient: Sendable {
     /// coder; this returns the processed text + whether it was delivered.
     /// Deliver-on-command — the user pressed send; never autonomous.
     func sendRemoteDictation(text: String) async throws -> RemoteDictationResult
+
+    // MARK: The Companion board (HSM-13-03)
+
+    /// The AI PI companion state (`GET /api/companion/status`): which coder sessions
+    /// are waiting, which is the selected reply target, confidence + blockers.
+    func companionStatus() async throws -> CompanionBoardState
+    /// Make a waiting session the active reply target (`POST /api/companion/select`),
+    /// so the next answer (HSM-13-01/02) delivers to it — no silent default.
+    func selectCompanionTarget(agent: String, sessionID: String) async throws
+    /// Clear a waiting session's captured question (`POST /api/companion/dismiss`).
+    func dismissCompanionTarget(agent: String, sessionID: String) async throws
+    /// Pin/unpin a waiting session as the sticky target (`POST /api/companion/pin`).
+    func pinCompanionTarget(agent: String, sessionID: String, pinned: Bool) async throws
 }
 
 /// The desktop's response to a remote-dictation inject (HSM-13-01).
@@ -82,6 +95,50 @@ public struct RemoteDictationResult: Sendable, Equatable, Decodable {
 
     public init(success: Bool, finalText: String, delivered: Bool) {
         self.success = success; self.finalText = finalText; self.delivered = delivered
+    }
+}
+
+/// One waiting coder session as the Companion board shows it (HSM-13-03) — a row in
+/// the AI PI overview (`/api/companion/status` → `agent.sessions.items[]`). The board
+/// makes the *selected* target unmistakable before any answer is sent.
+public struct CompanionTarget: Sendable, Equatable, Identifiable {
+    public var agent: String           // "claude" / "codex"
+    public var sessionID: String
+    public var question: String?       // the agent's last message — the ask
+    public var project: String?        // repo/project name, for telling sessions apart
+    public var selected: Bool          // the active reply target an answer would hit
+    public var pinned: Bool            // sticky target, never auto-expired
+    public var stale: Bool             // older than the freshness threshold
+    public var confidence: String?     // delivery confidence ("high"/"medium"/…)
+
+    public init(agent: String, sessionID: String, question: String? = nil, project: String? = nil,
+                selected: Bool = false, pinned: Bool = false, stale: Bool = false, confidence: String? = nil) {
+        self.agent = agent; self.sessionID = sessionID; self.question = question; self.project = project
+        self.selected = selected; self.pinned = pinned; self.stale = stale; self.confidence = confidence
+    }
+
+    public var id: String { "\(agent)/\(sessionID)" }
+}
+
+/// The Companion board's view of the AI PI loop (HSM-13-03), decoded from
+/// `GET /api/companion/status`. Honest by construction: an empty `targets` with
+/// `awaiting == false` means *nothing is waiting* — never a manufactured target.
+public struct CompanionBoardState: Sendable, Equatable {
+    public var readyForReply: Bool     // the desktop can deliver an answer right now
+    public var blockers: [String]      // why not, if not (e.g. "no_agent_waiting")
+    public var awaiting: Bool          // at least one coder is waiting on a reply
+    public var targets: [CompanionTarget]
+
+    public init(readyForReply: Bool = false, blockers: [String] = [],
+                awaiting: Bool = false, targets: [CompanionTarget] = []) {
+        self.readyForReply = readyForReply; self.blockers = blockers
+        self.awaiting = awaiting; self.targets = targets
+    }
+
+    /// The target an answer would currently land in (the selected one, else the first
+    /// waiting session). `nil` when nothing is waiting.
+    public var activeTarget: CompanionTarget? {
+        targets.first(where: { $0.selected }) ?? targets.first
     }
 }
 

--- a/apple/Sources/RuntimeCore/Companion/CompanionBoard.swift
+++ b/apple/Sources/RuntimeCore/Companion/CompanionBoard.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Contracts
+import Providers
+
+/// The Companion board at the Runtime-Core layer (HSM-13-03): surface the AI PI loop's
+/// waiting coder sessions on the iPad and let the user pick *which* one an answer
+/// targets, before sending. It depends on the `IDesktopClient` seam, never a transport,
+/// and degrades honestly — an unreachable desktop is a `.failure` the view renders, not
+/// a throw on the caller path (the same posture as `CompanionMeetings`).
+///
+/// Target selection is **server-side**: `select` makes a session the desktop's active
+/// reply target, so the next answer (HSM-13-01/02 → `/api/dictation/remote`) delivers to
+/// it with no silent client default. The board's job is to make that target visible and
+/// changeable; the desktop holds the truth.
+public struct CompanionBoard: Sendable {
+    let client: IDesktopClient
+
+    public init(client: IDesktopClient) {
+        self.client = client
+    }
+
+    /// Load the current board (`GET /api/companion/status`).
+    public func load() async -> Result<CompanionBoardState, Error> {
+        await wrap { try await self.client.companionStatus() }
+    }
+
+    /// Make `target` the active reply target, then return the refreshed board so the
+    /// selection is reflected from the desktop's truth (not assumed client-side).
+    public func select(_ target: CompanionTarget) async -> Result<CompanionBoardState, Error> {
+        await wrap {
+            try await self.client.selectCompanionTarget(agent: target.agent, sessionID: target.sessionID)
+            return try await self.client.companionStatus()
+        }
+    }
+
+    /// Dismiss a waiting session (clears its captured question), then refresh.
+    public func dismiss(_ target: CompanionTarget) async -> Result<CompanionBoardState, Error> {
+        await wrap {
+            try await self.client.dismissCompanionTarget(agent: target.agent, sessionID: target.sessionID)
+            return try await self.client.companionStatus()
+        }
+    }
+
+    /// Pin/unpin a waiting session (sticky target, never auto-expired), then refresh.
+    public func pin(_ target: CompanionTarget, pinned: Bool) async -> Result<CompanionBoardState, Error> {
+        await wrap {
+            try await self.client.pinCompanionTarget(agent: target.agent, sessionID: target.sessionID, pinned: pinned)
+            return try await self.client.companionStatus()
+        }
+    }
+
+    /// Honest egress for the badge — the board talks to the paired LAN desktop.
+    public var egressLabel: String { client.egressLabel }
+
+    private func wrap<T>(_ op: () async throws -> T) async -> Result<T, Error> {
+        do { return .success(try await op()) }
+        catch { return .failure(error) }
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/CompanionBoardTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CompanionBoardTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import Contracts
+@testable import Providers
+@testable import RuntimeCore
+
+/// HSM-13-03 — the Companion board view-model. A scriptable fake `IDesktopClient`
+/// drives it with no network: targets render, select/dismiss/pin update the desktop's
+/// truth and the refreshed board reflects it, and an unreachable desktop degrades to a
+/// `.failure` (never a throw on the caller path, never a faked target).
+final class CompanionBoardTests: XCTestCase {
+
+    private func target(_ agent: String, _ sid: String, question: String, selected: Bool = false,
+                        pinned: Bool = false, stale: Bool = false) -> CompanionTarget {
+        CompanionTarget(agent: agent, sessionID: sid, question: question, project: "repo",
+                        selected: selected, pinned: pinned, stale: stale, confidence: "high")
+    }
+
+    private func desktop(_ targets: [CompanionTarget], reachable: Bool = true) -> CompanionMeetingsTests.FakeDesktop {
+        let d = CompanionMeetingsTests.FakeDesktop(reachable: reachable)
+        d.board = CompanionBoardState(readyForReply: !targets.isEmpty, blockers: targets.isEmpty ? ["no_agent_waiting"] : [],
+                                      awaiting: !targets.isEmpty, targets: targets)
+        return d
+    }
+
+    func testLoadsWaitingTargets() async {
+        let d = desktop([target("claude", "s1", question: "Redis or Postgres?", selected: true),
+                         target("codex", "s2", question: "Rename the module?")])
+        let result = await CompanionBoard(client: d).load()
+        guard case .success(let state) = result else { return XCTFail("expected success") }
+        XCTAssertEqual(state.targets.map(\.sessionID), ["s1", "s2"])
+        XCTAssertEqual(state.activeTarget?.sessionID, "s1")
+        XCTAssertTrue(state.awaiting)
+        XCTAssertEqual(state.targets[0].question, "Redis or Postgres?")
+    }
+
+    func testSelectMakesTheTargetActive() async {
+        let d = desktop([target("claude", "s1", question: "Q1", selected: true),
+                         target("codex", "s2", question: "Q2")])
+        let board = CompanionBoard(client: d)
+        let result = await board.select(target("codex", "s2", question: "Q2"))
+        guard case .success(let state) = result else { return XCTFail("expected success") }
+        XCTAssertEqual(d.selected.map(\.1), ["s2"], "the select hit the desktop")
+        XCTAssertEqual(state.activeTarget?.sessionID, "s2", "the refreshed board reflects the new target")
+        XCTAssertFalse(state.targets.first(where: { $0.sessionID == "s1" })!.selected)
+    }
+
+    func testPinAndUnpin() async {
+        let d = desktop([target("claude", "s1", question: "Q1")])
+        let board = CompanionBoard(client: d)
+        _ = await board.pin(target("claude", "s1", question: "Q1"), pinned: true)
+        XCTAssertEqual(d.pinnedCalls.map(\.2), [true])
+        let result = await board.pin(target("claude", "s1", question: "Q1"), pinned: false)
+        guard case .success(let state) = result else { return XCTFail("expected success") }
+        XCTAssertEqual(d.pinnedCalls.map(\.2), [true, false])
+        XCTAssertFalse(state.targets[0].pinned)
+    }
+
+    func testDismissRemovesTheTarget() async {
+        let d = desktop([target("claude", "s1", question: "Q1"),
+                         target("codex", "s2", question: "Q2")])
+        let result = await CompanionBoard(client: d).dismiss(target("claude", "s1", question: "Q1"))
+        guard case .success(let state) = result else { return XCTFail("expected success") }
+        XCTAssertEqual(d.dismissed.map(\.1), ["s1"])
+        XCTAssertEqual(state.targets.map(\.sessionID), ["s2"])
+    }
+
+    func testEmptyBoardIsHonest_neverManufacturesATarget() async {
+        let d = desktop([])
+        let result = await CompanionBoard(client: d).load()
+        guard case .success(let state) = result else { return XCTFail("expected success") }
+        XCTAssertTrue(state.targets.isEmpty)
+        XCTAssertFalse(state.awaiting)
+        XCTAssertNil(state.activeTarget)
+        XCTAssertEqual(state.blockers, ["no_agent_waiting"])
+    }
+
+    func testUnreachableDesktopDegradesToFailure() async {
+        let d = desktop([target("claude", "s1", question: "Q1")], reachable: false)
+        let board = CompanionBoard(client: d)
+        if case .success = await board.load() { XCTFail("expected failure on load") }
+        if case .success = await board.select(target("claude", "s1", question: "Q1")) { XCTFail("expected failure on select") }
+    }
+
+    func testEgressLabelMirrorsTheClient() {
+        XCTAssertEqual(CompanionBoard(client: desktop([])).egressLabel, "local + LAN → fake.desk")
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/CompanionLinkTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CompanionLinkTests.swift
@@ -23,6 +23,11 @@ final class CompanionLinkTests: XCTestCase {
         func sendRemoteDictation(text: String) async throws -> RemoteDictationResult {
             RemoteDictationResult(success: true, finalText: text, delivered: true)
         }
+        // HSM-13-03 companion-board verbs — unused by these tests; default stubs.
+        func companionStatus() async throws -> CompanionBoardState { CompanionBoardState() }
+        func selectCompanionTarget(agent: String, sessionID: String) async throws {}
+        func dismissCompanionTarget(agent: String, sessionID: String) async throws {}
+        func pinCompanionTarget(agent: String, sessionID: String, pinned: Bool) async throws {}
     }
 
     func testProbeReportsReadyConnection() async {

--- a/apple/Tests/RuntimeCoreTests/CompanionMeetingsTests.swift
+++ b/apple/Tests/RuntimeCoreTests/CompanionMeetingsTests.swift
@@ -17,6 +17,10 @@ final class CompanionMeetingsTests: XCTestCase {
         var started: [String?] = []
         var stopped = 0
         var remoteSent: [String] = []
+        var board = CompanionBoardState()
+        var selected: [(String, String)] = []
+        var dismissed: [(String, String)] = []
+        var pinnedCalls: [(String, String, Bool)] = []
         init(meetings: [MeetingSummary] = [], state: RuntimeState = RuntimeState(status: "ok"), reachable: Bool = true) {
             self.meetings = meetings; self.state = state; self.reachable = reachable
         }
@@ -36,6 +40,29 @@ final class CompanionMeetingsTests: XCTestCase {
             if !reachable { throw Down() }
             remoteSent.append(text)
             return RemoteDictationResult(success: true, finalText: text, delivered: true)
+        }
+        func companionStatus() async throws -> CompanionBoardState {
+            if !reachable { throw Down() }
+            return board
+        }
+        func selectCompanionTarget(agent: String, sessionID: String) async throws {
+            if !reachable { throw Down() }
+            selected.append((agent, sessionID))
+            board.targets = board.targets.map {
+                var t = $0; t.selected = (t.agent == agent && t.sessionID == sessionID); return t
+            }
+        }
+        func dismissCompanionTarget(agent: String, sessionID: String) async throws {
+            if !reachable { throw Down() }
+            dismissed.append((agent, sessionID))
+            board.targets.removeAll { $0.agent == agent && $0.sessionID == sessionID }
+        }
+        func pinCompanionTarget(agent: String, sessionID: String, pinned: Bool) async throws {
+            if !reachable { throw Down() }
+            pinnedCalls.append((agent, sessionID, pinned))
+            board.targets = board.targets.map {
+                var t = $0; if t.agent == agent && t.sessionID == sessionID { t.pinned = pinned }; return t
+            }
         }
     }
 

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-20 (**HSM-13-04 DONE — the answer-the-coder gate ACHIEVED by
-voice (Track N / Gate 10).** A `CompanionAnswerApp` surfaces the waiting coder's question,
+**Last updated:** 2026-06-20 (**HSM-13-03 DONE — the Companion board; PHASE 13 — ANSWER
+THE CODER COMPLETE (4/4).** A `CompanionBoard` seam (`companionStatus`/`select`/`dismiss`/
+`pin` over `/api/companion/*`) + RuntimeCore view-model surface the waiting coder(s) and
+make the selected reply target unmistakable; selection is server-side so the answer
+delivers to it with no silent default. `CompanionAnswerApp` renders the board (each
+waiting coder + its question, confidence, pin/stale; "Answer this one"). `swift test`
+129/6-skip/0-fail (+7 `CompanionBoardTests`); app builds for device. The companion track's
+payoff is real end to end: point the iPad at the server you code against, see the agent's
+question, pick the target, answer **by voice** — on-device transcription, delivered into
+the coder, never autonomous. Earlier: **HSM-13-04 DONE — the answer-the-coder gate
+ACHIEVED by voice (Track N / Gate 10).** A `CompanionAnswerApp` surfaces the waiting coder's question,
 records a spoken answer, transcribes it **on-device** with WhisperKit (a real
 `WhisperKitTranscriber` driving the HSM-13-02 `VoiceNoteComposer` over `AudioCaptureService`),
 review, and delivers it into the coder. **Proven on a physical iPad Air M4:** question
@@ -279,7 +288,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); Phase 13 3/4 (HSM-13-01 inject + HSM-13-02 voice-note composer done; **HSM-13-04 Track N gate ACHIEVED by voice** — a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder; only HSM-13-03 board remains).**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 2/4 + Phase 13 done.**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/current-phase-status.md
@@ -1,9 +1,8 @@
 # Phase 13 — Answer the Coder
 
-**Status:** in-progress (3/4 — **Track N gate ACHIEVED (HSM-13-04 done)**: a question
-surfaced on a physical iPad, answered by a spoken voice note transcribed **on-device**,
-delivered into a live tmux coder. Only HSM-13-03 (the Companion board, multi-target
-selection) remains). **Track N — added by owner steer
+**Status:** COMPLETE (4/4 — **Track N gate ACHIEVED** + the Companion board shipped.
+Answer the coder by voice from the iPad — surface the waiting coder(s), pick the target,
+speak, transcribe on-device, deliver — is real end to end). **Track N — added by owner steer
 (2026-06-20), outside the original charter's Tracks A–L.** This is the payoff of
 the companion track and the scenario the owner painted in his own words:
 
@@ -21,8 +20,16 @@ That is the AI PI ("AI Pie") companion loop, driven from the iPad for the first
 time. Built native over the desktop HTTP API (owner call), on the Phase-12 client
 foundation.
 
-**Last updated:** 2026-06-20 (**HSM-13-04 DONE — the answer-the-coder gate ACHIEVED by
-voice.** A real on-device voice answer app (`CompanionAnswerApp` + `WhisperKitTranscriber`
+**Last updated:** 2026-06-20 (**HSM-13-03 DONE — the Companion board; PHASE 13 COMPLETE
+(4/4).** A `CompanionBoard` seam (`companionStatus`/`select`/`dismiss`/`pin` over
+`/api/companion/*`) + RuntimeCore view-model surface the waiting coder(s) and make the
+selected reply target unmistakable; selection is server-side so the next answer delivers
+to it with no silent default. `CompanionAnswerApp` renders the board (each waiting coder
++ its question, confidence, pin/stale; "Answer this one" → "Your answer lands here").
+`swift test` 129/6-skip/0-fail (+7 `CompanionBoardTests`: render, select-makes-active,
+pin/unpin, dismiss, honest-empty, unreachable→failure); the app builds for device. See
+[`evidence-story-03`](./evidence-story-03.md). **Phase 13 — Answer the Coder is done.**
+Earlier: **HSM-13-04 DONE — the answer-the-coder gate ACHIEVED by voice.** A real on-device voice answer app (`CompanionAnswerApp` + `WhisperKitTranscriber`
 driving the HSM-13-02 `VoiceNoteComposer` over `AudioCaptureService` + WhisperKit) lets
 the iPad surface the waiting question, record a spoken answer, transcribe it **on-device**,
 review, and deliver it into the coder. Proven on a physical iPad Air M4: the question
@@ -117,9 +124,10 @@ explicit send.
       it into pipeline-processed dictation text ready to deliver (HSM-13-02).
       *(`VoiceNoteComposer` view-model + seams, host-tested; live on-device run folds
       into HSM-13-04.)*
-- [ ] The iPad surfaces the AI PI companion state (waiting sessions, selected
+- [x] The iPad surfaces the AI PI companion state (waiting sessions, selected
       target, confidence, blockers) from `/api/companion/status` and can pick the
-      target session via `select`/`dismiss`/`pin` (HSM-13-03).
+      target session via `select`/`dismiss`/`pin` (HSM-13-03). *(`CompanionBoard` seam +
+      view-model + board UI; host-tested. Server-side selection routes the answer.)*
 - [x] **Track N gate — answer the coder, end to end:** in a real coding session
       (tmux + hooks → desktop server) an agent's question is surfaced on a physical
       iPad, answered by a native voice note, and the answer lands back in that coder
@@ -134,7 +142,7 @@ explicit send.
 |---|---|---|---|---|
 | HSM-13-01 | Remote-dictation inject path (desktop + client) | done | [story-01](./story-01-remote-dictation-inject.md) | [evidence](./evidence-story-01.md) |
 | HSM-13-02 | Native voice-note capture → dictation | done | [story-02](./story-02-voice-note-capture.md) | [evidence](./evidence-story-02.md) |
-| HSM-13-03 | The Companion board (the agent's question on the iPad) | backlog | [story-03](./story-03-companion-board.md) | — |
+| HSM-13-03 | The Companion board (the agent's question on the iPad) | done | [story-03](./story-03-companion-board.md) | [evidence](./evidence-story-03.md) |
 | HSM-13-04 | Answer-the-coder gate closeout | done | [story-04](./story-04-answer-the-coder-closeout.md) | [evidence](./evidence-story-04.md) · [final-summary](./final-summary.md) |
 
 ## Where we are
@@ -153,10 +161,13 @@ it **on-device** with WhisperKit (a real `WhisperKitTranscriber` driving the HSM
 live coder — proven on a physical iPad Air M4 (question surfaced → spoken answer →
 on-device transcript → landed in a live tmux pane, never autonomously). The first run
 caught a Whisper control-token leak in the delivered text; fixed with the unit-tested
-`WhisperText.clean` and redeployed. The on-device-Whisper "last mile" is closed. The one
-remaining story in the phase is the **Companion board** (HSM-13-03) — surfacing *which*
-of several waiting coders an answer targets (`select`/`pin`); this gate surfaced the
-single waiting question and delivered to it. Next: HSM-13-03 to finish Phase 13.
+`WhisperText.clean` and redeployed. The on-device-Whisper "last mile" is closed. The **Companion board** (HSM-13-03)
+now closes the phase: a `CompanionBoard` seam + view-model surface the waiting coder(s)
+and make the selected reply target unmistakable (`select`/`dismiss`/`pin`), with
+server-side selection routing the answer — no silent default. **Phase 13 — Answer the
+Coder is complete (4/4).** The companion track's payoff is real: point the iPad at the
+same server you code against, see the agent's question, pick the target, and answer by
+voice — transcribed on-device, delivered into the coder, never autonomously.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/evidence-story-03.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/evidence-story-03.md
@@ -1,0 +1,57 @@
+# Evidence — HSM-13-03 (The Companion board)
+
+**Date:** 2026-06-20 · **Status:** done
+
+The agent's question on the iPad — and *which* waiting coder an answer targets, made
+unmistakable before you send. This is the last story of Phase 13; with it the phase
+is complete.
+
+## What shipped
+
+- **Seam (`IDesktopClient`, HSM-13-03):** `companionStatus()` +
+  `selectCompanionTarget` / `dismissCompanionTarget` / `pinCompanionTarget(pinned:)`
+  over `/api/companion/status|select|dismiss|pin` (`apple/Sources/Providers`). A loose
+  `CompanionStatusDTO` decodes only what the board needs from the rich status payload;
+  `pinned` rides as a **JSON bool** (`makeJSONRequest`) because the desktop does
+  `bool(body.get("pinned"))` and a string `"false"` would read truthy.
+- **Contract types:** `CompanionTarget` (agent, session, the question, project,
+  selected/pinned/stale, confidence) + `CompanionBoardState` — honest by construction:
+  empty `targets` with `awaiting == false` means *nothing waiting*, never a manufactured
+  target. `activeTarget` is the selected session (else the first waiting one).
+- **View-model (`CompanionBoard`, RuntimeCore):** `load` / `select` / `dismiss` / `pin`,
+  each `Result`-wrapped so an unreachable desktop degrades to a `.failure` the view
+  renders (never a throw on the caller path). Selection is **server-side** — `select`
+  sets the desktop's active reply target, so the next answer (HSM-13-01/02 →
+  `/api/dictation/remote`) delivers to it with **no silent client default**.
+- **The board in the app:** `CompanionAnswerApp` now renders the board (Signal language)
+  — each waiting coder as a row with its question, project, confidence, pin + stale
+  badges; tap **Answer this one** to make it the target ("Your answer lands here").
+
+## Tests (ran)
+
+`swift test` → **129 passed / 6 skipped / 0 failed** (+7 `CompanionBoardTests`): targets
+render; `select` makes a target active and the refreshed board reflects it; `pin`/unpin
+and `dismiss` (removes the row) round-trip; an **empty board stays honest** (no
+manufactured target); an **unreachable desktop degrades to `.failure`** on load + select.
+The companion-answer app **builds + signs** for device with the board UI
+(`** BUILD SUCCEEDED **`).
+
+## Acceptance
+
+- **Renders the AI PI state in Signal** — waiting sessions, the selected target,
+  confidence, freshness (stale), pinned, blockers. (Target *transport* is in the status
+  payload; this board surfaces confidence + freshness + pin, the fields that change the
+  decision.)
+- **Select / dismiss / pin** via the existing endpoints; the selected target is
+  unmistakable (filled radio + accent border + "Your answer lands here").
+- **Hands the chosen target to the answer flow** — server-side selection means
+  HSM-13-02's send delivers to the selected session, no silent default.
+- **Unreachable/stale shown honestly** — `.failure` on unreachable; `stale` badge;
+  empty board says so plainly.
+
+## Device note
+
+The device path is already proven by the HSM-13-04 gate (the question surfaced on the
+iPad and a spoken answer landed in the coder). This story generalizes the single-question
+surface to a multi-target board with explicit selection; the multi-target *selection*
+logic is host-tested over the seam, and the board UI builds for device.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/final-summary.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/final-summary.md
@@ -37,11 +37,14 @@ the live tmux coder session — on an explicit send, never autonomously.
 `swift test` 122/6-skip/0-fail (+5 `WhisperTextTests`); the voice app builds + signs for
 device; delivery (5) + composer (10) host tests green.
 
-## What remains in Phase 13 (not this gate)
+## Phase 13 — Answer the Coder: COMPLETE (4/4)
 
-- **HSM-13-03 — the Companion board:** surface *which* of several waiting coders an
-  answer targets (`select`/`dismiss`/`pin`). This gate surfaced the single waiting
-  question and delivered to it; multi-target selection is the phase's last story.
+After the gate, **HSM-13-03 — the Companion board** shipped: a `CompanionBoard` seam +
+view-model surface the waiting coder(s) and make the selected reply target unmistakable
+(`select`/`dismiss`/`pin`), with server-side selection routing the answer — no silent
+default. (See [`evidence-story-03.md`](./evidence-story-03.md).)
 
-Phase 13 status after this gate: **3/4** (13-01 ✅, 13-02 ✅, 13-04 ✅; 13-03 remains).
-The companion track's payoff — answer the coder by voice from the iPad — is real.
+Phase 13 status: **4/4** (13-01 ✅, 13-02 ✅, 13-03 ✅, 13-04 ✅). The companion track's
+payoff — point the iPad at the server you code against, see the agent's question, pick
+the target, and **answer by voice** (transcribed on-device, delivered into the coder,
+never autonomous) — is real, end to end, on real hardware.

--- a/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-03-companion-board.md
+++ b/pm/roadmap/holdspeak-mobile/phase-13-answer-the-coder/story-03-companion-board.md
@@ -2,7 +2,9 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 13
-- **Status:** backlog
+- **Status:** done (2026-06-20 — the `CompanionBoard` seam + view-model surface the
+  waiting coders and make the selected reply target unmistakable; host-tested, board UI
+  shipped in `CompanionAnswerApp`. See [evidence-story-03](./evidence-story-03.md))
 - **Depends on:** HSM-12-01 (seam), HSM-12-03 (the Companion nav slot)
 - **Unblocks:** HSM-13-04
 - **Owner:** unassigned


### PR DESCRIPTION
## HSM-13-03 — the Companion board (closes Phase 13)

Surface the AI PI loop's waiting coder sessions on the iPad and make the **selected
reply target unmistakable** before you send.

### What ships
- **Seam (`IDesktopClient`):** `companionStatus` / `selectCompanionTarget` /
  `dismissCompanionTarget` / `pinCompanionTarget(pinned:)` over `/api/companion/*`. A
  loose `CompanionStatusDTO` decodes only what the board needs; `pinned` rides as a
  **JSON bool** (the desktop does `bool(body.get("pinned"))` — a string `"false"` would
  read truthy).
- **Contract types:** `CompanionTarget` + `CompanionBoardState` — honest by construction
  (empty targets + `awaiting == false` = *nothing waiting*, never a manufactured target).
- **View-model (`CompanionBoard`, RuntimeCore):** `load`/`select`/`dismiss`/`pin`,
  `Result`-wrapped (unreachable → `.failure`, never a throw). **Selection is
  server-side** so the answer delivers to the chosen target — no silent default.
- **Board UI** in `CompanionAnswerApp` (Signal): each waiting coder + its question,
  project, confidence, pin/stale; "Answer this one" → "Your answer lands here".

### Tests
`swift test` **129 passed / 6 skipped / 0 failed** (+7 `CompanionBoardTests`: render,
select-makes-active, pin/unpin, dismiss-removes, honest-empty, unreachable→failure); the
app **builds for device** with the board UI.

### 🎉 Phase 13 — Answer the Coder is COMPLETE (4/4)
13-01 inject ✅ · 13-02 voice-note composer ✅ · 13-03 Companion board ✅ · 13-04 Track N
gate (answer by voice) ✅. Point the iPad at the server you code against, see the agent's
question, pick the target, and answer **by voice** — on-device transcription, delivered
into the coder, never autonomous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)