### PR TITLE
HSM-18-04: spoken-symbol dictionary ported to Swift (dictation path only)

### DIFF
--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -517,7 +517,11 @@ final class VoiceCaptureState: ObservableObject {
         do {
             let segs = try await WhisperKitTranscriber(chunks: sink.drain(), model: "base").transcribe()
             let said = segs.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-            if said.isEmpty { self.error = "Didn't catch that — try again, or type it." } else { text = said }
+            // HSM-18-04 — this is the DICTATION (speak-to-fill) path, so spoken symbols apply here
+            // ("new line" -> newline, "open paren" -> "("). Meeting capture (Stores.swift) stays
+            // verbatim and never runs this. Built-ins only for now; the user-symbol editor follows.
+            if said.isEmpty { self.error = "Didn't catch that — try again, or type it." }
+            else { text = SpokenSymbols().process(said) }
         } catch { self.error = "Couldn't transcribe: \(error)" }
     }
 }

--- a/apple/Sources/Providers/Transcription/SpokenSymbols.swift
+++ b/apple/Sources/Providers/Transcription/SpokenSymbols.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// HSM-18-04 — the spoken-symbol dictionary, a faithful port of `holdspeak/text_processor.py`
+/// (Phase 59). Turns spoken punctuation/format commands into symbols ("new line" -> a newline,
+/// "open paren" -> "(", "hello period" -> "hello.") on DICTATION output. It is applied on the
+/// dictation path only, NEVER to verbatim meeting transcripts (where "the period of the project"
+/// must stay words).
+///
+/// Built-in tables plus the user's symbols are merged into ONE combined longest-first pass with
+/// user-wins precedence: a user entry with the same spoken phrase as a built-in replaces it (the
+/// phrase is dropped from every table first, then inserted into its attach mode's table). With no
+/// user entries the output is byte-identical to the built-ins. Pure + testable.
+public struct SpokenSymbols: Sendable {
+    /// A user-defined symbol. `attach` is "left" | "right" | "both" | "none" (default), matching
+    /// the hub's spoken-symbol dictionary shape.
+    public struct UserSymbol: Sendable, Equatable {
+        public let spoken: String
+        public let symbol: String
+        public let attach: String
+        public init(spoken: String, symbol: String, attach: String = "none") {
+            self.spoken = spoken
+            self.symbol = symbol
+            self.attach = attach
+        }
+    }
+
+    /// Removes the space BEFORE (attaches to the previous word): "hello period" -> "hello."
+    public static let attachLeft: [String: String] = [
+        "period": ".", "full stop": ".", "comma": ",", "question mark": "?",
+        "exclamation mark": "!", "exclamation point": "!", "colon": ":", "semicolon": ";",
+        "close quote": "\"", "end quote": "\"", "unquote": "\"",
+        "close paren": ")", "close parenthesis": ")",
+    ]
+    /// Removes the space AFTER (attaches to the next word): "open quote hello" -> "\"hello"
+    public static let attachRight: [String: String] = [
+        "open quote": "\"", "open paren": "(", "open parenthesis": "(",
+    ]
+    /// Removes the space on BOTH sides: "self dash aware" -> "self-aware"
+    public static let attachBoth: [String: String] = ["dash": "-", "hyphen": "-"]
+    /// Newline commands (surrounding spaces removed).
+    public static let newlines: [String: String] = [
+        "new line": "\n", "newline": "\n", "new paragraph": "\n\n",
+    ]
+
+    private let left: [String: String]
+    private let right: [String: String]
+    private let both: [String: String]
+    private let news: [String: String]
+    private let plain: [String: String]
+
+    public init(userSymbols: [UserSymbol] = []) {
+        var l = Self.attachLeft, r = Self.attachRight, b = Self.attachBoth, n = Self.newlines
+        var p: [String: String] = [:]
+        for entry in userSymbols {
+            let spoken = entry.spoken.trimmingCharacters(in: .whitespaces).lowercased()
+            let symbol = entry.symbol
+            guard !spoken.isEmpty, !symbol.isEmpty else { continue }
+            // user wins: drop the phrase from every table before inserting
+            l[spoken] = nil; r[spoken] = nil; b[spoken] = nil; n[spoken] = nil; p[spoken] = nil
+            switch entry.attach.lowercased() {
+            case "left": l[spoken] = symbol
+            case "right": r[spoken] = symbol
+            case "both": b[spoken] = symbol
+            default: p[spoken] = symbol
+            }
+        }
+        left = l; right = r; both = b; news = n; plain = p
+    }
+
+    /// Apply all spoken-symbol substitutions. One combined pass, longest command first across
+    /// every table (so a short built-in "colon" never eats the inside of a longer phrase).
+    public func process(_ text: String) -> String {
+        guard !text.isEmpty else { return text }
+        var entries: [(cmd: String, rep: String, mode: String)] = []
+        for (c, r) in plain { entries.append((c, r, "plain")) }
+        for (c, r) in left { entries.append((c, r, "left")) }
+        for (c, r) in right { entries.append((c, r, "right")) }
+        for (c, r) in both { entries.append((c, r, "both")) }
+        for (c, r) in news { entries.append((c, r, "newline")) }
+        entries.sort { $0.cmd.count > $1.cmd.count }
+
+        var out = text
+        for e in entries {
+            let escaped = NSRegularExpression.escapedPattern(for: e.cmd)
+            let pattern: String
+            switch e.mode {
+            case "left": pattern = "\\s*\\b\(escaped)\\b"        // remove space before
+            case "right": pattern = "\\b\(escaped)\\b\\s*"       // remove space after
+            case "plain": pattern = "\\b\(escaped)\\b"           // spacing preserved
+            default: pattern = "\\s*\\b\(escaped)\\b\\s*"        // both / newline
+            }
+            guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
+            // the replacement is LITERAL text, never a regex template ($ / backslash must not be special)
+            let template = NSRegularExpression.escapedTemplate(for: e.rep)
+            let range = NSRange(out.startIndex..., in: out)
+            out = re.stringByReplacingMatches(in: out, options: [], range: range, withTemplate: template)
+        }
+        return out
+    }
+}

--- a/apple/Tests/ProvidersTests/SpokenSymbolsTests.swift
+++ b/apple/Tests/ProvidersTests/SpokenSymbolsTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Providers
+
+/// HSM-18-04 — `SpokenSymbols` ports `holdspeak/text_processor.py` (Phase 59) to Swift so the
+/// iPad's DICTATION path turns spoken commands into symbols, exactly as the hub does. Pins the
+/// built-in tables, the attach-side spacing, the one-pass longest-first guarantee, and user-wins.
+final class SpokenSymbolsTests: XCTestCase {
+
+    func testAttachLeftRemovesSpaceBefore() {
+        XCTAssertEqual(SpokenSymbols().process("hello period"), "hello.")
+        XCTAssertEqual(SpokenSymbols().process("wait comma then go"), "wait, then go")
+        XCTAssertEqual(SpokenSymbols().process("really question mark"), "really?")
+    }
+
+    func testAttachRightRemovesSpaceAfter() {
+        XCTAssertEqual(SpokenSymbols().process("open paren hello"), "(hello")
+    }
+
+    func testAttachBothRemovesSurroundingSpace() {
+        XCTAssertEqual(SpokenSymbols().process("self dash aware"), "self-aware")
+    }
+
+    func testNewlineCommands() {
+        XCTAssertEqual(SpokenSymbols().process("line one new line line two"), "line one\nline two")
+        XCTAssertEqual(SpokenSymbols().process("a new paragraph b"), "a\n\nb")
+    }
+
+    func testWordBoundaryDoesNotEatPartialWords() {
+        // "periodic" must not match "period"
+        XCTAssertEqual(SpokenSymbols().process("the periodic table"), "the periodic table")
+    }
+
+    func testCaseInsensitive() {
+        XCTAssertEqual(SpokenSymbols().process("done PERIOD"), "done.")
+    }
+
+    func testPlainTextUntouched() {
+        XCTAssertEqual(SpokenSymbols().process("just regular words here"), "just regular words here")
+        XCTAssertEqual(SpokenSymbols().process(""), "")
+    }
+
+    func testUserSymbolWinsOverBuiltIn() {
+        // a user remaps "dash" to an em dash; the built-in hyphen mapping must be replaced
+        let s = SpokenSymbols(userSymbols: [.init(spoken: "dash", symbol: "—", attach: "both")])
+        XCTAssertEqual(s.process("a dash b"), "a—b")
+    }
+
+    func testUserPlainSymbol() {
+        let s = SpokenSymbols(userSymbols: [.init(spoken: "smiley", symbol: ":)")])
+        XCTAssertEqual(s.process("hi smiley"), "hi :)")
+    }
+
+    func testLongestFirstAcrossTables() {
+        // a longer user phrase that contains a shorter built-in must win as a whole
+        let s = SpokenSymbols(userSymbols: [.init(spoken: "double colon", symbol: "::")])
+        XCTAssertEqual(s.process("scope double colon name"), "scope :: name")
+    }
+
+    func testReplacementIsLiteralNotRegexTemplate() {
+        // a user symbol containing $ and backslash must be inserted literally
+        let s = SpokenSymbols(userSymbols: [.init(spoken: "money", symbol: "$1\\2")])
+        XCTAssertEqual(s.process("give money now"), "give $1\\2 now")
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
@@ -66,7 +66,7 @@ reuses three proven seams:
 | HSM-18-01 | The dictation pipeline client + authoring/preview screen — **leads** | todo |
 | HSM-18-02 | Voice command macros fire on the remote relay + the iPad CommandsBoard | in-progress (hub half landed; iPad board todo) |
 | HSM-18-03 | Spoken language at every WhisperKit call site | in-progress (main app done; harness apps + metal proof remain) |
-| HSM-18-04 | The spoken-symbol dictionary, ported to Swift | todo |
+| HSM-18-04 | The spoken-symbol dictionary, ported to Swift | in-progress (built-ins ported + tested + on the dictation path; user-symbol editor + metal proof remain) |
 | HSM-18-05 | Activity pre-briefing — the source-cited nudge client | todo |
 | HSM-18-06 | The real-metal proof + entry-point docs | todo |
 


### PR DESCRIPTION
Ports `holdspeak/text_processor.py` (Phase 59) to Swift as `Providers/SpokenSymbols`: the four built-in tables (attach-left / right / both, newlines) plus user symbols, merged into **one combined longest-first pass with user-wins** precedence. "new line" → a newline, "open paren" → "(", "hello period" → "hello.".

**The careful part is placement.** It runs on the **dictation path only** (`VoiceCaptureState`, the speak-to-fill mic), **never** the meeting transcriber (`Stores.swift`), so verbatim meeting transcripts keep "the period of the project" as words. The audit's "run after `WhisperText.clean`" one-liner would have corrupted meetings; this scopes it correctly to dictation.

**Verified:** `swift test --filter SpokenSymbolsTests` **11/11** (built-ins, attach-side spacing, word boundaries, case-insensitivity, user-wins, longest-first across tables, literal-not-regex replacement) — CI's `swift test` covers it. Meeting-capture `xcodebuild` **SUCCEEDED**.

Built-ins only for now; the user-symbol editor in `AppSettings` + the metal proof follow (HSM-18-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)