### PR TITLE
HSM-14-10: Models, front and center — import + AirDrop open-in (owner-requested)

### DIFF
--- a/apple/App/Capture-Info.plist
+++ b/apple/App/Capture-Info.plist
@@ -31,5 +31,38 @@
          No networking — capture, transcription and storage all stay on the device. -->
     <key>NSMicrophoneUsageDescription</key>
     <string>HoldSpeak records your meeting so it can transcribe it on-device and keep the notes here on your iPad.</string>
+    <!-- HSM-14: let the owner import models. AirDrop / Files offers "Save to HoldSpeak" for a
+         .gguf, which the app copies into its container (the on-device runtime loads from there). -->
+    <key>UTImportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>dev.holdspeak.gguf</string>
+            <key>UTTypeDescription</key>
+            <string>GGUF model</string>
+            <key>UTTypeConformsTo</key>
+            <array><string>public.data</string></array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array><string>gguf</string></array>
+            </dict>
+        </dict>
+    </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>GGUF model</string>
+            <key>LSItemContentTypes</key>
+            <array><string>dev.holdspeak.gguf</string></array>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+        </dict>
+    </array>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <false/>
 </dict>
 </plist>

--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -6,6 +6,7 @@ import Vision
 import os
 import UIKit
 import MarkdownUI
+import UniformTypeIdentifiers
 
 // HSM-8-01 — the iPad's on-device meeting-capture loop. Open the app, see your
 // recordings, press Record, watch the transcript appear, stop to keep it. Capture
@@ -23,6 +24,11 @@ struct MeetingCaptureApp: App {
                 DemoNotebookView().preferredColorScheme(.dark)
             } else {
                 MeetingListView().preferredColorScheme(.dark)
+                    // AirDrop / "Open in HoldSpeak" a .gguf → copy it into the app's container.
+                    .onOpenURL { url in
+                        guard url.pathExtension.lowercased() == "gguf" else { return }
+                        try? ModelFiles.importModel(from: url)
+                    }
             }
         }
     }
@@ -363,6 +369,143 @@ final class VoiceCaptureState: ObservableObject {
     }
 }
 
+// MARK: - Models (import & manage — front and center, owner-requested)
+
+/// An on-device model file in the app's container.
+struct InstalledModel: Identifiable {
+    let url: URL
+    var sizeBytes: Int
+    var id: String { url.lastPathComponent }
+    var name: String { url.deletingPathExtension().lastPathComponent }
+    enum Kind { case language, visionProjector
+        var label: String { self == .visionProjector ? "Vision projector" : "Language / vision model" }
+        var glyph: String { self == .visionProjector ? "eye.fill" : "brain.head.profile" }
+        var tint: Color { self == .visionProjector ? Sig.local : Sig.accent }
+    }
+    var kind: Kind { url.lastPathComponent.lowercased().contains("mmproj") ? .visionProjector : .language }
+}
+
+/// The app-side model-files helper: imports/lists/deletes `.gguf` in the app's **Documents**
+/// (where the on-device runtime's `localGGUF()` loads from + where pushes land). Delegates to
+/// the tested Providers `ModelStore` (HSM-5-03), wrapping the security scope for picker URLs.
+enum ModelFiles {
+    static var root: URL { FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0] }
+    static var store: ModelStore { ModelStore(root: root) }
+
+    static func installed() -> [InstalledModel] {
+        ((try? store.installedModels()) ?? [])
+            .map { InstalledModel(url: $0, sizeBytes: (try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0) }
+    }
+
+    /// Copy an imported/AirDropped file into the container (the host owns the security scope).
+    @discardableResult
+    static func importModel(from src: URL) throws -> URL {
+        let scoped = src.startAccessingSecurityScopedResource()
+        defer { if scoped { src.stopAccessingSecurityScopedResource() } }
+        return try store.importModel(from: src)
+    }
+
+    static func delete(_ m: InstalledModel) { try? store.delete(m.url) }
+
+    static func size(_ bytes: Int) -> String {
+        let f = ByteCountFormatter(); f.allowedUnits = [.useGB, .useMB]; f.countStyle = .file
+        return f.string(fromByteCount: Int64(bytes))
+    }
+    static var ggufTypes: [UTType] { [UTType(filenameExtension: "gguf") ?? .data] }
+}
+
+struct ModelsView: View {
+    @State private var models: [InstalledModel] = []
+    @State private var importing = false
+    @State private var note = ""
+    @State private var busy = false
+
+    var body: some View {
+        ZStack {
+            Sig.bg.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Models").font(.system(size: 32, weight: .heavy)).foregroundStyle(Sig.text)
+                        Text("Everything runs on this iPad. Import a .gguf from Files or AirDrop — no Mac, no account.")
+                            .font(.system(size: 14)).foregroundStyle(Sig.faint)
+                    }
+                    Button { importing = true } label: { importCta }.disabled(busy)
+                    if !note.isEmpty {
+                        HStack(spacing: 7) {
+                            if busy { ProgressView().tint(Sig.accent) }
+                            Text(note).font(.system(size: 13, weight: .semibold)).foregroundStyle(Sig.muted)
+                        }
+                    }
+                    if models.isEmpty && !busy {
+                        Text("No models yet. Import one to power on-device intelligence.")
+                            .font(.callout).foregroundStyle(Sig.faint).padding(.top, 6)
+                    } else {
+                        ForEach(models) { modelCard($0) }
+                    }
+                }
+                .padding(20).frame(maxWidth: 760).frame(maxWidth: .infinity)
+            }
+        }
+        .toolbar(.hidden, for: .navigationBar)
+        .fileImporter(isPresented: $importing, allowedContentTypes: ModelFiles.ggufTypes, allowsMultipleSelection: true) { result in
+            guard case .success(let urls) = result, !urls.isEmpty else { return }
+            busy = true; note = "Importing \(urls.count) file\(urls.count == 1 ? "" : "s")…"; tactile()
+            Task.detached {
+                var ok = 0
+                for u in urls { if (try? ModelFiles.importModel(from: u)) != nil { ok += 1 } }
+                await MainActor.run {
+                    busy = false; note = "Imported \(ok) model\(ok == 1 ? "" : "s"). They're on this iPad now."; refresh()
+                }
+            }
+        }
+        .onAppear(perform: refresh)
+    }
+
+    private func refresh() { withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) { models = ModelFiles.installed() } }
+
+    private var importCta: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "square.and.arrow.down.fill").font(.system(size: 20, weight: .bold)).foregroundStyle(Sig.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Import a model").font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text)
+                Text("Pick a .gguf from Files (AirDrop a model, then import it here)").font(.system(size: 12)).foregroundStyle(Sig.faint)
+            }
+            Spacer()
+            Image(systemName: "chevron.right").font(.system(size: 13, weight: .bold)).foregroundStyle(Sig.faint)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity)
+        .background(Sig.accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [7, 5])).foregroundStyle(Sig.accent.opacity(0.5)))
+    }
+
+    private func modelCard(_ m: InstalledModel) -> some View {
+        HStack(spacing: 13) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous).fill(m.kind.tint.opacity(0.16))
+                Image(systemName: m.kind.glyph).font(.system(size: 18, weight: .bold)).foregroundStyle(m.kind.tint)
+            }.frame(width: 44, height: 44)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(m.name).font(.system(size: 15.5, weight: .bold)).foregroundStyle(Sig.text).lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(m.kind.label).font(.system(size: 12, weight: .heavy)).foregroundStyle(m.kind.tint)
+                    Text("·").foregroundStyle(Sig.faint)
+                    Text(ModelFiles.size(m.sizeBytes)).font(.system(size: 12, weight: .semibold)).foregroundStyle(Sig.faint)
+                }
+            }
+            Spacer(minLength: 4)
+            Button { tactile(); ModelFiles.delete(m); refresh() } label: {
+                Image(systemName: "trash").font(.system(size: 15, weight: .semibold)).foregroundStyle(Sig.faint)
+                    .frame(width: 38, height: 38).background(Sig.s3, in: Circle())
+            }
+        }
+        .padding(13)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(Sig.line, lineWidth: 1))
+    }
+}
+
 // MARK: - Meeting list
 
 struct MeetingListView: View {
@@ -377,6 +520,7 @@ struct MeetingListView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         header
                         Button { capturing = true } label: { recordCta }
+                        NavigationLink { ModelsView() } label: { modelsCta }.buttonStyle(.plain)
                         if !model.error.isEmpty { errorNote(model.error) }
                         if model.meetings.isEmpty {
                             Text("No recordings yet. Press record to capture a meeting — it stays on this iPad.")
@@ -419,6 +563,27 @@ struct MeetingListView: View {
         }
         .foregroundStyle(.black).padding(.horizontal, 18).padding(.vertical, 15)
         .background(Sig.accent, in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var modelsCta: some View {
+        let n = ModelFiles.installed().count
+        return HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous).fill(Sig.local.opacity(0.16))
+                Image(systemName: "cpu.fill").font(.system(size: 18, weight: .bold)).foregroundStyle(Sig.local)
+            }.frame(width: 44, height: 44)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Models").font(.system(size: 16, weight: .heavy)).foregroundStyle(Sig.text)
+                Text(n == 0 ? "Import a model to enable on-device intelligence"
+                            : "\(n) on this iPad · import or manage")
+                    .font(.system(size: 12)).foregroundStyle(Sig.faint)
+            }
+            Spacer()
+            Image(systemName: "chevron.right").font(.system(size: 13, weight: .bold)).foregroundStyle(Sig.faint)
+        }
+        .padding(14)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(Sig.line, lineWidth: 1))
     }
 
     private func meetingRow(_ m: Meeting) -> some View {

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -87,6 +87,7 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 | HSM-14-07 | Voice correction — reject by voice → local model re-routes | in-progress | [story-07](./story-07-voice-correction.md) | host-tested + on iPad |
 | HSM-14-08 | The Pencil as a diagram language (sketch → Mermaid) | in-progress | [story-08](./story-08-pencil-diagram-language.md) | engine host-tested (209/0) |
 | HSM-14-09 | Local vision model (Gemma 4) seam + ambiguity resolution | in-progress | [story-09](./story-09-local-vision-model.md) | seam host-tested (211/0) |
+| HSM-14-10 | Models, front and center (import + manage, AirDrop-ready) | in-progress | [story-10](./story-10-model-import.md) | device-built |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-10-model-import.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-10-model-import.md
@@ -1,0 +1,59 @@
+# HSM-14-10 — Models, front and center (import + manage, AirDrop-ready)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** in-progress (the Models screen + import + AirDrop open-in are built + device-built; on-device import/AirDrop proof = owner verification)
+- **Depends on:** HSM-5-03 (the Providers `ModelStore`)
+- **Owner:** unassigned
+
+## Vision (owner)
+
+> "Why not just AirDrop it? … Add that feature of importing a model. That should be front and
+> center."
+
+The user should **own their models** — no Mac tether, no `devicectl`. AirDrop a `.gguf` to the
+iPad, or pick one from Files, and it lands in the app where the on-device runtime loads it.
+
+## Why AirDrop alone isn't enough (the real constraint)
+
+iOS sandboxes each app: AirDrop drops a file into **Files**, but the runtime loads only from
+the app's **own container**. So AirDrop needs the app to either (a) register as a `.gguf`
+open-in handler ("Save to HoldSpeak") or (b) offer an in-app **Import** picker. This story does
+both — turning AirDrop/Files into a real model path.
+
+## Scope
+
+- **In:** a **Models** screen (`ModelsView`) — front-and-center entry on the home — that lists
+  installed `.gguf` models (name, size, language-model vs vision-projector), an **Import a
+  model** button (`.fileImporter` over the security-scoped picker), and delete; the app
+  **registered as a `.gguf` open-in handler** (Info.plist `CFBundleDocumentTypes` +
+  `UTImportedTypeDeclarations`) so AirDrop/Files offer **"Save to HoldSpeak"**, with
+  `onOpenURL` copying the incoming file into the container. All file ops delegate to the tested
+  Providers `ModelStore` (HSM-5-03) pointed at the runtime's `Documents` directory.
+- **Out:** an in-app model **catalog/download** UI (HF download exists in `ModelDownloader`;
+  surfacing it is a follow-up). Per-model "active" selection UI (the runtime picks the first
+  `.gguf` today). Model verification/checksums.
+
+## Acceptance criteria
+
+- [x] A **Models** screen lists installed models with size + type, reachable front-and-center
+      from the home; **Import** opens the Files picker and copies the chosen `.gguf` into the
+      container; delete works. Builds + signs for device.
+- [x] The app is a **`.gguf` open-in handler** — AirDrop / Files "Save to HoldSpeak" routes to
+      `onOpenURL`, which copies the file into the container (Info.plist declares the type).
+- [ ] **Owner-verified on the iPad:** AirDrop a `.gguf` → Save to HoldSpeak → it appears in
+      Models and the runtime can load it; and the in-app Import picker works.
+
+## Evidence
+
+`apple/App/MeetingCaptureApp.swift` (`ModelFiles` wrapper over Providers `ModelStore`,
+`ModelsView`, the home `modelsCta`, `onOpenURL`) + `apple/App/Capture-Info.plist` (the `.gguf`
+document type). **Device build SUCCEEDED.**
+
+## Notes
+
+- Reuses the HSM-5-03 `ModelStore` (installed/import/delete) rather than duplicating it —
+  pointed at `Documents` (where `localGGUF()` + the dev `devicectl` push land), so the UI and
+  the runtime see the same models.
+- This is the proper **shipping** path the dev `push-model-device.sh` always flagged ("Files
+  sideload + HF download"). It also surfaces the Gemma 4 + Qwen models already on the device.


### PR DESCRIPTION
Owner: *"Why not just AirDrop it? … Add that feature of importing a model. That should be front and center."* The user should own their models — no Mac tether, no `devicectl`.

- **`ModelsView`** — a front-and-center *Models* entry on the home: lists installed `.gguf` (name, size, language-model vs vision-projector), an **Import a model** button (`.fileImporter`), delete.
- The app is now a **`.gguf` open-in handler** — Info.plist declares the type, so AirDrop / Files offer **"Save to HoldSpeak"**; `onOpenURL` copies it into the container.
- File ops delegate to the **tested Providers `ModelStore`** (HSM-5-03) — reused, not duplicated — pointed at `Documents` (where `localGGUF()` + pushes land).

**Why AirDrop alone isn't enough:** iOS sandboxes apps, so an AirDropped file lands in Files, not the app's container. The open-in handler + import picker make AirDrop/Files a real model path.

Device build **SUCCEEDED**. Owner-verification on the iPad pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)