### PR TITLE
HSM-14-08: the Pencil as a diagram language — strokes → Mermaid engine (host-tested)

### DIFF
--- a/apple/Sources/RuntimeCore/Sketch/SketchToMermaid.swift
+++ b/apple/Sources/RuntimeCore/Sketch/SketchToMermaid.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// HSM-14-08 — the Pencil as a diagram language. Strokes, NOT pixels: PencilKit gives us
+/// vector geometry, so we recognize shapes deterministically, build a graph, and emit Mermaid
+/// — reserving any VLM/LLM for ambiguity only. This file is the pure, host-tested engine:
+/// `ShapeRecognizer` (a stroke → a shape or a connector), `DiagramBuilder` (shapes + connectors
+/// → a graph), `MermaidGenerator` (graph → `flowchart`). No CoreGraphics, no model, no device.
+
+public struct StrokePoint: Equatable, Sendable {
+    public let x: Double, y: Double
+    public init(_ x: Double, _ y: Double) { self.x = x; self.y = y }
+}
+
+public struct Bounds: Equatable, Sendable {
+    public let minX, minY, maxX, maxY: Double
+    public var w: Double { maxX - minX }
+    public var h: Double { maxY - minY }
+    public var cx: Double { (minX + maxX) / 2 }
+    public var cy: Double { (minY + maxY) / 2 }
+    public var center: StrokePoint { StrokePoint(cx, cy) }
+}
+
+public enum ShapeKind: String, Sendable, Equatable { case rectangle, diamond, ellipse }
+
+public enum RecognizedStroke: Equatable, Sendable {
+    case shape(ShapeKind, Bounds)
+    case connector(from: StrokePoint, to: StrokePoint)
+}
+
+// MARK: - Stroke → shape / connector
+
+public enum ShapeRecognizer {
+
+    /// Classify one stroke (a polyline) into a closed shape (rectangle / diamond / ellipse) or
+    /// an open connector (an arrow/line, carrying its start + end). Geometry only.
+    public static func classify(_ points: [StrokePoint]) -> RecognizedStroke {
+        guard let first = points.first, let last = points.last, points.count >= 2 else {
+            let p = points.first ?? StrokePoint(0, 0)
+            return .connector(from: p, to: p)
+        }
+        let b = bounds(points)
+        let diag = max((b.w * b.w + b.h * b.h).squareRoot(), 1)
+        // Closed if the ends meet relative to the size → a node; else a connector.
+        guard dist(first, last) < 0.28 * diag else { return .connector(from: first, to: last) }
+        let simplified = simplify(points, epsilon: 0.06 * diag)
+        return .shape(classifyClosed(simplified, bounds: b), b)
+    }
+
+    static func bounds(_ pts: [StrokePoint]) -> Bounds {
+        var minX = pts[0].x, minY = pts[0].y, maxX = pts[0].x, maxY = pts[0].y
+        for p in pts { minX = min(minX, p.x); minY = min(minY, p.y); maxX = max(maxX, p.x); maxY = max(maxY, p.y) }
+        return Bounds(minX: minX, minY: minY, maxX: maxX, maxY: maxY)
+    }
+    static func dist(_ a: StrokePoint, _ b: StrokePoint) -> Double {
+        ((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y)).squareRoot()
+    }
+
+    /// A closed simplified polygon → its kind. Count the SHARP corners (~>63° turns): ~4 sharp
+    /// corners at the bounding-box corners → rectangle; at the edge midpoints → diamond; few
+    /// sharp corners (gradual all the way round) → ellipse.
+    static func classifyClosed(_ raw: [StrokePoint], bounds b: Bounds) -> ShapeKind {
+        var v = raw
+        if v.count > 1, v.first == v.last { v.removeLast() }   // drop the closing duplicate
+        let n = v.count
+        guard n >= 3 else { return .rectangle }
+        let thresh = 0.25 * max(b.w, b.h, 1)
+        let corners = [StrokePoint(b.minX, b.minY), StrokePoint(b.maxX, b.minY),
+                       StrokePoint(b.maxX, b.maxY), StrokePoint(b.minX, b.maxY)]
+        let mids = [StrokePoint(b.cx, b.minY), StrokePoint(b.maxX, b.cy),
+                    StrokePoint(b.cx, b.maxY), StrokePoint(b.minX, b.cy)]
+        var sharp = 0, cornerVotes = 0, midVotes = 0
+        for i in 0..<n {
+            let a = v[(i - 1 + n) % n], c = v[i], d = v[(i + 1) % n]
+            guard turnAngle(a, c, d) > 1.1 else { continue }   // ~63°+
+            sharp += 1
+            let dc = corners.map { dist($0, c) }.min() ?? .infinity
+            let dm = mids.map { dist($0, c) }.min() ?? .infinity
+            if dc <= thresh && dc <= dm { cornerVotes += 1 }
+            else if dm <= thresh { midVotes += 1 }
+        }
+        guard (3...6).contains(sharp) else { return .ellipse }   // round → ellipse
+        return midVotes > cornerVotes ? .diamond : .rectangle
+    }
+
+    /// Direction change (radians) at the middle point — 0 straight, ~π/2 a square corner.
+    static func turnAngle(_ a: StrokePoint, _ c: StrokePoint, _ d: StrokePoint) -> Double {
+        let d1 = atan2(c.y - a.y, c.x - a.x), d2 = atan2(d.y - c.y, d.x - c.x)
+        var t = abs(d2 - d1)
+        if t > .pi { t = 2 * .pi - t }
+        return t
+    }
+
+    /// Ramer–Douglas–Peucker polyline simplification — keeps the corners, drops the noise.
+    static func simplify(_ pts: [StrokePoint], epsilon: Double) -> [StrokePoint] {
+        guard pts.count > 2 else { return pts }
+        var dmax = 0.0, index = 0
+        for i in 1..<(pts.count - 1) {
+            let d = perpendicular(pts[i], pts.first!, pts.last!)
+            if d > dmax { dmax = d; index = i }
+        }
+        if dmax > epsilon {
+            let left = simplify(Array(pts[0...index]), epsilon: epsilon)
+            let right = simplify(Array(pts[index...]), epsilon: epsilon)
+            return left.dropLast() + right
+        }
+        return [pts.first!, pts.last!]
+    }
+    static func perpendicular(_ p: StrokePoint, _ a: StrokePoint, _ b: StrokePoint) -> Double {
+        let dx = b.x - a.x, dy = b.y - a.y
+        let len = (dx * dx + dy * dy).squareRoot()
+        guard len > 0 else { return dist(p, a) }
+        return abs(dy * p.x - dx * p.y + b.x * a.y - b.y * a.x) / len
+    }
+}
+
+// MARK: - Graph
+
+public struct DiagramNode: Equatable, Sendable {
+    public let id: String; public let kind: ShapeKind; public let text: String; public let bounds: Bounds
+    public init(id: String, kind: ShapeKind, text: String, bounds: Bounds) {
+        self.id = id; self.kind = kind; self.text = text; self.bounds = bounds
+    }
+}
+public struct DiagramEdge: Equatable, Sendable {
+    public let from: String; public let to: String; public let label: String?
+    public init(from: String, to: String, label: String? = nil) { self.from = from; self.to = to; self.label = label }
+}
+public struct DiagramGraph: Equatable, Sendable {
+    public let nodes: [DiagramNode]; public let edges: [DiagramEdge]
+    public init(nodes: [DiagramNode], edges: [DiagramEdge]) { self.nodes = nodes; self.edges = edges }
+}
+
+public enum DiagramBuilder {
+    public struct NodeInput { public let kind: ShapeKind; public let text: String; public let bounds: Bounds
+        public init(kind: ShapeKind, text: String, bounds: Bounds) { self.kind = kind; self.text = text; self.bounds = bounds } }
+    public struct ConnectorInput { public let from: StrokePoint; public let to: StrokePoint; public let label: String?
+        public init(from: StrokePoint, to: StrokePoint, label: String? = nil) { self.from = from; self.to = to; self.label = label } }
+
+    /// Build a graph: each node gets a stable id; each connector becomes an edge from the node
+    /// nearest its start to the node nearest its end (skipping self-loops / no-node cases).
+    public static func build(nodes: [NodeInput], connectors: [ConnectorInput]) -> DiagramGraph {
+        let built = nodes.enumerated().map { i, n in DiagramNode(id: "n\(i + 1)", kind: n.kind, text: n.text, bounds: n.bounds) }
+        var edges: [DiagramEdge] = []
+        for c in connectors {
+            guard let a = nearest(to: c.from, in: built), let b = nearest(to: c.to, in: built), a.id != b.id else { continue }
+            edges.append(DiagramEdge(from: a.id, to: b.id, label: c.label))
+        }
+        return DiagramGraph(nodes: built, edges: edges)
+    }
+    static func nearest(to p: StrokePoint, in nodes: [DiagramNode]) -> DiagramNode? {
+        nodes.min { ShapeRecognizer.dist($0.bounds.center, p) < ShapeRecognizer.dist($1.bounds.center, p) }
+    }
+}
+
+// MARK: - Mermaid
+
+public enum MermaidGenerator {
+    /// Render a graph as a Mermaid `flowchart`. Rectangle → `id["t"]`, diamond → `id{"t"}`,
+    /// ellipse → `id(("t"))`. Edges → `a --> b` (with `|label|` when present).
+    public static func flowchart(_ g: DiagramGraph, direction: String = "TD") -> String {
+        var lines = ["flowchart \(direction)"]
+        for n in g.nodes {
+            let t = escape(n.text.isEmpty ? n.id : n.text)
+            switch n.kind {
+            case .rectangle: lines.append("    \(n.id)[\"\(t)\"]")
+            case .diamond:   lines.append("    \(n.id){\"\(t)\"}")
+            case .ellipse:   lines.append("    \(n.id)((\"\(t)\"))")
+            }
+        }
+        for e in g.edges {
+            if let l = e.label, !l.isEmpty { lines.append("    \(e.from) -->|\(escape(l))| \(e.to)") }
+            else { lines.append("    \(e.from) --> \(e.to)") }
+        }
+        return lines.joined(separator: "\n")
+    }
+    static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\"", with: "'").replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/SketchToMermaidTests.swift
+++ b/apple/Tests/RuntimeCoreTests/SketchToMermaidTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import RuntimeCore
+
+/// HSM-14-08 — the Pencil-as-diagram-language engine: strokes → shapes → graph → Mermaid,
+/// deterministic + pure (no model, no device). Synthetic strokes prove the recognizer, and
+/// the owner's login-flow example proves the full pipeline emits the right Mermaid.
+final class SketchToMermaidTests: XCTestCase {
+
+    // MARK: synthetic stroke makers
+
+    private func trace(_ corners: [(Double, Double)], step: Double = 0.18) -> [StrokePoint] {
+        var p: [StrokePoint] = []
+        for i in 0..<(corners.count - 1) {
+            let (ax, ay) = corners[i]; let (bx, by) = corners[i + 1]
+            var t = 0.0
+            while t < 1.0 { p.append(StrokePoint(ax + (bx - ax) * t, ay + (by - ay) * t)); t += step }
+        }
+        p.append(StrokePoint(corners.last!.0, corners.last!.1))
+        return p
+    }
+    private func rect(_ x: Double, _ y: Double, _ w: Double, _ h: Double) -> [StrokePoint] {
+        trace([(x, y), (x + w, y), (x + w, y + h), (x, y + h), (x, y)])
+    }
+    private func diamond(_ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double) -> [StrokePoint] {
+        trace([(cx, cy - ry), (cx + rx, cy), (cx, cy + ry), (cx - rx, cy), (cx, cy - ry)])
+    }
+    private func ellipse(_ cx: Double, _ cy: Double, _ rx: Double, _ ry: Double, _ n: Int = 60) -> [StrokePoint] {
+        (0...n).map { i in
+            let a = 2 * Double.pi * Double(i) / Double(n)
+            return StrokePoint(cx + rx * cos(a), cy + ry * sin(a))
+        }
+    }
+
+    // MARK: recognizer
+
+    func testRectangleRecognized() {
+        guard case .shape(let k, _) = ShapeRecognizer.classify(rect(0, 0, 100, 60)) else { return XCTFail("not a shape") }
+        XCTAssertEqual(k, .rectangle)
+    }
+    func testDiamondRecognized() {
+        guard case .shape(let k, _) = ShapeRecognizer.classify(diamond(50, 40, 50, 40)) else { return XCTFail("not a shape") }
+        XCTAssertEqual(k, .diamond)
+    }
+    func testEllipseRecognized() {
+        guard case .shape(let k, _) = ShapeRecognizer.classify(ellipse(50, 30, 50, 30)) else { return XCTFail("not a shape") }
+        XCTAssertEqual(k, .ellipse)
+    }
+    func testOpenStrokeIsAConnectorCarryingDirection() {
+        guard case .connector(let from, let to) = ShapeRecognizer.classify(
+            [StrokePoint(0, 0), StrokePoint(50, 40), StrokePoint(100, 80)]) else { return XCTFail("not a connector") }
+        XCTAssertEqual(from, StrokePoint(0, 0)); XCTAssertEqual(to, StrokePoint(100, 80))
+    }
+
+    // MARK: full pipeline — the owner's login flow
+
+    func testLoginFlowBuildsTheExpectedMermaid() {
+        let nodes = [
+            DiagramBuilder.NodeInput(kind: .rectangle, text: "Login", bounds: Bounds(minX: 0, minY: 0, maxX: 100, maxY: 40)),
+            DiagramBuilder.NodeInput(kind: .diamond, text: "Validate User", bounds: Bounds(minX: 20, minY: 80, maxX: 80, maxY: 140)),
+            DiagramBuilder.NodeInput(kind: .rectangle, text: "Home", bounds: Bounds(minX: 0, minY: 200, maxX: 60, maxY: 240)),
+            DiagramBuilder.NodeInput(kind: .rectangle, text: "Error", bounds: Bounds(minX: 100, minY: 200, maxX: 160, maxY: 240)),
+        ]
+        let connectors = [
+            DiagramBuilder.ConnectorInput(from: StrokePoint(50, 40), to: StrokePoint(50, 80)),
+            DiagramBuilder.ConnectorInput(from: StrokePoint(40, 140), to: StrokePoint(30, 200), label: "yes"),
+            DiagramBuilder.ConnectorInput(from: StrokePoint(60, 140), to: StrokePoint(130, 200), label: "no"),
+        ]
+        let mermaid = MermaidGenerator.flowchart(DiagramBuilder.build(nodes: nodes, connectors: connectors))
+        XCTAssertTrue(mermaid.contains("flowchart TD"))
+        XCTAssertTrue(mermaid.contains(#"n1["Login"]"#))
+        XCTAssertTrue(mermaid.contains(#"n2{"Validate User"}"#))   // decision → diamond
+        XCTAssertTrue(mermaid.contains(#"n3["Home"]"#))
+        XCTAssertTrue(mermaid.contains("n1 --> n2"))
+        XCTAssertTrue(mermaid.contains("n2 -->|yes| n3"))
+        XCTAssertTrue(mermaid.contains("n2 -->|no| n4"))
+    }
+
+    func testSelfLoopAndNodelessConnectorsAreSkipped() {
+        let nodes = [DiagramBuilder.NodeInput(kind: .rectangle, text: "A", bounds: Bounds(minX: 0, minY: 0, maxX: 10, maxY: 10))]
+        let g = DiagramBuilder.build(nodes: nodes, connectors: [
+            DiagramBuilder.ConnectorInput(from: StrokePoint(1, 1), to: StrokePoint(2, 2)),   // both nearest A → self-loop
+        ])
+        XCTAssertTrue(g.edges.isEmpty)
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -85,6 +85,7 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 | HSM-14-05 | Accessibility + adaptivity | backlog | story-05 | — |
 | HSM-14-06 | Polish & craft QA (states, micro-copy, screenshot gallery) | backlog | story-06 | — |
 | HSM-14-07 | Voice correction — reject by voice → local model re-routes | in-progress | [story-07](./story-07-voice-correction.md) | host-tested + on iPad |
+| HSM-14-08 | The Pencil as a diagram language (sketch → Mermaid) | in-progress | [story-08](./story-08-pencil-diagram-language.md) | engine host-tested (209/0) |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-08-pencil-diagram-language.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-08-pencil-diagram-language.md
@@ -1,0 +1,65 @@
+# HSM-14-08 — The Pencil as a diagram language (sketch → Mermaid)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** in-progress (the strokes→shapes→graph→Mermaid ENGINE is host-tested; live PencilKit preview + Vision text + VLM-for-ambiguity = next)
+- **Depends on:** HSM-8-02 (PencilKit notebook), HSM-8-06 (on-device Vision)
+- **Owner:** unassigned
+
+## Vision (owner)
+
+iPad + Apple Pencil changes the problem from "convert an image into Mermaid" to **"capture
+intent while the user is drawing."** Strokes, not pixels: PencilKit gives vector geometry, so
+recognize shapes deterministically, build a graph, emit Mermaid, and use a VLM/LLM **only for
+ambiguity**. The magic: draw a box → it's recognized; draw an arrow → recognized; write a
+label → it becomes a node title; **the Mermaid preview updates live.** The Pencil becomes a
+diagram programming language; the user never thinks about Mermaid.
+
+## Architecture (owner-chosen: Option 1 strokes-first + Option 2 hybrid for text/ambiguity)
+
+```
+PencilKit → ShapeRecognizer → DiagramBuilder → MermaidGenerator → live preview
+                  ↑ Vision (handwriting → node text)
+                  ↑ local VLM/LLM (ambiguity only: "is this a decision diamond?")
+```
+
+## Scope
+
+- **In (this story, host-tested):** the pure engine in `RuntimeCore/Sketch/SketchToMermaid` —
+  `ShapeRecognizer.classify(_:)` (a stroke → rectangle / diamond / ellipse via RDP simplify +
+  sharp-corner analysis, or an open **connector** carrying its endpoints), `DiagramBuilder`
+  (shapes + connectors → a graph; each connector → an edge between the nearest nodes),
+  `MermaidGenerator.flowchart(_:)` (rect `["t"]`, diamond `{"t"}`, ellipse `(("t"))`, edges
+  `a -->|label| b`). No CoreGraphics, no model, no device.
+- **Next (under this story):** the **live PencilKit surface** — recognize each stroke as it's
+  drawn, run **on-device Vision** per shape region for the node text (HSM-8-06 path), and a
+  **live Mermaid preview** that updates stroke-by-stroke; the local VLM/LLM only to resolve a
+  shape the geometry can't (diamond vs rectangle, a missed edge), never as the primary path.
+- **Out:** cloud vision. Arbitrary diagram types beyond flowcharts (sequence/class later).
+  Replacing geometry with a VLM (Option 3 — fragile, rejected).
+
+## Acceptance criteria
+
+- [x] **Stroke recognition (host-tested):** a drawn rectangle, diamond, and ellipse classify
+      correctly; an open stroke is a connector carrying its start+end.
+- [x] **Graph + Mermaid (host-tested):** connectors resolve to edges between nearest nodes
+      (self-loops/no-node skipped); the owner's login-flow geometry emits the expected
+      `flowchart TD` (Login → Validate{decision} →|yes| Home / →|no| Error).
+- [ ] **Live PencilKit surface:** strokes recognized as drawn, Vision supplies node text, a
+      Mermaid preview updates live on the iPad.
+- [ ] **Ambiguity only via the model:** the local VLM/LLM is invoked only when geometry is
+      uncertain, with a measurable fallback path.
+
+## Evidence
+
+`Sources/RuntimeCore/Sketch/SketchToMermaid.swift` + `SketchToMermaidTests.swift`
+(`swift test` → 209/0, +6): rectangle/diamond/ellipse/connector recognition + the full
+login-flow pipeline emitting the exact target Mermaid.
+
+## Notes
+
+- Recognition is RDP polyline simplification + sharp-corner counting (≈4 sharp corners at the
+  bbox corners → rectangle, at the edge midpoints → diamond; gradual all round → ellipse).
+  Deliberately simple + tunable; the model is the safety net, not the engine.
+- This is the strokes-first foundation for the "magic pencil" — it makes the live, AI-optional
+  diagram experience possible, and it's already correct + tested before any device work.


### PR DESCRIPTION
The owner's architecture, exactly: iPad + Pencil = **capture intent while drawing**, not convert an image. **Strokes, not pixels** — recognize shapes from PencilKit's vector geometry, build a graph, emit Mermaid, reserve any VLM/LLM for **ambiguity only**.

Lands the pure, host-tested **engine** (`RuntimeCore/Sketch/SketchToMermaid`):
- **`ShapeRecognizer`** — a stroke → rectangle / diamond / ellipse (RDP simplify + sharp-corner analysis) or an open **connector** carrying its endpoints.
- **`DiagramBuilder`** — shapes + connectors → a graph (each connector → an edge between nearest nodes; self-loops skipped).
- **`MermaidGenerator`** — rect `["t"]`, diamond `{"t"}`, ellipse `(("t"))`, edges `a -->|label| b`.

No CoreGraphics, no model, no device — deterministic + testable.

`swift test` → **209/0** (+6): recognition + the login-flow geometry emitting exactly
`flowchart TD / Login --> Validate{decision} / Validate -->|yes| Home / -->|no| Error`.

Next under HSM-14-08: the live PencilKit surface (recognize as you draw, on-device Vision for node text, live Mermaid preview, model only for ambiguity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)