### PR TITLE
HSM-14-09: local vision model (Gemma 3) seam + sketch ambiguity resolution

### DIFF
--- a/apple/Sources/Providers/Providers.swift
+++ b/apple/Sources/Providers/Providers.swift
@@ -24,6 +24,17 @@ public protocol ILLMProvider: Sendable {
     func complete(prompt: String) async throws -> String
 }
 
+/// HSM-14-09 — the vision seam: answer a prompt about an image. Same Mode A/B/C shape as
+/// `ILLMProvider`: backed on-device by a local VLM (Gemma 3 4B via MLX-VLM on Apple Silicon)
+/// for the air-gapped case, or an OpenAI-compatible vision endpoint (Modes B/C). The Runtime
+/// Core depends on this seam, never on a concrete model — so a VLM is swappable. Used first as
+/// the ambiguity resolver for the strokes-first sketch→Mermaid path (HSM-14-08), and for
+/// general image understanding (whiteboard photos, pasted screenshots).
+public protocol IVisionProvider: Sendable {
+    /// Answer `prompt` about the PNG-encoded `image`. Fully local when Mode A.
+    func describe(image: Data, prompt: String) async throws -> String
+}
+
 public protocol IStorage: Sendable {
     func saveMeeting(_ meeting: Meeting) throws
     func loadMeeting(id: String) throws -> Meeting?

--- a/apple/Sources/RuntimeCore/Sketch/SketchToMermaid.swift
+++ b/apple/Sources/RuntimeCore/Sketch/SketchToMermaid.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Providers
 
 /// HSM-14-08 — the Pencil as a diagram language. Strokes, NOT pixels: PencilKit gives us
 /// vector geometry, so we recognize shapes deterministically, build a graph, and emit Mermaid
@@ -176,5 +177,29 @@ public enum MermaidGenerator {
     static func escape(_ s: String) -> String {
         s.replacingOccurrences(of: "\"", with: "'").replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - VLM ambiguity resolution (HSM-14-09)
+
+/// The geometry is the primary path (fast, deterministic, offline). When it's UNCERTAIN about
+/// a shape, fall back to a local vision model (Gemma 3 via the `IVisionProvider` seam) — the
+/// owner's Option-2 hybrid: the VLM only resolves ambiguity, it never drives the graph.
+public enum SketchVision {
+    /// Ask the VLM what a hand-drawn shape is, mapping its words to a `ShapeKind`. Returns nil
+    /// if the model errors or its answer is unrecognizable (caller keeps the geometry guess).
+    public static func resolveShape(image: Data, using vlm: IVisionProvider) async -> ShapeKind? {
+        let prompt = "This is a single hand-drawn flowchart shape. Reply with ONE word only: rectangle, diamond, or ellipse."
+        guard let answer = try? await vlm.describe(image: image, prompt: prompt) else { return nil }
+        return parse(answer)
+    }
+
+    /// Map a free-text VLM answer to a `ShapeKind` (diamond = decision; ellipse = circle/oval).
+    public static func parse(_ answer: String) -> ShapeKind? {
+        let s = answer.lowercased()
+        if s.contains("diamond") || s.contains("rhombus") || s.contains("decision") { return .diamond }
+        if s.contains("ellipse") || s.contains("circle") || s.contains("oval") || s.contains("round") { return .ellipse }
+        if s.contains("rectangle") || s.contains("rect") || s.contains("box") || s.contains("square") { return .rectangle }
+        return nil
     }
 }

--- a/apple/Tests/RuntimeCoreTests/SketchToMermaidTests.swift
+++ b/apple/Tests/RuntimeCoreTests/SketchToMermaidTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Providers
 @testable import RuntimeCore
 
 /// HSM-14-08 — the Pencil-as-diagram-language engine: strokes → shapes → graph → Mermaid,
@@ -81,5 +82,24 @@ final class SketchToMermaidTests: XCTestCase {
             DiagramBuilder.ConnectorInput(from: StrokePoint(1, 1), to: StrokePoint(2, 2)),   // both nearest A → self-loop
         ])
         XCTAssertTrue(g.edges.isEmpty)
+    }
+
+    // MARK: VLM ambiguity resolution (HSM-14-09)
+
+    final class FakeVLM: IVisionProvider, @unchecked Sendable {
+        let answer: String
+        init(_ a: String) { answer = a }
+        func describe(image: Data, prompt: String) async throws -> String { answer }
+    }
+
+    func testVLMResolvesAmbiguousShape() async {
+        let k = await SketchVision.resolveShape(image: Data(), using: FakeVLM("It looks like a decision diamond."))
+        XCTAssertEqual(k, .diamond)
+    }
+    func testVLMAnswerParsing() {
+        XCTAssertEqual(SketchVision.parse("a rounded oval"), .ellipse)
+        XCTAssertEqual(SketchVision.parse("Rectangle / box"), .rectangle)
+        XCTAssertEqual(SketchVision.parse("rhombus"), .diamond)
+        XCTAssertNil(SketchVision.parse("no idea, sorry"))
     }
 }

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -86,6 +86,7 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 | HSM-14-06 | Polish & craft QA (states, micro-copy, screenshot gallery) | backlog | story-06 | — |
 | HSM-14-07 | Voice correction — reject by voice → local model re-routes | in-progress | [story-07](./story-07-voice-correction.md) | host-tested + on iPad |
 | HSM-14-08 | The Pencil as a diagram language (sketch → Mermaid) | in-progress | [story-08](./story-08-pencil-diagram-language.md) | engine host-tested (209/0) |
+| HSM-14-09 | Local vision model (Gemma 3) seam + ambiguity resolution | in-progress | [story-09](./story-09-local-vision-model.md) | seam host-tested (211/0) |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-09-local-vision-model.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-09-local-vision-model.md
@@ -1,0 +1,69 @@
+# HSM-14-09 — Local vision model (Gemma 3) seam + ambiguity resolution
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** in-progress (the `IVisionProvider` seam + the sketch ambiguity resolver are host-tested; the concrete VLM backings — on-device MLX Gemma 3 (Mode A) and a vision endpoint (Modes B/C) — are next)
+- **Depends on:** HSM-14-08 (sketch engine), HSM-5 (the provider/Mode seam pattern)
+- **Owner:** unassigned
+
+## Vision (owner)
+
+Bring a strong small local vision model — **Gemma 3 4B (4-bit)** — into the intelligence. It's
+excellent at handwriting + diagram understanding, and it's the natural "ambiguity resolver"
+for the strokes-first sketch→Mermaid path (HSM-14-08), plus a general image-understanding
+capability (whiteboard photos, pasted screenshots).
+
+## Architecture — the same Mode A/B/C seam as the text model
+
+```
+IVisionProvider  (describe(image, prompt) → text)
+   ├── Mode A: on-device Gemma 3 4B via MLX-VLM (Apple Silicon, air-gapped)
+   ├── Mode B: LAN endpoint (OpenAI-compatible vision)
+   └── Mode C: cloud endpoint (OpenAI-compatible vision)
+```
+
+The Runtime Core depends on the seam, never a concrete model — so the VLM is swappable, and we
+can prove the loop on an endpoint (Mode B/C) **today**, before the on-device MLX work.
+
+## Scope
+
+- **In (this story, host-tested):** the `IVisionProvider` seam (`describe(image:prompt:)`) in
+  Providers, and `SketchVision` (RuntimeCore) — the **ambiguity resolver**: when the geometry
+  is uncertain about a shape, ask the VLM ("rectangle, diamond, or ellipse?") and map its
+  answer to a `ShapeKind`. The geometry stays the primary path; the VLM only resolves
+  ambiguity (owner's Option-2 hybrid). Host-tested with a fake VLM.
+- **Next (under this story):**
+  (1) an **endpoint-backed** `IVisionProvider` (Mode B/C) — proves the loop on a real vision
+  model now (the `.13` / a cloud VLM), wired as the sketch ambiguity fallback + a
+  "describe this image" capability for pasted/whiteboard images;
+  (2) the **on-device** `IVisionProvider` — Gemma 3 4B (4-bit) via **MLX-VLM** (mlx-swift),
+  the air-gapped Mode A backing, behind the same seam (a separate SPM product so the domain
+  never links the VLM runtime, mirroring `InferenceLlama`).
+- **Out:** replacing the geometry with the VLM (Option 3 — rejected as fragile). Video. Cloud
+  as the default (local-first stays the posture).
+
+## Acceptance criteria
+
+- [x] **The seam exists + the domain depends on it** — `IVisionProvider.describe(image:prompt:)`,
+      and `SketchVision.resolveShape(image:using:)` maps a VLM answer to a `ShapeKind`,
+      returning nil on an unusable answer (caller keeps the geometry guess). Host-tested.
+- [ ] **Endpoint VLM (Mode B/C)** backs the seam and resolves a genuinely ambiguous sketch
+      shape on a real vision model.
+- [ ] **On-device Gemma 3 4B (MLX-VLM, Mode A)** backs the seam fully air-gapped, proven on
+      the iPad.
+- [ ] **General image understanding** — describe/extract from a pasted whiteboard photo via
+      the same seam.
+
+## Evidence
+
+`Sources/Providers/Providers.swift` (`IVisionProvider`) + `Sources/RuntimeCore/Sketch/
+SketchToMermaid.swift` (`SketchVision`) + `SketchToMermaidTests.swift`
+(`swift test` → 211/0, +2: VLM resolves an ambiguous shape; answer parsing variants).
+
+## Notes
+
+- MLX-VLM (mlx-swift) is the right on-device VLM runtime on Apple Silicon (Gemma 3 / Qwen2.5-VL
+  supported, Metal-accelerated). llama.cpp/LLM.swift vision (mmproj) support is newer/less
+  exposed; keep the seam runtime-agnostic so either can back it.
+- Prove the loop on an endpoint first (cheap, fast), then bring it on-device — same sequencing
+  that worked for the text model (Modes B/C before Mode A).


### PR DESCRIPTION
Owner: bring **Gemma 3 4B (4-bit)** — a strong small local VLM — into the intelligence as the ambiguity resolver for the strokes-first sketch→Mermaid path + general image understanding.

Same **Mode A/B/C seam** as the text model:
- **`IVisionProvider`** (Providers) — `describe(image:prompt:)` → text. On-device Gemma 3 via **MLX-VLM** (Mode A, air-gapped), or an OpenAI-compatible vision **endpoint** (Modes B/C). The Runtime Core depends on the seam, never a concrete model.
- **`SketchVision`** (RuntimeCore) — when geometry is uncertain, ask the VLM ("rectangle, diamond, or ellipse?") → `ShapeKind`; nil on an unusable answer. Geometry stays primary; the VLM only resolves ambiguity (Option-2 hybrid).

`swift test` → **211/0** (+2).

Next: an endpoint-backed VLM (Mode B/C) to prove the loop now, then on-device Gemma 3 via MLX-VLM (separate SPM product, mirroring InferenceLlama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)