### PR TITLE
HSM-14-18 Real-time MIR: the cadence/trigger brain (LiveIntelCadence)

### DIFF
--- a/apple/Sources/RuntimeCore/Capture/LiveIntelCadence.swift
+++ b/apple/Sources/RuntimeCore/Capture/LiveIntelCadence.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// HSM-14-18 — the "when does a live intelligence pass fire, and why" brain for real-time MIR on the
+/// iPad. Pure + host-tested; no model, no UI. Two INDEPENDENT triggers (both user-configurable in the
+/// real-time-intelligence setup screen):
+///
+///   • **Tack** — the user flagged a moment ⇒ fire immediately. The most useful and cheapest real-time
+///     signal: intelligence on the thing you just chose to flag.
+///   • **Cadence** — periodically over the growing transcript, deliberately SPARSE so a live pass never
+///     fights Whisper + diarization on one chip: it fires only when BOTH enough *new* transcript has
+///     accrued (`minNewSegments`) AND enough time has passed since the last pass (`minSecondsBetweenRuns`).
+public struct LiveIntelCadence: Sendable, Equatable {
+    public var tackTriggerEnabled: Bool
+    public var cadenceEnabled: Bool
+    public var minSecondsBetweenRuns: Double
+    public var minNewSegments: Int
+
+    public init(tackTriggerEnabled: Bool = true,
+                cadenceEnabled: Bool = true,
+                minSecondsBetweenRuns: Double = 25,
+                minNewSegments: Int = 4) {
+        self.tackTriggerEnabled = tackTriggerEnabled
+        self.cadenceEnabled = cadenceEnabled
+        self.minSecondsBetweenRuns = minSecondsBetweenRuns
+        self.minNewSegments = minNewSegments
+    }
+
+    public enum Trigger: String, Sendable, Equatable { case tack, cadence }
+
+    /// Whether a live intel pass should fire now, and why. A pending tack wins (immediate, user-driven).
+    /// Otherwise the cadence fires only when BOTH floors are met (so it stays sparse). `nil` ⇒ don't run.
+    public func decide(now: Double, lastRun: Double?, newSegmentsSinceLastRun: Int, tackPending: Bool) -> Trigger? {
+        if tackTriggerEnabled, tackPending { return .tack }
+        guard cadenceEnabled else { return nil }
+        guard newSegmentsSinceLastRun >= minNewSegments else { return nil }
+        if let last = lastRun, (now - last) < minSecondsBetweenRuns { return nil }   // too soon
+        return .cadence
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/LiveIntelCadenceTests.swift
+++ b/apple/Tests/RuntimeCoreTests/LiveIntelCadenceTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import RuntimeCore
+
+final class LiveIntelCadenceTests: XCTestCase {
+    func testTackFiresImmediatelyRegardlessOfCadence() {
+        let c = LiveIntelCadence(minSecondsBetweenRuns: 60, minNewSegments: 10)
+        // Tack wins even with no new segments and a recent run.
+        XCTAssertEqual(c.decide(now: 100, lastRun: 99, newSegmentsSinceLastRun: 0, tackPending: true), .tack)
+    }
+
+    func testTackSuppressedWhenTackTriggerOff() {
+        let c = LiveIntelCadence(tackTriggerEnabled: false, cadenceEnabled: false)
+        XCTAssertNil(c.decide(now: 100, lastRun: nil, newSegmentsSinceLastRun: 99, tackPending: true))
+    }
+
+    func testCadenceFiresWhenSegmentsAndTimeFloorsMet() {
+        let c = LiveIntelCadence(minSecondsBetweenRuns: 25, minNewSegments: 4)
+        XCTAssertEqual(c.decide(now: 130, lastRun: 100, newSegmentsSinceLastRun: 5, tackPending: false), .cadence)
+    }
+
+    func testFirstCadenceFiresOnceEnoughSegmentsAccrue() {
+        let c = LiveIntelCadence(minNewSegments: 4)
+        XCTAssertEqual(c.decide(now: 40, lastRun: nil, newSegmentsSinceLastRun: 4, tackPending: false), .cadence)
+        XCTAssertNil(c.decide(now: 40, lastRun: nil, newSegmentsSinceLastRun: 3, tackPending: false))   // not enough yet
+    }
+
+    func testCadenceHeldWhenTooSoon() {
+        let c = LiveIntelCadence(minSecondsBetweenRuns: 25, minNewSegments: 4)
+        // Enough new segments, but only 10s since the last run.
+        XCTAssertNil(c.decide(now: 110, lastRun: 100, newSegmentsSinceLastRun: 8, tackPending: false))
+    }
+
+    func testCadenceDisabledNeverFiresCadenceButTackStillWorks() {
+        let c = LiveIntelCadence(tackTriggerEnabled: true, cadenceEnabled: false)
+        XCTAssertNil(c.decide(now: 999, lastRun: nil, newSegmentsSinceLastRun: 100, tackPending: false))
+        XCTAssertEqual(c.decide(now: 999, lastRun: nil, newSegmentsSinceLastRun: 100, tackPending: true), .tack)
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/current-phase-status.md
@@ -92,6 +92,7 @@ Pencil), accessibility + adaptivity, and a polish pass — each delivered with c
 | HSM-14-12 | Constant-time live transcription (sliding window + commit) | in-progress (built + host-proven + sim-shown; device cadence pending) | [story-12](./story-12-constant-time-transcription.md) | [shot](./screenshots/constant-time-transcription-canvas.png) + story "Evidence" |
 | HSM-14-13 | The spatial workspace (OS-like capture surface) | in-progress (deliverables 1–4 built + host-proven + sim-shown; stretch 5–6 + device feel remain) | [story-13](./story-13-spatial-workspace.md) | [docked](./screenshots/recorder-docked-top.png) / [orb](./screenshots/recorder-minimized-orb.png) / [free-place vs tack](./screenshots/recorder-freeplace-vs-tack.png) / [resize](./screenshots/recorder-resizable-card.png) / [tidy](./screenshots/recorder-tidy-grid.png) |
 | HSM-14-15 | The Workbench (visual intelligence builder) | in-progress (engine + gamified canvas + run-from-meeting shipped; transforms/outputs next) | [story-15](./story-15-workbench.md) | [builder](./screenshots/workbench-builder.png) + `WorkflowTests` (7) |
+| HSM-14-18 | Real-time MIR (live intelligence on the iPad, configurable) | in-progress (the cadence/trigger brain `LiveIntelCadence` host-tested; runner + Queue HUD + setup screen + device proof pending) | [story-18](./story-18-realtime-mir.md) | `LiveIntelCadenceTests` (6/0) |
 
 ## Where we are
 
@@ -248,6 +249,17 @@ a NAME field + an INPUT selector + a full multi-line **prompt editor** (with `{i
 `swift test` **241/6/0** (+1 llmCall test). Built for Simulator + device; shots
 `workbench-custom-node.png`, `workbench-llm-editor.png`. Remaining: execute the custom prompt + the
 other transforms/outputs.
+
+**2026-06-23 — HSM-14-18 opened, the cadence/trigger brain landed (host slice).** Real-time MIR closes
+the parity gap where the iPad only runs intelligence *post-meeting* while the desktop runs it **live**.
+The first verifiable, device-free slice ships: `LiveIntelCadence` (`Sources/RuntimeCore/Capture/`) — a
+pure decision struct answering *should a live intel pass fire now, and why*. Two INDEPENDENT,
+user-tunable triggers: **tack** (the user flagged a moment ⇒ fire immediately — the cheapest, most
+useful real-time signal) always wins when enabled; **cadence** fires only when BOTH floors are met
+(`minNewSegments` new transcript AND `minSecondsBetweenRuns` elapsed) so a live pass never fights
+Whisper + diarization on one chip. Both toggle + tune independently. `LiveIntelCadenceTests` 6/0;
+`swift test` green. Remaining on the story: the live-intel runner, the gamified tack moment + Queue
+HUD, the setup screen (incl. an OpenRouter endpoint with a fetched model picker), and the device proof.
 
 ## Operating principle (standing, beyond this phase)
 

--- a/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-18-realtime-mir.md
+++ b/pm/roadmap/holdspeak-mobile/phase-14-mobile-experience-craft/story-18-realtime-mir.md
@@ -1,0 +1,74 @@
+# HSM-14-18 — Real-time MIR (live intelligence on the iPad, configurable)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 14
+- **Status:** in-progress — opened 2026-06-23. The iPad's intelligence is post-meeting only; the
+  desktop runs it **live**. Closes that parity gap, with the owner's refinements (config surfaces,
+  gamified tack moment, any-endpoint offload) as first-class.
+- **Depends on:** the live capture loop + tacking (HSM-8-03), `InferenceConfigStore` (the inference
+  target seam), the Queue HUD (`RunQueueStore`), the generation-theater treatment.
+- **Owner:** unassigned
+
+## The parity gap (grounded)
+
+The desktop runs intelligence **during** the meeting: `meeting_session/intel_analysis.py` (*"the live
+intel cadence"*) fires `_run_intel_analysis(final=False)` repeatedly over the partial transcript,
+**streaming**; `transcribe_loop.py` streams each segment via `on_segment`; `session.py` wires a
+`mir_segment_probe` so MIR routes live. The iPad does NONE of this — `MeetingReviewState.generate`
+runs at review; tacking only *marks* a moment for that later pass.
+
+## The design (owner-refined)
+
+### 1. Cadence-gated, user-tunable
+A live intel pass fires periodically over the growing transcript — never per-segment (it must not
+fight Whisper + diarization on one chip). Cadence is **user-configurable** (interval + min-new-segments).
+
+### 2. Tack-triggered — and it's a MOMENT, not a silent task
+Tacking fires an intel pass *immediately* on the recent context (the most useful real-time signal:
+intelligence on the thing you just flagged). It must be:
+- **Explicit** — the tacked card shows a "thinking" state right on the flagged moment.
+- **Queued** — a real job populates the **Queue HUD** ("Intel · this moment · {target} · working"), so
+  it rides the transparency surface; you see what's asked + where it runs.
+- **Gamified** — the result *materializes* with the generation-theater treatment + haptic, not a silent
+  append. Tacking → watching intelligence bloom from that moment should feel great.
+
+### 3. Configurable inference target — on-device / mesh / ANY OpenAI endpoint (OpenRouter)
+Reuses `InferenceConfigStore` (Mode A on-device / Mode B mesh / Mode C endpoint with URL+key+a model
+**fetched** from `/v1/models`). Point Mode C at **`openrouter.ai/api/v1`** → **any model** (GPT-5,
+Claude, a cheap fast model for the live cadence), user-chosen + swappable. Egress-honest: the badge
+says cloud → {model} when it leaves the device. Resource-aware: offload to the mesh/endpoint when
+connected; gentler on-device cadence when air-gapped.
+
+### 4. The SETUP surface (first-class, the owner's emphasis)
+A "Real-time intelligence" settings screen where the user actually sets this up: on/off, the cadence
+(interval + threshold), tack-trigger on/off, the inference target + endpoint (URL/key/**fetched model
+picker**, an OpenRouter preset), and the egress posture made plain.
+
+## Build plan (verifiable pieces; device wiring waits for the iPad's return)
+1. **The cadence/trigger brain (host-testable, NOW)** — `LiveIntelCadence`: given (now, lastRun,
+   newSegmentsSinceLastRun, tackPending) → fire `.tack` / `.cadence` / nothing; tack-trigger + cadence
+   independently toggleable + tunable. Pure, unit-tested.
+2. **The live-intel runner** — on a cadence/tack, select the context window, route through the MIR
+   profile + the configured provider (`InferenceConfigStore.makeProvider`), produce artifacts
+   incrementally; reuse the post-meeting engine where possible.
+3. **The Queue HUD + the gamified tack moment** — a live-intel job per pass; the tacked-card "thinking"
+   state; the materialize/theater reveal of the result.
+4. **The setup screen** — the config UI (cadence, target, OpenRouter endpoint + fetched model picker,
+   egress badge).
+5. **Device proof** — a real meeting where tacking a moment fires live intel against on-device AND an
+   OpenRouter model, with the Queue HUD + the gamified reveal — owner-verified.
+
+## Acceptance criteria
+- [ ] `LiveIntelCadence` host-tested (tack always fires when enabled; cadence respects interval +
+      min-segments; both independently toggleable). *(this slice)*
+- [ ] Live intel runs on cadence + on tack over the partial transcript through the configured target.
+- [ ] Tack is explicit (card thinking-state) + populates the Queue HUD + a gamified materialize reveal.
+- [ ] Inference target configurable incl. an OpenAI endpoint (OpenRouter) with a fetched model picker;
+      egress-honest.
+- [ ] A "Real-time intelligence" setup screen exposes all of it.
+- [ ] Device-proven: tack → live intel, on-device and via OpenRouter.
+
+## Notes
+- Resource reality: on-device LLM during capture competes with Whisper + diarization — hence
+  cadence-gating + offload. Don't firehose. See [[project_phase15_the_mesh]] (the iPad-full-peer /
+  mesh-additive principle), [[feedback_verify_on_device_not_seeded]].


### PR DESCRIPTION
Opens **HSM-14-18 — Real-time MIR** (live intelligence on the iPad). The desktop runs meeting intelligence *during* the meeting; the iPad ran it post-meeting only. This closes that parity gap, starting with the device-free brain.

## This slice
`LiveIntelCadence` (`Sources/RuntimeCore/Capture/`) — a pure decision struct: *should a live intel pass fire now, and why?*

- **tack** — the user flagged a moment ⇒ fire immediately (cheapest, most useful real-time signal). Wins when enabled.
- **cadence** — fires only when BOTH floors are met (`minNewSegments` new transcript AND `minSecondsBetweenRuns` elapsed), so a live pass never fights Whisper + diarization on one chip.

Both triggers toggle + tune independently. No model, no UI, no device.

## Tests
`swift test --filter LiveIntelCadenceTests` → **6 passed, 0 failures**.

## Scope
Story stays **in-progress** — the live-intel runner, the gamified tack moment + Queue HUD, the setup screen (OpenRouter + fetched model picker), and the device proof remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)