### PR TITLE
HSM-8-07 + HSM-8-08: chunked extraction + OOM-safe budget (host-complete)

### DIFF
--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -3,6 +3,7 @@ import AVFoundation
 import WhisperKit
 import PencilKit
 import Vision
+import os
 
 // HSM-8-01 — the iPad's on-device meeting-capture loop. Open the app, see your
 // recordings, press Record, watch the transcript appear, stop to keep it. Capture
@@ -530,11 +531,17 @@ final class MeetingReviewState: ObservableObject {
 
     /// Generate the meeting's artifacts ON-DEVICE (Mode A): the MIR profile picks the
     /// types, the local GGUF model drafts each, and they persist as proposals.
-    /// The on-device model's context budget. 16K tokens ≈ ~12k words ≈ ~80 min of speech
-    /// (vs 8K ≈ ~45 min). The cost is a bigger KV cache (~+1.2 GB) — safe on an 8 GB iPad
-    /// for a single meeting, but HSM-8-08 makes this memory-aware and HSM-8-07 chunks
-    /// anything longer so we NEVER gamble on RAM regardless of meeting length.
-    private static let contextTokens: Int32 = 16384
+    /// The on-device context CEILING — what we'd *like* (16K ≈ ~80 min of speech).
+    /// HSM-8-08 lowers it to what THIS device can actually afford (the KV-cache is RAM),
+    /// and HSM-8-07 chunks anything that still won't fit — so we never gamble on memory
+    /// regardless of meeting length.
+    private static let contextCeiling = 16_384
+
+    /// Memory headroom before the iOS jetsam limit, with a conservative fallback.
+    private static func availableMemoryBytes() -> Int {
+        let avail = Int(os_proc_available_memory())
+        return avail > 0 ? avail : Int(ProcessInfo.processInfo.physicalMemory / 2)
+    }
 
     func generate() async {
         guard !meeting.segments.isEmpty else {
@@ -544,14 +551,37 @@ final class MeetingReviewState: ObservableObject {
             note = "No on-device model found. Push a .gguf to the app's Documents first."; return
         }
         generating = true; defer { generating = false }
+
+        // HSM-8-08 — size the context to THIS device, never a blind constant.
+        let modelBytes = ((try? FileManager.default.attributesOfItem(atPath: modelPath))?[.size] as? Int) ?? 0
+        let context = OnDeviceBudget.contextTokens(
+            availableBytes: Self.availableMemoryBytes(), modelBytes: modelBytes,
+            marginBytes: 768 * 1_048_576,            // app + WhisperKit + activations
+            ceiling: Self.contextCeiling)
+        let windowBudget = OnDeviceBudget.windowTokens(context: context)
+
         do {
-            let provider = try LlamaProvider(modelPath: modelPath, maxTokenCount: Self.contextTokens)
+            let provider = try LlamaProvider(modelPath: modelPath, maxTokenCount: Int32(context))
             let engine = ArtifactGenerationEngine(provider: provider, maxAttempts: 2)
             let transcript = Transcript(meetingId: meeting.id, segments: meeting.segments,
                                         transcriptHash: "ondevice-\(meeting.segments.count)")
             let types = marks.isEmpty
                 ? (MIRRouter.baseEmphasis[profile] ?? [.decisions, .actionItems, .requirements])
                 : InkEmphasis.routedTypes(profile: profile, transcript: transcript, marks: marks)
+
+            // HSM-8-07 — a long meeting extracts in length-independent windows so peak
+            // memory stays flat; a short one keeps the single fast streaming pass.
+            let extractor = ChunkedExtractor(engine: engine, windowTokens: windowBudget)
+            if extractor.shouldChunk(transcript) {
+                let passes = TranscriptWindowing.windows(transcript.segments, maxTokens: windowBudget).count
+                note = "Long meeting — extracting in \(passes) pass\(passes == 1 ? "" : "es")…"
+                let artifacts = await extractor.generate(types: types, from: transcript)
+                for a in artifacts { try? storage?.saveArtifact(a) }
+                load()
+                note = artifacts.isEmpty ? "The model produced nothing." : ""
+                return
+            }
+
             var any = false
             var lastError = ""
             for (i, type) in types.enumerated() {

--- a/apple/Sources/RuntimeCore/MeetingIntelligence/ChunkedExtraction.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/ChunkedExtraction.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Contracts
+import Providers
+
+/// HSM-8-07 — chunked map-reduce extraction for long meetings. Windows a transcript
+/// into budget-bounded, segment-aligned, overlapping chunks (so a decision spanning a
+/// boundary is captured), extracts per window over the existing engine, then merges the
+/// per-window artifacts into one deduplicated set. Peak context stays FLAT with meeting
+/// length — a 2-hour transcript uses the same per-pass context as a 20-minute one — so
+/// we never grow the window to fit and never gamble on RAM (HSM-8-08 sizes the budget).
+/// All on-device (the air-gapped gate forbids any network path).
+
+public enum TranscriptWindowing {
+    /// Segment-aligned windows, each ≤ `maxTokens` of transcript text, with `overlap`
+    /// segments shared between neighbours. Never splits a segment. A single segment that
+    /// already exceeds `maxTokens` is kept whole in its own window rather than dropped —
+    /// correctness over the budget for the pathological case (the budget has slack for it).
+    public static func windows(
+        _ segments: [Segment], maxTokens: Int, overlap: Int = 1,
+        estimate: (String) -> Int = OnDeviceBudget.estimateTokens
+    ) -> [[Segment]] {
+        guard !segments.isEmpty else { return [] }
+        let safeOverlap = max(0, overlap)
+        var windows: [[Segment]] = []
+        var start = 0
+        while start < segments.count {
+            var window: [Segment] = []
+            var tokens = 0
+            var end = start
+            while end < segments.count {
+                let t = estimate(segments[end].text)
+                if !window.isEmpty && tokens + t > maxTokens { break }   // full — but never empty
+                window.append(segments[end]); tokens += t; end += 1
+            }
+            windows.append(window)
+            if end >= segments.count { break }
+            start = max(start + 1, end - safeOverlap)                    // share `overlap`; always progress
+        }
+        return windows
+    }
+}
+
+public enum ArtifactMerge {
+    /// Merge per-window artifacts into one set: keep one per (type + normalized body),
+    /// preferring the higher-confidence copy. Order-stable by first appearance — so a
+    /// decision found in three overlapping windows surfaces once, not three times.
+    public static func dedup(_ artifacts: [Artifact]) -> [Artifact] {
+        var indexByKey: [String: Int] = [:]
+        var out: [Artifact] = []
+        for a in artifacts {
+            let body = a.bodyMarkdown.isEmpty ? a.title : a.bodyMarkdown
+            let key = "\(a.artifactType.rawValue)\u{1}\(normalize(body))"
+            if let idx = indexByKey[key] {
+                if a.confidence > out[idx].confidence { out[idx] = a }   // keep the stronger draft
+            } else {
+                indexByKey[key] = out.count
+                out.append(a)
+            }
+        }
+        return out
+    }
+
+    /// Whitespace/punctuation/case-insensitive normalization so trivially-different
+    /// restatements of the same item collapse.
+    static func normalize(_ s: String) -> String {
+        s.lowercased()
+            .split(whereSeparator: { $0.isWhitespace || $0.isPunctuation })
+            .joined(separator: " ")
+    }
+}
+
+/// Drives the engine over windows and merges. The caller opens the provider ONCE at the
+/// windowed budget (HSM-8-08), so peak context is one window's worth regardless of how
+/// long the meeting ran — the OOM guard made structural.
+public struct ChunkedExtractor: Sendable {
+    let engine: ArtifactGenerationEngine
+    let windowTokens: Int
+    let overlap: Int
+
+    public init(engine: ArtifactGenerationEngine, windowTokens: Int, overlap: Int = 1) {
+        self.engine = engine
+        self.windowTokens = windowTokens
+        self.overlap = overlap
+    }
+
+    /// Whether `transcript` needs windowing (else the caller uses the single fast pass).
+    public func shouldChunk(_ transcript: Transcript) -> Bool {
+        OnDeviceBudget.needsChunking(
+            transcriptTokens: OnDeviceBudget.transcriptTokens(transcript.segments),
+            windowTokens: windowTokens)
+    }
+
+    /// Map-reduce: extract `types` over each window, merge into one deduped set. Each
+    /// window's artifacts keep a `#w<i>` provenance suffix on the transcript hash so the
+    /// source window is traceable. `onProgress(windowIndex, windowCount)` lets the host
+    /// stream the passes rather than show a dead spinner.
+    public func generate(
+        types: [ArtifactType], from transcript: Transcript,
+        onProgress: ((Int, Int) -> Void)? = nil
+    ) async -> [Artifact] {
+        let windows = TranscriptWindowing.windows(
+            transcript.segments, maxTokens: windowTokens, overlap: overlap)
+        guard !windows.isEmpty else { return [] }
+        var all: [Artifact] = []
+        for (idx, window) in windows.enumerated() {
+            onProgress?(idx, windows.count)
+            let sub = Transcript(meetingId: transcript.meetingId, segments: window,
+                                 transcriptHash: "\(transcript.transcriptHash)#w\(idx)")
+            for outcome in await engine.generate(types: types, from: sub) {
+                if case .success(let a) = outcome.result { all.append(a) }   // failures drop, others survive
+            }
+        }
+        return ArtifactMerge.dedup(all)
+    }
+}

--- a/apple/Sources/RuntimeCore/MeetingIntelligence/OnDeviceBudget.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/OnDeviceBudget.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Contracts
+
+/// HSM-8-08 — OOM-safe on-device budgeting. The model's context window drives the
+/// KV-cache, and the KV-cache is RAM on top of the resident weights. A hard-coded
+/// context (the 16K from HSM-8-06) is a bet on the device; this makes it a number the
+/// device vouches for: the largest context that leaves a conservative headroom over
+/// the model + an estimated KV-cache, clamped to a usable floor and the model's
+/// ceiling. Pure + deterministic — the host reads `contextTokens` to size the provider
+/// and `needsChunking` to decide whether HSM-8-07's map-reduce kicks in. The increased-
+/// memory entitlement is never *assumed*: without it the budget simply lands lower and
+/// chunking carries the rest, so correctness is independent of the entitlement.
+public enum OnDeviceBudget {
+
+    /// Conservative KV-cache cost per context token (bytes) for a 4B-class GGUF.
+    /// Qwen3-4B (GQA, fp16 KV) is ≈ 144 KB/token; we round UP so the estimate biases
+    /// toward under-filling rather than an OOM — the entire point of this story.
+    public static let kvBytesPerToken = 160_000
+
+    /// The largest safe context (in tokens) for this device.
+    /// - availableBytes: memory headroom the app may still draw on (e.g. iOS
+    ///   `os_proc_available_memory()` — the bytes left before the jetsam limit), *before*
+    ///   the model is resident.
+    /// - modelBytes: the GGUF's on-disk size — a proxy for the weights about to load.
+    /// - marginBytes: headroom to leave for activations, WhisperKit, the app, the OS.
+    ///
+    /// Clamped to `[floor, ceiling]`. For any device that can clear the floor's KV cost
+    /// the result never exceeds `(availableBytes − modelBytes − marginBytes)` worth of
+    /// tokens — it under-fills, it does not gamble.
+    public static func contextTokens(
+        availableBytes: Int, modelBytes: Int, marginBytes: Int,
+        floor: Int = 4_096, ceiling: Int = 16_384
+    ) -> Int {
+        let forKV = availableBytes - modelBytes - marginBytes
+        let affordable = max(0, forKV) / kvBytesPerToken
+        return min(ceiling, max(floor, affordable))
+    }
+
+    /// How many of the context's tokens may hold transcript text in a *single* pass —
+    /// the rest is reserved for the prompt scaffolding + the model's own output. A
+    /// transcript longer than this must be chunked (HSM-8-07).
+    public static func windowTokens(
+        context: Int, promptOverhead: Int = 512, outputReserve: Int = 1_024
+    ) -> Int {
+        max(256, context - promptOverhead - outputReserve)
+    }
+
+    /// A rough token estimate for transcript text (≈ 4 chars/token, English-ish).
+    /// Deliberately simple + deterministic; the safety margin absorbs the slop.
+    public static func estimateTokens(_ text: String) -> Int { max(1, text.count / 4) }
+
+    /// Total estimated transcript tokens across segments.
+    public static func transcriptTokens(_ segments: [Segment]) -> Int {
+        segments.reduce(0) { $0 + estimateTokens($1.text) }
+    }
+
+    /// Does this transcript need chunking under the chosen window budget? True when
+    /// its text won't fit one window's worth of context, so HSM-8-07 windows it.
+    public static func needsChunking(transcriptTokens: Int, windowTokens: Int) -> Bool {
+        transcriptTokens > windowTokens
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/ChunkedExtractionTests.swift
+++ b/apple/Tests/RuntimeCoreTests/ChunkedExtractionTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import Contracts
+import Providers
+@testable import RuntimeCore
+
+/// HSM-8-07 + HSM-8-08 — long meetings never gamble on RAM. A memory-aware budget
+/// (8-08) sizes the context to the device and decides when to chunk; chunked map-reduce
+/// extraction (8-07) windows the transcript, extracts per window, and merges the results
+/// so peak memory stays flat regardless of meeting length. Pure + deterministic.
+final class ChunkedExtractionTests: XCTestCase {
+
+    private let GiB = 1_073_741_824
+
+    // MARK: OnDeviceBudget (HSM-8-08)
+
+    func testBudgetReturnsCeilingWhenRAMIsAmple() {
+        // ~8 GB headroom, 3.2 GB model, 2 GB margin → KV room ≈ 2.8 GB ≈ 18k tokens → ceiling.
+        let t = OnDeviceBudget.contextTokens(
+            availableBytes: 8 * GiB, modelBytes: 3_435_973_837, marginBytes: 2 * GiB)
+        XCTAssertEqual(t, 16_384)
+    }
+
+    func testBudgetShrinksOnConstrainedDeviceAndNeverExceedsRAM() {
+        let available = 5 * GiB
+        let model = 3_435_973_837
+        let margin = 768 * 1_048_576
+        let t = OnDeviceBudget.contextTokens(availableBytes: available, modelBytes: model, marginBytes: margin)
+        XCTAssertLessThan(t, 16_384)                 // can't afford the full ceiling
+        XCTAssertGreaterThanOrEqual(t, 4_096)        // but still usable (floor)
+        // The chosen context's estimated KV footprint never exceeds the affordable headroom.
+        XCTAssertLessThanOrEqual(t * OnDeviceBudget.kvBytesPerToken, available - model - margin)
+    }
+
+    func testBudgetIsMonotonicInRAM() {
+        let a = OnDeviceBudget.contextTokens(availableBytes: 5_000_000_000, modelBytes: 3_400_000_000, marginBytes: 500_000_000)
+        let b = OnDeviceBudget.contextTokens(availableBytes: 6_000_000_000, modelBytes: 3_400_000_000, marginBytes: 500_000_000)
+        XCTAssertLessThanOrEqual(a, b)
+    }
+
+    func testWindowReservesPromptAndOutput() {
+        XCTAssertEqual(OnDeviceBudget.windowTokens(context: 16_384), 16_384 - 512 - 1_024)
+    }
+
+    func testNeedsChunkingThreshold() {
+        XCTAssertFalse(OnDeviceBudget.needsChunking(transcriptTokens: 1_000, windowTokens: 2_000))
+        XCTAssertTrue(OnDeviceBudget.needsChunking(transcriptTokens: 5_000, windowTokens: 2_000))
+    }
+
+    // MARK: windowing (HSM-8-07)
+
+    private func seg(_ text: String, _ s: Double) -> Segment {
+        Segment(text: text, speaker: "S", startTime: s, endTime: s + 1)
+    }
+
+    func testWindowsCoverAllSegmentsAndOverlap() {
+        let segs = (0..<6).map { seg(String(repeating: "x", count: 12), Double($0)) }  // ~3 tokens each
+        let windows = TranscriptWindowing.windows(segs, maxTokens: 6, overlap: 1)
+        XCTAssertGreaterThan(windows.count, 1)
+        // Every original segment appears in at least one window (coverage by start time).
+        let covered = Set(windows.flatMap { $0 }.map { $0.startTime })
+        XCTAssertEqual(covered, Set(segs.map { $0.startTime }))
+        // Adjacent windows share the overlap segment.
+        XCTAssertEqual(windows[0].last?.startTime, windows[1].first?.startTime)
+    }
+
+    func testOversizedSegmentIsKeptWholeNotDropped() {
+        let big = seg(String(repeating: "y", count: 400), 0)   // ~100 tokens alone
+        let small = seg(String(repeating: "z", count: 12), 1)  // ~3
+        let windows = TranscriptWindowing.windows([big, small], maxTokens: 10, overlap: 0)
+        XCTAssertTrue(windows.contains { $0.count == 1 && $0[0].startTime == 0 })
+        XCTAssertEqual(Set(windows.flatMap { $0 }.map { $0.startTime }), [0, 1])
+    }
+
+    func testEmptyTranscriptYieldsNoWindows() {
+        XCTAssertTrue(TranscriptWindowing.windows([], maxTokens: 10).isEmpty)
+    }
+
+    // MARK: merge (HSM-8-07)
+
+    private func art(_ type: ArtifactType, _ body: String, _ conf: Double, id: String) -> Artifact {
+        Artifact(id: id, meetingId: "m", artifactType: type, title: "t", bodyMarkdown: body,
+                 structuredJson: .object([:]), confidence: conf, status: .draft,
+                 pluginId: "p", pluginVersion: "0.1.0",
+                 sources: [ArtifactSource(sourceType: "transcript", sourceRef: "h")])
+    }
+
+    func testDedupCollapsesCrossWindowDuplicatesKeepingHigherConfidence() {
+        let merged = ArtifactMerge.dedup([
+            art(.decisions, "Ship on Friday.", 0.4, id: "a"),
+            art(.decisions, "ship on friday", 0.8, id: "b"),   // same item; punctuation/case differ
+            art(.actionItems, "Email the vendor", 0.5, id: "c"),
+        ])
+        XCTAssertEqual(merged.count, 2)                        // the two decisions collapsed
+        XCTAssertEqual(merged.first { $0.artifactType == .decisions }?.confidence, 0.8)  // stronger draft kept
+    }
+
+    func testDedupKeepsDifferentTypesSeparate() {
+        let merged = ArtifactMerge.dedup([
+            art(.decisions, "same body", 0.5, id: "a"),
+            art(.actionItems, "same body", 0.5, id: "b"),
+        ])
+        XCTAssertEqual(merged.count, 2)
+    }
+
+    // MARK: ChunkedExtractor integration (HSM-8-07)
+
+    /// A fake provider returning a constant valid draft — every window/type yields the
+    /// same body, so we can prove cross-window collapse: N windows × M types → M artifacts.
+    final class ConstantLLM: ILLMProvider, @unchecked Sendable {
+        func complete(prompt: String) async throws -> String {
+            #"{"title":"x","body_markdown":"constant body","confidence":0.5}"#
+        }
+    }
+
+    func testChunkedExtractionWindowsThenMergesAcrossWindows() async {
+        let segs = (0..<8).map { seg(String(repeating: "w", count: 20), Double($0)) }  // ~5 tokens each
+        let transcript = Transcript(meetingId: "m", segments: segs, transcriptHash: "h")
+        let engine = ArtifactGenerationEngine(provider: ConstantLLM())
+        let extractor = ChunkedExtractor(engine: engine, windowTokens: 10, overlap: 1)
+
+        XCTAssertTrue(extractor.shouldChunk(transcript))      // 8×5 = 40 tokens > 10
+        var passes = 0
+        let artifacts = await extractor.generate(
+            types: [.decisions, .actionItems], from: transcript,
+            onProgress: { _, total in passes = total })
+        XCTAssertGreaterThan(passes, 1)                       // ran multiple windows
+        XCTAssertEqual(artifacts.count, 2)                    // constant body ⇒ one per type
+        XCTAssertEqual(Set(artifacts.map { $0.artifactType }), [.decisions, .actionItems])
+        XCTAssertTrue(artifacts.allSatisfy { $0.status == .draft })   // propose-only preserved
+    }
+
+    func testShortTranscriptDoesNotChunk() {
+        let transcript = Transcript(meetingId: "m", segments: [seg("short", 0)], transcriptHash: "h")
+        let extractor = ChunkedExtractor(engine: ArtifactGenerationEngine(provider: ConstantLLM()), windowTokens: 2_000)
+        XCTAssertFalse(extractor.shouldChunk(transcript))
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,7 +1,18 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-21 (**HSM-8-06 DONE — ink into intelligence, the magic pencil
-made involved (Phase 8 now 5/8).** `InkPromoter` (RuntimeCore) promotes recognized
+**Last updated:** 2026-06-21 (**HSM-8-07 + HSM-8-08 HOST-COMPLETE — long meetings never
+gamble on RAM.** `OnDeviceBudget` (RuntimeCore, pure) sizes the model context to *this*
+device (the KV-cache is RAM): the 16K from HSM-8-06 becomes the *ceiling*, lowered when the
+device can't afford it, never exceeding the affordable footprint. `TranscriptWindowing` +
+`ArtifactMerge` + `ChunkedExtractor` do **map-reduce extraction** — window (segment-aligned,
+overlapping, budget-bounded) → extract per window over the real engine → merge/dedup — so
+**peak memory stays flat regardless of meeting length**. The app's `generate()` opens the
+provider at the budget and routes long meetings through chunking ("extracting in N passes…");
+short meetings keep the single fast pass. `swift test` **182/6-skip/0-fail (+12)**; the app
+builds + signs for device. Owner steer: "increase the baseline … but let's chunk it. Let's
+not risk OOM ever." These land **host-complete** — the on-device long-meeting proof is the
+only deferred item (owner not at the iPad), so no story flips to `done` yet. Earlier:
+**HSM-8-06 DONE — ink into intelligence, the magic pencil made involved (Phase 8 now 5/8).** `InkPromoter` (RuntimeCore) promotes recognized
 handwriting to a schema-valid `.draft` `Artifact` (propose-and-confirm); `InkEmphasis`
 boosts the intents in hand-marked segments so a starred moment **measurably changes the
 routed artifact chain** (host-proven). The app's **"Add your handwritten notes"** action
@@ -343,7 +354,7 @@ Earlier today: **program scaffolded** — the Council Implementation
 Charter (Rev 1.0) mapped onto a 12-phase roadmap (Phase 0 Contract Extraction →
 Phase 11 Hardening), charter captured as [`CHARTER.md`](./CHARTER.md), every phase
 folder carrying a `current-phase-status.md` + story stubs grounded in its track.)
-**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 5/8: HSM-8-01 capture + 8-02 notebook + 8-03 linking + 8-04 on-device artifact review (the Track I workflow gate ACHIEVED on a physical iPad) + 8-06 ink-into-intelligence (handwriting → image + on-device Vision text + marked-moment-weighted MIR, proven on a real 13-min meeting) done; HSM-8-05 (air-gapped gate) + 8-07 (chunked long-meeting extraction) + 8-08 (OOM-safe budget) remain.**
+**Current phase:** [phase-7-mir-port](./phase-7-mir-port/current-phase-status.md) closed; Phases 0 ✅, 1 ✅, 4 ✅, **6 ✅ Gate 5**, **7 ✅ Gate H**; Phase 5 host-complete (engine pick + structured output + endpoint Modes B/C + on-device Mode A + model packaging — all host-proven; device runs pending the iPad unlock); Phase 10 in-progress (HSM-10-01 done); 2 + 3 testable cores done, device-gated remainder; 6-06 Follow-ups deferred. **Phases 12–13 (Tracks M–N — the Companion Client + Answer the Coder) in progress (owner steer 2026-06-20): Phase 12 2/4 (HSM-12-01 seam + HSM-12-02 meetings remote, merged); **Phase 13 — Answer the Coder COMPLETE (4/4): HSM-13-01 inject, 13-02 voice-note composer, 13-03 Companion board, 13-04 Track N gate ACHIEVED by voice** (a spoken answer from a physical iPad, transcribed on-device, lands in a live tmux coder). Companion track (Tracks M–N) is now Phase 12 3/4 (12-01 seam, 12-02 meetings, 12-03 unified shell; only 12-04 gate remains) + Phase 13 done. **Phase 8 (Track I — the iPad on-device experience) 5/8: HSM-8-01 capture + 8-02 notebook + 8-03 linking + 8-04 on-device artifact review (the Track I workflow gate ACHIEVED on a physical iPad) + 8-06 ink-into-intelligence (handwriting → image + on-device Vision text + marked-moment-weighted MIR, proven on a real 13-min meeting) done; **8-07 (chunked long-meeting extraction) + 8-08 (OOM-safe budget) HOST-COMPLETE** (cores + 12 host tests + app wiring + device build; on-device proofs deferred — owner not at the iPad); HSM-8-05 (air-gapped gate) + the 8-07/8-08 device proofs remain.**
 
 **Highest-value direction (owner steer, 2026-06-20; ratified in charter Amendment
 1.1).** The program's value now concentrates on the **two device faces, both

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/current-phase-status.md
@@ -1,16 +1,35 @@
 # Phase 8 — iPad Experience
 
-**Status:** in-progress (5/8 — **HSM-8-01..04 + HSM-8-06 done; the Track I workflow gate
-ACHIEVED**: record → live transcript → PencilKit notebook → linked moments → **on-device
-artifact review** + **ink-into-intelligence** run end to end on a physical iPad
-(owner-witnessed). Remaining: HSM-8-05 (air-gapped notetaker gate) + two stories the
-real-metal testing motivated — HSM-8-07 (chunked extraction for long meetings) + HSM-8-08
-(OOM-safe budgeting)). Track I of the Council Implementation Charter. The first Platform
-Host (Layer 4): the iPad app that turns the runtime into the charter's flagship experience
-— record a meeting, take PencilKit notes, link them to the transcript, and review the
-artifacts, all on an iPad Air/Pro M4.
+**Status:** in-progress (5/8 done + HSM-8-07/8-08 host-complete — **HSM-8-01..04 + HSM-8-06
+done; the Track I workflow gate ACHIEVED**: record → live transcript → PencilKit notebook →
+linked moments → **on-device artifact review** + **ink-into-intelligence** run end to end on
+a physical iPad (owner-witnessed). **HSM-8-07 (chunked extraction) + HSM-8-08 (OOM-safe
+budget) are host-complete** — cores + 12 host tests landed, app wired + device-built; only
+their on-device walkthroughs remain, deferred per the owner ("not at my iPad — don't consider
+any iPad gates"). Remaining: HSM-8-05 (air-gapped notetaker gate) + the 8-07/8-08 device
+proofs). Track I of the Council Implementation Charter. The first Platform Host (Layer 4): the
+iPad app that turns the runtime into the charter's flagship experience — record a meeting,
+take PencilKit notes, link them to the transcript, and review the artifacts, all on an iPad
+Air/Pro M4.
 
-**Last updated:** 2026-06-21 (**HSM-8-06 done — ink into intelligence (the magic pencil,
+**Last updated:** 2026-06-21 (**HSM-8-07 + HSM-8-08 host-complete — long meetings never
+gamble on RAM.** `OnDeviceBudget` (RuntimeCore, pure) sizes the model context to *this*
+device — `contextTokens(availableBytes, modelBytes, marginBytes)` returns the largest safe
+window (the KV-cache is RAM), clamped to a floor/ceiling, never exceeding the affordable
+footprint; the 16K from HSM-8-06 becomes the *ceiling*, lowered when the device can't pay.
+`TranscriptWindowing` + `ArtifactMerge` + `ChunkedExtractor` do **map-reduce extraction**:
+window the transcript (segment-aligned, overlapping, budget-bounded), extract per window over
+the real `ArtifactGenerationEngine`, merge/dedup into one `.draft` set — so **peak memory
+stays flat regardless of meeting length** (a 2-hour transcript uses the same per-pass context
+as a 20-min one). The app's `generate()` opens the provider at the budget and routes any
+meeting that exceeds one window through chunking with a legible "extracting in N passes…"
+note; short meetings keep the single fast pass. Owner steer: "increase the baseline … but
+let's chunk it. Let's not risk OOM ever." `swift test` **182/6-skip/0-fail (+12)**; the
+meeting app **builds + signs for device** (the on-device long-meeting proof is the only
+deferred item — owner not at the iPad). These two land **host-complete** (no story flips to
+`done`; their evidence files ship with the device proof at the reconvene). See
+[`story-07`](./story-07-chunked-extraction.md) + [`story-08`](./story-08-oom-safe-budget.md).
+Earlier: **HSM-8-06 done — ink into intelligence (the magic pencil,
 involved).** `InkPromoter` (RuntimeCore) turns recognized handwriting into a schema-valid
 `.draft` `Artifact` proposal (propose-and-confirm); `InkEmphasis` boosts the intents in
 hand-marked segments so a starred moment **measurably changes the routed artifact chain**
@@ -158,8 +177,8 @@ the Runtime Core, it does not own business logic.
 | HSM-8-04 | Artifact review + notebook closeout | done | [story-04](./story-04-artifact-review-closeout.md) | [evidence](./evidence-story-04.md) |
 | HSM-8-05 | The air-gapped notetaker (fully-local, zero-connectivity) | backlog | [story-05](./story-05-air-gapped-notetaker.md) | — |
 | HSM-8-06 | Ink into intelligence (the magic pencil, involved) | done | [story-06](./story-06-ink-into-intelligence.md) | [evidence](./evidence-story-06.md) |
-| HSM-8-07 | Chunked extraction for long meetings (map-reduce, length-safe) | backlog | [story-07](./story-07-chunked-extraction.md) | — |
-| HSM-8-08 | OOM-safe on-device budgeting (never gamble on RAM) | backlog | [story-08](./story-08-oom-safe-budget.md) | — |
+| HSM-8-07 | Chunked extraction for long meetings (map-reduce, length-safe) | host-complete | [story-07](./story-07-chunked-extraction.md) | device proof deferred |
+| HSM-8-08 | OOM-safe on-device budgeting (never gamble on RAM) | host-complete | [story-08](./story-08-oom-safe-budget.md) | device proof deferred |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-07-chunked-extraction.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-07-chunked-extraction.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 8
-- **Status:** backlog
+- **Status:** host-complete (cores + host tests landed; on-device walkthrough deferred per owner — not at the iPad)
 - **Depends on:** HSM-8-04 (on-device artifact review + generation), HSM-5-02 (Mode A on-device inference), HSM-6-02 (artifacts), HSM-8-08 (the memory budget that decides *when* to chunk)
 - **Unblocks:** hour-plus meetings on-device without growing the context window
 - **Owner:** unassigned
@@ -79,6 +79,30 @@ with meeting length; **memory stays flat** regardless of how long the meeting ra
   on-device, and watch it extract per window without OOM, producing a coherent merged
   artifact set in review — folded into the HSM-8-05 air-gapped walkthrough where
   practical.
+
+## Host-complete (2026-06-21)
+
+Cores + host tests landed (PR pending); the on-device walkthrough is the only remaining
+acceptance item, deferred per the owner ("not at my iPad — don't consider any iPad gates").
+
+- **`TranscriptWindowing.windows`** (RuntimeCore) — segment-aligned, budget-bounded,
+  overlapping windows; never splits a segment; an oversized lone segment is kept whole
+  rather than dropped. Host-tested (coverage, overlap, budget bound, empty, oversized).
+- **`ArtifactMerge.dedup`** — collapses cross-window duplicates by (type + normalized
+  body), keeping the higher-confidence draft, order-stable. Host-tested.
+- **`ChunkedExtractor`** — `shouldChunk` decides the path; `generate` runs the real
+  `ArtifactGenerationEngine` per window and merges. Host-tested over a fake provider
+  (N windows × M types collapse to M artifacts; propose-only `.draft` preserved).
+- **App wiring** — `generate()` opens the provider at the HSM-8-08 budget, and a meeting
+  that exceeds one window routes through `ChunkedExtractor` with a legible "extracting in
+  N passes…" note; a short meeting keeps the single fast streaming pass. The meeting app
+  **builds + signs for device** (verified); the on-device long-meeting run is the deferred
+  item.
+- `swift test` → **182 passed / 6 skipped / 0 failed** (+12 with HSM-8-08).
+
+**Remaining for `done`:** the physical-iPad long-meeting (hour-plus) walkthrough —
+extract via chunking with no OOM, coherent merged set in review. Folds into the HSM-8-05
+air-gapped walkthrough at the reconvene.
 
 ## Notes / open questions
 

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-08-oom-safe-budget.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-08-oom-safe-budget.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 8
-- **Status:** backlog
+- **Status:** host-complete (cores + host tests landed; on-device walkthrough deferred per owner — not at the iPad)
 - **Depends on:** HSM-8-04 (on-device generation), HSM-5-02 (Mode A / `LlamaProvider`)
 - **Unblocks:** HSM-8-07 (chunking consumes the budget this story computes)
 - **Owner:** unassigned
@@ -72,6 +72,27 @@ gambling on RAM at any meeting length.
 - Device: confirm the chosen budget on the real iPad (log/inspect the opened context),
   then run a long meeting end to end with no OOM — folded into the HSM-8-07 / HSM-8-05
   device walkthroughs.
+
+## Host-complete (2026-06-21)
+
+Cores + host tests landed (PR pending); the on-device no-OOM proof is the only remaining
+acceptance item, deferred per the owner ("not at my iPad — don't consider any iPad gates").
+
+- **`OnDeviceBudget`** (RuntimeCore) — pure, deterministic: `contextTokens(availableBytes,
+  modelBytes, marginBytes, floor, ceiling)` returns the largest safe context, clamped, never
+  exceeding the affordable KV footprint; `windowTokens` reserves prompt + output room;
+  `transcriptTokens` + `needsChunking` give HSM-8-07 its threshold. Host-tested (ample RAM →
+  16K ceiling; constrained device → smaller, never exceeds RAM−margin; monotonic in RAM;
+  window reserve; chunk threshold).
+- **App wiring** — `generate()` sizes `LlamaProvider` from the budget (the 16K becomes the
+  *ceiling*, lowered when the device can't afford it), drawing memory headroom from iOS
+  `os_proc_available_memory()` with a `physicalMemory/2` fallback and the GGUF's on-disk size
+  as the model footprint. The 768 MB margin covers the app + WhisperKit + activations. Builds
+  + signs for device (verified).
+- `swift test` → **182 passed / 6 skipped / 0 failed** (shared suite with HSM-8-07).
+
+**Remaining for `done`:** confirm the chosen budget on the physical iPad and run a long
+meeting end to end with no jetsam kill (owner-witnessed) — at the reconvene.
 
 ## Notes / open questions
 


### PR DESCRIPTION
Long meetings stop gambling on RAM. Two tightly-coupled stories — **8-08 computes the budget 8-07 consumes** — landing **host-complete** (cores + 12 host tests + app wiring + a device build). The on-device long-meeting walkthrough is **deferred per the owner** ("not at my iPad"), so no story flips to `done`.

**HSM-8-08 — `OnDeviceBudget` (pure):** `contextTokens(availableBytes, modelBytes, marginBytes, …)` returns the largest safe context — the KV-cache is RAM, so the 16K from HSM-8-06 becomes the *ceiling*, lowered when the device can't afford it, never exceeding the affordable footprint. The increased-memory entitlement is never assumed.

**HSM-8-07 — chunked map-reduce extraction:** `TranscriptWindowing` (segment-aligned, overlapping, budget-bounded) → `ChunkedExtractor` runs the real engine per window → `ArtifactMerge.dedup` collapses cross-window duplicates. **Peak context is one window's worth regardless of meeting length** — a 2-hour transcript uses the same per-pass memory as a 20-minute one.

**App wiring:** `generate()` opens the provider at the computed budget (headroom from `os_proc_available_memory()` with a `physicalMemory/2` fallback) and routes long meetings through chunking with a legible "extracting in N passes…" note; short meetings keep the single fast pass.

Owner steer: *"increase the baseline … but let's chunk it. Let's not risk OOM ever."*

`swift test` → **182 passed / 6 skipped / 0 failures** (+12). xcodebuild device build **SUCCEEDED**.

**Remaining for `done` on both:** the physical-iPad hour-plus walkthrough with no jetsam kill, at the reconvene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)