### PR TITLE
HSM-14-12 + 14-13: plan constant-time transcription + the spatial workspace

### DIFF
--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -1,6 +1,11 @@
 # HoldSpeak Mobile Runtime — Roadmap
 
-**Last updated:** 2026-06-21 (**PHASE 14 — MOBILE EXPERIENCE & CRAFT.** Latest: the
+**Last updated:** 2026-06-22 (**PHASE 14 — MOBILE EXPERIENCE & CRAFT.** Live-dynamism batch
+shipped (PRs #117/#118): transcription root-caused + cached, audio-reactive waveform, draggable
+floating recorder, one free-form dot-grid desktop, note→artifact promotion. Two next stories
+**planned (not built)** on owner request: **HSM-14-12** constant-time live transcription
+(timestamp-driven sliding window) + **HSM-14-13** the spatial workspace (dock/minimize recorder,
+free-place vs tack, resizable cards, tidy; stretch: minimap + windowed panes). Earlier: the
 intelligence pane now **materializes** artifacts (tint-ring glow + animated insert) and the
 MIR profile is a meaningful **lens** (blurb + emphasized-type chips, named on the Generate
 button) — HSM-14-03; and the live transcript "wall of text" is replaced by the **live capture

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -89,6 +89,8 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 | HSM-14-09 | Local vision model (Gemma 4) seam + ambiguity resolution | in-progress | [story-09](./story-09-local-vision-model.md) | seam host-tested (211/0) |
 | HSM-14-10 | Models, front and center (import + manage, AirDrop-ready) | in-progress | [story-10](./story-10-model-import.md) | device-built |
 | HSM-14-11 | The live capture canvas (transcription bubbles + tack-to-board) | in-progress | [story-11](./story-11-live-capture-canvas.md) | built + on iPad + Simulator-proven |
+| HSM-14-12 | Constant-time live transcription (sliding window + commit) | planned | [story-12](./story-12-constant-time-transcription.md) | designed |
+| HSM-14-13 | The spatial workspace (OS-like capture surface) | planned | [story-13](./story-13-spatial-workspace.md) | designed |
 
 ## Where we are
 
@@ -112,6 +114,19 @@ float up as bubbles, the live fragment breathes as a caption, and you grab a bub
 Pencil and **tack it to a pin board**, which marks the moment so the on-device intelligence
 weights it. Three bespoke **Pixellab** pixel-art assets (Qlippy mascot, brass pushpin, waveform
 orb) bundled offline. Built + installed on the iPad Air M4; Simulator screenshot committed.
+
+**2026-06-22 — shipped the live-dynamism batch + planned the next two.** PRs #117/#118 landed:
+the transcription slowness was root-caused (the Whisper model reloaded every tick → cached;
+3 s → 1.2 s cadence), an **audio-reactive waveform** off the real mic level, the recording
+controls collapsed into a **draggable floating recorder** (no big button), the canvas became
+**one free-form dot-grid desktop** (fling a bubble anywhere to tack), and note cards now
+**promote to real `needs_review` artifacts**. Then the owner asked to **plan, not build, the next
+two properly**: **HSM-14-12** (constant-time live transcription — a timestamp-driven sliding
+window so long meetings stay immediate; the model-cache fixed the acute pain but per-tick cost
+still grows O(length)) and **HSM-14-13** (the spatial workspace — dockable/minimizable recorder,
+free-place vs tack, resizable cards, tidy, and stretch: minimap + windowed panes). Both are
+written up as stories with architecture, acceptance criteria, and test plans; implementation is
+deferred.
 
 ## Operating principle (standing, beyond this phase)
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-12-constant-time-transcription.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-12-constant-time-transcription.md
@@ -1,0 +1,104 @@
+# HSM-14-12 — Constant-time live transcription (sliding window + commit)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** planned (designed; not started)
+- **Depends on:** HSM-14-11 (the live canvas + the model-cache fix), HSM-8-01 (MeetingCapture)
+- **Unblocks:** a live transcript that stays immediate on a long meeting (the felt "control plane")
+- **Owner:** unassigned
+
+## Problem
+
+`MeetingCapture.tick()` re-transcribes the **entire accumulated buffer every tick**, and
+`WhisperKitTranscriber` collapses all of WhisperKit's segments into a single zero-timestamp
+segment. HSM-14-11 (PR #117) removed the dominant cost — the model was being reloaded from disk
+every tick — by caching the `WhisperKit` instance and tightening the cadence to 1.2 s. But the
+per-tick work still grows **O(meeting length)**: a 40-minute meeting re-transcribes ~40 minutes
+of audio on every tick, so late in a long meeting the live transcript stops feeling immediate.
+
+The owner's bar: "once a meeting goes on, there's gotta be movement nearly immediately visible
+on the control plane." That has to hold at minute 40, not just minute 1.
+
+## Goal
+
+Bound the per-tick transcription cost to a constant (a fixed audio window) **regardless of
+meeting length**, while keeping:
+- the **live transcript monotonic and complete** (so the bubble sentence-count accumulation in
+  `CaptureModel.ingest` stays correct), and
+- the **final saved transcript** at least as accurate/complete as today.
+
+## Architecture — committed prefix + live tail (timestamp-driven)
+
+The enabler is **real per-segment timestamps**, which WhisperKit already returns and we currently
+throw away:
+
+1. **`WhisperKitTranscriber` preserves timestamps.** Return the real `[Segment]` with
+   `startTime`/`endTime` from `results.flatMap { $0.segments }` (relative to the transcribed
+   window), instead of one segment with `startTime: 0, endTime: 0`. `WhisperText.clean` still
+   runs per segment.
+
+2. **`MeetingCapture` keeps a committed prefix + an active window:**
+   - `committedSegments: [Segment]` — frozen, already-final transcript.
+   - `committedFrames: Int` — audio frames already represented by `committedSegments`.
+   - Each `tick()` transcribes **only the active window** = audio from `committedFrames` to the
+     end. If that window's duration exceeds `maxWindowSeconds` (≈ 60 s), commit the front first.
+   - **Commit policy (no mid-word cuts):** when the active window's duration > `commitThreshold`
+     (≈ 45 s), freeze every window segment whose `endTime < (windowDuration − overlap)` (overlap
+     ≈ 8 s, so the in-progress sentence is never cut), append them to `committedSegments`, and
+     advance `committedFrames` by `round(lastCommittedEnd * sampleRate)`. Timestamps make the
+     audio↔text boundary exact.
+   - **Live transcript = `committedSegments` + active-window segments.** Always the full meeting,
+     always monotonic; only the bounded tail is recomputed each tick.
+
+3. **`stop()`** assembles `committedSegments` + a final transcription of the remaining tail (or a
+   single authoritative full pass if cheaper) for the persisted meeting — never worse than today.
+
+This bounds each `tick()` to transcribing ≤ `maxWindowSeconds` of audio. Commits are periodic and
+cheap. The cadence stays ~constant at minute 40.
+
+## Scope
+
+- **In (host-testable):** the windowing/commit logic in `MeetingCapture` behind the existing
+  seams; `WhisperKitTranscriber` returning real multi-segment timestamps; preserve the
+  `lastGoodSegments` blank-pass fallback (a window that comes back empty must not lose the take).
+- **Out:** token-level streaming ASR, speaker diarization, changing the Whisper model/size, any
+  UI change (the canvas/bubbles are unaffected — they consume the same live transcript string).
+
+## Acceptance criteria
+
+- [ ] **Bounded per-tick audio** — with a synthetic long buffer, the audio handed to the
+      transcriber per tick never exceeds `maxWindowSeconds` (host-tested with a fake timestamped
+      `ITranscriber` that records the window length it was asked to transcribe).
+- [ ] **No loss or duplication across a commit boundary** — committed prefix + active tail
+      reconstruct the full transcript with no dropped or repeated words at the seam (host-tested;
+      overlap proves the in-progress sentence is re-transcribed, not split).
+- [ ] **Monotonic live transcript** — the live string only grows; `CaptureModel.ingest`'s
+      sentence-count diffing still emits one bubble per finished utterance (host/UI-tested).
+- [ ] **Commit math** — `committedFrames` advances by the committed segments' end time × sample
+      rate; never past the overlap guard (host-tested).
+- [ ] **Saved transcript not worse** — the meeting persisted at `stop()` is at least as complete
+      as the pre-change full-pass result (host-tested on a fixture).
+- [ ] **Steady on real metal** — a ≥ 10-minute real meeting on the iPad Air M4 shows ~constant
+      live latency late in the meeting (owner/device verification).
+
+## Test plan
+
+- New `SlidingWindowTests` (or extend `MeetingCaptureTests`) with a **fake `ITranscriber`** that
+  returns deterministic timestamped segments and records the window length it received: assert
+  window bound, commit advancement, no loss/dup across the boundary, blank-window fallback.
+- `uv run`-equivalent: `swift test` (the package suite; target ≥ current 211/0 + the new cases).
+- Device: a long real meeting; eyeball the cadence at the end vs the start.
+
+## Risks / mitigations
+
+- **WhisperKit base timestamp accuracy** → the `overlap` guard absorbs small errors; commit only
+  whole segments before the guard.
+- **Concurrency on the cached model** → live ticks are already sequential (the model awaits each
+  tick); keep the cached-instance access serialized.
+- **A window that returns blank** → keep `lastGoodSegments`; never commit on a blank pass.
+
+## Evidence
+
+(To fill at implementation.) `Sources/RuntimeCore/Capture/MeetingCapture.swift` (windowing) +
+`App/MeetingCaptureApp.swift` (`WhisperKitTranscriber` timestamps) + `SlidingWindowTests`
+(`swift test` count). Device: a long-meeting cadence note.

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-13-spatial-workspace.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-13-spatial-workspace.md
@@ -1,0 +1,101 @@
+# HSM-14-13 — The spatial workspace (OS-like capture surface)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** planned (designed; not started)
+- **Depends on:** HSM-14-11 (free-form desktop + draggable floating recorder)
+- **Unblocks:** the "nearly like an operating system" capture experience the owner is after
+- **Owner:** unassigned
+
+## Vision (owner)
+
+> "Why must we be contained to those big-ass pages? Why can't we minimize the recording button to
+> something smaller, move things around? This is nearly like an operating system. iOS. Incredible."
+
+HSM-14-11 took the first steps: the canvas became one free-form dot-grid **desktop**, the recorder
+became a **draggable floating capsule**, and bubbles can be **flung anywhere to tack**. This story
+makes it a real **spatial workspace** — elements you arrange, dock, resize, and that remember where
+you put them — without losing the one-handed, glanceable feel.
+
+## Design principles
+
+- **Spatial, not modal.** Fewer hard mode switches (the Transcript/Notes segmented toggle); more
+  one surface where things coexist and you arrange them.
+- **Everything has a place and remembers it.** Positions/sizes persist per meeting.
+- **Direct manipulation + haptics.** Drag, snap, resize, dock — all gesture-first with feedback.
+- **Never trap the user.** Anything moved/minimized is one gesture from restored; an "organize"
+  affordance re-tidies the surface.
+
+## Deliverables (ordered; later ones are stretch)
+
+1. **Dockable floating recorder.** The `FloatingRecorder` can **dock** to an edge (bottom / top /
+   side) or float free; magnetic **snap zones** with a haptic; **minimize** to a compact "rec
+   orb" (timer dot + waveform tick) and re-expand on tap. Position/dock state persists per session.
+2. **Free-place vs tack.** Dragging a streaming bubble can drop it as a **loose card** anywhere on
+   the desktop (just placed) **or** tack it as a **marked moment** (feeds MIR, HSM-8-03) — a clear,
+   discoverable distinction (e.g. a drop onto the "pin" gutter / a long-press-then-drag = tack;
+   a plain drag = loose place). Loose cards persist; tacked cards also mark the moment.
+3. **Resizable cards.** Corner-drag (and/or pinch) to resize `NoteCard` / pinned cards; text reflows;
+   min/max bounds; size persists.
+4. **Organize / tidy.** A one-tap "tidy" that re-flows loose cards into a readable layout (so the
+   freedom never becomes a mess), with an undo.
+5. **Minimap / overview.** On a surface larger than the viewport, a small overview thumbnail of
+   where cards live; tap a region to pan/jump. (Stretch.)
+6. **Panes as windows.** Replace the Transcript/Notes segmented toggle with **movable panels**
+   (transcript, notes, and — post-meeting — intelligence) that can sit side by side, overlap, or
+   minimize — a windowed workspace. (Stretch / likely its own follow-up story.)
+
+## Architecture
+
+- A small **layout model** persisted per meeting (extend the existing `notecards-<id>.json` pattern,
+  or a sibling `workspace-<id>.json`): card id → `{x, y, w, h, kind: loose|tacked}`, plus recorder
+  dock state. Reuses `CaptureModel` / `NotebookModel` ownership; no new store seam needed.
+- **Snap/dock** is a pure function (drop point + viewport → nearest dock/snap target) — host-testable.
+- **Coordinate spaces:** keep the named `"canvas"` space from HSM-14-11; the recorder uses the
+  screen space. Resizing uses the card's local space.
+- Build on the existing `LiveCaptureCanvas`, `PinnedNoteView`, `NoteCardView`, `FloatingRecorder`,
+  `DesktopGrid` — extend, don't rewrite.
+
+## Scope
+
+- **In:** deliverables 1–4 (dock/minimize recorder, free-place vs tack, resizable cards, tidy),
+  with per-meeting spatial persistence; the snap/dock/tidy math host-tested; Simulator-proven +
+  device-verified for hardware feel (drag latency, haptics).
+- **Stretch (in this story if time, else split to 14-14):** minimap (5), windowed panes (6).
+- **Out:** multi-meeting/global workspace, external-display/Stage-Manager multi-window, collaboration.
+
+## Acceptance criteria
+
+- [ ] **Recorder docks + minimizes** — drag the floating recorder to an edge → it snaps/docks with
+      a haptic; minimize → a compact rec orb; re-expand on tap; state persists across a pane switch
+      and re-entry. Simulator-proven + device feel verified.
+- [ ] **Free-place vs tack is clear** — a bubble can be dropped as a loose card OR tacked as a
+      marked moment, with a discoverable distinction; tacking still calls `markMoment` (MIR weight).
+      Both persist per meeting.
+- [ ] **Cards resize** — corner-drag resizes a note/pinned card within bounds; text reflows; size
+      persists across re-entry.
+- [ ] **Tidy works + is reversible** — one tap re-flows loose cards into a readable layout; undo
+      restores the prior arrangement.
+- [ ] **Spatial persistence** — positions/sizes/dock state reload intact when the meeting is
+      reopened (host-tested for the layout model; device-verified end to end).
+- [ ] **Snap/dock/tidy math host-tested** — pure functions for nearest-dock, snap target, and tidy
+      layout have unit tests.
+- [ ] **No trap** — every minimized/moved element is one gesture from restored (UI-verified).
+
+## Test plan
+
+- Host tests for the pure layout math (`dock(for:in:)`, `snap`, `tidy`) and the layout
+  model's encode/decode round-trip → `swift test`.
+- Simulator screenshots (committed) for each deliverable's states (docked / minimized / loose
+  card / resized / tidied), via the existing `HS_DEMO` sim seeds.
+- Device: hardware feel — drag latency, snap haptics, Pencil vs finger — on the iPad Air M4.
+
+## Notes
+
+- Sequencing: land **1 (dock/minimize)** and **2 (free-place vs tack)** first — they deliver the
+  most "OS-like" feel for the least surface area. **6 (windowed panes)** is the biggest lever but
+  also the biggest change; if it grows, split it into **HSM-14-14 (windowed panes + minimap)** so
+  this story stays shippable.
+- Keep it one-handed and glanceable — spatial freedom must not cost the press-record-and-go speed.
+- Honors the standing UX bar ([[feedback_high_ui_standards]], [[feedback_deliver_mobile_craft_not_plumbing]]):
+  shown via Simulator screenshots, hardware feel on the device.


### PR DESCRIPTION
Planning only (per owner: "just make those stories… to implement it properly and well"). No code.

## HSM-14-12 — Constant-time live transcription
`MeetingCapture.tick()` re-transcribes the whole accumulated buffer each tick; PR #117's model-cache fixed the acute slowness but per-tick cost still grows **O(meeting length)**. Plan: a **timestamp-driven sliding window** — `WhisperKitTranscriber` preserves real per-segment timestamps; `MeetingCapture` keeps a **committed prefix + bounded live tail**, committing whole segments before an overlap guard (no mid-word cuts) and advancing `committedFrames` by `endTime × sampleRate`. Bounds each tick to a fixed window; live transcript stays full + monotonic; saved transcript no worse. Host-testable with a fake timestamped transcriber.

## HSM-14-13 — The spatial workspace (OS-like)
Builds on the free-form desktop (#118) + draggable recorder (#117): **dockable/minimizable** floating recorder, **free-place vs tack**, **resizable cards**, **tidy/undo**; stretch: **minimap** + **windowed panes**. Per-meeting spatial persistence; pure dock/snap/tidy math host-tested; Simulator-proven + device feel. Sequencing + a possible 14-14 split noted.

Both stories carry architecture, acceptance criteria, and test plans. Tracker rows + "Where we are" + mobile README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)