### PR TITLE
HSM-8-04: artifact review + the Track I gate (on-device intelligence)

### DIFF
--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -228,11 +228,14 @@ private enum Sig {
     static let bg = Color(hex: 0x0E0F13)
     static let s1 = Color(hex: 0x15171D)
     static let s2 = Color(hex: 0x1C1F27)
+    static let s3 = Color(hex: 0x242833)
     static let line = Color.white.opacity(0.07)
     static let text = Color(hex: 0xF2F3F5)
     static let muted = Color(hex: 0x9BA2B0)
     static let faint = Color(hex: 0x767E8D)
     static let accent = Color(hex: 0xFF6B35)
+    static let ok = Color(hex: 0x3ECF8E)
+    static let warn = Color(hex: 0xF2A33C)
     static let bad = Color(hex: 0xE5544B)
     static let local = Color(hex: 0x5B8DEF)
 }
@@ -497,16 +500,97 @@ struct CaptureView: View {
     }
 }
 
+// MARK: - On-device artifact generation + review (HSM-8-04)
+
+@MainActor
+final class MeetingReviewState: ObservableObject {
+    let meeting: Meeting
+    @Published var artifacts: [Artifact] = []
+    @Published var profile: MIRProfile
+    @Published var generating = false
+    @Published var note = ""
+
+    private let storage: SQLiteStorage?
+
+    init(meeting: Meeting) {
+        self.meeting = meeting
+        self.profile = meeting.routingProfile
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        storage = try? SQLiteStorage(path: docs.appendingPathComponent("meetings.sqlite").path)
+        load()
+    }
+
+    func load() { artifacts = (try? storage?.loadArtifacts(meetingId: meeting.id)) ?? [] }
+
+    var groups: [ArtifactGroup] { ReviewModel(artifacts: artifacts).grouped(profile: profile) }
+    var pendingCount: Int { ReviewModel(artifacts: artifacts).pendingCount }
+
+    /// Generate the meeting's artifacts ON-DEVICE (Mode A): the MIR profile picks the
+    /// types, the local GGUF model drafts each, and they persist as proposals.
+    func generate() async {
+        guard !meeting.segments.isEmpty else { note = "No transcript to analyze."; return }
+        guard let modelPath = Self.localGGUF() else {
+            note = "No on-device model found. Push a .gguf to the app's Documents first."
+            return
+        }
+        generating = true; defer { generating = false }
+        do {
+            let provider = try LlamaProvider(modelPath: modelPath, maxTokenCount: 8192)
+            // maxAttempts: 2 keeps the bounded repair but halves the worst-case on-device
+            // cost vs the default 3 — each retry is a full completion on a 4B model.
+            let engine = ArtifactGenerationEngine(provider: provider, maxAttempts: 2)
+            let transcript = Transcript(meetingId: meeting.id, segments: meeting.segments,
+                                        transcriptHash: "ondevice-\(meeting.segments.count)")
+            // The profile's emphasis types, generated ONE AT A TIME so each artifact
+            // streams in as it lands — a multi-minute on-device run should feel alive,
+            // not a dead wait.
+            let types = MIRRouter.baseEmphasis[profile] ?? [.decisions, .actionItems, .requirements]
+            var any = false
+            for (i, type) in types.enumerated() {
+                note = "Generating \(artifactTypeLabel(type))…  (\(i + 1)/\(types.count))"
+                if let artifact = try? await engine.generate(type, from: transcript) {
+                    try? storage?.saveArtifact(artifact)
+                    any = true
+                    load()   // publish immediately — the user sees it appear
+                }
+            }
+            note = any ? "" : "The model returned nothing usable."
+        } catch {
+            note = "Generation failed: \(error)"
+        }
+    }
+
+    func approve(_ id: String) {
+        try? ReviewModel(artifacts: artifacts, store: storage).approve(id); load()
+    }
+    func reject(_ id: String) {
+        try? ReviewModel(artifacts: artifacts, store: storage).reject(id); load()
+    }
+
+    static func localGGUF() -> String? {
+        guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return nil }
+        return ((try? FileManager.default.contentsOfDirectory(at: docs, includingPropertiesForKeys: nil)) ?? [])
+            .filter { $0.pathExtension.lowercased() == "gguf" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }.first?.path
+    }
+}
+
+private func artifactTypeLabel(_ t: ArtifactType) -> String {
+    t.rawValue.replacingOccurrences(of: "_", with: " ").capitalized
+}
+
 // MARK: - Meeting detail (reopen-intact)
 
 struct MeetingDetailView: View {
     let meeting: Meeting
     @StateObject private var notes: NotebookModel
+    @StateObject private var review: MeetingReviewState
     private let links: [TranscriptLink]
 
     init(meeting: Meeting) {
         self.meeting = meeting
         _notes = StateObject(wrappedValue: NotebookModel(store: FileNotebookStore(), meetingID: meeting.id))
+        _review = StateObject(wrappedValue: MeetingReviewState(meeting: meeting))
         links = TranscriptLinker(store: FileLinkStore(), meetingID: meeting.id).links()
     }
 
@@ -541,6 +625,8 @@ struct MeetingDetailView: View {
                         }
                     }
 
+                    artifactsSection
+
                     Text("TRANSCRIPT").font(.caption2.weight(.bold)).tracking(1.5).foregroundStyle(Sig.faint).padding(.top, 4)
                     if meeting.segments.isEmpty {
                         Text("No speech was transcribed.").font(.callout).foregroundStyle(Sig.faint)
@@ -562,5 +648,106 @@ struct MeetingDetailView: View {
             }
         }
         .toolbar(.hidden, for: .navigationBar)
+    }
+
+    // MARK: artifact review (HSM-8-04)
+
+    @ViewBuilder private var artifactsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Text("INTELLIGENCE").font(.caption2.weight(.bold)).tracking(1.5).foregroundStyle(Sig.accent)
+                Spacer()
+                egressBadge
+            }
+            Picker("Profile", selection: $review.profile) {
+                ForEach(MIRProfile.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) }
+            }
+            .pickerStyle(.segmented)
+
+            if review.generating {
+                HStack(spacing: 8) {
+                    ProgressView().tint(Sig.accent)
+                    Text(review.note.isEmpty ? "Thinking on-device…" : review.note)
+                        .font(.caption).foregroundStyle(Sig.muted)
+                }
+                Text("Runs fully on this iPad — a few minutes for a 4B model, no network.")
+                    .font(.caption2).foregroundStyle(Sig.faint)
+            }
+
+            if review.artifacts.isEmpty {
+                if !review.generating {
+                    Text(review.note.isEmpty ? "Generate decisions, action items, risks and more from this meeting — fully on-device." : review.note)
+                        .font(.caption).foregroundStyle(Sig.faint)
+                    Button { Task { await review.generate() } } label: {
+                        HStack(spacing: 6) { Image(systemName: "sparkles"); Text("Generate on-device") }
+                            .font(.subheadline.weight(.semibold)).foregroundStyle(.black)
+                            .frame(maxWidth: .infinity).padding(.vertical, 12)
+                            .background(Sig.accent, in: RoundedRectangle(cornerRadius: 12))
+                    }
+                }
+            } else {
+                // Artifacts stream in as the model finishes each type.
+                ForEach(review.groups, id: \.type) { group in
+                    Text(artifactTypeLabel(group.type).uppercased())
+                        .font(.caption2.weight(.bold)).tracking(1).foregroundStyle(Sig.local).padding(.top, 4)
+                    ForEach(group.items, id: \.id) { a in artifactCard(a) }
+                }
+            }
+        }
+        .padding(16).frame(maxWidth: .infinity, alignment: .leading)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(Sig.line, lineWidth: 1))
+    }
+
+    private func artifactCard(_ a: Artifact) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text(a.title).font(.subheadline.weight(.semibold)).foregroundStyle(Sig.text)
+                Spacer()
+                statusChip(a.status)
+            }
+            if !a.bodyMarkdown.isEmpty {
+                Text(a.bodyMarkdown).font(.caption).foregroundStyle(Sig.muted).lineLimit(6)
+            }
+            if a.status == .draft || a.status == .needsReview {
+                HStack(spacing: 10) {
+                    Button { review.approve(a.id) } label: {
+                        Label("Approve", systemImage: "checkmark.circle.fill").font(.caption.weight(.semibold))
+                            .foregroundStyle(.black).padding(.horizontal, 12).padding(.vertical, 7)
+                            .background(Sig.ok, in: Capsule())
+                    }
+                    Button { review.reject(a.id) } label: {
+                        Label("Dismiss", systemImage: "xmark").font(.caption.weight(.semibold))
+                            .foregroundStyle(Sig.muted).padding(.horizontal, 12).padding(.vertical, 7)
+                            .background(Sig.s3, in: Capsule())
+                    }
+                }
+            }
+        }
+        .padding(12).background(Sig.s2, in: RoundedRectangle(cornerRadius: 11))
+        .overlay(RoundedRectangle(cornerRadius: 11).stroke(Sig.line, lineWidth: 1))
+    }
+
+    private func statusChip(_ s: ArtifactStatus) -> some View {
+        let (label, color): (String, Color) = {
+            switch s {
+            case .accepted: ("Approved", Sig.ok)
+            case .rejected: ("Dismissed", Sig.faint)
+            case .needsReview: ("Review", Sig.warn)
+            case .draft: ("Proposed", Sig.local)
+            }
+        }()
+        return Text(label).font(.caption2.weight(.bold)).foregroundStyle(color)
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+
+    private var egressBadge: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "lock.fill").font(.caption2)
+            Text("on-device").font(.caption2.weight(.medium))
+        }
+        .foregroundStyle(Sig.ok).padding(.horizontal, 8).padding(.vertical, 4)
+        .background(Sig.ok.opacity(0.1), in: Capsule())
     }
 }

--- a/apple/Sources/Providers/Transcription/Transcription.swift
+++ b/apple/Sources/Providers/Transcription/Transcription.swift
@@ -31,14 +31,20 @@ public enum WhisperModel: String, Sendable, CaseIterable {
 
 /// Cleaning Whisper output into deliverable prose. A WhisperKit segment's raw `text`
 /// carries control tokens — `<|startoftranscript|>`, `<|en|>`, `<|0.00|>` timestamps,
-/// `<|endoftext|>` — which must never reach the coder (HSM-13-04 real-metal run caught
-/// this). Pure + testable so the on-device transcriber can stay a thin adapter.
+/// `<|endoftext|>` (HSM-13-04 real-metal run) — and non-speech markers like
+/// `[BLANK_AUDIO]` / `[MUSIC]` / `[INAUDIBLE]` it emits for silence or music (HSM-8-04
+/// real-metal run, recording a meeting off a speaker). Neither belongs in a transcript.
+/// Pure + testable so the on-device transcriber can stay a thin adapter.
 public enum WhisperText {
-    /// Strip Whisper special tokens (`<|...|>`) and collapse the whitespace they leave.
+    /// Strip Whisper special tokens (`<|...|>`) + all-caps bracketed non-speech markers
+    /// (`[BLANK_AUDIO]`, `[MUSIC]`, …) and collapse the whitespace they leave. A take
+    /// that is entirely non-speech cleans to `""` (the caller then keeps the last good
+    /// transcript instead of saving a blank marker).
     public static func clean(_ raw: String) -> String {
-        let withoutTokens = raw.replacingOccurrences(
-            of: "<\\|[^|]*\\|>", with: " ", options: .regularExpression)
-        let collapsed = withoutTokens
+        let stripped = raw
+            .replacingOccurrences(of: "<\\|[^|]*\\|>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "\\[[A-Z][A-Z0-9 _]*\\]", with: " ", options: .regularExpression)
+        let collapsed = stripped
             .split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" })
             .joined(separator: " ")
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apple/Sources/RuntimeCore/Capture/MeetingCapture.swift
+++ b/apple/Sources/RuntimeCore/Capture/MeetingCapture.swift
@@ -22,6 +22,7 @@ public final class MeetingCapture: @unchecked Sendable {
     private var _state: CaptureState = .idle
     private var startedAt: Date?
     private var meetingID: String?
+    private var lastGoodSegments: [Segment] = []   // last non-empty transcript (blank-pass fallback)
 
     public init(capture: IAudioCapture,
                 store: MeetingStore,
@@ -46,7 +47,7 @@ public final class MeetingCapture: @unchecked Sendable {
 
     /// Begin a recording. Audio accumulates on-device; the live transcript starts empty.
     public func start() {
-        locked { chunks.removeAll(); startedAt = now(); meetingID = makeID(); _state = .recording(liveTranscript: "") }
+        locked { chunks.removeAll(); lastGoodSegments = []; startedAt = now(); meetingID = makeID(); _state = .recording(liveTranscript: "") }
         do {
             try capture.start { [weak self] chunk in
                 guard let self else { return }
@@ -58,14 +59,22 @@ public final class MeetingCapture: @unchecked Sendable {
     }
 
     /// Re-transcribe the audio captured so far and update the live transcript. The view
-    /// drives this on a timer while recording; a no-op outside `.recording`.
+    /// drives this on a timer while recording; a no-op outside `.recording`. The last
+    /// **non-empty** result is remembered, so a later blank pass can't lose the take.
     public func tick() async {
         guard case .recording = state else { return }
         let captured = locked { chunks }
         guard !captured.isEmpty else { return }
         let segments = (try? await makeTranscriber(captured).transcribe()) ?? []
         let text = segments.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-        locked { if case .recording = _state { _state = .recording(liveTranscript: text) } }
+        locked {
+            if !text.isEmpty { lastGoodSegments = segments }
+            if case .recording = _state {
+                // Don't flicker back to empty if this window came back blank.
+                let shown = text.isEmpty ? lastGoodSegments.map(\.text).joined(separator: " ") : text
+                _state = .recording(liveTranscript: shown)
+            }
+        }
     }
 
     /// Stop capture, transcribe the full take, persist the meeting, and return it. Lands
@@ -81,7 +90,12 @@ public final class MeetingCapture: @unchecked Sendable {
         let id = locked { meetingID } ?? makeID()
         let ended = now()
 
-        let segments = (try? await makeTranscriber(captured).transcribe()) ?? []
+        // A single pass over a long buffer can come back blank (WhisperKit emits
+        // [BLANK_AUDIO] for non-speech); when it does, keep the best live transcript
+        // rather than persist nothing (HSM-8-04 real-metal run caught this).
+        let finalSegs = (try? await makeTranscriber(captured).transcribe()) ?? []
+        let finalText = finalSegs.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        let segments = finalText.isEmpty ? locked { lastGoodSegments } : finalSegs
         let meeting = Meeting(
             id: id, startedAt: started, endedAt: ended,
             duration: ended.timeIntervalSince(started),

--- a/apple/Sources/RuntimeCore/MeetingIntelligence/ReviewModel.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/ReviewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Contracts
+import Providers
+
+/// The artifact-review surface at the Runtime-Core layer (HSM-8-04) — the iPad meeting
+/// workflow's last beat. A recorded meeting yields Phase-6 artifacts (decisions / action
+/// items / risks / requirements / …) as **proposals**; this groups them by type in the
+/// active MIR profile's emphasis order, and lets the user **review + approve** on-device.
+///
+/// Approve flips a draft to `.accepted` and persists it — it **never executes** anything
+/// (the charter non-goal: no connector/action runs here; that's a later platform).
+public final class ReviewModel: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _artifacts: [Artifact]
+    private let store: IStorage?
+    private let now: @Sendable () -> Date
+
+    public init(artifacts: [Artifact], store: IStorage? = nil, now: @escaping @Sendable () -> Date = { Date() }) {
+        self._artifacts = artifacts
+        self.store = store
+        self.now = now
+    }
+
+    public var artifacts: [Artifact] { locked { _artifacts } }
+
+    /// Proposals still awaiting a decision (draft / needs-review).
+    public var pendingCount: Int { artifacts.filter { $0.status == .draft || $0.status == .needsReview }.count }
+
+    /// Capture + intelligence are on-device; the badge says so (positioning canon — one
+    /// badge, no privacy prose).
+    public var egressLabel: String { "on-device · nothing leaves" }
+
+    /// Artifacts grouped by type, ordered by the MIR profile's emphasis first, then any
+    /// remaining types. Empty groups are omitted — the review reflects the profile.
+    public func grouped(profile: MIRProfile = .balanced) -> [ArtifactGroup] {
+        let present = Dictionary(grouping: artifacts, by: { $0.artifactType })
+        let emphasis = MIRRouter.baseEmphasis[profile] ?? []
+        var orderedTypes = emphasis.filter { present[$0] != nil }
+        for t in ArtifactType.allCases where present[t] != nil && !orderedTypes.contains(t) {
+            orderedTypes.append(t)
+        }
+        return orderedTypes.map { ArtifactGroup(type: $0, items: present[$0] ?? []) }
+    }
+
+    /// Approve a proposal: `.accepted` + persisted. Review-and-approve only — nothing runs.
+    @discardableResult public func approve(_ id: String) throws -> Bool { try setStatus(id, .accepted) }
+    /// Reject a proposal: `.rejected` + persisted.
+    @discardableResult public func reject(_ id: String) throws -> Bool { try setStatus(id, .rejected) }
+
+    private func setStatus(_ id: String, _ status: ArtifactStatus) throws -> Bool {
+        let updated: Artifact? = locked {
+            guard let i = _artifacts.firstIndex(where: { $0.id == id }) else { return nil }
+            _artifacts[i].status = status
+            _artifacts[i].updatedAt = now()
+            return _artifacts[i]
+        }
+        guard let artifact = updated else { return false }
+        try store?.saveArtifact(artifact)
+        return true
+    }
+
+    private func locked<T>(_ body: () -> T) -> T { lock.lock(); defer { lock.unlock() }; return body() }
+}
+
+/// A type's artifacts in the review surface (one section).
+public struct ArtifactGroup: Sendable, Equatable {
+    public var type: ArtifactType
+    public var items: [Artifact]
+    public init(type: ArtifactType, items: [Artifact]) { self.type = type; self.items = items }
+}

--- a/apple/Tests/ProvidersTests/WhisperTextTests.swift
+++ b/apple/Tests/ProvidersTests/WhisperTextTests.swift
@@ -28,4 +28,11 @@ final class WhisperTextTests: XCTestCase {
         XCTAssertEqual(WhisperText.clean("<|startoftranscript|><|endoftext|>"), "")
         XCTAssertEqual(WhisperText.clean("   "), "")
     }
+
+    func testStripsNonSpeechMarkers() {
+        // HSM-8-04: recording a meeting off a speaker, WhisperKit emits these for silence/music.
+        XCTAssertEqual(WhisperText.clean("[BLANK_AUDIO]"), "")
+        XCTAssertEqual(WhisperText.clean("[MUSIC] ship it [BLANK_AUDIO]"), "ship it")
+        XCTAssertEqual(WhisperText.clean("we decided [INAUDIBLE] to use postgres"), "we decided to use postgres")
+    }
 }

--- a/apple/Tests/RuntimeCoreTests/MeetingCaptureTests.swift
+++ b/apple/Tests/RuntimeCoreTests/MeetingCaptureTests.swift
@@ -111,6 +111,37 @@ final class MeetingCaptureTests: XCTestCase {
         if case .failed = mc.state {} else { XCTFail("expected failed on save error") }
     }
 
+    func testStopFallsBackToLastGoodWhenFinalPassBlanks() async {
+        // The transcriber yields good text on a short buffer but blanks once it's long
+        // (>= 5 chunks) — exactly the on-device [BLANK_AUDIO] symptom. Stop must keep the
+        // last good live transcript, not persist the blank.
+        let date = fixedDate
+        let cap = PushCapture(); let store = MemStore()
+        let mc = MeetingCapture(
+            capture: cap, store: store,
+            makeTranscriber: { CountTranscriber(count: $0.count >= 5 ? 0 : $0.count) },
+            now: { date }, makeID: { "m-1" })
+        mc.start()
+        cap.emit(2); await mc.tick()
+        XCTAssertEqual(mc.state, .recording(liveTranscript: "w0 w1"))
+        cap.emit(4)                              // now 6 chunks → the final pass blanks
+        let meeting = await mc.stop()
+        XCTAssertEqual(meeting?.segments.map(\.text), ["w0", "w1"], "blank final pass keeps the last good transcript")
+    }
+
+    func testLiveTranscriptDoesNotFlickerToBlank() async {
+        let date = fixedDate
+        let cap = PushCapture(); let store = MemStore()
+        let mc = MeetingCapture(
+            capture: cap, store: store,
+            makeTranscriber: { CountTranscriber(count: $0.count >= 5 ? 0 : $0.count) },
+            now: { date }, makeID: { "m-1" })
+        mc.start()
+        cap.emit(2); await mc.tick()             // "w0 w1"
+        cap.emit(4); await mc.tick()             // blank window → keep showing the last good
+        XCTAssertEqual(mc.state, .recording(liveTranscript: "w0 w1"))
+    }
+
     func testTickIsNoOpWhenIdle() async {
         let mc = make(PushCapture(), MemStore())
         await mc.tick()

--- a/apple/Tests/RuntimeCoreTests/ReviewModelTests.swift
+++ b/apple/Tests/RuntimeCoreTests/ReviewModelTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+import Contracts
+@testable import Providers
+@testable import RuntimeCore
+
+/// HSM-8-04 — the artifact-review view-model groups a meeting's proposals by type in the
+/// active MIR profile's emphasis order, and approves/rejects on-device WITHOUT executing
+/// anything (the charter non-goal: review + approve only).
+final class ReviewModelTests: XCTestCase {
+
+    final class FakeStore: IStorage, @unchecked Sendable {
+        var savedArtifacts: [Artifact] = []
+        var failSave = false
+        func saveMeeting(_ m: Meeting) throws {}
+        func loadMeeting(id: String) throws -> Meeting? { nil }
+        func saveArtifact(_ a: Artifact) throws {
+            if failSave { throw NSError(domain: "db", code: 1) }
+            savedArtifacts.append(a)
+        }
+        func loadArtifacts(meetingId: String) throws -> [Artifact] { savedArtifacts.filter { $0.meetingId == meetingId } }
+    }
+
+    private func art(_ id: String, _ type: ArtifactType, status: ArtifactStatus = .draft) -> Artifact {
+        Artifact(id: id, meetingId: "m1", artifactType: type, title: id, bodyMarkdown: "b",
+                 structuredJson: .null, confidence: 0.7, status: status, pluginId: "p", pluginVersion: "v")
+    }
+
+    func testGroupsByType() {
+        let m = ReviewModel(artifacts: [art("a1", .decisions), art("a2", .actionItems), art("a3", .decisions)])
+        let groups = m.grouped(profile: .balanced)
+        let decisions = groups.first { $0.type == .decisions }
+        XCTAssertEqual(decisions?.items.map(\.id), ["a1", "a3"])
+        XCTAssertEqual(groups.first { $0.type == .actionItems }?.items.count, 1)
+    }
+
+    func testProfileEmphasisOrdersTheGroups() {
+        let m = ReviewModel(artifacts: [art("a1", .requirements), art("a2", .adr), art("a3", .actionItems)])
+        // .architect emphasis is [adr, decisions, dependencyMap, requirements] — adr leads,
+        // then requirements; actionItems (off-profile) sorts after the emphasis types.
+        XCTAssertEqual(m.grouped(profile: .architect).map(\.type), [.adr, .requirements, .actionItems])
+    }
+
+    func testApproveFlipsToAcceptedPersistsAndNeverExecutes() throws {
+        let store = FakeStore()
+        let m = ReviewModel(artifacts: [art("a1", .decisions)], store: store)
+        XCTAssertTrue(try m.approve("a1"))
+        XCTAssertEqual(m.artifacts.first?.status, .accepted)
+        XCTAssertEqual(store.savedArtifacts.map { $0.status }, [.accepted], "the approval persisted")
+        // The only side effect is a persist — no execution path exists or was taken.
+        XCTAssertEqual(store.savedArtifacts.count, 1)
+    }
+
+    func testRejectFlipsToRejected() throws {
+        let store = FakeStore()
+        let m = ReviewModel(artifacts: [art("a1", .actionItems)], store: store)
+        XCTAssertTrue(try m.reject("a1"))
+        XCTAssertEqual(m.artifacts.first?.status, .rejected)
+        XCTAssertEqual(store.savedArtifacts.first?.status, .rejected)
+    }
+
+    func testApproveUnknownReturnsFalse() throws {
+        let m = ReviewModel(artifacts: [art("a1", .decisions)])
+        XCTAssertFalse(try m.approve("nope"))
+    }
+
+    func testPendingCountIgnoresDecided() {
+        let m = ReviewModel(artifacts: [
+            art("a1", .decisions, status: .draft),
+            art("a2", .actionItems, status: .needsReview),
+            art("a3", .requirements, status: .accepted),
+        ])
+        XCTAssertEqual(m.pendingCount, 2)
+    }
+
+    func testSaveFailurePropagates() {
+        let store = FakeStore(); store.failSave = true
+        let m = ReviewModel(artifacts: [art("a1", .decisions)], store: store)
+        XCTAssertThrowsError(try m.approve("a1"))
+    }
+
+    func testEgressIsOnDevice() {
+        XCTAssertEqual(ReviewModel(artifacts: []).egressLabel, "on-device · nothing leaves")
+    }
+}

--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -16,8 +16,11 @@ TEAM = ENV.fetch('HS_TEAM', 'M84954HNL6')
 BUNDLE_ID = 'dev.holdspeak.mobile'
 DEPLOY = '17.0'
 
-LAYER_DIRS = %w[Sources/Contracts Sources/Providers Sources/RuntimeCore]
-INTRA_IMPORT = /^import\s+(Contracts|Providers|RuntimeCore)\s*$/
+# Includes InferenceLlama (the llama.cpp adapter) so the meeting can generate Phase-6
+# artifacts ON-DEVICE (Mode A) from its transcript for the HSM-8-04 review. `import LLM`
+# (the external package) is kept; only intra-package imports are stripped.
+LAYER_DIRS = %w[Sources/Contracts Sources/Providers Sources/RuntimeCore Sources/InferenceLlama]
+INTRA_IMPORT = /^import\s+(Contracts|Providers|RuntimeCore|InferenceLlama)\s*$/
 
 FileUtils.rm_rf(STAGE); FileUtils.mkdir_p(STAGE)
 staged = []; seen = {}
@@ -40,18 +43,24 @@ target = project.new_target(:application, 'HoldSpeakMobile', :ios, DEPLOY)
 group = project.new_group('Sources', STAGE)
 staged.each { |p| target.add_file_references([group.new_reference(p)]) }
 
-# --- Swift Package dependency: WhisperKit (on-device transcription) ---
-pkg = project.new(Xcodeproj::Project::Object::XCRemoteSwiftPackageReference)
-pkg.repositoryURL = 'https://github.com/argmaxinc/WhisperKit'
-pkg.requirement = { 'kind' => 'exactVersion', 'version' => '0.11.0' }
-project.root_object.package_references << pkg
-dep = project.new(Xcodeproj::Project::Object::XCSwiftPackageProductDependency)
-dep.package = pkg
-dep.product_name = 'WhisperKit'
-target.package_product_dependencies << dep
-bf = project.new(Xcodeproj::Project::Object::PBXBuildFile)
-bf.product_ref = dep
-target.frameworks_build_phase.files << bf
+# --- Swift Package dependencies: WhisperKit (transcription) + LLM.swift (on-device LLM) ---
+def add_pkg(project, target, url, requirement, product)
+  pkg = project.new(Xcodeproj::Project::Object::XCRemoteSwiftPackageReference)
+  pkg.repositoryURL = url
+  pkg.requirement = requirement
+  project.root_object.package_references << pkg
+  dep = project.new(Xcodeproj::Project::Object::XCSwiftPackageProductDependency)
+  dep.package = pkg
+  dep.product_name = product
+  target.package_product_dependencies << dep
+  bf = project.new(Xcodeproj::Project::Object::PBXBuildFile)
+  bf.product_ref = dep
+  target.frameworks_build_phase.files << bf
+end
+add_pkg(project, target, 'https://github.com/argmaxinc/WhisperKit',
+        { 'kind' => 'exactVersion', 'version' => '0.11.0' }, 'WhisperKit')
+add_pkg(project, target, 'https://github.com/eastriverlee/LLM.swift',
+        { 'kind' => 'upToNextMajorVersion', 'minimumVersion' => '2.1.0' }, 'LLM')
 
 info_plist = File.join(ROOT, 'App/Capture-Info.plist')
 target.build_configurations.each do |config|

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,16 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-21 (**HSM-8-03 DONE — transcript linking (Phase 8 now 3/6).**
+**Last updated:** 2026-06-21 (**HSM-8-04 DONE — artifact review + the TRACK I GATE ACHIEVED
+(Phase 8 now 4/6).** `ReviewModel` (RuntimeCore) groups a meeting's artifacts by type in
+the MIR profile's emphasis + approve/reject (never executes). The meeting app generates
+Phase-6 artifacts **on-device** (the `ArtifactGenerationEngine` over the on-device
+`LlamaProvider`/GGUF) and reviews them with Approve/Dismiss + an on-device egress badge.
+The full **record → transcript → notebook → linked moments → on-device review** workflow
+ran end to end on a physical iPad (owner-witnessed, no network). A real-metal `[BLANK_AUDIO]`
+bug was caught + fixed (`WhisperText.clean` strips non-speech markers; `MeetingCapture.stop`
+keeps the last good live transcript). `swift test` 165/6-skip/0-fail (+11). On-device 4B
+latency is a few minutes per meeting (streamed + trimmed). HSM-8-05 (air-gapped gate) +
+HSM-8-06 (ink-into-intelligence) remain. Earlier: **HSM-8-03 DONE — transcript linking (Phase 8 now 3/6).**
 `TranscriptLinker` (RuntimeCore) anchors a note/mark on a `Segment` start time (stable
 across re-render/sync, not text offsets), resolves to the containing/nearest segment (nil
 when no transcript — graceful), bidirectionally, persisted per meeting via a `LinkStore`
@@ -318,7 +328,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 3/6: HSM-8-01 the on-device meeting-capture loop + HSM-8-02 the PencilKit notebook + HSM-8-03 transcript linking done, run live on the iPad.**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 4/6: HSM-8-01 capture + 8-02 notebook + 8-03 linking + 8-04 on-device artifact review (the Track I workflow gate ACHIEVED on a physical iPad) done; HSM-8-05 (air-gapped gate) + 8-06 (ink-into-intelligence) remain.**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
@@ -1,15 +1,29 @@
 # Phase 8 — iPad Experience
 
-**Status:** in-progress (3/6 — **HSM-8-01 + HSM-8-02 + HSM-8-03 done**: the on-device
-meeting-capture loop + the PencilKit notebook + transcript linking (notes/marks anchored
-on a `Segment` moment, bidirectional, re-render-stable) — host-tested, screenshot-verified,
-run live on a physical iPad). Track I of the Council
+**Status:** in-progress (4/6 — **HSM-8-01..04 done; the Track I workflow gate ACHIEVED**:
+record → live transcript → PencilKit notebook → linked moments → **on-device artifact
+review** runs end to end on a physical iPad (owner-witnessed). The owner's later additions
+HSM-8-05 (air-gapped notetaker gate) + HSM-8-06 (ink-into-intelligence) remain). Track I of the Council
 Implementation Charter. The first Platform Host (Layer 4): the iPad app that
 turns the runtime into the charter's flagship experience — record a meeting, take
 PencilKit notes, link them to the transcript, and review the artifacts, all on an
 iPad Air/Pro M4.
 
-**Last updated:** 2026-06-21 (**HSM-8-03 done — transcript linking.** `TranscriptLinker`
+**Last updated:** 2026-06-21 (**HSM-8-04 done — artifact review + the Track I gate.**
+`ReviewModel` (RuntimeCore) groups a meeting's artifacts by type in the active MIR
+profile's emphasis order + approve/reject (draft→accepted, persisted, **never executes**).
+The meeting detail's INTELLIGENCE section runs the Phase-6 `ArtifactGenerationEngine` over
+the transcript with the **on-device `LlamaProvider`** (Mode A, the GGUF in the app
+container) for the profile's types, streaming each artifact in (one type at a time,
+`maxAttempts: 2`) with Approve/Dismiss + an on-device egress badge. The **Track I gate is
+ACHIEVED on a physical iPad** (owner-witnessed: record→transcript→on-device intelligence→
+review, no network). A real-metal bug was caught + fixed: WhisperKit's final pass over a
+long buffer returned `[BLANK_AUDIO]` — `WhisperText.clean` now strips non-speech markers
+and `MeetingCapture.stop` falls back to the last good live transcript. `swift test`
+165/6-skip/0-fail (+11). On-device latency for a 4B model over a multi-min meeting is a few
+minutes (now streamed + trimmed). See [`evidence-story-04`](./evidence-story-04.md). Phase
+8 is **4/6** — HSM-8-05 (air-gapped gate; the app is already network-free) + HSM-8-06
+(ink-into-intelligence) remain. Earlier: **HSM-8-03 done — transcript linking.** `TranscriptLinker`
 (RuntimeCore) anchors a note/mark on a `Segment` start time (the contract's stable timing,
 not text offsets), resolves to the segment whose window contains it (else nearest, else nil
 when no transcript — graceful), bidirectionally (`links(atSegmentIndex:)`), persisted per
@@ -115,7 +129,7 @@ the Runtime Core, it does not own business logic.
 | HSM-8-01 | iPad shell + meeting capture | done | [story-01](./story-01-ipad-shell-meeting-capture.md) | [evidence](./evidence-story-01.md) |
 | HSM-8-02 | PencilKit notebook | done | [story-02](./story-02-pencilkit-notebook.md) | [evidence](./evidence-story-02.md) |
 | HSM-8-03 | Transcript linking | done | [story-03](./story-03-transcript-linking.md) | [evidence](./evidence-story-03.md) |
-| HSM-8-04 | Artifact review + notebook closeout | backlog | [story-04](./story-04-artifact-review-closeout.md) | — |
+| HSM-8-04 | Artifact review + notebook closeout | done | [story-04](./story-04-artifact-review-closeout.md) | [evidence](./evidence-story-04.md) |
 | HSM-8-05 | The air-gapped notetaker (fully-local, zero-connectivity) | backlog | [story-05](./story-05-air-gapped-notetaker.md) | — |
 | HSM-8-06 | Ink into intelligence (the magic pencil, involved) | backlog | [story-06](./story-06-ink-into-intelligence.md) | — |
 

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/evidence-story-04.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/evidence-story-04.md
@@ -1,0 +1,65 @@
+# Evidence — HSM-8-04 (Artifact review + Track I gate)
+
+**Date:** 2026-06-21 · **Status:** done
+
+The iPad meeting-notebook workflow closes the loop: a recorded meeting yields Phase-6
+artifacts the user reviews on-device, alongside the linked notes. The Track I gate —
+record → live transcript → PencilKit notebook → linked moments → on-device artifact
+review — runs **end to end on a real iPad**, proven by the owner.
+
+## What shipped
+
+- **`ReviewModel` (RuntimeCore):** groups a meeting's artifacts by type in the active
+  **MIR profile's emphasis order**, and `approve`/`reject` flips a proposal's status
+  (`.draft → .accepted/.rejected`) and persists it — **never executing** anything (the
+  charter non-goal: review + approve only). Host-tested over fake artifacts + store.
+- **On-device generation:** the meeting detail's **INTELLIGENCE** section runs the
+  Phase-6 `ArtifactGenerationEngine` over the transcript using the **on-device
+  `LlamaProvider`** (the GGUF in the app container, Mode A) for the MIR profile's types,
+  persists each via the Phase-4 store, and shows them grouped with Approve/Dismiss and the
+  honest **on-device** egress badge. Generation **streams** — one type at a time, each
+  artifact appears as it lands, with progress — and uses `maxAttempts: 2` (bounded repair
+  without the default 3× worst case). `gen-meeting-capture.rb` gained LLM.swift +
+  InferenceLlama.
+- **Bug fixed by the real-metal run:** recording a meeting off a speaker, WhisperKit's
+  single final pass over the long buffer returned `[BLANK_AUDIO]`, which was being saved
+  as the transcript. `WhisperText.clean` now strips `[BLANK_AUDIO]`/`[MUSIC]`/`[INAUDIBLE]`
+  markers, and `MeetingCapture.stop` **falls back to the last good live transcript** when
+  the final pass blanks — so what you saw live is what's saved.
+
+## Tests (ran)
+
+`swift test` → **165 passed / 6 skipped / 0 failed** (+8 `ReviewModelTests`: group-by-type,
+profile-emphasis ordering, approve/reject persist + never-execute, pending count, save
+failure; +2 `MeetingCapture` blank-pass-fallback; +1 `WhisperText` non-speech markers).
+
+## Track I gate — ACHIEVED on real metal (owner-witnessed)
+
+On the physical iPad Air M4, the owner ran the full workflow:
+**record a ~4-minute meeting → live on-device transcript (correct after the blank-audio
+fix) → stop + reopen → Generate on-device → the 4B model produced decisions / action items
+/ risks / requirements → review.** No network at any point.
+
+Honest note on latency: a 4B model generating several artifact types over a multi-minute
+transcript takes a few minutes on-device and uses battery — the on-device reality. The
+streaming UI + trimmed retries make the wait legible rather than a dead spinner; a smaller
+model / a dedicated latency gate is the future optimization (Phase 5/HSM-3-05 territory).
+
+## Acceptance
+
+- **Artifacts render grouped by type, reflecting the active MIR profile** (the profile
+  picker drives `ReviewModel.grouped(profile:)`). ✅
+- **Proposals reviewed + approved on-device; nothing executes autonomously** — approve
+  flips status + persists; no connector/executor exists or runs. ✅
+- **Track I gate: the full record→notebook→link→review workflow on a real iPad** —
+  owner-witnessed end to end. ✅
+- **Egress shown as a badge** (the green "on-device") on the actionable surface, not
+  privacy prose. ✅
+
+## Phase 8 status
+
+This closes the **original Track I gate** (the meeting-notebook workflow, HSM-8-01..04).
+Phase 8 is **4/6**; the owner's later additions — **HSM-8-05** (the air-gapped fully-local
+notetaker as its own airplane-mode gate; note this app is *already* network-free, so it's
+within reach) and **HSM-8-06** (ink-into-intelligence: on-device handwriting recognition,
+marked moments weighting MIR) — remain.

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-04-artifact-review-closeout.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-04-artifact-review-closeout.md
@@ -2,7 +2,10 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 8
-- **Status:** backlog
+- **Status:** done (2026-06-21 — the `ReviewModel` (group by type + MIR profile +
+  approve-without-execute) + on-device artifact generation in the meeting app; the Track I
+  workflow gate (record→notebook→link→review) ACHIEVED on a physical iPad, owner-witnessed.
+  See [evidence-story-04](./evidence-story-04.md))
 - **Depends on:** HSM-8-01, HSM-8-02, HSM-8-03, HSM-6-02, HSM-7-03
 - **Owner:** unassigned
 


### PR DESCRIPTION
## HSM-8-04 — artifact review + the Track I gate 🏁

The iPad meeting-notebook workflow closes the loop: a recorded meeting yields Phase-6
artifacts reviewed **on-device**, alongside the linked notes.

### What ships
- **`ReviewModel` (RuntimeCore):** groups artifacts by type in the active MIR profile's
  emphasis; approve/reject flips status + persists and **never executes** anything.
- **On-device generation:** the meeting detail runs the Phase-6 `ArtifactGenerationEngine`
  over the transcript with the on-device `LlamaProvider` (Mode A / GGUF) for the profile's
  types, **streaming** each artifact in (one type at a time, `maxAttempts: 2`) with
  Approve/Dismiss + an on-device egress badge. `gen-meeting-capture.rb` gained LLM.swift +
  InferenceLlama.
- **Real-metal bug fixed:** WhisperKit's final pass over a long buffer returned
  `[BLANK_AUDIO]` (saved as the transcript). `WhisperText.clean` now strips non-speech
  markers, and `MeetingCapture.stop` falls back to the last good live transcript.

### Track I gate — ACHIEVED on a physical iPad (owner-witnessed)
record ~4-min meeting → live on-device transcript → stop+reopen → **Generate on-device** →
the 4B model produced decisions / action items / risks / requirements → review. **No
network at any point.** (On-device 4B latency is a few minutes/meeting — now streamed +
trimmed.)

### Tests
`swift test` **165 passed / 6 skipped / 0 failed** (+8 ReviewModel, +2 blank-fallback, +1
non-speech).

### Phase 8 → 4/6
HSM-8-05 (air-gapped gate — the app is already network-free) + HSM-8-06 (ink-into-intelligence)
remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)