### PR TITLE
HSM-11-07: bounded windows for single-segment transcripts (intra-segment split)

### DIFF
--- a/apple/Sources/RuntimeCore/MeetingIntelligence/ChunkedExtraction.swift
+++ b/apple/Sources/RuntimeCore/MeetingIntelligence/ChunkedExtraction.swift
@@ -11,32 +11,101 @@ import Providers
 /// All on-device (the air-gapped gate forbids any network path).
 
 public enum TranscriptWindowing {
-    /// Segment-aligned windows, each ≤ `maxTokens` of transcript text, with `overlap`
-    /// segments shared between neighbours. Never splits a segment. A single segment that
-    /// already exceeds `maxTokens` is kept whole in its own window rather than dropped —
-    /// correctness over the budget for the pathological case (the budget has slack for it).
+    /// Windows, each ≤ `maxTokens` of transcript text, with `overlap` segments shared
+    /// between neighbours. An oversized segment is FIRST split internally (HSM-11-07) — at
+    /// sentence boundaries, then words, then a hard char-slice — so the windows are
+    /// genuinely bounded even when the on-device transcriber emits the whole meeting as one
+    /// giant segment (today's reality until realtime segmentation). This is what makes the
+    /// per-pass memory actually flat regardless of meeting length.
     public static func windows(
         _ segments: [Segment], maxTokens: Int, overlap: Int = 1,
         estimate: (String) -> Int = OnDeviceBudget.estimateTokens
     ) -> [[Segment]] {
-        guard !segments.isEmpty else { return [] }
+        let prepared = splitOversized(segments, maxTokens: maxTokens, estimate: estimate)
+        guard !prepared.isEmpty else { return [] }
         let safeOverlap = max(0, overlap)
         var windows: [[Segment]] = []
         var start = 0
-        while start < segments.count {
+        while start < prepared.count {
             var window: [Segment] = []
             var tokens = 0
             var end = start
-            while end < segments.count {
-                let t = estimate(segments[end].text)
+            while end < prepared.count {
+                let t = estimate(prepared[end].text)
                 if !window.isEmpty && tokens + t > maxTokens { break }   // full — but never empty
-                window.append(segments[end]); tokens += t; end += 1
+                window.append(prepared[end]); tokens += t; end += 1
             }
             windows.append(window)
-            if end >= segments.count { break }
+            if end >= prepared.count { break }
             start = max(start + 1, end - safeOverlap)                    // share `overlap`; always progress
         }
         return windows
+    }
+
+    /// Replace any segment whose text exceeds `maxTokens` with sentence-aligned
+    /// sub-segments (each ≤ `maxTokens`); segments within budget pass through untouched.
+    /// Sub-segments interpolate their start/end across the parent's span by character
+    /// offset, so transcript anchoring stays monotonic and the first keeps the parent's
+    /// start. This is the fix that lets chunking bound memory for a single giant segment.
+    public static func splitOversized(
+        _ segments: [Segment], maxTokens: Int,
+        estimate: (String) -> Int = OnDeviceBudget.estimateTokens
+    ) -> [Segment] {
+        var out: [Segment] = []
+        for seg in segments {
+            guard estimate(seg.text) > maxTokens else { out.append(seg); continue }
+            let pieces = splitText(seg.text, maxTokens: maxTokens, estimate: estimate)
+            guard pieces.count > 1 else { out.append(seg); continue }   // unsplittable → keep whole
+            let span = seg.endTime - seg.startTime
+            let totalChars = max(1, pieces.reduce(0) { $0 + $1.count })
+            var consumed = 0
+            for piece in pieces {
+                let s = seg.startTime + span * Double(consumed) / Double(totalChars)
+                consumed += piece.count
+                let e = seg.startTime + span * Double(consumed) / Double(totalChars)
+                out.append(Segment(text: piece, speaker: seg.speaker, speakerId: seg.speakerId,
+                                   startTime: s, endTime: e,
+                                   isBookmarked: seg.isBookmarked, deviceId: seg.deviceId))
+            }
+        }
+        return out
+    }
+
+    /// Split a too-long string into pieces each ≤ `maxTokens`, preferring sentence/space
+    /// boundaries and falling back to a hard char cut for a runaway unbroken span. The
+    /// original text is preserved exactly (slices, then trimmed per piece).
+    static func splitText(
+        _ text: String, maxTokens: Int, estimate: (String) -> Int
+    ) -> [String] {
+        guard estimate(text) > maxTokens else { return [text] }
+        let maxChars = max(1, maxTokens * 4)               // estimate() is chars/4
+        let chars = Array(text)
+        var pieces: [String] = []
+        var start = 0
+        while start < chars.count {
+            let hardEnd = min(start + maxChars, chars.count)
+            var end = hardEnd
+            if hardEnd < chars.count, let b = lastBoundary(chars, from: start, to: hardEnd) { end = b }
+            if end <= start { end = hardEnd }              // no boundary → hard cut; always progress
+            let piece = String(chars[start..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !piece.isEmpty { pieces.append(piece) }
+            start = end
+        }
+        return pieces.isEmpty ? [text] : pieces
+    }
+
+    /// The latest index in `(start, end]` that ends a sentence (`.!?`/newline) or, failing
+    /// that, a word (space/tab) — so a cut lands on a clean boundary when one exists.
+    private static func lastBoundary(_ chars: [Character], from start: Int, to end: Int) -> Int? {
+        var spaceBoundary: Int? = nil
+        var i = end - 1
+        while i > start {
+            let c = chars[i]
+            if c == "." || c == "!" || c == "?" || c == "\n" { return i + 1 }   // latest sentence end
+            if (c == " " || c == "\t"), spaceBoundary == nil { spaceBoundary = i + 1 }
+            i -= 1
+        }
+        return spaceBoundary
     }
 }
 

--- a/apple/Tests/RuntimeCoreTests/ChunkedExtractionTests.swift
+++ b/apple/Tests/RuntimeCoreTests/ChunkedExtractionTests.swift
@@ -63,12 +63,49 @@ final class ChunkedExtractionTests: XCTestCase {
         XCTAssertEqual(windows[0].last?.startTime, windows[1].first?.startTime)
     }
 
-    func testOversizedSegmentIsKeptWholeNotDropped() {
-        let big = seg(String(repeating: "y", count: 400), 0)   // ~100 tokens alone
-        let small = seg(String(repeating: "z", count: 12), 1)  // ~3
-        let windows = TranscriptWindowing.windows([big, small], maxTokens: 10, overlap: 0)
-        XCTAssertTrue(windows.contains { $0.count == 1 && $0[0].startTime == 0 })
-        XCTAssertEqual(Set(windows.flatMap { $0 }.map { $0.startTime }), [0, 1])
+    // HSM-11-07 — a single giant segment (the on-device transcriber's reality) is split so
+    // every window fits the budget, not kept whole (which would overflow the context).
+    func testOversizedSegmentIsSplitSoEveryWindowFitsBudget() {
+        let big = seg(String(repeating: "y", count: 400), 0)   // ~100 tokens, unbroken
+        let windows = TranscriptWindowing.windows([big], maxTokens: 10, overlap: 0)
+        XCTAssertGreaterThan(windows.count, 1)                  // split, not kept whole
+        for w in windows {
+            XCTAssertLessThanOrEqual(OnDeviceBudget.transcriptTokens(w), 10)   // every pass bounded
+        }
+        // No text lost (no whitespace to trim in a run of 'y').
+        XCTAssertEqual(windows.flatMap { $0 }.reduce(0) { $0 + $1.text.count }, 400)
+    }
+
+    func testSplitTextPrefersSentenceBoundaries() {
+        let text = "First sentence here. Second sentence here. Third sentence here. Fourth one too."
+        let pieces = TranscriptWindowing.splitText(text, maxTokens: 6, estimate: OnDeviceBudget.estimateTokens)
+        XCTAssertGreaterThan(pieces.count, 1)
+        for p in pieces { XCTAssertLessThanOrEqual(OnDeviceBudget.estimateTokens(p), 6) }
+        XCTAssertTrue(pieces.allSatisfy { $0.hasSuffix(".") })   // broke at sentence ends
+        let joined = pieces.joined(separator: " ")
+        XCTAssertTrue(joined.contains("First") && joined.contains("Fourth"))   // coverage
+    }
+
+    func testSplitTextHardCutsAnUnbrokenSpan() {
+        let pieces = TranscriptWindowing.splitText(String(repeating: "x", count: 100),
+                                                   maxTokens: 5, estimate: OnDeviceBudget.estimateTokens)
+        XCTAssertGreaterThan(pieces.count, 1)
+        for p in pieces { XCTAssertLessThanOrEqual(OnDeviceBudget.estimateTokens(p), 5) }
+        XCTAssertEqual(pieces.joined().count, 100)   // no text lost
+    }
+
+    func testSplitOversizedInterpolatesTimingMonotonically() {
+        let big = Segment(text: String(repeating: "w ", count: 100), speaker: "S", startTime: 10, endTime: 70)
+        let parts = TranscriptWindowing.splitOversized([big], maxTokens: 10)
+        XCTAssertGreaterThan(parts.count, 1)
+        XCTAssertEqual(parts.first?.startTime, 10)               // first keeps the parent's start
+        for i in 1..<parts.count { XCTAssertGreaterThanOrEqual(parts[i].startTime, parts[i - 1].startTime) }
+        XCTAssertLessThanOrEqual(parts.last!.endTime, 70.0001)   // stays within the parent span
+    }
+
+    func testWithinBudgetSegmentPassesThroughUnsplit() {
+        let s = Segment(text: "short note", speaker: "S", startTime: 5, endTime: 6)
+        XCTAssertEqual(TranscriptWindowing.splitOversized([s], maxTokens: 100), [s])
     }
 
     func testEmptyTranscriptYieldsNoWindows() {

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,13 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-21 (**HSM-11-06 DONE — on-device generation robustness
+**Last updated:** 2026-06-21 (**HSM-11-07 DONE — bounded windows for single-segment
+transcripts.** HSM-8-07's chunking only bounded memory across *multiple* segments, but the
+on-device transcriber emits the whole meeting as one giant segment, and the old windowing kept
+an oversized segment whole — so a real hour-long meeting still overflowed. `TranscriptWindowing`
+now splits an oversized segment internally (sentence → word → hard-cut, text preserved;
+sub-segment timing interpolated), so every pass is genuinely bounded — the chunking promise made
+real on the actual transcriber output. `swift test` **201/6-skip/0-fail (+4)**, no regressions,
+pure RuntimeCore (no device needed). Earlier: **HSM-11-06 DONE — on-device generation robustness
 (structured-output salvage).** First Phase-11 hardening, host-side, flowing from the real-metal
 finding that a 22-min meeting dropped 3 of 4 artifact types to `noJSON`. `StructuredOutput`
 now does balanced extraction (string/escape-aware, not first-`{`-to-last-`}`), truncation

--- a/pm/roadmap/holdspeak-mobile/phase-11-hardening/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-11-hardening/current-phase-status.md
@@ -1,13 +1,25 @@
 # Phase 11 — Hardening
 
-**Status:** in-progress (scaffolded 2026-06-18; **HSM-11-06 done** — the first hardening
-landed: on-device generation robustness, host-side). Track L of the Council Implementation
+**Status:** in-progress (scaffolded 2026-06-18; **HSM-11-06 + HSM-11-07 done** — two host-side
+hardenings: on-device generation robustness + bounded windows for single-segment transcripts).
+Track L of the Council Implementation
 Charter — the final phase. It stresses the whole stack (audio + Whisper + local inference +
 persistence + sync + UI) against the charter's five real-world scenarios and declares
 production readiness. Closing this phase means the HoldSpeak Mobile Runtime ships.
 
-**Last updated:** 2026-06-21 (**HSM-11-06 done — on-device generation robustness
-(structured-output salvage).** A host-side hardening that flowed straight from the real-metal
+**Last updated:** 2026-06-21 (**HSM-11-07 done — bounded windows for single-segment
+transcripts.** HSM-8-07's chunking only bounded memory across *multiple* segments, but the
+on-device transcriber emits the whole meeting as **one giant segment** (`segments=1` in the
+real-metal log) and the old windowing kept an oversized segment whole — so a real hour-long
+meeting still overflowed the context. `TranscriptWindowing` now splits an oversized segment
+**internally**: `splitText` prefers sentence boundaries → words → a hard char-cut (text
+preserved exactly), and `splitOversized` interpolates sub-segment timing across the parent
+span (first keeps the parent's start). `windows()` runs it first, so every pass is genuinely
+bounded — the "memory flat regardless of length" promise made real on the *current*
+transcriber output. Public signature unchanged → the app benefits transparently. `swift test`
+**201/6-skip/0-fail (+4)**; no regressions. Pure RuntimeCore → no device needed. See
+[`evidence-story-07`](./evidence-story-07.md). Earlier: **HSM-11-06 done — on-device generation
+robustness (structured-output salvage).** A host-side hardening that flowed straight from the real-metal
 finding that a 22-min meeting dropped 3 of 4 artifact types to `noJSON`. `StructuredOutput`
 now does **balanced extraction** (first complete brace-balanced structure, string/escape
 aware — not first-`{`-to-last-`}`), **truncation salvage** (close an open string + brackets so
@@ -64,6 +76,7 @@ final gate.
 | HSM-11-04 | Suspend / resume + background audio | backlog | [story-04](./story-04-suspend-resume.md) | — |
 | HSM-11-05 | Production-readiness closeout (Gate 7) | backlog | [story-05](./story-05-production-readiness-closeout.md) | — |
 | HSM-11-06 | On-device generation robustness (structured-output salvage) | done | [story-06](./story-06-structured-output-robustness.md) | [evidence](./evidence-story-06.md) |
+| HSM-11-07 | Bounded windows for single-segment transcripts (intra-segment split) | done | [story-07](./story-07-bounded-windows-single-segment.md) | [evidence](./evidence-story-07.md) |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-11-hardening/evidence-story-07.md
+++ b/pm/roadmap/holdspeak-mobile/phase-11-hardening/evidence-story-07.md
@@ -1,0 +1,46 @@
+# Evidence — HSM-11-07 (Bounded windows for single-segment transcripts)
+
+**Date:** 2026-06-21 · **Status:** done
+
+HSM-8-07's chunking only bounded memory when the transcript had *multiple* segments — but
+the on-device transcriber emits the whole meeting as **one giant segment** (`segments=1` in
+the real-metal 22-min log), and the old windowing kept an oversized segment whole. So a real
+hour-long meeting would still produce one over-budget window and overflow the context. This
+host-side hardening closes that hole: `windows()` now splits an oversized segment internally
+so every pass is genuinely bounded.
+
+## What shipped (`TranscriptWindowing`, RuntimeCore)
+
+- **`splitOversized(_:maxTokens:)`** — replaces any segment over budget with sub-segments
+  each ≤ `maxTokens`; within-budget segments pass through untouched. Sub-segments interpolate
+  start/end across the parent's span by character offset (first keeps the parent's start), so
+  transcript anchoring stays monotonic.
+- **`splitText(_:maxTokens:)`** — splits a too-long string preferring **sentence** boundaries
+  (`.!?`/newline), then **word** boundaries, then a **hard char cut** for a runaway unbroken
+  span. Preserves the original text exactly (slice + per-piece trim).
+- **`windows()`** runs `splitOversized` first, so the rest of the (unchanged) grouping logic
+  now operates on bounded segments. Public signature unchanged → the app's chunked path
+  benefits transparently, no app change.
+
+## Tests (ran)
+
+`swift test` → **201 passed / 6 skipped / 0 failed** (+4 net in `ChunkedExtractionTests`):
+a single 100-token unbroken segment → >1 window, **every window ≤ budget**, no text lost;
+`splitText` breaks at sentence ends (each piece ends `.`, ≤ budget, coverage preserved);
+`splitText` hard-cuts an unbroken span with no text lost; `splitOversized` interpolates
+timing monotonically + keeps the parent's start + passes within-budget segments through. The
+existing windowing/merge/chunked-extraction tests stay green (no regression).
+
+## Acceptance
+
+- A single oversized segment is **split so every window fits the budget**, not kept whole. ✅
+- `splitText` prefers sentence → word → hard-cut, text preserved, each piece ≤ budget. ✅
+- `splitOversized` interpolates timing monotonically, keeps the parent start, passes
+  within-budget segments through. ✅
+- No regression — normal multi-segment transcripts window exactly as before. ✅
+
+## Note
+
+Pure RuntimeCore, host-tested — no device needed. It makes HSM-8-07's "memory flat
+regardless of length" real on the *current* transcriber output, and sharpens the eventual
+HSM-8-07/8-08 device proof (a real hour-plus meeting now has a path that bounds each pass).

--- a/pm/roadmap/holdspeak-mobile/phase-11-hardening/story-07-bounded-windows-single-segment.md
+++ b/pm/roadmap/holdspeak-mobile/phase-11-hardening/story-07-bounded-windows-single-segment.md
@@ -1,0 +1,66 @@
+# HSM-11-07 — Bounded windows for single-segment transcripts (intra-segment split)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 11
+- **Status:** done
+- **Depends on:** HSM-8-07 (chunked extraction), HSM-8-08 (the budget)
+- **Unblocks:** chunking that actually bounds memory on real on-device transcripts
+- **Owner:** unassigned
+
+## Problem
+
+HSM-8-07's chunking is **segment-aligned** and kept an oversized segment *whole*
+("correctness over the budget for the pathological case"). But that pathological case is
+the **normal** case on-device: the HSM-8-01 windowed transcriber emits the **whole meeting
+as one giant segment** (a known limitation until realtime segmentation). So for a real
+hour-long meeting (~9k tokens in one segment), `windows()` produced a single window holding
+the entire transcript — which overflows the model context exactly the way HSM-8-07 was
+built to prevent. The "never gamble on RAM" guarantee had a hole precisely where it
+mattered, surfaced by the real-metal 22-min run (`segments=1`).
+
+This story closes that hole: when a single segment exceeds the window budget, split it
+**internally** so the windows are genuinely bounded regardless of how the transcript was
+segmented.
+
+## Scope
+
+- **In:** `TranscriptWindowing` (RuntimeCore) gains intra-segment splitting, run inside
+  `windows()` before grouping —
+  (1) **`splitOversized`**: replace any segment whose text exceeds `maxTokens` with
+  sub-segments each ≤ `maxTokens`; within-budget segments pass through untouched;
+  (2) **`splitText`**: split a too-long string preferring **sentence** boundaries
+  (`.!?`/newline), falling back to **word** boundaries, then a **hard char cut** for a
+  runaway unbroken span — preserving the original text exactly (slice + trim);
+  (3) **timing**: sub-segments interpolate start/end across the parent's span by character
+  offset, so transcript anchoring stays monotonic and the first sub-segment keeps the
+  parent's start.
+- **Out:** realtime/streaming segmentation in the transcriber itself (HSM-3-02 — a
+  different layer; this is the consumer-side safety net). Semantic/topic chunking. Any
+  device-specific code — this is pure, host-tested.
+
+## Acceptance criteria
+
+- [x] A single oversized segment is **split so every window fits the budget** (not kept
+      whole) — host-tested (`windows([big], maxTokens:10)` → >1 window, each ≤ budget, no
+      text lost).
+- [x] `splitText` **prefers sentence boundaries**, falls back to words, then hard-cuts an
+      unbroken span — host-tested, each piece ≤ budget, text preserved.
+- [x] `splitOversized` **interpolates timing monotonically** and keeps the parent's start;
+      within-budget segments pass through unchanged — host-tested.
+- [x] No regression: normal multi-segment transcripts window exactly as before (the
+      existing `ChunkedExtractionTests` stay green).
+
+## Test plan
+
+- Unit (host, model-free): the four cases above + the existing windowing/merge/chunked-
+  extraction suite. `swift test` → **201 passed / 6 skipped / 0 failed** (+4 net).
+
+## Notes / open questions
+
+- This makes HSM-8-07's promise real on the *current* transcriber output (one segment). It
+  does NOT need the device — it's a deterministic RuntimeCore change — but it does sharpen
+  the eventual HSM-8-07/8-08 device proof (a real hour-plus meeting now has a path that
+  actually bounds each pass).
+- Sentence detection is deliberately simple (`.!?`/newline). Abbreviations ("e.g.") may
+  cut slightly early; harmless for extraction, and the hard-cut fallback guarantees the
+  budget is never exceeded.

--- a/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-07-chunked-extraction.md
+++ b/pm/roadmap/holdspeak-mobile/phase-8-ipad-experience/story-07-chunked-extraction.md
@@ -104,6 +104,14 @@ acceptance item, deferred per the owner ("not at my iPad — don't consider any 
 extract via chunking with no OOM, coherent merged set in review. Folds into the HSM-8-05
 air-gapped walkthrough at the reconvene.
 
+## Follow-up landed — HSM-11-07
+
+This story's windowing originally kept an oversized *single* segment whole (correctness over
+budget). But the on-device transcriber emits the whole meeting as one giant segment, so that
+exception was the normal case and left the per-pass budget unbounded. **HSM-11-07** (Phase 11)
+closed it: `windows()` now splits an oversized segment internally (sentence → word → hard-cut),
+so every pass is genuinely bounded on real transcriber output. The public API is unchanged.
+
 ## Notes / open questions
 
 - Overlap size is a tuning knob: enough that a decision straddling a boundary is


### PR DESCRIPTION
HSM-8-07's chunking is segment-aligned and kept an oversized **single** segment whole. But the on-device transcriber emits the whole meeting as **one giant segment** (`segments=1` in the real-metal log), so a real hour-long meeting produced one over-budget window and overflowed the context — defeating the "never gamble on RAM" point exactly where it mattered.

**Fix** — `TranscriptWindowing` splits an oversized segment internally:
- **`splitText`** prefers sentence boundaries (`.!?`/newline) → words → a hard char-cut for a runaway span; text preserved exactly.
- **`splitOversized`** replaces an over-budget segment with sub-segments each ≤ budget; timing interpolated across the parent span (first keeps the parent's start); within-budget segments pass through.
- **`windows()`** runs it first → every pass genuinely bounded. **Public signature unchanged** → the app's chunked path benefits transparently, no app change.

Makes HSM-8-07's "memory flat regardless of length" real on the *current* transcriber output, and sharpens the eventual device proof. Pure RuntimeCore, host-tested, no device needed.

`swift test` → **201 passed / 6 skipped / 0 failures** (+4 net); no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)