### PR TITLE
HSM-18-02 (hub half): voice macros fire on the remote relay + open Phase 18

### DIFF
--- a/holdspeak/web/routes/dictation/pipeline.py
+++ b/holdspeak/web/routes/dictation/pipeline.py
@@ -329,6 +329,46 @@ def build_pipeline_router(
                 status_code=400,
             )
 
+        # HSM-18-02 — voice command macros must fire on the remote relay too, exactly
+        # as they do on the local dictation path (dictation_capture._maybe_dispatch_
+        # voice_command). A configured, enabled macro keyword is NOT dictated as prose;
+        # it fires through the same bounded, guarded connector and returns a "fired"
+        # result the companion renders as the macro-object chip (the Phase-18 signature
+        # moment). Off by default: macros disabled -> dispatch returns None -> the
+        # normal dictation path below runs, byte-identical to before this fix.
+        from ....config import Config
+        from ....dictation_runner import dispatch_voice_command
+
+        def _remote_type(t: str) -> None:
+            # a `type_text` macro free-types into the focused Mac app via the proven
+            # focused-delivery relay; if nothing can deliver, the macro still fires its
+            # action, it just cannot type.
+            if ctx.on_remote_dictation is not None:
+                ctx.on_remote_dictation(t, target="focused")
+
+        try:
+            fired = dispatch_voice_command(
+                text, config=Config.load(), type_writer=_remote_type
+            )
+        except Exception as exc:  # a macro failure must never block plain dictation
+            log.error(f"Remote voice-command dispatch failed: {exc}")
+            fired = None
+        if fired is not None and fired.handled:
+            return JSONResponse(
+                {
+                    "success": True,
+                    "fired": {
+                        "keyword": fired.keyword,
+                        "kind": fired.kind,
+                        "preview": fired.preview,
+                        "ok": fired.ok,
+                        "error": fired.error,
+                    },
+                    "delivered": fired.ok,
+                    "final_text": "",
+                }
+            )
+
         # Reuse the exact rich-pipeline path the browser dry-run uses, so the same
         # corrections/blocks/plugins apply — the answer is as smart as one spoken at
         # the desk, not raw transcript.

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -9,21 +9,31 @@
 > 🚀 **New agent (general):** [`HANDOVER.md`](./HANDOVER.md) — the build→deploy→show loop,
 > gotchas, and the exact remaining work to finish **Phase 8** and **Phase 14** (top priority).
 
-**Current phase:** [Phase 17 — Agent Sync (the coder on your desk)](./phase-17-agent-sync/current-phase-status.md)
-(live Claude/Codex coding sessions as synced DeskOS primitives: a coder asks → it surfaces on your desk →
-you answer by voice / typed / dropped-context / **AI-drafted** → injected back into the live session).
-Phase 16 (web parity + mesh sync) remains open in parallel.
+**Current phase:** [Phase 18 — The iPad joins the dictation contracts](./phase-18-ipad-dictation-contracts/current-phase-status.md)
+— **THE EQUILIBRIUM PROGRAM HAS BEGUN** ([`EQUILIBRIUM.md`](./EQUILIBRIUM.md)), built against the
+[Experience Vision](./EXPERIENCE-VISION-2026-06-27.md). First fix landed: voice-command macros now fire
+on the remote relay (HSM-18-02 hub half, tested), the backend behind the "macro fires as an object"
+signature moment. Phases 16/17 (web parity + mesh sync; agent sync) remain open in parallel.
 
-**📐 Next program — THE EQUILIBRIUM (authored, ready to open):**
+**📐 The program — THE EQUILIBRIUM:**
 [`EQUILIBRIUM.md`](./EQUILIBRIUM.md) — bringing every original HoldSpeak feature into full
 contract parity across desktop / web / iPad / iPhone. Six phases (**18–23**), one per systemic
 pattern the parity audit found, grounded in [`PARITY-AUDIT-2026-06-27.md`](./PARITY-AUDIT-2026-06-27.md)
-(50-agent flotilla, 22 features, 70 verified gaps). **Phase 18 leads** (the iPad joins the
-dictation contracts) and ships with full stories; the rest open in sequence.
+(50-agent flotilla, 22 features, 70 verified gaps). **Phase 18 is open and leads** (the iPad joins the
+dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-06-27 (**THE EXPERIENCE VISION authored** — a 16-agent design flotilla
+**Last updated:** 2026-06-27 (**PHASE 18 OPENED — THE EQUILIBRIUM BEGINS.** Merged the
+equilibrium package (PR #144: parity audit + the 6-phase program + the Experience Vision), then
+opened **Phase 18 (the iPad joins the dictation contracts)** and landed its first fix: the
+**voice-command macro relay** (HSM-18-02 hub half). `api_dictation_remote` never fired macros, so
+a macro keyword spoken from the iPad was silently dictated as prose; it now fires through the same
+bounded/guarded connector as the local path, a `type_text` macro free-types into the focused Mac
+app via the proven focused relay, and the response carries a `fired` object the companion renders
+as the macro chip (the vision's "macro fires as an object" moment). Off by default (byte-identical
+plain dictation). Proven: `test_web_routes_remote_dictation.py` 11/11 incl. the remote-path macro
+test the audit demanded. Earlier today: **THE EXPERIENCE VISION authored** — a 16-agent design flotilla
 (ground → design → adversarial crit → direct) reframed the equilibrium gaps as experiences and
 designed them masterfully across web + iOS, iPad=iPhone: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md).
 Philosophy: *"HoldSpeak is a debugger for trust... it ships the receipt a half-second before the

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
@@ -1,12 +1,18 @@
 # Phase 18 — The iPad joins the dictation contracts
 
-**Status:** planned — **leads The Equilibrium program** ([`EQUILIBRIUM.md`](../EQUILIBRIUM.md)).
-Ready to open; stories authored.
+**Status:** in-progress (opened 2026-06-27) — **leads The Equilibrium program**
+([`EQUILIBRIUM.md`](../EQUILIBRIUM.md)), built against the
+[Experience Vision](../EXPERIENCE-VISION-2026-06-27.md) (the dictation teleprompter + the
+"macro fires as an object" signature moment).
 
-**Last updated:** 2026-06-27 (**authored** from the parity audit. The biggest single
-imbalance the flotilla found: the iPad authors desk primitives but is a *tourist* for the
-dictation contracts. The hub already serves every route; the iPad has no Swift client. This
-phase builds the clients.)
+**Last updated:** 2026-06-27 (**OPENED + first fix landed.** HSM-18-02's hub half shipped:
+`api_dictation_remote` now fires voice-command macros on the remote relay (it never did, so a
+macro spoken from the iPad was silently dictated as prose). The macro fires through the same
+bounded/guarded connector as the local path; a `type_text` macro free-types into the focused
+Mac app via the proven focused relay; the response carries a `fired` object the companion
+renders as the macro chip. Off by default (macros disabled → byte-identical plain dictation).
+Proven: `tests/unit/test_web_routes_remote_dictation.py` 11/11 incl. the remote-path macro
+test the audit demanded — the seam that shipped broken because only the local path was tested.)
 
 ## Why this phase exists
 
@@ -58,7 +64,7 @@ reuses three proven seams:
 | ID | Title | Status |
 |----|-------|--------|
 | HSM-18-01 | The dictation pipeline client + authoring/preview screen — **leads** | todo |
-| HSM-18-02 | Voice command macros fire on the remote relay + the iPad CommandsBoard | todo |
+| HSM-18-02 | Voice command macros fire on the remote relay + the iPad CommandsBoard | in-progress (hub half landed; iPad board todo) |
 | HSM-18-03 | Spoken language at every WhisperKit call site | todo |
 | HSM-18-04 | The spoken-symbol dictionary, ported to Swift | todo |
 | HSM-18-05 | Activity pre-briefing — the source-cited nudge client | todo |
@@ -66,11 +72,12 @@ reuses three proven seams:
 
 ## Where we are
 
-Not started. The audit supplies every story's starting `file:symbol` evidence. **18-01
-leads** (it stands up the client surface the dictation features hang off); **18-02 is the
-highest-value single fix** (a one-function hub gap that makes the entire macro feature work
-from the iPad). 18-03 and 18-04 are independent on-device ports and can run in parallel.
-18-06 is the gate.
+**Opened, with the first fix landed.** HSM-18-02's hub half is done + tested (the macro
+relay; see Last updated). Remaining: 18-02's iPad CommandsBoard; 18-01 (the dictation pipeline
+client + teleprompter preview screen, the phase's experience hero); 18-03/18-04 (the
+independent on-device language + symbol ports, parallel-startable); 18-05 (activity nudges,
+needs 18-01's dictate path); 18-06 (the real-metal gate). The audit supplies every story's
+starting `file:symbol` evidence.
 
 ## Carried context
 

--- a/tests/unit/test_web_routes_remote_dictation.py
+++ b/tests/unit/test_web_routes_remote_dictation.py
@@ -30,6 +30,16 @@ def _stub_pipeline(monkeypatch):
     monkeypatch.setattr(PIPELINE, lambda text, *a, **k: {"final_text": f"[corrected] {text}"})
 
 
+@pytest.fixture(autouse=True)
+def _default_macros_off(monkeypatch):
+    # HSM-18-02: the remote route now consults ``Config.load()`` to fire voice-command
+    # macros. Default macros OFF for hermetic, byte-identical plain-dictation tests; the
+    # macro test below overrides this with an enabled config.
+    from holdspeak.config import Config
+
+    monkeypatch.setattr(Config, "load", classmethod(lambda cls: Config()))
+
+
 def _ctx(**kw) -> WebContext:
     return WebContext(get_state=lambda: {}, **kw)
 
@@ -136,3 +146,48 @@ def test_rejects_unknown_target_mode():
         "/api/dictation/remote", json={"text": "hi", "target_mode": "nonsense"}
     )
     assert r.status_code == 400
+
+
+# ── HSM-18-02: voice command macros fire on the remote relay (not just the local path) ──
+
+
+def test_voice_macro_fires_on_relay_and_is_not_dictated(monkeypatch):
+    """A configured, enabled macro keyword posted over the relay FIRES (it is not
+    dictated as prose). This is the exact seam that shipped broken: the local path
+    dispatched macros, the remote path went straight to the dry-run. A ``type_text``
+    macro free-types into the focused Mac app via the relay; the response carries the
+    ``fired`` object the companion renders as the macro-object chip."""
+    from holdspeak.config import Config, MacrosConfig, VoiceMacro, VoiceMacroAction
+
+    cfg = Config()
+    cfg.dictation.macros = MacrosConfig(
+        enabled=True, items=[VoiceMacro("standup", VoiceMacroAction("type_text", "## Standup"))]
+    )
+    monkeypatch.setattr(Config, "load", classmethod(lambda cls: cfg))
+
+    typed: list = []
+    ctx = _ctx(on_remote_dictation=lambda t, *, target="agent": typed.append((t, target)))
+    r = _client(ctx).post("/api/dictation/remote", json={"text": "standup"})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["fired"]["kind"] == "type_text"
+    assert body["fired"]["keyword"] == "standup"
+    assert body["fired"]["ok"] is True
+    assert body["final_text"] == ""  # NOT run through the dictation pipeline
+    # the macro typed into the focused app via the relay, not delivered as a dictation answer
+    assert typed == [("## Standup", "focused")]
+
+
+def test_no_macro_match_falls_through_to_dictation():
+    """With macros off (the autouse default), a normal utterance is dictated exactly as
+    before this fix: no ``fired`` key, pipeline-processed, delivered into the coder."""
+    delivered: list = []
+    ctx = _ctx(on_remote_dictation=lambda t: delivered.append(t))
+    r = _client(ctx).post("/api/dictation/remote", json={"text": "ship it friday"})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert "fired" not in body
+    assert body["final_text"] == "[corrected] ship it friday"
+    assert delivered == ["[corrected] ship it friday"]


### PR DESCRIPTION
Opens **Phase 18 — the iPad joins the dictation contracts** (the lead of The Equilibrium) and lands its first fix.

## The bug (audit gap, adversarially verified)
`api_dictation_remote` ran the dry-run pipeline and delivered, but **never called `dispatch_voice_command`** — so a macro keyword spoken from the iPad/companion was silently dictated as prose instead of firing. The local dictation path dispatched macros; the remote relay did not. It shipped broken because **only the local path had a test**.

## The fix
Mirror the local path: before the dry-run, `dispatch_voice_command(text, config=Config.load(), type_writer=<focused relay>)`.
- A fired macro returns `{fired: {kind, keyword, preview, ok, error}}` (with `final_text: ""`) — the object the companion renders as the **"macro fires as an object"** chip from the Experience Vision.
- A `type_text` macro free-types into the focused Mac app via the proven focused relay.
- Off by default: macros disabled → normal dictation, **byte-identical** to before.

## Proof
`test_web_routes_remote_dictation.py` **11/11**, including the remote-path macro test the audit demanded. A hermetic macros-off default fixture keeps the existing route tests byte-identical. Regression sweep (dispatch + route-split + connector) 17/17.

Phase 18 opened in the roadmap (current-phase-status → in-progress, 18-02 hub half landed; README current phase moved to Phase 18). Remaining in 18-02: the iPad CommandsBoard. The on-device walk is the Phase 18 gate (HSM-18-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)