### PR TITLE
HSM-14-15 Workbench: the user-defined intelligence workflow engine (foundation)

### DIFF
--- a/apple/Sources/RuntimeCore/Workbench/Workflow.swift
+++ b/apple/Sources/RuntimeCore/Workbench/Workflow.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Contracts
+
+/// HSM-14 — The Workbench engine. A **user-defined intelligence workflow**: pick a SOURCE (what the
+/// model reads), chain a few STEPS (lenses / extractions / transforms — the "basic set of logic"),
+/// and send the result to an OUTPUT. A deliberately *linear pipeline* (not a free node graph) so the
+/// builder has crushing usability — every workflow reads top-to-bottom and is impossible to wire
+/// wrong. Pure + Codable + host-tested here; the gamified visual canvas binds to this model, and the
+/// App runs it through the configured `ILLMProvider` (on-device or LAN endpoint).
+public enum WorkflowSource: String, Codable, Sendable, CaseIterable {
+    case fullTranscript    // the whole meeting
+    case tackedMoments     // only the moments you tacked (HSM-8-03 marks)
+    case selection         // a highlighted span
+
+    public var label: String {
+        switch self {
+        case .fullTranscript: return "Full transcript"
+        case .tackedMoments:  return "Tacked moments"
+        case .selection:      return "Selected text"
+        }
+    }
+    public var glyph: String {
+        switch self {
+        case .fullTranscript: return "text.alignleft"
+        case .tackedMoments:  return "pin.fill"
+        case .selection:      return "selection.pin.in.out"
+        }
+    }
+}
+
+/// One step in the pipeline — the basic logic blocks the builder offers.
+public enum WorkflowStep: Codable, Sendable, Equatable, Identifiable {
+    case lens(MIRProfile)        // surface through a meeting lens (weights what to find)
+    case extract(ArtifactType)   // draft a specific artifact type
+    case summarize               // condense to a tight summary
+    case rewrite(tone: String)   // restate in a tone (e.g. "executive", "plain")
+    case keepIf(String)          // basic filter: keep only items mentioning a keyword
+
+    public var id: String { label }
+
+    public var label: String {
+        switch self {
+        case .lens(let p):    return "Lens · \(p.rawValue.capitalized)"
+        case .extract(let t): return "Extract · \(t.rawValue)"
+        case .summarize:      return "Summarize"
+        case .rewrite(let t): return "Rewrite · \(t)"
+        case .keepIf(let k):  return "Keep if · \(k)"
+        }
+    }
+    public var glyph: String {
+        switch self {
+        case .lens:      return "camera.filters"
+        case .extract:   return "doc.text.magnifyingglass"
+        case .summarize: return "text.append"
+        case .rewrite:   return "pencil.and.outline"
+        case .keepIf:    return "line.3.horizontal.decrease.circle"
+        }
+    }
+}
+
+/// Where the pipeline's result goes.
+public enum WorkflowOutput: String, Codable, Sendable, CaseIterable {
+    case artifacts   // reviewable artifact cards (the default)
+    case note        // a single note on the meeting
+    case slack       // propose → approve → send (reuses the existing connector path)
+
+    public var label: String {
+        switch self {
+        case .artifacts: return "Artifact cards"
+        case .note:      return "A note"
+        case .slack:     return "Send to Slack"
+        }
+    }
+    public var glyph: String {
+        switch self {
+        case .artifacts: return "rectangle.stack.fill"
+        case .note:      return "note.text"
+        case .slack:     return "paperplane.fill"
+        }
+    }
+    /// Outputs that leave the device (so the UI can show the egress reality).
+    public var isEgress: Bool { self == .slack }
+}
+
+/// A complete, named, user-defined workflow.
+public struct Workflow: Identifiable, Codable, Sendable, Equatable {
+    public var id: UUID
+    public var name: String
+    public var source: WorkflowSource
+    public var steps: [WorkflowStep]
+    public var output: WorkflowOutput
+
+    public init(id: UUID = UUID(), name: String, source: WorkflowSource,
+                steps: [WorkflowStep], output: WorkflowOutput) {
+        self.id = id
+        self.name = name
+        self.source = source
+        self.steps = steps
+        self.output = output
+    }
+
+    /// A workflow runs only if it has at least one step (a source + output alone does nothing).
+    public var isRunnable: Bool { !steps.isEmpty }
+
+    /// A human-readable, top-to-bottom plan — the sentence the builder shows so the workflow is
+    /// never a mystery: "Full transcript → Lens · Delivery → Summarize → Artifact cards".
+    public var plan: String {
+        ([source.label] + steps.map(\.label) + [output.label]).joined(separator: "  →  ")
+    }
+
+    /// The artifact types this workflow will produce, derived from its extract/lens steps — what a
+    /// run will surface (so the canvas can preview it, like the generation theater's constellation).
+    public func producedTypes(default base: [ArtifactType]) -> [ArtifactType] {
+        var out: [ArtifactType] = []
+        for step in steps {
+            switch step {
+            case .extract(let t): out.append(t)
+            case .lens(let p):    out.append(contentsOf: MIRRouter.baseEmphasis[p] ?? [])
+            default: break
+            }
+        }
+        var seen = Set<ArtifactType>(), ordered: [ArtifactType] = []
+        for t in out where seen.insert(t).inserted { ordered.append(t) }
+        return ordered.isEmpty ? base : ordered
+    }
+}
+
+/// The starter workflows the Workbench ships with — one tap to a useful pipeline, the on-ramp to
+/// building your own. (The "absolute crushing usability" entry point: don't start from blank.)
+public enum WorkflowPresets {
+    public static let all: [Workflow] = [
+        Workflow(name: "Decisions & owners", source: .fullTranscript,
+                 steps: [.lens(.delivery), .extract(.decisions), .extract(.actionItems)], output: .artifacts),
+        Workflow(name: "What I flagged", source: .tackedMoments,
+                 steps: [.extract(.actionItems), .extract(.riskRegister)], output: .artifacts),
+        Workflow(name: "Exec summary → Slack", source: .fullTranscript,
+                 steps: [.summarize, .rewrite(tone: "executive")], output: .slack),
+        Workflow(name: "Risks only", source: .fullTranscript,
+                 steps: [.lens(.incident), .extract(.riskRegister), .keepIf("risk")], output: .artifacts),
+    ]
+}

--- a/apple/Tests/RuntimeCoreTests/WorkflowTests.swift
+++ b/apple/Tests/RuntimeCoreTests/WorkflowTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import Contracts
+@testable import RuntimeCore
+
+/// HSM-14 Workbench — the user-defined workflow model (the engine the visual builder binds to).
+final class WorkflowTests: XCTestCase {
+
+    func testPlanReadsTopToBottom() {
+        let w = Workflow(name: "x", source: .fullTranscript,
+                         steps: [.lens(.delivery), .summarize], output: .artifacts)
+        XCTAssertEqual(w.plan, "Full transcript  →  Lens · Delivery  →  Summarize  →  Artifact cards")
+    }
+
+    func testRunnableRequiresAStep() {
+        XCTAssertFalse(Workflow(name: "empty", source: .fullTranscript, steps: [], output: .note).isRunnable)
+        XCTAssertTrue(Workflow(name: "ok", source: .fullTranscript, steps: [.summarize], output: .note).isRunnable)
+    }
+
+    func testProducedTypesFromExtractAndLensDeduped() {
+        // delivery lens emphasis + an explicit extract that overlaps → de-duplicated, order kept.
+        let lensTypes = MIRRouter.baseEmphasis[.delivery] ?? []
+        let w = Workflow(name: "x", source: .fullTranscript,
+                         steps: [.lens(.delivery), .extract(.decisions)], output: .artifacts)
+        let produced = w.producedTypes(default: [.requirements])
+        XCTAssertTrue(produced.contains(.decisions))
+        XCTAssertEqual(Set(produced).count, produced.count, "no duplicate types")
+        for t in lensTypes { XCTAssertTrue(produced.contains(t), "lens emphasis \(t) is included") }
+    }
+
+    func testProducedTypesFallsBackWhenNoExtractOrLens() {
+        let w = Workflow(name: "x", source: .fullTranscript, steps: [.summarize], output: .note)
+        XCTAssertEqual(w.producedTypes(default: [.requirements]), [.requirements])
+    }
+
+    func testEgressFlagOnlyForSlack() {
+        XCTAssertTrue(WorkflowOutput.slack.isEgress)
+        XCTAssertFalse(WorkflowOutput.artifacts.isEgress)
+        XCTAssertFalse(WorkflowOutput.note.isEgress)
+    }
+
+    func testCodableRoundTripIncludingAssociatedValueSteps() throws {
+        let w = Workflow(name: "Exec → Slack", source: .tackedMoments,
+                         steps: [.extract(.riskRegister), .rewrite(tone: "executive"), .keepIf("budget")],
+                         output: .slack)
+        let data = try JSONEncoder().encode(w)
+        let back = try JSONDecoder().decode(Workflow.self, from: data)
+        XCTAssertEqual(back, w, "name, source, every step (with its associated value), and output survive")
+    }
+
+    func testPresetsAreRunnableAndRoundTrip() throws {
+        XCTAssertFalse(WorkflowPresets.all.isEmpty)
+        for w in WorkflowPresets.all {
+            XCTAssertTrue(w.isRunnable, "\(w.name) has at least one step")
+            let back = try JSONDecoder().decode(Workflow.self, from: try JSONEncoder().encode(w))
+            XCTAssertEqual(back, w)
+        }
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -3,8 +3,14 @@
 > 🚀 **New agent? Start here:** [`HANDOVER.md`](./HANDOVER.md) — the build→deploy→show loop,
 > gotchas, and the exact remaining work to finish **Phase 8** and **Phase 14** (top priority).
 
-**Last updated:** 2026-06-22 (**PHASE 14 — MOBILE EXPERIENCE & CRAFT.** **App Settings (inference
-target)** — a real, persisted Settings surface (gear in the home header): choose where intelligence
+**Last updated:** 2026-06-22 (**PHASE 14 — MOBILE EXPERIENCE & CRAFT.** **The Workbench begins**
+(HSM-14-15) — the owner's gamified visual intelligence builder: user-defined workflows as a linear
+pipeline (SOURCE → STEPs → OUTPUT; the usability bet over a node graph) with basic logic blocks
+(lens/extract/summarize/rewrite/keep-if), egress-aware outputs, presets, a readable plan. **Engine
+foundation shipped + host-tested** (`Sources/RuntimeCore/Workbench/Workflow.swift`, `WorkflowTests`,
+`swift test` **240/6/0**); design in `phase-14…/story-15-workbench.md`; the gamified canvas (tap
+blocks, reorder, run through the configured provider with the theater treatment) is the next build.
+Prior same-day: **App Settings (inference target)** — a real, persisted Settings surface (gear in the home header): choose where intelligence
 runs — *This iPad* (on-device) or a *LAN endpoint* (any OpenAI-compatible server) — with URL/model/
 key fields + a live Test connection, persisted in `InferenceConfigStore` and **wired into
 `generate()`** (it branches the provider on the setting), so inference can finally target the LAN

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -91,6 +91,7 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 | HSM-14-11 | The live capture canvas (transcription bubbles + tack-to-board) | in-progress | [story-11](./story-11-live-capture-canvas.md) | built + on iPad + Simulator-proven |
 | HSM-14-12 | Constant-time live transcription (sliding window + commit) | in-progress (built + host-proven + sim-shown; device cadence pending) | [story-12](./story-12-constant-time-transcription.md) | [shot](./screenshots/constant-time-transcription-canvas.png) + story "Evidence" |
 | HSM-14-13 | The spatial workspace (OS-like capture surface) | in-progress (deliverables 1–4 built + host-proven + sim-shown; stretch 5–6 + device feel remain) | [story-13](./story-13-spatial-workspace.md) | [docked](./screenshots/recorder-docked-top.png) / [orb](./screenshots/recorder-minimized-orb.png) / [free-place vs tack](./screenshots/recorder-freeplace-vs-tack.png) / [resize](./screenshots/recorder-resizable-card.png) / [tidy](./screenshots/recorder-tidy-grid.png) |
+| HSM-14-15 | The Workbench (visual intelligence builder) | in-progress (engine shipped + host-tested; gamified canvas next) | [story-15](./story-15-workbench.md) | `WorkflowTests` (7) |
 
 ## Where we are
 
@@ -204,6 +205,16 @@ chosen target isn't ready — so the owner can finally point inference at the `.
 throughout (gradient target cards with accent-selected border, glyph chips, an honest egress pill).
 Built for Simulator + device; committed shot (`settings-intelligence.png`). Reuses the HSM-5-06
 `RuntimeMode`/`EndpointConfig` seam. **Still next: the Workbench (visual intelligence builder).**
+
+**2026-06-22 — the Workbench begins (HSM-14-15), on the owner's vision of a gamified visual
+intelligence builder.** The flagship is scoped + its **engine foundation shipped + host-tested**:
+`Sources/RuntimeCore/Workbench/Workflow.swift` — a user-defined workflow is a *linear pipeline*
+(SOURCE → STEPs → OUTPUT; the deliberate usability bet over a node-and-wire graph), with the basic
+logic blocks (lens / extract / summarize / rewrite / keep-if), egress-aware outputs, a human-readable
+`plan`, derived produced-types, and one-tap `WorkflowPresets`. `WorkflowTests` (7), `swift test`
+**240/6/0**. The design is in [`story-15`](./story-15-workbench.md). **Next build: the gamified
+canvas** (tap blocks from a palette, drag to reorder, run through the configured `ILLMProvider` with
+the generation-theater treatment, results to the chosen output).
 
 ## Operating principle (standing, beyond this phase)
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-15-workbench.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-15-workbench.md
@@ -1,0 +1,73 @@
+# HSM-14-15 — The Workbench (visual, user-defined intelligence builder)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** in-progress — **engine foundation shipped + host-tested** (2026-06-22); the gamified
+  visual canvas is the next build.
+- **Depends on:** HSM-14 Settings (the configured `ILLMProvider` target), HSM-8-04 (artifact gen)
+- **Owner:** unassigned
+
+## Vision (owner)
+
+> "Where is our workbench while we're in a meeting? Our own workflows that utilize the model and
+> intelligence, with explicit builders that let us create user-defined intelligence — a visual
+> builder with a basic set of logic. Gamified visual coding that lets us use intelligence in
+> whichever way we have it configured. The most basic of builders, with ABSOLUTE CRUSHING USABILITY."
+
+HoldSpeak's intelligence is fixed pipelines today (the lens picks types, the model drafts them). The
+Workbench makes intelligence **user-programmable**: you compose your own workflows and run them on a
+meeting, through whatever inference you've configured (on-device or your LAN box).
+
+## The design — a linear pipeline, not a node graph (this is the usability bet)
+
+A free-form node-and-wire graph is powerful and unusable on a tablet. The Workbench is instead a
+**linear pipeline** that reads top-to-bottom and is impossible to wire wrong:
+
+**SOURCE → STEP → STEP → … → OUTPUT**
+
+- **Source** (one): Full transcript · Tacked moments (your HSM-8-03 marks) · Selected text.
+- **Steps** (the "basic set of logic", tap from a palette, drag to reorder): **Lens** (a MIR
+  profile that weights what to find) · **Extract** (a specific artifact type) · **Summarize** ·
+  **Rewrite** (a tone) · **Keep if** (a keyword filter — the one branch/condition primitive).
+- **Output** (one): Artifact cards · A note · Send to Slack (egress, shown plainly).
+
+Every block is a Signal card with its glyph; the pipeline shows its plan as a sentence
+("Full transcript → Lens · Delivery → Summarize → Artifact cards"). **Presets** ("Decisions &
+owners", "What I flagged", "Exec summary → Slack", "Risks only") are the on-ramp — one tap to a
+working pipeline, then tweak. Workflows are named, saved, and reusable.
+
+**Running** reuses the generation theater: a Run button executes the pipeline through the configured
+`ILLMProvider`, the produced-types constellation lights up as each step lands, results flow to the
+chosen output. Egress outputs (Slack) ride the existing propose→approve→execute path.
+
+## Engine (shipped this story)
+
+`Sources/RuntimeCore/Workbench/Workflow.swift` — pure + Codable + host-tested
+(`WorkflowTests`, 7): `WorkflowSource` / `WorkflowStep` (lens/extract/summarize/rewrite/keepIf) /
+`WorkflowOutput` (with an `isEgress` flag) / `Workflow` (`isRunnable`, `plan`, `producedTypes`) and
+`WorkflowPresets`. This is the model the canvas binds to and the runner executes. `swift test`
+**240/6/0**.
+
+## Acceptance criteria
+
+- [x] **Engine** — a Codable workflow model (source + ordered steps + output), presets, a
+      human-readable plan, derived produced-types, host-tested.
+- [ ] **The canvas** — a Workbench screen (from the home) that builds a pipeline by tapping blocks
+      from a palette and dragging to reorder, Signal depth throughout, crushing usability.
+      Simulator-screenshot-proven.
+- [ ] **Run it** — execute a workflow against a meeting through the configured `ILLMProvider`, with
+      the generation-theater treatment; results land in the chosen output.
+- [ ] **Persistence + presets** — workflows save and reload; presets are the one-tap on-ramp.
+- [ ] **Egress honesty** — a Slack output shows the egress badge and rides propose→approve→execute.
+- [ ] **In-meeting** — the Workbench is reachable mid-meeting (the owner's "while we're in a meeting").
+
+## Build plan
+
+1. **Engine** (done). 2. The pipeline **canvas** + block palette (Simulator-proven). 3. **Run**
+wiring (reuse `generate()`'s provider + theater). 4. **Persistence** + presets surfaced. 5. In-meeting
+entry + egress honesty + polish.
+
+## Notes
+
+- Linearity is the deliberate usability choice; a richer branch/graph mode is a later option, not v1.
+- Reuses Settings' `InferenceConfigStore` (runs through on-device OR the LAN endpoint, the user's call).


### PR DESCRIPTION
Phase 14 — on the owner's vision of a **gamified, visual builder for user-defined intelligence** ("our own workflows… a visual builder with a basic set of logic… absolute crushing usability"). This lands the **tested engine** the visual canvas binds to; the gamified canvas is the next build.

## `Sources/RuntimeCore/Workbench/Workflow.swift` (pure, Codable, host-tested)
- A workflow is a **linear pipeline** — SOURCE → STEPs → OUTPUT — the deliberate usability bet over a node-and-wire graph (reads top-to-bottom, impossible to wire wrong).
- `WorkflowSource` (full transcript / tacked moments / selection), `WorkflowStep` (the basic logic: **lens / extract / summarize / rewrite / keep-if**), `WorkflowOutput` (artifact cards / note / Slack, with an `isEgress` flag).
- `Workflow`: `isRunnable`, a human-readable **`plan`**, derived **`producedTypes`** (for the canvas preview), and **`WorkflowPresets`** (the one-tap on-ramp).

The runner will execute a workflow through the configured `ILLMProvider` (Settings — on-device or LAN) with the **generation-theater** treatment; results to the chosen output (Slack rides propose→approve→execute). Design + build plan in `phase-14…/story-15-workbench.md`.

## Proof
`swift test` **240/6/0** (+7 `WorkflowTests`: plan, runnable, produced-types dedup + fallback, egress flag, Codable round-trip incl. associated-value steps, presets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)