### PR TITLE
HSM-8-06: ink into intelligence — the magic pencil, involved (Phase 8 5/8)

### DIFF
--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AVFoundation
 import WhisperKit
 import PencilKit
+import Vision
 
 // HSM-8-01 — the iPad's on-device meeting-capture loop. Open the app, see your
 // recordings, press Record, watch the transcript appear, stop to keep it. Capture
@@ -511,12 +512,14 @@ final class MeetingReviewState: ObservableObject {
     @Published var note = ""
 
     private let storage: SQLiteStorage?
+    private let marks: [Double]              // hand-flagged moments (HSM-8-03) — weight extraction
 
     init(meeting: Meeting) {
         self.meeting = meeting
         self.profile = meeting.routingProfile
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         storage = try? SQLiteStorage(path: docs.appendingPathComponent("meetings.sqlite").path)
+        marks = TranscriptLinker(store: FileLinkStore(), meetingID: meeting.id).links().map(\.anchorTime)
         load()
     }
 
@@ -527,36 +530,42 @@ final class MeetingReviewState: ObservableObject {
 
     /// Generate the meeting's artifacts ON-DEVICE (Mode A): the MIR profile picks the
     /// types, the local GGUF model drafts each, and they persist as proposals.
+    /// The on-device model's context budget. 16K tokens ≈ ~12k words ≈ ~80 min of speech
+    /// (vs 8K ≈ ~45 min). The cost is a bigger KV cache (~+1.2 GB) — safe on an 8 GB iPad
+    /// for a single meeting, but HSM-8-08 makes this memory-aware and HSM-8-07 chunks
+    /// anything longer so we NEVER gamble on RAM regardless of meeting length.
+    private static let contextTokens: Int32 = 16384
+
     func generate() async {
-        guard !meeting.segments.isEmpty else { note = "No transcript to analyze."; return }
+        guard !meeting.segments.isEmpty else {
+            note = "No transcript to analyze — this recording saved no text."; return
+        }
         guard let modelPath = Self.localGGUF() else {
-            note = "No on-device model found. Push a .gguf to the app's Documents first."
-            return
+            note = "No on-device model found. Push a .gguf to the app's Documents first."; return
         }
         generating = true; defer { generating = false }
         do {
-            let provider = try LlamaProvider(modelPath: modelPath, maxTokenCount: 8192)
-            // maxAttempts: 2 keeps the bounded repair but halves the worst-case on-device
-            // cost vs the default 3 — each retry is a full completion on a 4B model.
+            let provider = try LlamaProvider(modelPath: modelPath, maxTokenCount: Self.contextTokens)
             let engine = ArtifactGenerationEngine(provider: provider, maxAttempts: 2)
             let transcript = Transcript(meetingId: meeting.id, segments: meeting.segments,
                                         transcriptHash: "ondevice-\(meeting.segments.count)")
-            // The profile's emphasis types, generated ONE AT A TIME so each artifact
-            // streams in as it lands — a multi-minute on-device run should feel alive,
-            // not a dead wait.
-            let types = MIRRouter.baseEmphasis[profile] ?? [.decisions, .actionItems, .requirements]
+            let types = marks.isEmpty
+                ? (MIRRouter.baseEmphasis[profile] ?? [.decisions, .actionItems, .requirements])
+                : InkEmphasis.routedTypes(profile: profile, transcript: transcript, marks: marks)
             var any = false
+            var lastError = ""
             for (i, type) in types.enumerated() {
                 note = "Generating \(artifactTypeLabel(type))…  (\(i + 1)/\(types.count))"
-                if let artifact = try? await engine.generate(type, from: transcript) {
-                    try? storage?.saveArtifact(artifact)
-                    any = true
-                    load()   // publish immediately — the user sees it appear
+                do {
+                    let artifact = try await engine.generate(type, from: transcript)
+                    try? storage?.saveArtifact(artifact); any = true; load()   // stream it in
+                } catch {
+                    lastError = "\(error)"   // surface the real reason rather than fail silent
                 }
             }
-            note = any ? "" : "The model returned nothing usable."
+            note = any ? "" : "The model produced nothing." + (lastError.isEmpty ? "" : " (\(lastError))")
         } catch {
-            note = "Generation failed: \(error)"
+            note = "Couldn't load the on-device model: \(error)"
         }
     }
 
@@ -565,6 +574,96 @@ final class MeetingReviewState: ObservableObject {
     }
     func reject(_ id: String) {
         try? ReviewModel(artifacts: artifacts, store: storage).reject(id); load()
+    }
+
+    var hasInkArtifacts: Bool { artifacts.contains { $0.pluginId == "holdspeak.mobile.ink" } }
+    var hasGeneratedArtifacts: Bool { artifacts.contains { $0.pluginId == "holdspeak.mobile.intelligence" } }
+
+    /// HSM-8-06 — the magic pencil, involved. Render each handwritten page to an actual
+    /// IMAGE attached to the meeting (the literal scribble — arrows, sketches, stars),
+    /// AND recognize the handwriting on-device (Vision) into a text note. Both are
+    /// proposals you review; nothing is auto-committed.
+    func promoteNotes() async {
+        let pages = NotebookModel(store: FileNotebookStore(), meetingID: meeting.id).pages
+        let inked = pages.filter { !$0.strokes.isEmpty }
+        guard !inked.isEmpty else { note = "No handwritten notes on this meeting yet."; return }
+        generating = true; note = "Reading your handwriting on-device…"; defer { generating = false }
+        let dir = Self.inkDir()
+        for (i, drawing) in inked.enumerated() {
+            guard let image = Self.render(drawing) else { continue }
+            // 1) attach the literal ink as an image artifact
+            if let png = image.pngData() {
+                let url = dir.appendingPathComponent("\(meeting.id)-\(i).png")
+                try? png.write(to: url, options: .atomic)
+                let imageArtifact = Artifact(
+                    id: "ink-img-\(meeting.id)-\(i)", meetingId: meeting.id, artifactType: .diagram,
+                    title: "Handwritten note \(i + 1)", bodyMarkdown: "",
+                    structuredJson: .object(["source": .string("ink"), "image_path": .string(url.path)]),
+                    confidence: 1, status: .draft, pluginId: "holdspeak.mobile.ink",
+                    pluginVersion: HoldSpeakContracts.contractVersion,
+                    sources: [ArtifactSource(sourceType: "handwriting", sourceRef: "notebook")])
+                try? storage?.saveArtifact(imageArtifact); load()
+            }
+            // 2) recognize the handwriting → a text note proposal (best-effort; the image
+            //    above is already attached, so OCR never blocks the owner's ask)
+            let text = await Self.recognize(image)
+            if !text.isEmpty {
+                let recognized = InkPromoter.artifact(text: text, type: .actionItems,
+                                                      meetingID: meeting.id, id: "ink-txt-\(meeting.id)-\(i)")
+                try? storage?.saveArtifact(recognized); load()
+            }
+        }
+        note = ""
+    }
+
+    private static func inkDir() -> URL {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let dir = docs.appendingPathComponent("ink-images", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+
+    /// Render a PencilKit page to a light-background image (dark ink reads best for the
+    /// eye and Vision). Defensive: a sprawling canvas's bounds could be huge — clamp the
+    /// pixel budget so the renderer can't OOM (the crash on first try).
+    private static func render(_ drawing: PKDrawing) -> UIImage? {
+        var bounds = drawing.bounds
+        guard bounds.width > 1, bounds.height > 1, bounds.width.isFinite, bounds.height.isFinite else { return nil }
+        bounds = bounds.insetBy(dx: -24, dy: -24)
+        // Fit into ~6 megapixels at most, scaling down a large drawing rather than
+        // allocating a giant bitmap.
+        let budget: CGFloat = 6_000_000
+        let scale = min(2.0, (budget / (bounds.width * bounds.height)).squareRoot())
+        let ink = drawing.image(from: bounds, scale: scale)
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = scale
+        format.opaque = true
+        let renderer = UIGraphicsImageRenderer(size: bounds.size, format: format)
+        return renderer.image { ctx in
+            UIColor(white: 0.97, alpha: 1).setFill()
+            ctx.fill(CGRect(origin: .zero, size: bounds.size))
+            ink.draw(in: CGRect(origin: .zero, size: bounds.size))
+        }
+    }
+
+    /// On-device handwriting recognition (Vision). Runs in a **detached** task so the
+    /// synchronous `perform` (and its results read) never cross the main actor — the
+    /// actor-crossing was the crash. `nonisolated` + a fresh request per call.
+    nonisolated private static func recognize(_ image: UIImage) async -> String {
+        guard let cg = image.cgImage else { return "" }
+        return await Task.detached(priority: .userInitiated) {
+            let request = VNRecognizeTextRequest()
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = true
+            do {
+                try VNImageRequestHandler(cgImage: cg, options: [:]).perform([request])
+                let lines = (request.results)?.compactMap { $0.topCandidates(1).first?.string } ?? []
+                return lines.joined(separator: "\n")
+            } catch {
+                return ""
+            }
+        }.value
     }
 
     static func localGGUF() -> String? {
@@ -674,10 +773,24 @@ struct MeetingDetailView: View {
                     .font(.caption2).foregroundStyle(Sig.faint)
             }
 
-            if review.artifacts.isEmpty {
-                if !review.generating {
-                    Text(review.note.isEmpty ? "Generate decisions, action items, risks and more from this meeting — fully on-device." : review.note)
-                        .font(.caption).foregroundStyle(Sig.faint)
+            // Whatever's been produced so far — generated artifacts and/or handwritten
+            // notes — streams in here.
+            if review.artifacts.isEmpty && !review.generating {
+                Text("Generate decisions, action items, risks and more from this meeting — or add your handwritten notes. All on-device.")
+                    .font(.caption).foregroundStyle(Sig.faint)
+            } else {
+                ForEach(review.groups, id: \.type) { group in
+                    Text(artifactTypeLabel(group.type).uppercased())
+                        .font(.caption2.weight(.bold)).tracking(1).foregroundStyle(Sig.local).padding(.top, 4)
+                    ForEach(group.items, id: \.id) { a in artifactCard(a) }
+                }
+            }
+
+            // The two actions are INDEPENDENT — adding handwritten notes must never block
+            // generating the AI intelligence (and vice-versa). Generate shows until the
+            // model artifacts exist; Add-notes shows until the ink is attached.
+            if !review.generating {
+                if !review.hasGeneratedArtifacts {
                     Button { Task { await review.generate() } } label: {
                         HStack(spacing: 6) { Image(systemName: "sparkles"); Text("Generate on-device") }
                             .font(.subheadline.weight(.semibold)).foregroundStyle(.black)
@@ -685,12 +798,14 @@ struct MeetingDetailView: View {
                             .background(Sig.accent, in: RoundedRectangle(cornerRadius: 12))
                     }
                 }
-            } else {
-                // Artifacts stream in as the model finishes each type.
-                ForEach(review.groups, id: \.type) { group in
-                    Text(artifactTypeLabel(group.type).uppercased())
-                        .font(.caption2.weight(.bold)).tracking(1).foregroundStyle(Sig.local).padding(.top, 4)
-                    ForEach(group.items, id: \.id) { a in artifactCard(a) }
+                if !review.hasInkArtifacts {
+                    Button { Task { await review.promoteNotes() } } label: {
+                        HStack(spacing: 6) { Image(systemName: "hand.draw"); Text("Add your handwritten notes") }
+                            .font(.subheadline.weight(.semibold)).foregroundStyle(Sig.local)
+                            .frame(maxWidth: .infinity).padding(.vertical, 11)
+                            .background(Sig.local.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
+                            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Sig.local.opacity(0.35), lineWidth: 1))
+                    }
                 }
             }
         }
@@ -705,6 +820,11 @@ struct MeetingDetailView: View {
                 Text(a.title).font(.subheadline.weight(.semibold)).foregroundStyle(Sig.text)
                 Spacer()
                 statusChip(a.status)
+            }
+            if let img = inkImage(a) {
+                Image(uiImage: img).resizable().scaledToFit()
+                    .frame(maxHeight: 260).frame(maxWidth: .infinity)
+                    .background(Color.white, in: RoundedRectangle(cornerRadius: 8))
             }
             if !a.bodyMarkdown.isEmpty {
                 Text(a.bodyMarkdown).font(.caption).foregroundStyle(Sig.muted).lineLimit(6)
@@ -726,6 +846,14 @@ struct MeetingDetailView: View {
         }
         .padding(12).background(Sig.s2, in: RoundedRectangle(cornerRadius: 11))
         .overlay(RoundedRectangle(cornerRadius: 11).stroke(Sig.line, lineWidth: 1))
+    }
+
+    /// Load the attached ink image for an ink-image artifact, if any.
+    private func inkImage(_ a: Artifact) -> UIImage? {
+        guard a.pluginId == "holdspeak.mobile.ink",
+              case .object(let o) = a.structuredJson,
+              case .string(let path)? = o["image_path"] else { return nil }
+        return UIImage(contentsOfFile: path)
     }
 
     private func statusChip(_ s: ArtifactStatus) -> some View {

--- a/apple/Sources/RuntimeCore/MeetingIntelligence/InkIntelligence.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/InkIntelligence.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Contracts
+import Providers
+
+/// Ink into intelligence (HSM-8-06) — the magic pencil made a first-class input, not a
+/// parallel scratchpad. Two pure, on-device pieces the app drives:
+///   • `InkPromoter` turns a recognized handwritten note (or a marked moment) into a
+///     schema-valid Phase-0 `Artifact` proposal (propose-and-confirm; the user approves).
+///   • `InkEmphasis` lets the HSM-8-03 marked moments **weight what the model extracts**:
+///     the intents found in hand-flagged segments are boosted, so a user-marked moment
+///     measurably changes the routed artifact chain vs. the same transcript unmarked.
+/// All deterministic + model-free (the air-gapped gate forbids any network path).
+
+public enum InkPromoter {
+    /// Build an `Artifact` proposal from handwritten/recognized text. Status `.draft` —
+    /// the user confirms it in review; nothing is auto-committed (charter non-goal).
+    public static func artifact(
+        text: String, type: ArtifactType, meetingID: String,
+        atSegment: Int? = nil, id: String, now: Date = Date()
+    ) -> Artifact {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = String((trimmed.split(separator: "\n").first.map(String.init) ?? trimmed).prefix(80))
+        var structured: [String: JSONValue] = ["source": .string("handwriting")]
+        if let s = atSegment { structured["segment"] = .number(Double(s)) }
+        return Artifact(
+            id: id, meetingId: meetingID, artifactType: type,
+            title: title.isEmpty ? "Handwritten note" : title,
+            bodyMarkdown: trimmed,
+            structuredJson: .object(structured),
+            confidence: 0.5, status: .draft,
+            pluginId: "holdspeak.mobile.ink", pluginVersion: HoldSpeakContracts.contractVersion,
+            sources: [ArtifactSource(sourceType: "handwriting", sourceRef: "notebook")],
+            createdAt: now, updatedAt: now)
+    }
+}
+
+public enum InkEmphasis {
+    /// Boost the intents found in the segments a user hand-marked (HSM-8-03), so the
+    /// router weights what they flagged. Pure: the same marks always boost the same way.
+    public static func emphasized(
+        _ base: IntentScores, marks: [Double], in transcript: Transcript, boost: Double = 0.2
+    ) -> IntentScores {
+        guard !marks.isEmpty else { return base }
+        var scores = base.scores
+        for mark in marks {
+            guard let i = TranscriptLinker.segmentIndex(for: mark, in: transcript.segments) else { continue }
+            let local = IntentScorer.score(text: transcript.segments[i].text)
+            for (intent, value) in local.scores where value > 0 {
+                scores[intent, default: 0] += boost   // flagged by hand → extra weight
+            }
+        }
+        return IntentScores(scores)
+    }
+
+    /// The routed artifact chain for a profile, with the marked moments weighting it —
+    /// the convenience the app uses so a hand-flagged meeting extracts what was flagged.
+    public static func routedTypes(
+        profile: MIRProfile, transcript: Transcript, marks: [Double],
+        router: MIRRouter = MIRRouter()
+    ) -> [ArtifactType] {
+        let scores = emphasized(IntentScorer.score(transcript), marks: marks, in: transcript)
+        return router.route(profile: profile, scores: scores)
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/InkIntelligenceTests.swift
+++ b/apple/Tests/RuntimeCoreTests/InkIntelligenceTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+import Contracts
+@testable import Providers
+@testable import RuntimeCore
+
+/// HSM-8-06 — the magic pencil made "involved": a handwritten note promotes to a
+/// schema-valid artifact proposal, and a hand-marked moment measurably changes what the
+/// MIR routing extracts. Pure + on-device (no network).
+final class InkIntelligenceTests: XCTestCase {
+
+    private func seg(_ text: String, _ s: Double, _ e: Double) -> Segment {
+        TranscribedSegment(text: text, startTime: s, endTime: e).asContractSegment()
+    }
+
+    // Mostly-product transcript with ONE lightly-incident segment (below threshold whole).
+    private var transcript: Transcript {
+        Transcript(meetingId: "m1", segments: [
+            seg("user user user feature customer feedback roadmap", 0, 2),     // 0 product
+            seg("priority value experience usability persona market", 2, 4),  // 1 product
+            seg("there was an incident outage", 4, 6),                         // 2 incident (light)
+            seg("user requirement adoption feedback user value", 6, 8),        // 3 product
+        ], transcriptHash: "h")
+    }
+
+    // MARK: promote ink → artifact
+
+    func testPromoteProducesASchemaValidDraftArtifact() {
+        let a = InkPromoter.artifact(text: "Follow up with the vendor about pricing",
+                                     type: .actionItems, meetingID: "m1", atSegment: 2, id: "ink-1")
+        XCTAssertEqual(a.status, .draft)            // propose-and-confirm, never auto-committed
+        XCTAssertEqual(a.artifactType, .actionItems)
+        XCTAssertEqual(a.meetingId, "m1")
+        XCTAssertEqual(a.bodyMarkdown, "Follow up with the vendor about pricing")
+        XCTAssertEqual(a.sources.first?.sourceType, "handwriting")
+        // It round-trips through the contract coder (schema-valid).
+        let data = try! HoldSpeakContracts.encoder().encode(a)
+        let back = try! HoldSpeakContracts.decoder().decode(Artifact.self, from: data)
+        XCTAssertEqual(back.id, "ink-1")
+        XCTAssertEqual(back.artifactType, .actionItems)
+        XCTAssertEqual(back.status, .draft)
+        XCTAssertEqual(back.bodyMarkdown, a.bodyMarkdown)
+    }
+
+    func testPromoteTitleIsTheFirstLine() {
+        let a = InkPromoter.artifact(text: "Ship Friday\nand bump the cache TTL",
+                                     type: .decisions, meetingID: "m1", id: "ink-2")
+        XCTAssertEqual(a.title, "Ship Friday")
+    }
+
+    // MARK: marked moments weight extraction
+
+    func testUnmarkedDoesNotSurfaceTheIncidentArtifact() {
+        let types = InkEmphasis.routedTypes(profile: .product, transcript: transcript, marks: [])
+        XCTAssertFalse(types.contains(.incidentTimeline), "below threshold, the light incident mention isn't routed")
+    }
+
+    func testAHandMarkedMomentSurfacesTheIncidentArtifact() {
+        // The owner stars the incident moment (t=5, in segment 2) — it's now weighted.
+        let types = InkEmphasis.routedTypes(profile: .product, transcript: transcript, marks: [5.0])
+        XCTAssertTrue(types.contains(.incidentTimeline),
+                      "a hand-flagged moment measurably changes what is extracted")
+    }
+
+    func testNoMarksLeavesScoresUnchanged() {
+        let base = IntentScorer.score(transcript)
+        XCTAssertEqual(InkEmphasis.emphasized(base, marks: [], in: transcript), base)
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,16 +1,31 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-21 (**HSM-8-04 DONE — artifact review + the TRACK I GATE ACHIEVED
-(Phase 8 now 4/6).** `ReviewModel` (RuntimeCore) groups a meeting's artifacts by type in
-the MIR profile's emphasis + approve/reject (never executes). The meeting app generates
-Phase-6 artifacts **on-device** (the `ArtifactGenerationEngine` over the on-device
-`LlamaProvider`/GGUF) and reviews them with Approve/Dismiss + an on-device egress badge.
-The full **record → transcript → notebook → linked moments → on-device review** workflow
-ran end to end on a physical iPad (owner-witnessed, no network). A real-metal `[BLANK_AUDIO]`
-bug was caught + fixed (`WhisperText.clean` strips non-speech markers; `MeetingCapture.stop`
-keeps the last good live transcript). `swift test` 165/6-skip/0-fail (+11). On-device 4B
-latency is a few minutes per meeting (streamed + trimmed). HSM-8-05 (air-gapped gate) +
-HSM-8-06 (ink-into-intelligence) remain. Earlier: **HSM-8-03 DONE — transcript linking (Phase 8 now 3/6).**
+**Last updated:** 2026-06-21 (**HSM-8-06 DONE — ink into intelligence, the magic pencil
+made involved (Phase 8 now 5/8).** `InkPromoter` (RuntimeCore) promotes recognized
+handwriting to a schema-valid `.draft` `Artifact` (propose-and-confirm); `InkEmphasis`
+boosts the intents in hand-marked segments so a starred moment **measurably changes the
+routed artifact chain** (host-proven). The app's **"Add your handwritten notes"** action
+per inked page (1) attaches the literal ink as an **image artifact** (owner's ask:
+*"attach those notes as an actual image"*) and (2) recognizes the handwriting with
+**on-device Vision**; Generate + Add-notes are **independent**. `swift test`
+170/6-skip/0-fail (+5). **Proven on a real 13-min production meeting** on the iPad
+(owner-witnessed). Two real-metal fixes: a `@MainActor` static Vision call crashed
+off-actor (recognition now `nonisolated`/`Task.detached`); generation now **surfaces the
+real per-type error** instead of failing silent. **Context bumped 8K→16K** (≈ ~80 min of
+speech), and the long-meeting risk is backlogged as **HSM-8-07** (chunked map-reduce
+extraction, length-independent) + **HSM-8-08** (memory-aware OOM-safe budget) — owner:
+*"increase the baseline … but let's chunk it. Let's not risk OOM ever."* Phase 8 is **5/8**
+— HSM-8-05 (air-gapped gate), HSM-8-07, HSM-8-08 remain. Earlier: **HSM-8-04 DONE —
+artifact review + the TRACK I GATE ACHIEVED (Phase 8 now 4/6).** `ReviewModel` (RuntimeCore)
+groups a meeting's artifacts by type in the MIR profile's emphasis + approve/reject (never
+executes). The meeting app generates Phase-6 artifacts **on-device** (the
+`ArtifactGenerationEngine` over the on-device `LlamaProvider`/GGUF) and reviews them with
+Approve/Dismiss + an on-device egress badge. The full **record → transcript → notebook →
+linked moments → on-device review** workflow ran end to end on a physical iPad
+(owner-witnessed, no network). A real-metal `[BLANK_AUDIO]` bug was caught + fixed
+(`WhisperText.clean` strips non-speech markers; `MeetingCapture.stop` keeps the last good
+live transcript). `swift test` 165/6-skip/0-fail (+11). On-device 4B latency is a few
+minutes per meeting (streamed + trimmed). Earlier: **HSM-8-03 DONE — transcript linking (Phase 8 now 3/6).**
 `TranscriptLinker` (RuntimeCore) anchors a note/mark on a `Segment` start time (stable
 across re-render/sync, not text offsets), resolves to the containing/nearest segment (nil
 when no transcript — graceful), bidirectionally, persisted per meeting via a `LinkStore`
@@ -328,7 +343,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 4/6: HSM-8-01 capture + 8-02 notebook + 8-03 linking + 8-04 on-device artifact review (the Track I workflow gate ACHIEVED on a physical iPad) done; HSM-8-05 (air-gapped gate) + 8-06 (ink-into-intelligence) remain.**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 5/8: HSM-8-01 capture + 8-02 notebook + 8-03 linking + 8-04 on-device artifact review (the Track I workflow gate ACHIEVED on a physical iPad) + 8-06 ink-into-intelligence (handwriting → image + on-device Vision text + marked-moment-weighted MIR, proven on a real 13-min meeting) done; HSM-8-05 (air-gapped gate) + 8-07 (chunked long-meeting extraction) + 8-08 (OOM-safe budget) remain.**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
@@ -1,15 +1,36 @@
 # Phase 8 — iPad Experience
 
-**Status:** in-progress (4/6 — **HSM-8-01..04 done; the Track I workflow gate ACHIEVED**:
-record → live transcript → PencilKit notebook → linked moments → **on-device artifact
-review** runs end to end on a physical iPad (owner-witnessed). The owner's later additions
-HSM-8-05 (air-gapped notetaker gate) + HSM-8-06 (ink-into-intelligence) remain). Track I of the Council
-Implementation Charter. The first Platform Host (Layer 4): the iPad app that
-turns the runtime into the charter's flagship experience — record a meeting, take
-PencilKit notes, link them to the transcript, and review the artifacts, all on an
-iPad Air/Pro M4.
+**Status:** in-progress (5/8 — **HSM-8-01..04 + HSM-8-06 done; the Track I workflow gate
+ACHIEVED**: record → live transcript → PencilKit notebook → linked moments → **on-device
+artifact review** + **ink-into-intelligence** run end to end on a physical iPad
+(owner-witnessed). Remaining: HSM-8-05 (air-gapped notetaker gate) + two stories the
+real-metal testing motivated — HSM-8-07 (chunked extraction for long meetings) + HSM-8-08
+(OOM-safe budgeting)). Track I of the Council Implementation Charter. The first Platform
+Host (Layer 4): the iPad app that turns the runtime into the charter's flagship experience
+— record a meeting, take PencilKit notes, link them to the transcript, and review the
+artifacts, all on an iPad Air/Pro M4.
 
-**Last updated:** 2026-06-21 (**HSM-8-04 done — artifact review + the Track I gate.**
+**Last updated:** 2026-06-21 (**HSM-8-06 done — ink into intelligence (the magic pencil,
+involved).** `InkPromoter` (RuntimeCore) turns recognized handwriting into a schema-valid
+`.draft` `Artifact` proposal (propose-and-confirm); `InkEmphasis` boosts the intents in
+hand-marked segments so a starred moment **measurably changes the routed artifact chain**
+(host-proven: a marked light-incident moment surfaces `incidentTimeline` that the unmarked
+transcript does not route). The app's **"Add your handwritten notes"** action, per inked
+notebook page, (1) renders the ink to an **image artifact** attached to the meeting — the
+literal scribble, the owner's explicit ask: *"attach those notes as an actual image"* — and
+(2) recognizes the handwriting with **on-device Vision** into a text proposal; Generate +
+Add-notes are **independent actions** (run AI before or after adding ink). `swift test`
+170/6-skip/0-fail (+5 `InkIntelligenceTests`). **Proven on a real 13-min production meeting**
+on the physical iPad (owner-witnessed; artifacts good). Two real-metal fixes landed: a
+`@MainActor` static Vision call crashed off-actor — recognition is now `nonisolated` /
+`Task.detached`; and on-device generation now **surfaces the real per-type error** instead
+of failing silent. **Context bumped 8K→16K** (`maxTokenCount`, ≈ ~80 min of speech) — and
+the real-metal long-meeting concern is now backlogged as **HSM-8-07** (chunked map-reduce
+extraction, length-independent, never grows the context) + **HSM-8-08** (memory-aware OOM-
+safe budget that decides when to chunk). Owner steer: *"increase the baseline … but at the
+same time, let's protect this product — let's chunk it. Let's not risk OOM ever."* See
+[`evidence-story-06`](./evidence-story-06.md). Phase 8 is **5/8** — HSM-8-05, HSM-8-07,
+HSM-8-08 remain. Earlier: **HSM-8-04 done — artifact review + the Track I gate.**
 `ReviewModel` (RuntimeCore) groups a meeting's artifacts by type in the active MIR
 profile's emphasis order + approve/reject (draft→accepted, persisted, **never executes**).
 The meeting detail's INTELLIGENCE section runs the Phase-6 `ArtifactGenerationEngine` over
@@ -21,9 +42,8 @@ review, no network). A real-metal bug was caught + fixed: WhisperKit's final pas
 long buffer returned `[BLANK_AUDIO]` — `WhisperText.clean` now strips non-speech markers
 and `MeetingCapture.stop` falls back to the last good live transcript. `swift test`
 165/6-skip/0-fail (+11). On-device latency for a 4B model over a multi-min meeting is a few
-minutes (now streamed + trimmed). See [`evidence-story-04`](./evidence-story-04.md). Phase
-8 is **4/6** — HSM-8-05 (air-gapped gate; the app is already network-free) + HSM-8-06
-(ink-into-intelligence) remain. Earlier: **HSM-8-03 done — transcript linking.** `TranscriptLinker`
+minutes (now streamed + trimmed). See [`evidence-story-04`](./evidence-story-04.md).
+Earlier: **HSM-8-03 done — transcript linking.** `TranscriptLinker`
 (RuntimeCore) anchors a note/mark on a `Segment` start time (the contract's stable timing,
 not text offsets), resolves to the segment whose window contains it (else nearest, else nil
 when no transcript — graceful), bidirectionally (`links(atSegmentIndex:)`), persisted per
@@ -117,10 +137,16 @@ the Runtime Core, it does not own business logic.
       endpoint) with Mode-A on-device inference, **rich in functionality** (not a
       degraded fallback — the owner's bar for the gate to count), honest local
       egress, **proven on a physical iPad** with iPhone at parity (HSM-8-05).
-- [ ] **The magic pencil is involved:** handwriting is recognized on-device, a
+- [x] **The magic pencil is involved:** handwriting is recognized on-device, a
       note/marked moment can be promoted to a contract artifact (propose-and-confirm),
       and a marked moment measurably shapes MIR extraction — ink feeds the output,
-      it is not a parallel scratchpad (HSM-8-06).
+      it is not a parallel scratchpad. The literal ink also attaches as an **image
+      artifact** (owner's ask). Proven on a real 13-min production meeting (HSM-8-06).
+- [ ] **Long meetings never gamble on RAM:** generation over an hour-plus meeting runs
+      to completion on-device via **chunked map-reduce extraction** (HSM-8-07), with a
+      **memory-aware budget** that sizes the context to the device and decides when to
+      chunk (HSM-8-08) — so peak memory stays flat with meeting length and the app is
+      never OOM-killed mid-generation. Owner steer: "let's not risk OOM ever."
 
 ## Story status
 
@@ -131,7 +157,9 @@ the Runtime Core, it does not own business logic.
 | HSM-8-03 | Transcript linking | done | [story-03](./story-03-transcript-linking.md) | [evidence](./evidence-story-03.md) |
 | HSM-8-04 | Artifact review + notebook closeout | done | [story-04](./story-04-artifact-review-closeout.md) | [evidence](./evidence-story-04.md) |
 | HSM-8-05 | The air-gapped notetaker (fully-local, zero-connectivity) | backlog | [story-05](./story-05-air-gapped-notetaker.md) | — |
-| HSM-8-06 | Ink into intelligence (the magic pencil, involved) | backlog | [story-06](./story-06-ink-into-intelligence.md) | — |
+| HSM-8-06 | Ink into intelligence (the magic pencil, involved) | done | [story-06](./story-06-ink-into-intelligence.md) | [evidence](./evidence-story-06.md) |
+| HSM-8-07 | Chunked extraction for long meetings (map-reduce, length-safe) | backlog | [story-07](./story-07-chunked-extraction.md) | — |
+| HSM-8-08 | OOM-safe on-device budgeting (never gamble on RAM) | backlog | [story-08](./story-08-oom-safe-budget.md) | — |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/evidence-story-06.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/evidence-story-06.md
@@ -1,0 +1,63 @@
+# Evidence — HSM-8-06 (Ink into intelligence — the magic pencil, involved)
+
+**Date:** 2026-06-21 · **Status:** done
+
+The pencil stops being a parallel scratchpad: the handwritten notes are **attached to the
+meeting as actual images** (the literal ink — arrows, sketches, a starred priority), the
+handwriting is **recognized on-device** into a text proposal, and **hand-marked moments
+weight what the model extracts**. All on-device (the air-gapped gate forbids any network
+handwriting path).
+
+## What shipped
+
+- **`InkPromoter` (RuntimeCore):** turns recognized handwritten text into a schema-valid
+  Phase-0 `Artifact` proposal (`.draft`, sourced `handwriting`) — propose-and-confirm; the
+  user approves it in review, nothing is auto-committed.
+- **`InkEmphasis` (RuntimeCore):** the HSM-8-03 marked moments boost the intents found in
+  the hand-flagged segments, so a starred moment **measurably changes the routed artifact
+  chain** — proven deterministically (a marked light-incident moment surfaces the
+  `incidentTimeline` artifact a `.product` meeting wouldn't otherwise route).
+- **The app (on-device):** an **"Add your handwritten notes"** action in the meeting's
+  INTELLIGENCE surface that, per inked notebook page,
+  (1) renders the ink to an **image artifact** attached to the meeting (the literal
+  scribble, rendered dark-on-light, shown inline in review), and
+  (2) recognizes the handwriting with **on-device Vision** (`VNRecognizeTextRequest`,
+  accurate + language-corrected) into a text proposal via `InkPromoter`.
+  Both appear in review as `.draft` proposals with Approve/Dismiss. Generation now uses
+  `InkEmphasis.routedTypes`, so the marked moments weight what's produced.
+
+## Tests (ran)
+
+`swift test` → **170 passed / 6 skipped / 0 failed** (+5 `InkIntelligenceTests`):
+promote produces a schema-valid `.draft` artifact (round-trips the contract coder);
+title is the first line; **a hand-marked moment surfaces the incident artifact** while the
+unmarked transcript does not; no marks leave the scores unchanged.
+
+## Real-metal
+
+The ink-intelligence app **builds + signs for device** (WhisperKit + on-device LLM + Vision
++ PencilKit) and was installed on the physical iPad Air M4. The "Add your handwritten
+notes" walkthrough — draw a note in a meeting, attach it as an image + recognize it
+on-device, see both in review — runs on the deployed app; the on-device Vision path uses
+no network, keeping HSM-8-05's air-gapped loop intact.
+
+## Acceptance
+
+- **Handwriting recognized to text on-device** (Vision), surfaced as a proposal the user
+  accepts (Approve) or dismisses. ✅
+- **Promote a note/marked moment to an artifact** in the Phase-0 contract types, shown in
+  review, propose-and-confirm. ✅ (`InkPromoter`, host-tested.)
+- **Marked moments influence extraction** via the MIR seam — a marked moment measurably
+  changes what is routed/extracted. ✅ (`InkEmphasis`, host-tested.)
+- **The review shows the pencil's involvement** — the ink image + recognized note appear
+  in the meeting's intelligence, sourced `handwriting`; the marks shape the generated set.
+- **Fully on-device** — Vision recognition + the ink render are local; no network. ✅
+
+## Plus the owner's ask, delivered
+
+> "transcribing my scribbles is fine, but it should also literally attach those notes as
+> an actual image"
+
+The literal ink is now attached as an **image artifact** on the meeting (not just the
+recognized text) — the drawing's fidelity is preserved, with the recognition as an
+additional text layer on top.

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-06-ink-into-intelligence.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-06-ink-into-intelligence.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 8
-- **Status:** backlog
+- **Status:** done
 - **Depends on:** HSM-8-02 (notebook), HSM-8-03 (linking + marked moments), HSM-8-04 (artifact review), HSM-6-02 (artifacts), HSM-7-03 (MIR seam)
 - **Unblocks:** —
 - **Owner:** unassigned

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-07-chunked-extraction.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-07-chunked-extraction.md
@@ -1,0 +1,96 @@
+# HSM-8-07 — Chunked extraction for long meetings (map-reduce, length-safe)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 8
+- **Status:** backlog
+- **Depends on:** HSM-8-04 (on-device artifact review + generation), HSM-5-02 (Mode A on-device inference), HSM-6-02 (artifacts), HSM-8-08 (the memory budget that decides *when* to chunk)
+- **Unblocks:** hour-plus meetings on-device without growing the context window
+- **Owner:** unassigned
+
+## Problem
+
+On-device generation today (HSM-8-04) feeds the **whole transcript** to the model in
+a single context (`maxTokenCount`, raised to 16K in HSM-8-06 ≈ ~80 min of speech).
+That is fine for short meetings and a calculated bump for medium ones, but it does
+not scale: a one-hour meeting is ~10–12K tokens and a two-hour workshop simply will
+not fit any context we can afford on the device, because **context size drives the
+KV-cache, and the KV-cache is RAM** (see HSM-8-08). Growing the window forever is the
+wrong lever — it trades correctness for an OOM. The owner's steer: *"Let's not risk
+OOM ever … let's chunk it."*
+
+This story makes long-meeting extraction **length-independent**: split the transcript
+into windows that each fit a safe budget, extract per window on-device, then merge the
+per-window artifacts into one deduplicated set. Wall-clock and battery scale linearly
+with meeting length; **memory stays flat** regardless of how long the meeting ran.
+
+## Scope
+
+- **In:** a pure, host-testable **map-reduce extraction** over a `Transcript`, fully
+  on-device —
+  (1) **window** the transcript into overlapping segment-aligned chunks sized to a
+  token budget (the budget comes from HSM-8-08), never splitting mid-segment, with a
+  small overlap so a decision spanning a boundary is not lost;
+  (2) **map**: run the existing `ArtifactGenerationEngine` (Mode A `LlamaProvider`)
+  over each window for the routed types, carrying each window's `Segment` time range
+  so artifacts keep their transcript anchors;
+  (3) **reduce**: merge the per-window artifacts into one set — dedup near-identical
+  items (same type + near-identical body), preserve provenance (which window/segment
+  range), and keep them as `.draft` proposals for the HSM-8-04 review;
+  (4) wire it behind the existing **Generate on-device** action so anything longer
+  than the single-context budget routes through chunking automatically — the user
+  sees streamed progress per window, not a dead multi-minute spinner.
+- **Out:** changing the artifact engine (Phase 6) or MIR routing (Phase 7) — chunking
+  *drives* them, it does not rebuild them. A hierarchical summarize-then-extract pass
+  (a second reduce tier) — parked as a follow-up if simple merge proves lossy. Any
+  cloud/off-device path (the air-gapped gate HSM-8-05 forbids it). The memory-budget
+  policy itself (that is HSM-8-08; this story consumes its budget number).
+
+## Acceptance criteria
+
+- [ ] A transcript longer than the single-context budget is **windowed into
+      segment-aligned chunks** (never mid-segment, with overlap), proven by a unit
+      test over a long fixture transcript — windows cover the whole transcript and
+      adjacent windows overlap by the configured amount.
+- [ ] **Map-reduce produces one merged artifact set**: per-window extraction runs the
+      real engine over each window and the results merge into a deduplicated set of
+      `.draft` proposals, each retaining its `Segment`-range provenance — host-tested
+      against a fake/stub provider so it is deterministic and model-free.
+- [ ] **Memory stays flat with length**: the path never holds more than one window's
+      context at a time (the provider is sized to the window budget, not the whole
+      transcript), so a 2-hour transcript uses the same peak context as a 20-minute
+      one. Asserted structurally (the provider's `maxTokenCount` is the budget, and
+      windows are bounded by it), and verified on-device in the device walkthrough.
+- [ ] **Routed through the real action**: a meeting longer than the budget generates
+      via chunking through the existing Generate-on-device button, streaming progress
+      per window; a short meeting still uses the single-context fast path (no
+      regression). Proven on a physical iPad with a real long meeting.
+- [ ] **Fully on-device** — windowing, mapping, and merging are all local; no network,
+      so HSM-8-05's air-gapped loop holds at any meeting length.
+
+## Test plan
+
+- Unit (host, model-free): windowing over a long fixture (e.g. 200 segments) yields
+  budget-bounded, segment-aligned, overlapping windows covering the whole transcript;
+  map-reduce over a **stub provider** that returns one artifact per window merges +
+  dedups into the expected set with correct `Segment`-range provenance; the short-path
+  vs chunked-path selection picks chunking exactly when the transcript exceeds the
+  budget.
+- Device: record (or import) a real **hour-plus** meeting on the iPad, Generate
+  on-device, and watch it extract per window without OOM, producing a coherent merged
+  artifact set in review — folded into the HSM-8-05 air-gapped walkthrough where
+  practical.
+
+## Notes / open questions
+
+- Overlap size is a tuning knob: enough that a decision straddling a boundary is
+  captured in at least one window, small enough not to double the work. Default to a
+  modest segment overlap; expose it as a constant, not magic.
+- Merge/dedup is deliberately simple in v1 (same type + near-identical body). If the
+  owner finds duplicates or cross-window contradictions, a hierarchical reduce
+  (summarize each window, then extract over the summaries) is the next tier — parked
+  here intentionally, not built speculatively.
+- This is the desktop's long-meeting story in on-device form. Keep the windowing a
+  contract-level operation over `Segment`s so it can ride sync (Phase 10) and stay
+  compatible with the desktop's handling.
+- Sequencing: HSM-8-08 lands the **budget** (how many tokens is safe on this device);
+  this story consumes it. They can ship together, but the budget is the dependency.

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-08-oom-safe-budget.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-08-oom-safe-budget.md
@@ -1,0 +1,87 @@
+# HSM-8-08 — OOM-safe on-device budgeting (never gamble on RAM)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 8
+- **Status:** backlog
+- **Depends on:** HSM-8-04 (on-device generation), HSM-5-02 (Mode A / `LlamaProvider`)
+- **Unblocks:** HSM-8-07 (chunking consumes the budget this story computes)
+- **Owner:** unassigned
+
+## Problem
+
+On-device generation sizes the model's context with a **hard-coded** `maxTokenCount`
+(8K originally, raised to 16K in HSM-8-06). That number is a bet on the device's
+memory: the context window drives the **KV-cache**, and the KV-cache is RAM on top of
+the ~3.2 GB model. 16K is a safe-ish bump on an 8 GB iPad Air M4 for a single meeting
+— but it is still a constant we picked by hand, not a number the device vouches for.
+On a smaller device, with the increased-memory entitlement absent, or with WhisperKit
+also resident, a fixed 16K could push past the jetsam limit and **OOM-kill the app
+mid-generation** — the exact failure the owner said we must never risk: *"Let's not
+risk OOM ever."*
+
+This story replaces the hand-picked constant with a **memory-aware budget**: pick the
+largest context the *current device* can safely afford, and hand that number to
+HSM-8-07 so chunking kicks in whenever a transcript would exceed it. The product stops
+gambling on RAM at any meeting length.
+
+## Scope
+
+- **In:** a small, host-testable **budgeting policy** that, from the device's
+  available memory, the model's on-disk size, and a safety margin, computes
+  (1) the **safe context budget** (`maxTokenCount`) to open the provider with, and
+  (2) the **chunk-or-not threshold** HSM-8-07 reads — so the single-context fast path
+  is used only when the whole transcript fits the budget, and chunking is used
+  otherwise; (3) wire `generate()` to size `LlamaProvider` from the policy instead of
+  the hard-coded `contextTokens`, clamped to a sane floor/ceiling; (4) surface a
+  one-line honest note when a meeting is large enough to route through chunking ("long
+  meeting — extracting in N passes"), so the behavior is legible, not silent.
+- **Out:** the chunking mechanism itself (HSM-8-07 — this story only computes *when*
+  to chunk and *how big* each context may be). Quantizing the KV-cache or swapping the
+  model (Phase 5 territory). The increased-memory entitlement portal work (tracked
+  with device deploy). Per-token-exact KV-cache math — a calibrated estimate with a
+  conservative margin is the bar, not a perfect model.
+
+## Acceptance criteria
+
+- [ ] A **memory-aware budget** function, pure and host-tested: given (available RAM,
+      model size, margin) it returns a context-token budget that leaves a conservative
+      headroom over the model + a KV-cache estimate, clamped to a floor (usable) and a
+      ceiling (the model's max). Tested across representative inputs (8 GB vs more RAM;
+      model present/large) — smaller RAM yields a smaller budget; it never returns a
+      budget whose estimated footprint exceeds available RAM minus the margin.
+- [ ] **`generate()` opens the provider at the computed budget**, not a hard-coded
+      constant — the 16K from HSM-8-06 becomes the *ceiling/default*, lowered when the
+      device can't afford it. Structurally asserted (the provider's `maxTokenCount`
+      comes from the policy).
+- [ ] **The threshold drives chunking**: HSM-8-07 routes to map-reduce exactly when
+      the transcript's token estimate exceeds the budget, and uses the single-context
+      path otherwise — proven by a unit test pairing the budget with a short and a long
+      transcript.
+- [ ] **No OOM on device**: on the physical iPad, generation over a long meeting runs
+      to completion (via chunking) without a jetsam kill, and a short meeting still
+      uses the fast single pass. Owner-witnessed.
+- [ ] **Legible, not silent**: when a meeting is large enough to chunk, the
+      INTELLIGENCE surface says so in one honest line (no privacy/■ novel — a status,
+      per the egress-badge canon).
+
+## Test plan
+
+- Unit (host): the budget function across inputs (low/high RAM, model size, margin) —
+  monotonic in RAM, clamped to floor/ceiling, never exceeds RAM−margin; the
+  chunk-threshold decision (short → single pass, long → chunk) given a fixed budget.
+- Device: confirm the chosen budget on the real iPad (log/inspect the opened context),
+  then run a long meeting end to end with no OOM — folded into the HSM-8-07 / HSM-8-05
+  device walkthroughs.
+
+## Notes / open questions
+
+- The KV-cache estimate need not be exact — a calibrated linear estimate (per-token
+  bytes × context) with a generous safety margin is enough to stay clear of the
+  jetsam limit. Bias conservative: under-fill rather than OOM.
+- Honors the increased-memory entitlement when present (raises the ceiling) but never
+  *requires* it — without the entitlement the budget simply lands lower and chunking
+  carries the rest. That is the whole point: correctness is independent of the
+  entitlement.
+- This is the guardrail that lets HSM-8-06's 16K bump be aggressive *safely*: 16K is
+  the ceiling we'd like, the policy lowers it when the device can't pay, and HSM-8-07
+  makes any shortfall invisible to the result.


### PR DESCRIPTION
Closes **HSM-8-06** — the magic pencil stops being a parallel scratchpad. Fully on-device:

- **`InkPromoter`** promotes recognized handwriting to a schema-valid `.draft` `Artifact` proposal (propose-and-confirm).
- **`InkEmphasis`** boosts the intents in hand-marked segments, so a starred moment **measurably changes the routed artifact chain** (host-proven: a marked light-incident moment surfaces `incidentTimeline` the unmarked transcript does not route).
- The app's **"Add your handwritten notes"** action per inked page (1) attaches the literal ink as an **image artifact** on the meeting (the owner's ask: *"attach those notes as an actual image"*) and (2) recognizes the handwriting with **on-device Vision**. Generate-on-device + Add-notes are **independent**.

**Proven on a real 13-minute production meeting** on the physical iPad Air M4 (owner-witnessed; artifacts good). Two real-metal fixes the run exposed:
- A `@MainActor` static Vision call crashed off-actor → recognition is now `nonisolated` / `Task.detached`.
- On-device generation now **surfaces the real per-type error** instead of failing silent.

**Context bumped 8K→16K** (~80 min of speech). The long-meeting risk is backlogged, not gambled on — two new Phase-8 stories the real-metal run motivated:
- **HSM-8-07** — chunked map-reduce extraction (length-independent, peak memory flat).
- **HSM-8-08** — memory-aware OOM-safe budget that decides when to chunk.

Owner steer: *"increase the baseline … but let's chunk it. Let's not risk OOM ever."*

`swift test` → **170 passed / 6 skipped / 0 failures** (+5 `InkIntelligenceTests`). App builds + launches on the iPad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)