### PR TITLE
HSM-14-03: adopt Tactile Sheets into the real app — swipeable artifact cards (on device)

### DIFF
--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -4,6 +4,7 @@ import WhisperKit
 import PencilKit
 import Vision
 import os
+import UIKit
 
 // HSM-8-01 — the iPad's on-device meeting-capture loop. Open the app, see your
 // recordings, press Record, watch the transcript appear, stop to keep it. Capture
@@ -743,6 +744,127 @@ private func artifactTypeLabel(_ t: ArtifactType) -> String {
     t.rawValue.replacingOccurrences(of: "_", with: " ").capitalized
 }
 
+/// Per-type accent (HSM-14 Tactile Sheets — each artifact type reads at a glance).
+private func artifactTint(_ t: ArtifactType) -> Color {
+    switch t {
+    case .decisions, .decisionAnnouncement: return Sig.ok
+    case .actionItems, .milestonePlan: return Sig.accent
+    case .riskRegister, .incidentTimeline, .runbookDelta: return Sig.warn
+    case .requirements, .scopeReview, .dependencyMap: return Sig.local
+    default: return Sig.local
+    }
+}
+private func artifactGlyph(_ t: ArtifactType) -> String {
+    switch t {
+    case .decisions, .decisionAnnouncement: return "checkmark.seal.fill"
+    case .actionItems: return "bolt.fill"
+    case .riskRegister: return "exclamationmark.triangle.fill"
+    case .incidentTimeline: return "clock.badge.exclamationmark.fill"
+    case .requirements: return "list.bullet.rectangle.fill"
+    case .adr: return "doc.text.fill"
+    case .diagram, .dependencyMap: return "rectangle.3.group.fill"
+    case .milestonePlan: return "flag.checkered"
+    case .customerSignals, .stakeholderUpdate: return "person.2.fill"
+    default: return "sparkles"
+    }
+}
+/// A light tactile tap (HSM-14 — the app should feel hand-driven).
+private func tactile(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+    UIImpactFeedbackGenerator(style: style).impactOccurred()
+}
+
+/// HSM-14-03 — the Tactile Sheets artifact card: gesture-first (swipe → approve / ← dismiss
+/// with haptics), tinted by type, elevated. Wired to the live review actions.
+struct SwipeableArtifactCard: View {
+    let artifact: Artifact
+    let ink: UIImage?
+    let onApprove: () -> Void
+    let onDismiss: () -> Void
+    @State private var dragX: CGFloat = 0
+
+    private var actionable: Bool { artifact.status == .draft || artifact.status == .needsReview }
+    private var tint: Color { artifactTint(artifact.artifactType) }
+
+    var body: some View {
+        ZStack {
+            HStack {
+                sideAction("xmark", "Dismiss", Sig.bad, active: dragX > 55)
+                Spacer()
+                sideAction("checkmark", "Approve", Sig.ok, active: dragX < -55)
+            }
+            face.offset(x: dragX).gesture(actionable ? drag : nil)
+        }
+    }
+
+    private var drag: some Gesture {
+        DragGesture(minimumDistance: 12)
+            .onChanged { g in dragX = max(-150, min(150, g.translation.width)) }
+            .onEnded { g in
+                if g.translation.width < -100 { tactile(.medium); onApprove() }
+                else if g.translation.width > 100 { tactile(.medium); onDismiss() }
+                withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) { dragX = 0 }
+            }
+    }
+
+    private var face: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 11) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 11, style: .continuous).fill(tint.opacity(0.16))
+                    Image(systemName: artifactGlyph(artifact.artifactType)).font(.system(size: 15, weight: .bold)).foregroundStyle(tint)
+                }.frame(width: 36, height: 36)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(artifactTypeLabel(artifact.artifactType)).font(.system(size: 12, weight: .heavy)).tracking(0.4).foregroundStyle(tint)
+                    Text(artifact.title).font(.system(size: 16, weight: .bold)).foregroundStyle(Sig.text).lineLimit(2)
+                }
+                Spacer(minLength: 4)
+                statusView
+            }
+            if let ink {
+                Image(uiImage: ink).resizable().scaledToFit().frame(maxHeight: 240).frame(maxWidth: .infinity)
+                    .background(Color.white, in: RoundedRectangle(cornerRadius: 10))
+            }
+            if !artifact.bodyMarkdown.isEmpty {
+                Text(artifact.bodyMarkdown).font(.system(size: 14)).foregroundStyle(Sig.muted).lineSpacing(2).lineLimit(5)
+            }
+            if actionable {
+                HStack(spacing: 6) {
+                    Image(systemName: "hand.draw").font(.system(size: 11, weight: .bold))
+                    Text("swipe → approve   ·   ← dismiss").font(.system(size: 12, weight: .semibold))
+                }.foregroundStyle(Sig.faint.opacity(0.85))
+            }
+        }
+        .padding(15)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous).stroke(Sig.line, lineWidth: 1))
+        .shadow(color: .black.opacity(0.3), radius: 14, x: 0, y: 8)
+    }
+
+    @ViewBuilder private var statusView: some View {
+        switch artifact.status {
+        case .accepted: pill("Approved", Sig.ok)
+        case .rejected: pill("Dismissed", Sig.faint)
+        default: Image(systemName: "circle.dashed").font(.system(size: 14, weight: .semibold)).foregroundStyle(Sig.faint)
+        }
+    }
+    private func pill(_ t: String, _ c: Color) -> some View {
+        Text(t).font(.system(size: 11, weight: .heavy)).foregroundStyle(c)
+            .padding(.horizontal, 9).padding(.vertical, 4).background(c.opacity(0.14), in: Capsule())
+    }
+    private func sideAction(_ sys: String, _ label: String, _ c: Color, active: Bool) -> some View {
+        VStack(spacing: 5) {
+            ZStack { Circle().fill(c.opacity(active ? 1 : 0.2))
+                Image(systemName: sys).font(.system(size: 18, weight: .heavy)).foregroundStyle(active ? .black : c) }
+                .frame(width: 44, height: 44)
+            Text(label).font(.system(size: 11, weight: .bold)).foregroundStyle(c)
+        }
+        .padding(.horizontal, 16)
+        .scaleEffect(active ? 1.12 : 0.9)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: active)
+    }
+}
+
 // MARK: - Meeting detail (reopen-intact)
 
 struct MeetingDetailView: View {
@@ -845,9 +967,12 @@ struct MeetingDetailView: View {
                     .font(.caption).foregroundStyle(Sig.faint)
             } else {
                 ForEach(review.groups, id: \.type) { group in
-                    Text(artifactTypeLabel(group.type).uppercased())
-                        .font(.caption2.weight(.bold)).tracking(1).foregroundStyle(Sig.local).padding(.top, 4)
-                    ForEach(group.items, id: \.id) { a in artifactCard(a) }
+                    ForEach(group.items, id: \.id) { a in
+                        SwipeableArtifactCard(
+                            artifact: a, ink: inkImage(a),
+                            onApprove: { review.approve(a.id) },
+                            onDismiss: { review.reject(a.id) })
+                    }
                 }
             }
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -13,8 +13,11 @@ sheet / chip components, `haptic()` wired) built and **proven on the hero meetin
 intelligence screen — committed Simulator screenshot** (`./screenshots/tactile-sheets.png`,
 iPhone 17 Pro Max). Swipe-to-approve reveal, draggable Regenerate/Ink sheet, egress as the
 single `Local` badge (caught + removed a banned "privacy novel" line mid-build). Built as a
-one-module `swiftc` simulator harness so craft is shown **without the device**. Next: adopt the
-system into the app's real screens (HSM-14-03). — the missing dimension. The mobile roadmap was all
+one-module `swiftc` simulator harness so craft is shown **without the device**. **HSM-14-03 started + on device:** the Tactile Sheets
+`SwipeableArtifactCard` is now adopted into the REAL app (`MeetingCaptureApp`) — swipe
+left→approve / right→dismiss with haptics, type-tinted over all 15 artifact types, elevated —
+wired to the live `review.approve`/`review.reject`, built + deployed to the iPad Air M4. Next
+under 14-03: the header + transcript card + a draggable bottom action sheet. — the missing dimension. The mobile roadmap was all
 engineering tracks (Council Charter A–N); there was no track that owned whether the app is
 **usable, designed, and modern** as a hand-driven (touch + Apple Pencil) product. Phase 14
 is that track. It is **proven in the iOS Simulator with committed screenshots** — design and
@@ -77,7 +80,7 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 |---|---|---|---|---|
 | HSM-14-01 | Native design system (Signal → SwiftUI tokens + components) | in-progress | [story-01](./story-01-native-design-system.md) | [shot](./screenshots/tactile-sheets.png) |
 | HSM-14-02 | The capture experience, recrafted (flagship moment) | backlog | story-02 | — |
-| HSM-14-03 | The meeting + intelligence surface, recrafted | backlog | story-03 | — |
+| HSM-14-03 | The meeting + intelligence surface, recrafted | in-progress | [story-03](./story-03-meeting-intelligence-recrafted.md) | swipeable cards live on device |
 | HSM-14-04 | Interaction craft (gesture, haptic, motion, Pencil) | backlog | story-04 | — |
 | HSM-14-05 | Accessibility + adaptivity | backlog | story-05 | — |
 | HSM-14-06 | Polish & craft QA (states, micro-copy, screenshot gallery) | backlog | story-06 | — |

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-03-meeting-intelligence-recrafted.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-03-meeting-intelligence-recrafted.md
@@ -1,0 +1,53 @@
+# HSM-14-03 — The meeting + intelligence surface, recrafted (real app)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** in-progress (the swipeable artifact card is adopted into the live app + deployed to device; the rest of the screen — header, transcript, pinned action sheet — continues)
+- **Depends on:** HSM-14-01 (design system + Tactile Sheets direction)
+- **Unblocks:** the felt-good review flow on real meetings
+- **Owner:** unassigned
+
+## Problem
+
+HSM-14-01 proved the Tactile Sheets direction in a Simulator harness. This story brings it
+into the **real app** — the meeting detail's intelligence surface — wired to the live
+`review.approve` / `review.reject` / `review.generate` actions, so the craft is something the
+owner actually uses, not a mockup.
+
+## Scope
+
+- **In:** `SwipeableArtifactCard` in the real app (`MeetingCaptureApp.swift`) — gesture-first
+  (swipe **left → Approve**, **right → Dismiss**, with `UIImpactFeedbackGenerator` haptics),
+  **type-tinted** (per-type accent + SF Symbol via `artifactTint`/`artifactGlyph` over all 15
+  `ArtifactType`s), elevated (large radius, soft shadow), with the ink image, body, status
+  pill, and a swipe hint. Swapped into `artifactsSection` over the real grouped artifacts and
+  wired to `review.approve(id)` / `review.reject(id)`. Built + **deployed to the physical
+  iPad**.
+- **Out (continues here):** recrafting the screen **header** (title + metadata chips), the
+  **transcript** card, and turning the generate/ink actions into a **draggable bottom action
+  sheet** (the harness's pinned sheet) — landing next under this story. Empty/loading/error
+  states (HSM-14-06). The capture screen (HSM-14-02).
+
+## Acceptance criteria
+
+- [x] Artifact cards in the real app are **swipeable** (left→approve / right→dismiss) with
+      haptics, wired to the live review actions, type-tinted + elevated — built + deployed to
+      the iPad.
+- [ ] The header + transcript card are recrafted to the design system.
+- [ ] The generate/ink actions become a draggable bottom action sheet.
+- [ ] Empty / generating / error states are considered (with HSM-14-06).
+
+## Evidence
+
+`apple/App/MeetingCaptureApp.swift` — `SwipeableArtifactCard` + `artifactTint`/`artifactGlyph`/
+`tactile`, swapped into `artifactsSection`. Device build **SUCCEEDED** and installed on the
+iPad Air M4; the design matches the proven harness screenshot
+([../phase-14.../screenshots/tactile-sheets.png](./screenshots/tactile-sheets.png)).
+
+## Notes
+
+- Reuses the app's existing `Sig` palette (near-identical to the harness `DS`) rather than
+  importing `DS`, to avoid a `Color(hex:)` collision — reconciling the two into one shared
+  design-system file is a HSM-14-01 follow-up.
+- Swipe is the primary affordance per the owner's Tactile Sheets choice; a visible "swipe →
+  approve · ← dismiss" hint keeps it discoverable.


### PR DESCRIPTION
Brings the owner-chosen **Tactile Sheets** design out of the harness and into the **live** meeting intelligence surface, wired to the real review actions.

- **`SwipeableArtifactCard`** — gesture-first: swipe **left → Approve**, **right → Dismiss**, with haptics; **type-tinted** (per-type accent + SF Symbol across all 15 `ArtifactType`s); elevated; ink image + body + status pill + a discoverable swipe hint.
- Swapped into `artifactsSection` over the real grouped artifacts; wired to `review.approve(id)` / `review.reject(id)`.

Device build **SUCCEEDED**, installed + launched on the physical iPad Air M4 (owner is at the device). Matches the committed harness screenshot.

Next under HSM-14-03: header + transcript card + a draggable bottom action sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)