### PR TITLE
HSM-14-09: correct VLM target to Gemma 4 (verified release)

### DIFF
--- a/apple/Sources/Providers/Providers.swift
+++ b/apple/Sources/Providers/Providers.swift
@@ -25,11 +25,12 @@ public protocol ILLMProvider: Sendable {
 }
 
 /// HSM-14-09 — the vision seam: answer a prompt about an image. Same Mode A/B/C shape as
-/// `ILLMProvider`: backed on-device by a local VLM (Gemma 3 4B via MLX-VLM on Apple Silicon)
-/// for the air-gapped case, or an OpenAI-compatible vision endpoint (Modes B/C). The Runtime
-/// Core depends on this seam, never on a concrete model — so a VLM is swappable. Used first as
-/// the ambiguity resolver for the strokes-first sketch→Mermaid path (HSM-14-08), and for
-/// general image understanding (whiteboard photos, pasted screenshots).
+/// `ILLMProvider`: backed on-device by a local VLM (Gemma 4 — the small E4B variant — via
+/// MLX-VLM on Apple Silicon) for the air-gapped case, or an OpenAI-compatible vision endpoint
+/// (Modes B/C). The Runtime Core depends on this seam, never on a concrete model — so the VLM
+/// is swappable (Gemma 4 E4B/12B, Qwen2.5-VL, Phi-4 MM). Used first as the ambiguity resolver
+/// for the strokes-first sketch→Mermaid path (HSM-14-08), and for general image understanding
+/// (whiteboard photos, pasted screenshots).
 public protocol IVisionProvider: Sendable {
     /// Answer `prompt` about the PNG-encoded `image`. Fully local when Mode A.
     func describe(image: Data, prompt: String) async throws -> String

--- a/apple/Sources/RuntimeCore/Sketch/SketchToMermaid.swift
+++ b/apple/Sources/RuntimeCore/Sketch/SketchToMermaid.swift
@@ -183,7 +183,7 @@ public enum MermaidGenerator {
 // MARK: - VLM ambiguity resolution (HSM-14-09)
 
 /// The geometry is the primary path (fast, deterministic, offline). When it's UNCERTAIN about
-/// a shape, fall back to a local vision model (Gemma 3 via the `IVisionProvider` seam) — the
+/// a shape, fall back to a local vision model (Gemma 4 via the `IVisionProvider` seam) — the
 /// owner's Option-2 hybrid: the VLM only resolves ambiguity, it never drives the graph.
 public enum SketchVision {
     /// Ask the VLM what a hand-drawn shape is, mapping its words to a `ShapeKind`. Returns nil

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -86,7 +86,7 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 | HSM-14-06 | Polish & craft QA (states, micro-copy, screenshot gallery) | backlog | story-06 | — |
 | HSM-14-07 | Voice correction — reject by voice → local model re-routes | in-progress | [story-07](./story-07-voice-correction.md) | host-tested + on iPad |
 | HSM-14-08 | The Pencil as a diagram language (sketch → Mermaid) | in-progress | [story-08](./story-08-pencil-diagram-language.md) | engine host-tested (209/0) |
-| HSM-14-09 | Local vision model (Gemma 3) seam + ambiguity resolution | in-progress | [story-09](./story-09-local-vision-model.md) | seam host-tested (211/0) |
+| HSM-14-09 | Local vision model (Gemma 4) seam + ambiguity resolution | in-progress | [story-09](./story-09-local-vision-model.md) | seam host-tested (211/0) |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-09-local-vision-model.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-09-local-vision-model.md
@@ -1,14 +1,14 @@
-# HSM-14-09 — Local vision model (Gemma 3) seam + ambiguity resolution
+# HSM-14-09 — Local vision model (Gemma 4) seam + ambiguity resolution
 
 - **Project:** holdspeak-mobile
 - **Phase:** 14
-- **Status:** in-progress (the `IVisionProvider` seam + the sketch ambiguity resolver are host-tested; the concrete VLM backings — on-device MLX Gemma 3 (Mode A) and a vision endpoint (Modes B/C) — are next)
+- **Status:** in-progress (the `IVisionProvider` seam + the sketch ambiguity resolver are host-tested; the concrete VLM backings — on-device MLX Gemma 4 (Mode A) and a vision endpoint (Modes B/C) — are next)
 - **Depends on:** HSM-14-08 (sketch engine), HSM-5 (the provider/Mode seam pattern)
 - **Owner:** unassigned
 
 ## Vision (owner)
 
-Bring a strong small local vision model — **Gemma 3 4B (4-bit)** — into the intelligence. It's
+Bring a strong small local vision model — **Gemma 4 (the small E4B variant)** — into the intelligence. It's
 excellent at handwriting + diagram understanding, and it's the natural "ambiguity resolver"
 for the strokes-first sketch→Mermaid path (HSM-14-08), plus a general image-understanding
 capability (whiteboard photos, pasted screenshots).
@@ -17,7 +17,7 @@ capability (whiteboard photos, pasted screenshots).
 
 ```
 IVisionProvider  (describe(image, prompt) → text)
-   ├── Mode A: on-device Gemma 3 4B via MLX-VLM (Apple Silicon, air-gapped)
+   ├── Mode A: on-device Gemma 4 (E4B) via MLX-VLM (Apple Silicon, air-gapped)
    ├── Mode B: LAN endpoint (OpenAI-compatible vision)
    └── Mode C: cloud endpoint (OpenAI-compatible vision)
 ```
@@ -36,7 +36,7 @@ can prove the loop on an endpoint (Mode B/C) **today**, before the on-device MLX
   (1) an **endpoint-backed** `IVisionProvider` (Mode B/C) — proves the loop on a real vision
   model now (the `.13` / a cloud VLM), wired as the sketch ambiguity fallback + a
   "describe this image" capability for pasted/whiteboard images;
-  (2) the **on-device** `IVisionProvider` — Gemma 3 4B (4-bit) via **MLX-VLM** (mlx-swift),
+  (2) the **on-device** `IVisionProvider` — Gemma 4 (the small E4B variant) via **MLX-VLM** (mlx-swift),
   the air-gapped Mode A backing, behind the same seam (a separate SPM product so the domain
   never links the VLM runtime, mirroring `InferenceLlama`).
 - **Out:** replacing the geometry with the VLM (Option 3 — rejected as fragile). Video. Cloud
@@ -49,7 +49,7 @@ can prove the loop on an endpoint (Mode B/C) **today**, before the on-device MLX
       returning nil on an unusable answer (caller keeps the geometry guess). Host-tested.
 - [ ] **Endpoint VLM (Mode B/C)** backs the seam and resolves a genuinely ambiguous sketch
       shape on a real vision model.
-- [ ] **On-device Gemma 3 4B (MLX-VLM, Mode A)** backs the seam fully air-gapped, proven on
+- [ ] **On-device Gemma 4 E4B (MLX-VLM, Mode A)** backs the seam fully air-gapped, proven on
       the iPad.
 - [ ] **General image understanding** — describe/extract from a pasted whiteboard photo via
       the same seam.
@@ -62,8 +62,13 @@ SketchToMermaid.swift` (`SketchVision`) + `SketchToMermaidTests.swift`
 
 ## Notes
 
-- MLX-VLM (mlx-swift) is the right on-device VLM runtime on Apple Silicon (Gemma 3 / Qwen2.5-VL
+- MLX-VLM (mlx-swift) is the right on-device VLM runtime on Apple Silicon (Gemma 4 / Qwen2.5-VL
   supported, Metal-accelerated). llama.cpp/LLM.swift vision (mmproj) support is newer/less
   exposed; keep the seam runtime-agnostic so either can back it.
 - Prove the loop on an endpoint first (cheap, fast), then bring it on-device — same sequencing
   that worked for the text model (Modes B/C before Mode A).
+- **Gemma 4 variants (released 2026-04-02; 12B added 2026-06-03):** E2B / **E4B** use Per-Layer
+  Embeddings to cut active compute — E4B (~4B effective) is the natural iPad on-device pick
+  (strong OCR + chart/diagram understanding, multimodal from the ground up); the 12B fits a
+  plugged-in/desktop or LAN-endpoint role. The seam picks whichever is best at integration time.
+


### PR DESCRIPTION
The owner flagged Gemma 4 already exists. Verified: **Gemma 4 shipped 2026-04-02** (12B variant 2026-06-03) — after my training cutoff, which is why I'd defaulted to Gemma 3. Corrected the references.

- The **E4B** variant (Per-Layer Embeddings, ~4B effective) is the on-device iPad pick; the 12B for plugged-in/endpoint.
- **No logic change** — the `IVisionProvider` seam is model-agnostic, so the VLM choice is deferred to integration time. (Exactly why the seam exists.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)