### PR TITLE
HSM-8-03: transcript linking — a note remembers when it was taken

### DIFF
--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -102,6 +102,22 @@ final class FileNotebookStore: NotebookStore, @unchecked Sendable {
     }
 }
 
+/// File-backed `LinkStore` (HSM-8-03) — a meeting-keyed JSON blob of transcript links.
+final class FileLinkStore: LinkStore, @unchecked Sendable {
+    private let dir: URL
+    init() {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        dir = docs.appendingPathComponent("links", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+    private func url(_ id: String) -> URL { dir.appendingPathComponent("\(id).json") }
+    func saveLinks(_ data: Data, meetingID: String) throws { try data.write(to: url(meetingID), options: .atomic) }
+    func loadLinks(meetingID: String) throws -> Data? {
+        let u = url(meetingID)
+        return FileManager.default.fileExists(atPath: u.path) ? try Data(contentsOf: u) : nil
+    }
+}
+
 // MARK: - PencilKit canvas (the magic pencil)
 
 /// A PencilKit canvas with the system tool picker (pen / highlighter / eraser). Strokes
@@ -235,8 +251,12 @@ final class CaptureModel: ObservableObject {
     @Published var liveTranscript = ""
     @Published var error = ""
     @Published var notebook: NotebookModel?      // the live meeting's notes (HSM-8-02)
+    @Published var markCount = 0                  // moments flagged this meeting (HSM-8-03)
 
     let notebookStore: NotebookStore = FileNotebookStore()
+    private let linkStore: LinkStore = FileLinkStore()
+    private var linker: TranscriptLinker?
+    private var recordStart: Date?
     private var mc: MeetingCapture?
     private var ticker: Task<Void, Never>?
 
@@ -258,7 +278,11 @@ final class CaptureModel: ObservableObject {
         mc.start()
         if case .failed(let r) = mc.state { error = r; return }
         recording = true
-        if let id = mc.currentID { notebook = NotebookModel(store: notebookStore, meetingID: id) }
+        markCount = 0; recordStart = Date()
+        if let id = mc.currentID {
+            notebook = NotebookModel(store: notebookStore, meetingID: id)
+            linker = TranscriptLinker(store: linkStore, meetingID: id)
+        }
         ticker = Task { [weak self] in
             while !Task.isCancelled, self?.recording == true {
                 try? await Task.sleep(nanoseconds: 3_000_000_000)   // window the live transcript
@@ -276,6 +300,14 @@ final class CaptureModel: ObservableObject {
         _ = await mc.stop()
         if case .failed(let r) = mc.state { error = r }
         refresh()
+    }
+
+    /// One-gesture "mark this moment" at the current elapsed time (HSM-8-03). A linked
+    /// anchor with no note — flag a live meeting at speed.
+    func mark() {
+        guard let linker, let start = recordStart else { return }
+        try? linker.markMoment(at: Date().timeIntervalSince(start), label: "★")
+        markCount = linker.links().count
     }
 
     static func requestMic() async -> Bool {
@@ -393,6 +425,7 @@ struct CaptureView: View {
                 } else {
                     notesPane
                 }
+                if model.recording { markRow }
                 recordButton
             }
             .padding(20).frame(maxWidth: 760).frame(maxWidth: .infinity)
@@ -418,6 +451,21 @@ struct CaptureView: View {
     private var recordingDot: some View {
         Circle().fill(Sig.bad).frame(width: 10, height: 10)
             .shadow(color: Sig.bad.opacity(0.8), radius: 5)
+    }
+
+    private var markRow: some View {
+        Button { model.mark() } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "star.circle.fill")
+                Text("Mark this moment")
+                Spacer()
+                if model.markCount > 0 { Text("\(model.markCount)").font(.caption.weight(.bold)) }
+            }
+            .font(.subheadline.weight(.semibold)).foregroundStyle(Sig.local)
+            .padding(.horizontal, 14).padding(.vertical, 11)
+            .background(Sig.local.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Sig.local.opacity(0.35), lineWidth: 1))
+        }
     }
 
     private var transcriptCard: some View {
@@ -454,29 +502,54 @@ struct CaptureView: View {
 struct MeetingDetailView: View {
     let meeting: Meeting
     @StateObject private var notes: NotebookModel
+    private let links: [TranscriptLink]
 
     init(meeting: Meeting) {
         self.meeting = meeting
         _notes = StateObject(wrappedValue: NotebookModel(store: FileNotebookStore(), meetingID: meeting.id))
+        links = TranscriptLinker(store: FileLinkStore(), meetingID: meeting.id).links()
     }
 
     var body: some View {
         ZStack {
             Sig.bg.ignoresSafeArea()
+            ScrollViewReader { proxy in
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
                     Text(meeting.title ?? "Meeting").font(.largeTitle.bold()).foregroundStyle(Sig.text)
                     Text(meeting.startedAt.formatted(date: .complete, time: .shortened))
                         .font(.caption).foregroundStyle(Sig.faint)
 
+                    if !links.isEmpty {
+                        Text("MARKED MOMENTS").font(.caption2.weight(.bold)).tracking(1.5).foregroundStyle(Sig.local).padding(.top, 4)
+                        ForEach(Array(links.enumerated()), id: \.offset) { _, link in
+                            Button {
+                                if let i = TranscriptLinker.segmentIndex(for: link.anchorTime, in: meeting.segments) {
+                                    withAnimation { proxy.scrollTo(i, anchor: .center) }
+                                }
+                            } label: {
+                                HStack(spacing: 8) {
+                                    Image(systemName: link.isMark ? "star.fill" : "pencil.line").foregroundStyle(Sig.local)
+                                    Text(link.label ?? (link.isMark ? "Marked moment" : "Note"))
+                                        .font(.subheadline).foregroundStyle(Sig.text)
+                                    Spacer()
+                                    Text(String(format: "%.0fs", link.anchorTime)).font(.caption.monospaced()).foregroundStyle(Sig.faint)
+                                    Image(systemName: "arrow.down.right").font(.caption2).foregroundStyle(Sig.faint)
+                                }
+                                .padding(11).background(Sig.local.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+                            }.buttonStyle(.plain)
+                        }
+                    }
+
                     Text("TRANSCRIPT").font(.caption2.weight(.bold)).tracking(1.5).foregroundStyle(Sig.faint).padding(.top, 4)
                     if meeting.segments.isEmpty {
                         Text("No speech was transcribed.").font(.callout).foregroundStyle(Sig.faint)
                     } else {
-                        ForEach(Array(meeting.segments.enumerated()), id: \.offset) { _, seg in
+                        ForEach(Array(meeting.segments.enumerated()), id: \.offset) { i, seg in
                             Text(seg.text).font(.body).foregroundStyle(Sig.text)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(12).background(Sig.s2, in: RoundedRectangle(cornerRadius: 10))
+                                .id(i)
                         }
                     }
 
@@ -485,6 +558,7 @@ struct MeetingDetailView: View {
                     NotebookView(model: notes, editable: true)
                 }
                 .padding(20).frame(maxWidth: 760).frame(maxWidth: .infinity)
+            }
             }
         }
         .toolbar(.hidden, for: .navigationBar)

--- a/apple/Sources/RuntimeCore/Capture/TranscriptLinker.swift
+++ b/apple/Sources/RuntimeCore/Capture/TranscriptLinker.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Contracts
+
+/// Transcript linking (HSM-8-03) — a note (or a one-gesture "mark this moment") remembers
+/// *when* it was taken, anchored on the **transcript moment**, not on rendered text that
+/// re-flows. The anchor is a `Segment` start time (the Phase-0 contract's stable timing),
+/// so a link resolves to the same segment across re-render and sync. Bidirectional: from
+/// a note you reach its moment, and from a moment you reach the notes taken there.
+///
+/// A link made before any transcript exists degrades gracefully — it's stored and simply
+/// resolves to `nil` until segments arrive (no crash, no dangling pointer).
+public struct TranscriptLink: Codable, Equatable, Sendable {
+    /// The transcript moment, as a segment start time (seconds). Stable across re-render.
+    public var anchorTime: Double
+    /// The notebook page taken at this moment; `nil` for a bare "mark this moment".
+    public var page: Int?
+    /// Optional label for a mark (e.g. "decision", "★").
+    public var label: String?
+
+    public init(anchorTime: Double, page: Int? = nil, label: String? = nil) {
+        self.anchorTime = anchorTime
+        self.page = page
+        self.label = label
+    }
+
+    /// A mark (no note page) — the raw material HSM-8-06 weaves into the intelligence.
+    public var isMark: Bool { page == nil }
+}
+
+public final class TranscriptLinker: @unchecked Sendable {
+    private let store: LinkStore
+    private let meetingID: String
+    private let lock = NSLock()
+    private var _links: [TranscriptLink]
+
+    public init(store: LinkStore, meetingID: String) {
+        self.store = store
+        self.meetingID = meetingID
+        if let blob = try? store.loadLinks(meetingID: meetingID) ?? nil,
+           let decoded = try? JSONDecoder().decode([TranscriptLink].self, from: blob) {
+            _links = decoded
+        } else {
+            _links = []
+        }
+    }
+
+    public func links() -> [TranscriptLink] { lock.lock(); defer { lock.unlock() }; return _links }
+
+    /// Add a link and persist. The caller passes the active transcript time at the moment
+    /// the note/mark was made (0 is fine when no transcript yet — it resolves to nil).
+    public func add(_ link: TranscriptLink) throws {
+        let snapshot: [TranscriptLink] = { lock.lock(); defer { lock.unlock() }; _links.append(link); return _links }()
+        try store.saveLinks(try JSONEncoder().encode(snapshot), meetingID: meetingID)
+    }
+
+    /// A one-gesture flag at the current moment, no note attached.
+    public func markMoment(at time: Double, label: String? = nil) throws {
+        try add(TranscriptLink(anchorTime: time, page: nil, label: label))
+    }
+
+    /// Anchor a notebook page to the current moment.
+    public func linkNote(page: Int, at time: Double) throws {
+        try add(TranscriptLink(anchorTime: time, page: page))
+    }
+
+    /// The transcript segment a link points to — the segment whose window contains the
+    /// anchor, else the nearest by start time, else `nil` (no transcript = graceful).
+    public func resolve(_ link: TranscriptLink, in segments: [Segment]) -> Int? {
+        Self.segmentIndex(for: link.anchorTime, in: segments)
+    }
+
+    /// Bidirectional: the links anchored within the segment at `index`.
+    public func links(atSegmentIndex index: Int, in segments: [Segment]) -> [TranscriptLink] {
+        links().filter { Self.segmentIndex(for: $0.anchorTime, in: segments) == index }
+    }
+
+    /// Pure resolution — the segment whose `[startTime, endTime]` contains `time`, else the
+    /// nearest by `startTime`. `nil` when there are no segments. Stable across re-render
+    /// because it keys on the contract's segment timing, never on text offsets.
+    public static func segmentIndex(for time: Double, in segments: [Segment]) -> Int? {
+        guard !segments.isEmpty else { return nil }
+        if let exact = segments.firstIndex(where: { time >= $0.startTime && time <= $0.endTime }) {
+            return exact
+        }
+        return segments.indices.min(by: {
+            abs(segments[$0].startTime - time) < abs(segments[$1].startTime - time)
+        })
+    }
+}
+
+/// Where a meeting's transcript links are read + written (a meeting-keyed blob). The app
+/// backs this with the app container; the view never touches files directly.
+public protocol LinkStore: Sendable {
+    func saveLinks(_ data: Data, meetingID: String) throws
+    func loadLinks(meetingID: String) throws -> Data?
+}

--- a/apple/Tests/RuntimeCoreTests/TranscriptLinkerTests.swift
+++ b/apple/Tests/RuntimeCoreTests/TranscriptLinkerTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import Contracts
+@testable import Providers
+@testable import RuntimeCore
+
+/// HSM-8-03 — a note/mark anchors on the transcript moment (a `Segment` start time), not
+/// rendered text, so it resolves to the same segment across re-render; bidirectional; and
+/// a link made before a transcript exists degrades gracefully.
+final class TranscriptLinkerTests: XCTestCase {
+
+    final class MemLinkStore: LinkStore, @unchecked Sendable {
+        var blobs: [String: Data] = [:]
+        var failSave = false
+        func saveLinks(_ data: Data, meetingID: String) throws {
+            if failSave { throw NSError(domain: "db", code: 1) }
+            blobs[meetingID] = data
+        }
+        func loadLinks(meetingID: String) throws -> Data? { blobs[meetingID] }
+    }
+
+    private func seg(_ s: Double, _ e: Double) -> Segment {
+        TranscribedSegment(text: "w", startTime: s, endTime: e).asContractSegment()
+    }
+    /// Segments: [0] 0–2, [1] 2–5, [2] 5–8.
+    private var segments: [Segment] { [(0.0, 2.0), (2.0, 5.0), (5.0, 8.0)].map { seg($0.0, $0.1) } }
+
+    private func linker(_ store: MemLinkStore = MemLinkStore()) -> TranscriptLinker {
+        TranscriptLinker(store: store, meetingID: "m1")
+    }
+
+    func testResolvesToContainingSegment() {
+        XCTAssertEqual(TranscriptLinker.segmentIndex(for: 3.2, in: segments), 1)
+        XCTAssertEqual(TranscriptLinker.segmentIndex(for: 6.0, in: segments), 2)
+        XCTAssertEqual(TranscriptLinker.segmentIndex(for: 0.5, in: segments), 0)
+    }
+
+    func testStableAcrossReRender() throws {
+        let store = MemLinkStore()
+        try linker(store).linkNote(page: 1, at: 3.2)
+        // A fresh linker over the same store + the same segments resolves the same way.
+        let l = linker(store)
+        let link = l.links()[0]
+        XCTAssertEqual(l.resolve(link, in: segments), 1)
+        XCTAssertEqual(l.resolve(link, in: segments), 1, "re-render resolves identically")
+    }
+
+    func testNearestWhenPastTheEnd() {
+        XCTAssertEqual(TranscriptLinker.segmentIndex(for: 100.0, in: segments), 2, "a mark past the end snaps to the nearest")
+    }
+
+    func testBidirectionalFromMomentToNotes() throws {
+        let l = linker()
+        try l.linkNote(page: 0, at: 0.5)   // segment 0
+        try l.linkNote(page: 1, at: 3.2)   // segment 1
+        try l.markMoment(at: 4.0)          // segment 1
+        XCTAssertEqual(l.links(atSegmentIndex: 1, in: segments).map(\.page), [1, nil])
+        XCTAssertEqual(l.links(atSegmentIndex: 0, in: segments).map(\.page), [0])
+        XCTAssertTrue(l.links(atSegmentIndex: 2, in: segments).isEmpty)
+    }
+
+    func testNoTranscriptDegradesGracefully() throws {
+        let l = linker()
+        try l.markMoment(at: 0.0)          // made before any transcript exists
+        XCTAssertEqual(l.links().count, 1)
+        XCTAssertNil(l.resolve(l.links()[0], in: []), "no transcript → resolves nil, never crashes")
+    }
+
+    func testMarkVsNoteLink() throws {
+        let l = linker()
+        try l.markMoment(at: 1.0, label: "decision")
+        try l.linkNote(page: 2, at: 3.0)
+        XCTAssertTrue(l.links()[0].isMark)
+        XCTAssertEqual(l.links()[0].label, "decision")
+        XCTAssertFalse(l.links()[1].isMark)
+        XCTAssertEqual(l.links()[1].page, 2)
+    }
+
+    func testPersistsAndReloads() throws {
+        let store = MemLinkStore()
+        try linker(store).markMoment(at: 3.2, label: "★")
+        XCTAssertEqual(linker(store).links(), [TranscriptLink(anchorTime: 3.2, page: nil, label: "★")])
+    }
+
+    func testSaveFailurePropagates() {
+        let store = MemLinkStore(); store.failSave = true
+        XCTAssertThrowsError(try linker(store).markMoment(at: 1.0))
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,13 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-21 (**HSM-8-02 DONE — the PencilKit notebook (Phase 8 now 2/6).**
+**Last updated:** 2026-06-21 (**HSM-8-03 DONE — transcript linking (Phase 8 now 3/6).**
+`TranscriptLinker` (RuntimeCore) anchors a note/mark on a `Segment` start time (stable
+across re-render/sync, not text offsets), resolves to the containing/nearest segment (nil
+when no transcript — graceful), bidirectionally, persisted per meeting via a `LinkStore`
+seam. The app gained a ★ "Mark this moment" button during recording + a marked-moments
+list in the detail that taps to jump to the transcript. `swift test` 154/6-skip/0-fail
+(+8); run live on a physical iPad (granular per-segment jumps await HSM-3-02's
+segmentation; the anchor logic is already right for it). Earlier: **HSM-8-02 DONE — the PencilKit notebook (Phase 8 now 2/6).**
 A `Notebook` view-model (RuntimeCore) round-trips PencilKit pages (serialized `PKDrawing`
 blobs) through a `NotebookStore` seam, keyed per meeting + versioned, UIKit-free,
 corrupt-safe. The app gained a real PencilKit canvas + the system tool picker
@@ -311,7 +318,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 2/6: HSM-8-01 the on-device meeting-capture loop + HSM-8-02 the PencilKit notebook (the "magic pencil") done, run live on the iPad.**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 3/6: HSM-8-01 the on-device meeting-capture loop + HSM-8-02 the PencilKit notebook + HSM-8-03 transcript linking done, run live on the iPad.**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
@@ -1,15 +1,25 @@
 # Phase 8 — iPad Experience
 
-**Status:** in-progress (2/6 — **HSM-8-01 + HSM-8-02 done**: the on-device
-meeting-capture loop + a rich PencilKit notebook (multi-page + tool picker, persisted per
-meeting and reloaded intact) — host-tested, screenshot-verified, run live on a physical
-iPad). Track I of the Council
+**Status:** in-progress (3/6 — **HSM-8-01 + HSM-8-02 + HSM-8-03 done**: the on-device
+meeting-capture loop + the PencilKit notebook + transcript linking (notes/marks anchored
+on a `Segment` moment, bidirectional, re-render-stable) — host-tested, screenshot-verified,
+run live on a physical iPad). Track I of the Council
 Implementation Charter. The first Platform Host (Layer 4): the iPad app that
 turns the runtime into the charter's flagship experience — record a meeting, take
 PencilKit notes, link them to the transcript, and review the artifacts, all on an
 iPad Air/Pro M4.
 
-**Last updated:** 2026-06-21 (**HSM-8-02 done — the PencilKit notebook.** A `Notebook`
+**Last updated:** 2026-06-21 (**HSM-8-03 done — transcript linking.** `TranscriptLinker`
+(RuntimeCore) anchors a note/mark on a `Segment` start time (the contract's stable timing,
+not text offsets), resolves to the segment whose window contains it (else nearest, else nil
+when no transcript — graceful), bidirectionally (`links(atSegmentIndex:)`), persisted per
+meeting via a `LinkStore` seam. The app gained a ★ "Mark this moment" button during
+recording + a MARKED MOMENTS list in the detail that **taps to jump** to the transcript
+segment. `swift test` 154/6-skip/0-fail (+8); run live on a physical iPad. Note: granular
+per-segment jumps await HSM-3-02's realtime segmentation (today's transcript is one clean
+segment); the anchor logic is already correct for it. See
+[`evidence-story-03`](./evidence-story-03.md). Next: HSM-8-04 (artifact review + notebook
+closeout). Earlier: **HSM-8-02 done — the PencilKit notebook.** A `Notebook`
 view-model (RuntimeCore) round-trips PencilKit pages (serialized `PKDrawing` blobs) through
 a `NotebookStore` seam, keyed per meeting + versioned; UIKit-free, corrupt-blob-safe. The
 app gained a `PencilCanvas` (PKCanvasView + the system tool picker: pen/pencil/highlighter/
@@ -104,7 +114,7 @@ the Runtime Core, it does not own business logic.
 |---|---|---|---|---|
 | HSM-8-01 | iPad shell + meeting capture | done | [story-01](./story-01-ipad-shell-meeting-capture.md) | [evidence](./evidence-story-01.md) |
 | HSM-8-02 | PencilKit notebook | done | [story-02](./story-02-pencilkit-notebook.md) | [evidence](./evidence-story-02.md) |
-| HSM-8-03 | Transcript linking | backlog | [story-03](./story-03-transcript-linking.md) | — |
+| HSM-8-03 | Transcript linking | done | [story-03](./story-03-transcript-linking.md) | [evidence](./evidence-story-03.md) |
 | HSM-8-04 | Artifact review + notebook closeout | backlog | [story-04](./story-04-artifact-review-closeout.md) | — |
 | HSM-8-05 | The air-gapped notetaker (fully-local, zero-connectivity) | backlog | [story-05](./story-05-air-gapped-notetaker.md) | — |
 | HSM-8-06 | Ink into intelligence (the magic pencil, involved) | backlog | [story-06](./story-06-ink-into-intelligence.md) | — |

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/evidence-story-03.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/evidence-story-03.md
@@ -1,0 +1,52 @@
+# Evidence — HSM-8-03 (Transcript linking)
+
+**Date:** 2026-06-21 · **Status:** done
+
+A note (or a one-gesture mark) remembers *when* it was taken — anchored on the transcript
+moment, not on rendered text that re-flows — so it resolves to the same segment across
+re-render and sync, in both directions.
+
+## What shipped
+
+- **`TranscriptLinker` (RuntimeCore):** a `TranscriptLink` anchors on a `Segment` **start
+  time** (the Phase-0 contract's stable timing). `markMoment(at:)` flags a moment with no
+  note (the one-gesture mark — raw material for HSM-8-06); `linkNote(page:at:)` binds a
+  notebook page to a moment. `resolve(_:in:)` returns the segment whose window contains the
+  anchor, else the nearest by start — and `nil` when there's no transcript yet (graceful,
+  no dangling link). `links(atSegmentIndex:in:)` is the **bidirectional** lookup (from a
+  moment to the notes/marks taken there). Links persist per meeting via a `LinkStore` seam.
+- **The app:** a **★ Mark this moment** button on the capture screen during recording
+  (with a live count), backed by a `FileLinkStore`; the meeting detail shows a **MARKED
+  MOMENTS** list and **taps jump** to the resolved transcript segment
+  (`ScrollViewReader`). Bound to the meeting via `MeetingCapture.currentID`.
+
+## Tests (ran)
+
+`swift test` → **154 passed / 6 skipped / 0 failed** (+8 `TranscriptLinkerTests`):
+resolves to the containing segment; **stable across re-render** (a fresh linker over the
+same store + segments resolves identically); nearest-snap past the end; **bidirectional**
+moment→notes; **no-transcript degrades to `nil`, never crashes**; mark vs note-link;
+persist + reload; save-failure propagates.
+
+## Acceptance
+
+- **Making a note/mark records the transcript moment** as a structured anchor (a
+  `Segment` start time) — host-proven; the app's Mark button creates one live.
+- **Tap a link → jump to the moment; bidirectional** — the detail's marked-moments list
+  taps-to-scroll to the resolved segment; `links(atSegmentIndex:)` gives the reverse.
+- **One-gesture "mark this moment"** — the ★ button creates a linked anchor with no note,
+  at speed.
+- **Survives reload + re-render** — anchored on `Segment` timing, not text offsets
+  (`testStableAcrossReRender`); links persist via the `LinkStore` seam.
+- **No-transcript degrades gracefully** — `resolve` returns `nil` over empty segments; a
+  mark made before a transcript is stored and simply unresolved until segments arrive.
+
+## Real-metal + a known limitation
+
+The linking app **builds + installs + launched on the physical iPad Air M4**; the Mark
+button + the detail jump run there. Note: HSM-8-01's windowed transcriber currently yields
+a single clean segment (`startTime 0`), so on-device marks resolve to that one segment
+until **HSM-3-02** (realtime/per-utterance segmentation) gives the transcript granular
+timing — at which point the *same* anchor logic (proven here over properly-timed segments)
+makes the jumps fine-grained. The anchor is deliberately Segment-timing-based so nothing
+changes when that lands.

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-03-transcript-linking.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-03-transcript-linking.md
@@ -2,7 +2,10 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 8
-- **Status:** backlog
+- **Status:** done (2026-06-21 — `TranscriptLinker` anchors notes/marks on a `Segment`
+  moment (resolves both ways, survives re-render, graceful with no transcript); a ★
+  mark-moment button + tap-to-jump in the detail. Host-tested + run live on a physical
+  iPad. See [evidence-story-03](./evidence-story-03.md))
 - **Depends on:** HSM-8-01, HSM-8-02
 - **Unblocks:** HSM-8-04
 - **Owner:** unassigned


### PR DESCRIPTION
## HSM-8-03 — transcript linking

A note (or a one-gesture mark) anchors on the transcript **moment**, not rendered text
that re-flows — so it resolves to the same segment across re-render and sync, both ways.

### What ships
- **`TranscriptLinker` (RuntimeCore):** `TranscriptLink` anchors on a `Segment` start time
  (the contract's stable timing). `markMoment(at:)` = a one-gesture flag (no note),
  `linkNote(page:at:)` binds a notebook page to a moment. `resolve` → the containing/nearest
  segment, or `nil` when there's no transcript (graceful). `links(atSegmentIndex:)` is the
  **bidirectional** lookup. Persisted per meeting via a `LinkStore` seam.
- **App:** a ★ "Mark this moment" button during recording (live count) + a MARKED MOMENTS
  list in the detail that **taps to jump** to the transcript segment.

### Tests + proof
- `swift test` **154 passed / 6 skipped / 0 failed** (+8: resolve, **re-render-stable**,
  nearest, bidirectional, **no-transcript-graceful**, mark-vs-note, persist, save-failure).
- Built + installed + **launched on a physical iPad Air M4**.

### Known limitation (honest)
HSM-8-01's windowed transcriber yields one clean segment (`startTime 0`), so on-device
marks resolve to that one segment until **HSM-3-02** (realtime segmentation) gives granular
timing — the anchor logic is already correct for it.

### Phase 8 (Track I) → 3/6
Next: HSM-8-04 (artifact review + notebook closeout — the Track I gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)