### PR TITLE
Equilibrium Wave 1: 6 hub+web gaps (Phases 19/21/22/23)

### DIFF
--- a/holdspeak/db/plugins.py
+++ b/holdspeak/db/plugins.py
@@ -667,8 +667,15 @@ class PluginArtifactRepository(BaseRepository):
         plugin_id: str = "unknown",
         plugin_version: str = "unknown",
         sources: Optional[list[dict[str, str]]] = None,
+        updated_at: Optional[str] = None,
     ) -> None:
-        """Insert or update one synthesized artifact and its lineage sources."""
+        """Insert or update one synthesized artifact and its lineage sources.
+
+        ``updated_at`` defaults to now; the sync receiver passes the pushed
+        ``last_modified`` so the artifact's last-write-wins key survives the
+        round-trip (``pull`` re-emits ``updated_at`` as the artifact's
+        ``last_modified``), mirroring how meetings preserve ``started_at``.
+        """
         clean_artifact_id = str(artifact_id).strip()
         clean_meeting_id = str(meeting_id).strip()
         clean_type = str(artifact_type).strip().lower() or "plugin_output"
@@ -698,6 +705,7 @@ class PluginArtifactRepository(BaseRepository):
                 normalized_sources.append((source_type, source_ref))
 
         now_iso = datetime.now().isoformat()
+        updated_iso = str(updated_at).strip() if isinstance(updated_at, str) and updated_at.strip() else now_iso
         with self._connection() as conn:
             conn.execute(
                 """
@@ -730,7 +738,7 @@ class PluginArtifactRepository(BaseRepository):
                     clean_plugin_id,
                     clean_plugin_version,
                     now_iso,
-                    now_iso,
+                    updated_iso,
                 ),
             )
             conn.execute(
@@ -745,6 +753,64 @@ class PluginArtifactRepository(BaseRepository):
                     """,
                     (clean_artifact_id, source_type, source_ref, now_iso),
                 )
+
+    def get_artifact(self, artifact_id: str) -> Optional[ArtifactSummary]:
+        """Load one synthesized artifact by id (including lineage refs).
+
+        The single-record read path the sync receiver uses for last-write-wins
+        conflict resolution; mirrors the row shape `list_artifacts` returns.
+        """
+        clean_id = str(artifact_id or "").strip()
+        if not clean_id:
+            return None
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM artifacts WHERE id = ?", (clean_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            source_rows = conn.execute(
+                """
+                SELECT source_type, source_ref
+                FROM artifact_sources
+                WHERE artifact_id = ?
+                ORDER BY source_type ASC, source_ref ASC
+                """,
+                (clean_id,),
+            ).fetchall()
+
+        sources = [
+            {"source_type": str(r["source_type"]), "source_ref": str(r["source_ref"])}
+            for r in source_rows
+        ]
+        return ArtifactSummary(
+            id=str(row["id"]),
+            meeting_id=str(row["meeting_id"]),
+            artifact_type=str(row["artifact_type"]),
+            title=str(row["title"]),
+            body_markdown=str(row["body_markdown"] or ""),
+            structured_json=self._json_loads_dict(row["structured_json"]),
+            confidence=float(row["confidence"] if row["confidence"] is not None else 0.0),
+            status=str(row["status"] or "draft"),
+            plugin_id=str(row["plugin_id"] or "unknown"),
+            plugin_version=str(row["plugin_version"] or "unknown"),
+            sources=sources,
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def delete_artifact(self, artifact_id: str) -> bool:
+        """Hard-delete one artifact (sources cascade). Returns True if removed.
+
+        Artifacts are content (not first-class synced primitives), so a synced
+        delete is a hard removal, mirroring `delete_meeting`.
+        """
+        clean_id = str(artifact_id or "").strip()
+        if not clean_id:
+            return False
+        with self._connection() as conn:
+            result = conn.execute("DELETE FROM artifacts WHERE id = ?", (clean_id,))
+            return result.rowcount > 0
 
     def list_artifacts(
         self,

--- a/holdspeak/web/routes/primitives.py
+++ b/holdspeak/web/routes/primitives.py
@@ -699,6 +699,26 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
            order — we run the prompt fallback and return an honest `warning`
            naming why the graph could not run.
 
+        Per-node provenance: the iPad Blueprint carries a per-node `failure_policy`
+        (retryThenQueue / fallbackOnDevice / skip) and a `runs_on` model preference
+        (auto / onDevice / endpoint). The linearizer now carries both, and each
+        linear `steps` entry surfaces the node's resolved `failure_policy` and
+        `runs_on` so the trail is honest about what was requested. On a model-op
+        error the hub honours a faithful subset of the failure policy: `skip` and
+        `fallbackOnDevice` carry the input through unchanged and continue the chain
+        (the step's `status` records which), while `retryThenQueue` / unset surface
+        the error as a 502 (no silent empty).
+
+        NOT yet applied on the hub (carried + surfaced honestly, not enforced):
+        `runs_on` does not pin a node to a specific provider — the hub runs every
+        model op on its single configured provider, so `runs_on` is reported but the
+        target is not switched per node. `retryThenQueue` does not retry-with-backoff
+        or park/queue the run (the hub has no run queue); it fails fast. `fallbackOnDevice`
+        has no separate on-device fallback to swap to on the hub, so it degrades to
+        carrying the input through rather than re-running on another model. Full
+        per-node target routing and queue/park semantics live on the iPad runner
+        (`WorkflowRunner` / `BlueprintInterpreter`) and the mesh (HSM-15).
+
         404 if the workflow is missing; 502 on engine failure (no silent empty).
         Returns `{workflow_id, output, provider}` (+ optional `steps`, `warning`,
         and a `sources` lineage array).
@@ -722,6 +742,8 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
                 apply_pure_transform,
                 build_node_prompt,
                 linearize,
+                on_node_error,
+                resolved_failure_policy,
                 _MODEL_KINDS,
                 _PURE_TRANSFORM_KINDS,
             )
@@ -752,11 +774,33 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
                                 max_tokens=int(max_tokens) if max_tokens is not None else None,
                             )
                         except MeetingIntelError as exc:
-                            return JSONResponse(
-                                {"error": str(exc), "workflow_id": workflow_id,
-                                 "node_id": gnode.id},
-                                status_code=502,
-                            )
+                            # Honour a faithful subset of the node's failure policy:
+                            # `skip` / `fallbackOnDevice` carry the input through and
+                            # continue; `retryThenQueue` / unset surface the error.
+                            handled = on_node_error(gnode, current)
+                            if handled is None:
+                                return JSONResponse(
+                                    {"error": str(exc), "workflow_id": workflow_id,
+                                     "node_id": gnode.id,
+                                     "failure_policy": resolved_failure_policy(gnode)},
+                                    status_code=502,
+                                )
+                            current = handled
+                            run_steps.append({
+                                "node_id": gnode.id,
+                                "kind": gnode.kind,
+                                "output": current,
+                                "provider": None,
+                                "failure_policy": resolved_failure_policy(gnode),
+                                "runs_on": gnode.runs_on,
+                                "status": (
+                                    "skipped"
+                                    if resolved_failure_policy(gnode) == "skip"
+                                    else "fell_back"
+                                ),
+                                "error": str(exc),
+                            })
+                            continue
                         current = out
                         ran_a_model_op = True
                         run_steps.append({
@@ -764,6 +808,9 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
                             "kind": gnode.kind,
                             "output": out,
                             "provider": intel.active_provider,
+                            "failure_policy": resolved_failure_policy(gnode),
+                            "runs_on": gnode.runs_on,
+                            "status": "ok",
                         })
                     elif gnode.kind in _PURE_TRANSFORM_KINDS:
                         current = apply_pure_transform(gnode, current)
@@ -772,6 +819,9 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
                             "kind": gnode.kind,
                             "output": current,
                             "provider": None,
+                            "failure_policy": resolved_failure_policy(gnode),
+                            "runs_on": gnode.runs_on,
+                            "status": "ok",
                         })
                     # pass-through nodes (entry/source/merge/output) carry `current`.
 

--- a/holdspeak/web/routes/sync.py
+++ b/holdspeak/web/routes/sync.py
@@ -9,10 +9,14 @@ runtime). Two routes on the user's own server:
   as part of the Primitive Framework hub, the desk's new first-class primitives:
   notes, kbs, agents, chains, workflows, directories and directory memberships
   (the canonical filing map `primitive_id -> directory_id`). Read-only.
-- ``POST /api/sync/push`` — receive a pushed change-set. Meetings/artifacts land
-  in a durable JSON inbox (``<db_dir>/sync_inbox/``) exactly as before; the new
-  desk primitives are *merged into the live store* with last-write-wins on
-  ``last_modified`` and tombstone deletes, since they have real repositories.
+- ``POST /api/sync/push`` — receive a pushed change-set. Every kind is *merged
+  into the live store* with last-write-wins on ``last_modified`` and tombstone
+  deletes: the desk primitives through their repositories, and meetings +
+  artifacts through ``MeetingRepository``/``PluginArtifactRepository``, so a
+  meeting or artifact pushed from a peer is immediately queryable via the normal
+  read paths (``GET /api/meetings/{id}``, ``.../artifacts``), matching the other
+  kinds. A copy of the pushed meeting/artifact records is also kept in a durable
+  JSON inbox (``<db_dir>/sync_inbox/``) as a replayable audit trail.
 
 The wire is snake_case, ISO-8601 UTC ``Z`` timestamps, last-write-by
 ``last_modified`` conflict resolution, and tombstone deletes — mirroring how
@@ -127,6 +131,199 @@ def _primitive_record(rec: Any, kind: str) -> dict[str, Any]:
     }
 
 
+def _parse_dt(value: Any) -> Any:
+    """ISO-8601 string → naive datetime; tolerant of a trailing ``Z`` (UTC).
+
+    Returned naive (tzinfo dropped) to match how every other meeting path stores
+    timestamps (naive ``datetime.now()``); a stored mix of naive/aware stamps
+    breaks ``MeetingState.duration`` (naive ``now`` minus an aware ``started_at``).
+    """
+    from datetime import datetime
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=None) if value.tzinfo is not None else value
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+
+
+def _meeting_state_from_value(value: dict[str, Any]) -> Any:
+    """A pushed meeting `value` (the `MeetingState.to_dict` wire shape) → a
+    `MeetingState`, ready to hand to ``MeetingRepository.save_meeting``.
+
+    The exact inverse of `MeetingState.to_dict`: started/ended timestamps,
+    transcript segments, bookmarks and the latest intel snapshot all round-trip.
+    """
+    from ...meeting_session import (
+        Bookmark,
+        IntelSnapshot,
+        MeetingState,
+        TranscriptSegment,
+    )
+
+    segments = [
+        TranscriptSegment(
+            text=str(seg.get("text") or ""),
+            speaker=str(seg.get("speaker") or ""),
+            start_time=float(seg.get("start_time") or 0.0),
+            end_time=float(seg.get("end_time") or 0.0),
+            is_bookmarked=bool(seg.get("is_bookmarked")),
+            speaker_id=seg.get("speaker_id"),
+            device_id=seg.get("device_id"),
+        )
+        for seg in (value.get("segments") or [])
+        if isinstance(seg, dict)
+    ]
+    bookmarks = []
+    for bm in value.get("bookmarks") or []:
+        if not isinstance(bm, dict):
+            continue
+        created = _parse_dt(bm.get("created_at"))
+        kwargs: dict[str, Any] = {
+            "timestamp": float(bm.get("timestamp") or 0.0),
+            "label": str(bm.get("label") or ""),
+        }
+        if created is not None:
+            kwargs["created_at"] = created
+        bookmarks.append(Bookmark(**kwargs))
+
+    intel = None
+    raw_intel = value.get("intel")
+    if isinstance(raw_intel, dict):
+        intel = IntelSnapshot(
+            timestamp=float(raw_intel.get("timestamp") or 0.0),
+            topics=[str(t) for t in (raw_intel.get("topics") or [])],
+            action_items=list(raw_intel.get("action_items") or []),
+            summary=str(raw_intel.get("summary") or ""),
+        )
+
+    status_block = value.get("intel_status")
+    if isinstance(status_block, dict):
+        intel_status = str(status_block.get("state") or "disabled")
+        intel_status_detail = status_block.get("detail")
+        intel_requested_at = _parse_dt(status_block.get("requested_at"))
+        intel_completed_at = _parse_dt(status_block.get("completed_at"))
+    else:
+        intel_status = "disabled"
+        intel_status_detail = None
+        intel_requested_at = None
+        intel_completed_at = None
+
+    started = _parse_dt(value.get("started_at"))
+    if started is None:
+        from datetime import datetime
+
+        started = datetime.now()
+
+    return MeetingState(
+        id=str(value.get("id") or "").strip(),
+        started_at=started,
+        ended_at=_parse_dt(value.get("ended_at")),
+        title=value.get("title"),
+        tags=[str(t) for t in (value.get("tags") or [])],
+        segments=segments,
+        bookmarks=bookmarks,
+        intel=intel,
+        intel_status=intel_status,
+        intel_status_detail=intel_status_detail,
+        intel_requested_at=intel_requested_at,
+        intel_completed_at=intel_completed_at,
+        mic_label=str(value.get("mic_label") or "Me"),
+        remote_label=str(value.get("remote_label") or "Remote"),
+        web_url=value.get("web_url"),
+    )
+
+
+def _merge_meetings(db: Any, records: list[dict[str, Any]]) -> int:
+    """Live-merge pushed meeting records (LWW on `last_modified`, tombstone-aware).
+
+    The LWW stamp for the stored copy is the meeting's `started_at` ISO — exactly
+    the field ``pull`` emits as the meeting's `last_modified`, so the conflict key
+    is symmetric across surfaces.
+    """
+    merged = 0
+    for rec in records:
+        meta = rec["meta"]
+        rec_id = str(meta["id"]).strip()
+        if not rec_id:
+            continue
+        incoming_lm = _parse_dt(meta.get("last_modified"))
+        existing = db.meetings.get_meeting(rec_id)
+        if existing is not None and incoming_lm is not None:
+            # The stored copy's LWW key is `started_at` — the field `pull` emits
+            # as the meeting's `last_modified`, so the conflict key is symmetric.
+            if existing.started_at >= incoming_lm:
+                continue
+        if meta.get("deleted"):
+            db.meetings.delete_meeting(rec_id)
+            merged += 1
+            continue
+        value = rec.get("value") or {}
+        if not isinstance(value, dict):
+            continue
+        state = _meeting_state_from_value({**value, "id": rec_id})
+        if not state.id:
+            continue
+        db.meetings.save_meeting(state)
+        merged += 1
+    return merged
+
+
+def _merge_artifacts(db: Any, records: list[dict[str, Any]]) -> int:
+    """Live-merge pushed artifact records (LWW on `last_modified`, tombstone-aware).
+
+    The LWW stamp for the stored copy is the artifact's `updated_at` ISO — the
+    field ``pull`` emits as the artifact's `last_modified`.
+    """
+    merged = 0
+    for rec in records:
+        meta = rec["meta"]
+        rec_id = str(meta["id"]).strip()
+        if not rec_id:
+            continue
+        incoming_lm = _parse_dt(meta.get("last_modified"))
+        existing = db.plugins.get_artifact(rec_id)
+        if existing is not None and incoming_lm is not None:
+            # The stored copy's LWW key is `updated_at` — the field `pull` emits.
+            if existing.updated_at >= incoming_lm:
+                continue
+        if meta.get("deleted"):
+            db.plugins.delete_artifact(rec_id)
+            merged += 1
+            continue
+        value = rec.get("value") or {}
+        if not isinstance(value, dict):
+            continue
+        meeting_id = str(value.get("meeting_id") or "").strip()
+        if not meeting_id:
+            # An artifact with no meeting can't be filed (FK to meetings); skip.
+            continue
+        db.plugins.record_artifact(
+            artifact_id=rec_id,
+            meeting_id=meeting_id,
+            artifact_type=str(value.get("artifact_type") or "plugin_output"),
+            title=str(value.get("title") or "Artifact"),
+            body_markdown=str(value.get("body_markdown") or ""),
+            structured_json=value.get("structured_json") if isinstance(value.get("structured_json"), dict) else None,
+            confidence=float(value.get("confidence") or 0.0),
+            status=str(value.get("status") or "draft"),
+            plugin_id=str(value.get("plugin_id") or "unknown"),
+            plugin_version=str(value.get("plugin_version") or "unknown"),
+            sources=value.get("sources") if isinstance(value.get("sources"), list) else None,
+            # Preserve the wire LWW key (naive, to match the stored stamp format)
+            # so it survives the round-trip and `pull` re-emits it.
+            updated_at=incoming_lm.isoformat() if incoming_lm is not None else None,
+        )
+        merged += 1
+    return merged
+
+
 def build_sync_router(ctx: WebContext) -> APIRouter:
     router = APIRouter()
 
@@ -225,22 +422,29 @@ def build_sync_router(ctx: WebContext) -> APIRouter:
         db = get_database()
         received: dict[str, int] = {}
 
-        # Meetings/artifacts: durable JSON inbox (merge into the live store is
-        # HSM-10-03 territory; unchanged here).
-        n_meetings = len(body.get("meetings") or [])
-        n_artifacts = len(body.get("artifacts") or [])
-        if n_meetings or n_artifacts:
+        # Meetings/artifacts: live-merge into their real tables (LWW on
+        # last_modified, tombstone-aware) so a pushed meeting/artifact is
+        # immediately queryable via the normal read paths, matching the desk
+        # primitives. A copy of the pushed records is also kept in the durable
+        # JSON inbox as a replayable audit trail.
+        meeting_records = body.get("meetings") or []
+        artifact_records = body.get("artifacts") or []
+        if meeting_records or artifact_records:
             inbox = db.db_path.parent / "sync_inbox"
             inbox.mkdir(parents=True, exist_ok=True)
             idx = len(list(inbox.glob("inbox-*.json")))
             dest = inbox / f"inbox-{idx:06d}.json"
             dest.write_text(json.dumps(
-                {"meetings": body.get("meetings") or [],
-                 "artifacts": body.get("artifacts") or []}
+                {"meetings": meeting_records, "artifacts": artifact_records}
             ), encoding="utf-8")
-            log.info(f"sync push inboxed: meetings={n_meetings} artifacts={n_artifacts} -> {dest.name}")
-        received["meetings"] = n_meetings
-        received["artifacts"] = n_artifacts
+        # Meetings merge before artifacts so each artifact's meeting FK exists.
+        received["meetings"] = _merge_meetings(db, meeting_records)
+        received["artifacts"] = _merge_artifacts(db, artifact_records)
+        log.info(
+            "sync push merged: meetings=%s/%s artifacts=%s/%s",
+            received["meetings"], len(meeting_records),
+            received["artifacts"], len(artifact_records),
+        )
 
         # Desk primitives: merge into the live store, last-write-wins on
         # last_modified, tombstone deletes.

--- a/holdspeak/web/routes/system.py
+++ b/holdspeak/web/routes/system.py
@@ -27,6 +27,8 @@ log = get_logger("web.routes.system")
 
 # Validates outbound webhook header names on the settings PUT path.
 _HTTP_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9-]+$")
+# HSM-14: a GitHub `owner/name` slug for the companion GitHub connector.
+_GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 # The active reply target stays fresh (matches the device path in web_runtime),
 # but the companion overview shows a wider window so the user can see — and
@@ -875,6 +877,51 @@ def build_system_router(ctx: WebContext) -> APIRouter:
                         status_code=400,
                     )
             meeting_data["slack_webhook_url"] = slack_url
+
+            # HSM-14: the iPad desk's Webhook connector URL. Same consent posture
+            # as Slack — empty = the connector is off; anything else must pass THE
+            # shared rule (https with a host; plain http for loopback only). The
+            # URL's host is exactly what the Webhook connector may POST to, and the
+            # URL is a credential: it stays on the host and never rides a payload.
+            companion_webhook_url = str(
+                meeting_data.get(
+                    "companion_webhook_url",
+                    current.meeting.companion_webhook_url or "",
+                )
+                or ""
+            ).strip()
+            if companion_webhook_url:
+                from ...slack_export import slack_webhook_host
+
+                try:
+                    slack_webhook_host(companion_webhook_url)
+                except ValueError as exc:
+                    return JSONResponse(
+                        {"success": False, "error": f"companion_webhook_url: {exc}"},
+                        status_code=400,
+                    )
+            meeting_data["companion_webhook_url"] = companion_webhook_url
+
+            # HSM-14: the iPad desk's GitHub connector default repo (owner/name).
+            # Auth is the host's already-authenticated local `gh` — no token is
+            # stored or crosses the wire. Empty = the connector is off; otherwise
+            # it must be a plain `owner/name` slug.
+            companion_github_repo = str(
+                meeting_data.get(
+                    "companion_github_repo",
+                    current.meeting.companion_github_repo or "",
+                )
+                or ""
+            ).strip()
+            if companion_github_repo and not _GITHUB_REPO_RE.match(companion_github_repo):
+                return JSONResponse(
+                    {
+                        "success": False,
+                        "error": "companion_github_repo must be of the form owner/name",
+                    },
+                    status_code=400,
+                )
+            meeting_data["companion_github_repo"] = companion_github_repo
 
             similarity = float(meeting_data.get("similarity_threshold", current.meeting.similarity_threshold))
             if not (0.0 <= similarity <= 1.0):

--- a/holdspeak/web/routes/workflow_graph.py
+++ b/holdspeak/web/routes/workflow_graph.py
@@ -60,14 +60,56 @@ _PURE_TRANSFORM_KINDS = frozenset({"keep_if", "split_into_items"})
 
 _LINEAR_KINDS = _PASSTHROUGH_KINDS | _MODEL_KINDS | _PURE_TRANSFORM_KINDS
 
+# ── Per-node provenance the iPad Blueprint model carries (and we must not drop) ──
+#
+# Each `BPNode` (apple/Sources/RuntimeCore/Workbench/Blueprint.swift) carries a
+# `failure_policy`, and the node inspector adds a `runs_on` (model preference). The
+# raw on-the-wire values are the Swift enum raw strings; `None`/unset means inherit
+# the run default (== "auto" target, == the runner's default policy), which stays
+# byte-identical to the pre-provenance behaviour.
+#
+# What a run does when a node's model call throws (`FailurePolicy`):
+_FAILURE_POLICIES = frozenset({"retryThenQueue", "fallbackOnDevice", "skip"})
+# Where a model-op node prefers to run (`ModelPref`):
+_RUN_TARGETS = frozenset({"auto", "onDevice", "endpoint"})
+
+
+def _norm_failure_policy(raw: Any) -> Optional[str]:
+    """Normalize a node's raw `failure_policy` to a known value, else None (= inherit).
+
+    Accepts the Swift enum raw string (`retryThenQueue`/`fallbackOnDevice`/`skip`).
+    Unset / unrecognised → None so the runner falls back to its default (unchanged).
+    """
+    if isinstance(raw, str) and raw in _FAILURE_POLICIES:
+        return raw
+    return None
+
+
+def _norm_run_target(raw: Any) -> str:
+    """Normalize a node's raw `runs_on` to a known target; default "auto".
+
+    Accepts the iPad `ModelPref` raw string (`auto`/`onDevice`/`endpoint`). Unset /
+    unrecognised → "auto" (follow the hub's configured provider — byte-identical).
+    """
+    if isinstance(raw, str) and raw in _RUN_TARGETS:
+        return raw
+    return "auto"
+
 
 @dataclass(frozen=True)
 class GraphNode:
-    """One parsed Blueprint node: its id, its kind tag, and the kind's payload."""
+    """One parsed Blueprint node: id, kind tag, kind payload, and per-node provenance.
+
+    `failure_policy` (None == inherit the run default) and `runs_on` (the resolved
+    target, default "auto") are the per-node fields the iPad Blueprint carries; the
+    linear runner honours a faithful subset of them and surfaces them in the run steps.
+    """
 
     id: str
     kind: str
     payload: Any  # the value beside the kind tag (dict, str, or {} for nullary kinds)
+    failure_policy: Optional[str] = None  # retryThenQueue | fallbackOnDevice | skip | None
+    runs_on: str = "auto"  # auto | onDevice | endpoint
 
 
 @dataclass(frozen=True)
@@ -123,7 +165,13 @@ def parse_graph(graph_json: Any) -> Optional[list[GraphNode]]:
         if decoded is None:
             return None
         tag, payload = decoded
-        out.append(GraphNode(id=node_id, kind=tag, payload=payload))
+        out.append(GraphNode(
+            id=node_id,
+            kind=tag,
+            payload=payload,
+            failure_policy=_norm_failure_policy(raw.get("failure_policy")),
+            runs_on=_norm_run_target(raw.get("runs_on")),
+        ))
     return out
 
 
@@ -294,3 +342,40 @@ def apply_pure_transform(node: GraphNode, input_text: str) -> str:
         ]
         return "\n".join(items)
     return input_text
+
+
+# ── Per-node provenance the hub honours / surfaces ───────────────────────────
+
+
+def resolved_failure_policy(node: GraphNode, default: str = "retryThenQueue") -> str:
+    """The policy that governs this node: its own `failure_policy`, else the run default.
+
+    Mirrors the Swift `node.failurePolicy ?? policy.failurePolicy` resolution in
+    `BlueprintInterpreter`. `default` matches the runner's `RunPolicy` default
+    (`retryThenQueue`).
+    """
+    return node.failure_policy or default
+
+
+def on_node_error(node: GraphNode, carried_input: str) -> Optional[str]:
+    """Decide what the linear runner does when this node's model call throws.
+
+    Returns the text to carry forward (the step was handled), or None when the run
+    must surface the failure (the policy does not recover here):
+
+      * `skip`            → carry the resolved input through unchanged (Swift's
+                            `.skip`: "drop this step and carry the input straight
+                            through").
+      * `fallbackOnDevice`→ the hub has a single configured provider, so there is no
+                            separate fallback to swap to — carry the input through so
+                            the chain survives a transient endpoint failure rather
+                            than dropping the whole run (degrades gracefully).
+      * `retryThenQueue` / None (inherit) → None: the hub does not queue/park runs,
+                            so the caller surfaces the error honestly.
+
+    The runner records the chosen disposition in the step it returns.
+    """
+    policy = resolved_failure_policy(node)
+    if policy in ("skip", "fallbackOnDevice"):
+        return carried_input
+    return None

--- a/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
+++ b/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
@@ -83,4 +83,25 @@ no story begins from a blank page.
   Chain/Workflow each graded separately) — a chart refinement, folded into 23's sync-integrity
   story rather than its own phase.
 
+## Wave log
+
+Equilibrium gaps land in waves (a build flotilla of worktree-isolated agents, one disjoint
+gap each, integrated + full-suite-verified together). Stories stay the canonical unit; the
+waves are how the backlog drains in parallel.
+
+### Wave 1 (2026-06-27) — hub + web, 6 gaps
+
+| Gap | Phase | What landed |
+|-----|-------|-------------|
+| Graph node policy/target | 22 | the linear runner carries + applies per-node `failure_policy` (skip/fallback continue, retry/unset fail fast) + `runs_on`, surfaced in the run steps; honestly documents what the hub does not yet enforce |
+| Banned copy + guard | 21 | "intelligent typing" replaced with canonical names in web product copy; the voice guard now scans `web/src/**/*.astro` so a reintroduction fails CI |
+| Web connector configs | 21 | the hub reads/writes `companion_webhook_url` + `companion_github_repo` (Slack-parity validation); the web settings page exposes them |
+| Sync live-merge | 23 | `POST /api/sync/push` live-merges pushed meeting + artifact content into their real tables (was a JSON inbox), so they are immediately queryable like the other kinds |
+| Workflow run signals | 22 | the web run UI surfaces the hub's honest `warning` (ran linear, branches skipped) + the per-node `steps` trail; `primitives.ts` `graphJson` type corrected |
+| Intent-timeline + plugin-runs | 19 | the web meeting-detail consumes the two persisted read routes (an intent-timeline strip + a plugin-run table) that had no consumer |
+
+Integrated + verified together: full Python suite **2924 passed**, web build green.
+**Known follow-up:** the shipped `docs/INTELLIGENT_TYPING_GUIDE.md` (asserted verbatim by a
+test) still carries the old name; the ban is scoped to product copy until that doc is renamed.
+
 See [[project_primitive_framework]], [[project_phase15_the_mesh]], [[project_phase17_agent_sync]].

--- a/tests/integration/test_primitive_framework_sync.py
+++ b/tests/integration/test_primitive_framework_sync.py
@@ -291,3 +291,176 @@ def test_malformed_changeset_is_rejected_and_not_merged(env) -> None:
     resp = client.post("/api/sync/push", json=bad)
     assert resp.status_code == 422
     assert client.get("/api/notes/x1").status_code == 404
+
+
+# ── Equilibrium 23-04: meeting + artifact content live-merges (not just inbox) ──
+# The desktop footnote: a meeting/artifact pushed from a peer must round-trip into
+# its REAL table and be queryable through the normal read paths, matching the desk
+# primitives. These prove readability (not inboxing), plus LWW + tombstone.
+
+def _meeting_changeset(meeting_id, lm, *, title="Pushed meeting", deleted=False):
+    """A pushed meeting record in the `MeetingState.to_dict` wire shape."""
+    return {
+        "meta": {"id": meeting_id, "kind": "meeting",
+                 "last_modified": lm, "deleted": deleted},
+        "value": {
+            "id": meeting_id,
+            "started_at": lm,
+            "ended_at": None,
+            "title": title,
+            "tags": ["mobile"],
+            "segments": [{
+                "text": "spoken on the iPad", "speaker": "Me",
+                "speaker_id": None, "start_time": 0.0, "end_time": 2.5,
+                "is_bookmarked": False, "device_id": None,
+            }],
+            "bookmarks": [],
+            "intel": None,
+            "intel_status": {"state": "disabled", "detail": None,
+                             "requested_at": None, "completed_at": None},
+            "mic_label": "Me", "remote_label": "Remote", "web_url": None,
+        },
+    }
+
+
+def _artifact_changeset(artifact_id, meeting_id, lm, *, title="Pushed artifact", deleted=False):
+    """A pushed artifact record in the Phase-0 `Artifact` contract shape."""
+    return {
+        "meta": {"id": artifact_id, "kind": "artifact",
+                 "last_modified": lm, "deleted": deleted},
+        "value": {
+            "id": artifact_id,
+            "meeting_id": meeting_id,
+            "artifact_type": "summary",
+            "title": title,
+            "body_markdown": "# From the iPad\n\nlive-merged",
+            "structured_json": {"k": "v"},
+            "confidence": 0.8,
+            "status": "draft",
+            "plugin_id": "mobile",
+            "plugin_version": "1.0",
+            "sources": [{"source_type": "segment", "source_ref": "seg-1"}],
+        },
+    }
+
+
+def test_pushed_meeting_and_artifact_are_readable_via_crud_and_pull(env) -> None:
+    """A meeting + its artifact pushed the IPAD way live-merge into their real
+    tables and are queryable via the normal read paths (NOT just inboxed)."""
+    db, client = env
+    lm = "2030-06-26T12:00:00Z"
+    changeset = {
+        "meetings": [_meeting_changeset("ipad_meeting_1", lm)],
+        "artifacts": [_artifact_changeset("ipad_artifact_1", "ipad_meeting_1", lm)],
+    }
+    push = client.post("/api/sync/push", json=changeset)
+    assert push.status_code == 200, push.text
+    rcv = push.json()["received"]
+    assert rcv["meetings"] == 1 and rcv["artifacts"] == 1
+
+    # Readable via the normal meeting read path (GET /api/meetings/{id}).
+    meeting = client.get("/api/meetings/ipad_meeting_1")
+    assert meeting.status_code == 200
+    body = meeting.json()
+    assert body["title"] == "Pushed meeting"
+    assert body["tags"] == ["mobile"]
+    assert len(body["segments"]) == 1
+    assert body["segments"][0]["text"] == "spoken on the iPad"
+
+    # Readable via the normal artifact read path (GET .../artifacts).
+    arts = client.get("/api/meetings/ipad_meeting_1/artifacts")
+    assert arts.status_code == 200
+    rows = arts.json()["artifacts"]
+    assert len(rows) == 1
+    assert rows[0]["id"] == "ipad_artifact_1"
+    assert rows[0]["title"] == "Pushed artifact"
+    assert rows[0]["body_markdown"] == "# From the iPad\n\nlive-merged"
+    assert rows[0]["structured_json"] == {"k": "v"}
+    assert rows[0]["sources"] == [{"source_type": "segment", "source_ref": "seg-1"}]
+
+    # And both ride the next pull (the round-trip a second surface would read).
+    pulled = client.get("/api/sync/pull").json()
+    assert _bucket_by_id(pulled["meetings"], "ipad_meeting_1") is not None
+    assert _bucket_by_id(pulled["artifacts"], "ipad_artifact_1") is not None
+
+
+def test_pushed_meeting_lww_older_does_not_clobber_newer(env) -> None:
+    """An older pushed meeting edit does NOT clobber a newer stored one; a newer
+    push wins — LWW on last_modified, in the real meetings table."""
+    db, client = env
+    newer = "2030-06-26T12:00:00Z"
+    older = "2020-01-01T00:00:00Z"
+    assert client.post(
+        "/api/sync/push",
+        json={"meetings": [_meeting_changeset("m_lww", newer, title="Newer")]},
+    ).status_code == 200
+
+    # Older push for the same id → skipped.
+    resp = client.post(
+        "/api/sync/push",
+        json={"meetings": [_meeting_changeset("m_lww", older, title="Stale")]},
+    )
+    assert resp.json()["received"]["meetings"] == 0
+    assert client.get("/api/meetings/m_lww").json()["title"] == "Newer"
+
+    # A strictly newer push → wins.
+    newest = "2040-01-01T00:00:00Z"
+    resp = client.post(
+        "/api/sync/push",
+        json={"meetings": [_meeting_changeset("m_lww", newest, title="Newest")]},
+    )
+    assert resp.json()["received"]["meetings"] == 1
+    assert client.get("/api/meetings/m_lww").json()["title"] == "Newest"
+
+
+def test_pushed_meeting_tombstone_removes_it(env) -> None:
+    """A newer `deleted:true` meeting push removes it from the live store."""
+    db, client = env
+    lm = "2030-06-26T12:00:00Z"
+    client.post("/api/sync/push", json={"meetings": [_meeting_changeset("m_tomb", lm)]})
+    assert client.get("/api/meetings/m_tomb").status_code == 200
+
+    later = "2031-01-01T00:00:00Z"
+    resp = client.post(
+        "/api/sync/push",
+        json={"meetings": [_meeting_changeset("m_tomb", later, deleted=True)]},
+    )
+    assert resp.json()["received"]["meetings"] == 1
+    assert client.get("/api/meetings/m_tomb").status_code == 404
+
+
+def test_pushed_artifact_lww_and_tombstone(env) -> None:
+    """Artifact LWW + tombstone hold in the real artifacts table."""
+    db, client = env
+    lm = "2030-06-26T12:00:00Z"
+    # Need a meeting for the artifact FK; push it first.
+    client.post("/api/sync/push", json={
+        "meetings": [_meeting_changeset("a_meet", lm)],
+        "artifacts": [_artifact_changeset("a_art", "a_meet", lm, title="v1")],
+    })
+    rows = client.get("/api/meetings/a_meet/artifacts").json()["artifacts"]
+    assert rows[0]["title"] == "v1"
+
+    # Older push → skipped.
+    older = "2020-01-01T00:00:00Z"
+    resp = client.post("/api/sync/push", json={
+        "artifacts": [_artifact_changeset("a_art", "a_meet", older, title="stale")],
+    })
+    assert resp.json()["received"]["artifacts"] == 0
+    assert client.get("/api/meetings/a_meet/artifacts").json()["artifacts"][0]["title"] == "v1"
+
+    # Newer push → wins.
+    newer = "2040-01-01T00:00:00Z"
+    resp = client.post("/api/sync/push", json={
+        "artifacts": [_artifact_changeset("a_art", "a_meet", newer, title="v2")],
+    })
+    assert resp.json()["received"]["artifacts"] == 1
+    assert client.get("/api/meetings/a_meet/artifacts").json()["artifacts"][0]["title"] == "v2"
+
+    # Newer tombstone → removed.
+    newest = "2050-01-01T00:00:00Z"
+    resp = client.post("/api/sync/push", json={
+        "artifacts": [_artifact_changeset("a_art", "a_meet", newest, deleted=True)],
+    })
+    assert resp.json()["received"]["artifacts"] == 1
+    assert client.get("/api/meetings/a_meet/artifacts").json()["artifacts"] == []

--- a/tests/integration/test_web_dictation_settings_api.py
+++ b/tests/integration/test_web_dictation_settings_api.py
@@ -550,3 +550,67 @@ class TestVoiceMacrosSettingsApi:
         persisted = Config.load(settings_path)
         assert persisted.dictation.macros.enabled is True
         assert persisted.dictation.macros.items[0].keyword == "docs"
+
+
+class TestSettingsCompanionConnectors:
+    """HSM-14 / EQ-21-03: the iPad desk's Webhook + GitHub connectors are
+    configured from the hub's settings, same posture as the Slack field."""
+
+    def test_put_round_trips_companion_webhook_and_github(
+        self, test_client: TestClient, settings_path: Path
+    ) -> None:
+        payload = {
+            "meeting": {
+                "companion_webhook_url": "https://hooks.example.com/abc",
+                "companion_github_repo": "karolswdev/HoldSpeak",
+            }
+        }
+        response = test_client.put("/api/settings", json=payload)
+        assert response.status_code == 200, response.text
+        out = response.json()["settings"]["meeting"]
+        assert out["companion_webhook_url"] == "https://hooks.example.com/abc"
+        assert out["companion_github_repo"] == "karolswdev/HoldSpeak"
+
+        persisted = Config.load(path=settings_path)
+        assert persisted.meeting.companion_webhook_url == "https://hooks.example.com/abc"
+        assert persisted.meeting.companion_github_repo == "karolswdev/HoldSpeak"
+
+        # And the GET read path surfaces them.
+        got = test_client.get("/api/settings").json()["meeting"]
+        assert got["companion_webhook_url"] == "https://hooks.example.com/abc"
+        assert got["companion_github_repo"] == "karolswdev/HoldSpeak"
+
+    def test_put_rejects_non_https_companion_webhook(
+        self, test_client: TestClient, settings_path: Path
+    ) -> None:
+        response = test_client.put(
+            "/api/settings",
+            json={"meeting": {"companion_webhook_url": "http://hooks.example.com/x"}},
+        )
+        assert response.status_code == 400
+        assert "companion_webhook_url" in response.json()["error"]
+
+    def test_put_rejects_malformed_companion_github_repo(
+        self, test_client: TestClient, settings_path: Path
+    ) -> None:
+        response = test_client.put(
+            "/api/settings",
+            json={"meeting": {"companion_github_repo": "not-a-slug"}},
+        )
+        assert response.status_code == 400
+        assert "companion_github_repo" in response.json()["error"]
+
+    def test_put_omitting_connectors_preserves_them(
+        self, test_client: TestClient, settings_path: Path
+    ) -> None:
+        seed = {
+            "meeting": {
+                "companion_webhook_url": "https://hooks.example.com/keep",
+                "companion_github_repo": "owner/repo",
+            }
+        }
+        assert test_client.put("/api/settings", json=seed).status_code == 200
+        assert test_client.put("/api/settings", json={"ui": {"theme": "light"}}).status_code == 200
+        persisted = Config.load(settings_path)
+        assert persisted.meeting.companion_webhook_url == "https://hooks.example.com/keep"
+        assert persisted.meeting.companion_github_repo == "owner/repo"

--- a/tests/unit/test_doc_drift_guard.py
+++ b/tests/unit/test_doc_drift_guard.py
@@ -266,7 +266,24 @@ _AI_VOCAB = re.compile(
 )
 
 # Banned synonyms for canonical feature names (POSITIONING.md table).
+#
+# "intelligent typing" is a banned synonym for the dictation pipeline in
+# user-facing *product copy* (the web/src astro templates). The historical
+# setup guide docs/INTELLIGENT_TYPING_GUIDE.md keeps that name as its own
+# established title and is referenced verbatim across the docs corpus (and by
+# test_qlippy_doc_states_the_guarantees_verbatim), so the docs scan below uses
+# _BANNED_NAMES_DOCS, which omits that one term. Renaming the guide is a
+# separate, larger move outside this guard's scope.
 _BANNED_NAMES = re.compile(
+    r"\bvoice macros?\b"               # canonical: voice commands
+    r"|\bintelligent dictation\b"      # canonical: the dictation pipeline
+    r"|\bintelligent typing\b"         # canonical: the dictation pipeline / dictation
+    r"|\bslack (?:integration|export)\b",  # canonical: Send to Slack
+    re.IGNORECASE,
+)
+
+# The docs-corpus variant: same table, minus "intelligent typing" (see above).
+_BANNED_NAMES_DOCS = re.compile(
     r"\bvoice macros?\b"               # canonical: voice commands
     r"|\bintelligent dictation\b"      # canonical: the dictation pipeline
     r"|\bslack (?:integration|export)\b",  # canonical: Send to Slack
@@ -316,11 +333,23 @@ def test_no_user_facing_doc_uses_ai_vocabulary() -> None:
     )
 
 
+def _web_src_astro() -> list[Path]:
+    """The user-facing web copy in `web/src/**/*.astro`.
+
+    These templates carry product copy a user reads, so banned synonyms for
+    canonical feature names must not creep back in (e.g. "intelligent typing").
+    The generated bundle under holdspeak/static/_built is NOT scanned (it is
+    rebuilt from this source).
+    """
+    web_src = _REPO / "web" / "src"
+    return sorted(web_src.rglob("*.astro"))
+
+
 def test_no_user_facing_doc_uses_banned_feature_names() -> None:
     offenders = []
     for doc in _user_facing_docs():
         for lineno, line in _prose_lines(doc):
-            match = _BANNED_NAMES.search(line)
+            match = _BANNED_NAMES_DOCS.search(line)
             if match:
                 offenders.append(
                     f"{doc.relative_to(_REPO)}:{lineno}: {match.group(0)!r}"
@@ -329,6 +358,35 @@ def test_no_user_facing_doc_uses_banned_feature_names() -> None:
         "Non-canonical feature names (the canonical table lives in "
         "docs/internal/POSITIONING.md):\n  " + "\n  ".join(offenders)
     )
+
+
+def test_no_web_src_copy_uses_banned_feature_names() -> None:
+    """The user-facing web copy (web/src/**/*.astro) speaks in canonical names.
+    'intelligent typing' is a banned synonym for the dictation pipeline; this
+    catches a reintroduction in product copy. The generated bundle under
+    holdspeak/static/_built is rebuilt from this source and is not scanned."""
+    offenders = []
+    for tmpl in _web_src_astro():
+        for lineno, line in _prose_lines(tmpl):
+            match = _BANNED_NAMES.search(line)
+            if match:
+                offenders.append(
+                    f"{tmpl.relative_to(_REPO)}:{lineno}: {match.group(0)!r}"
+                )
+    assert not offenders, (
+        "Non-canonical feature names in web/src copy (the canonical table lives "
+        "in docs/internal/POSITIONING.md; 'intelligent typing' -> 'the dictation "
+        "pipeline' / 'dictation'):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_banned_name_guard_scans_web_src() -> None:
+    """Sanity: the banned-name scan reaches the web/src astro templates, so a
+    reintroduction of a synonym like 'intelligent typing' fails here."""
+    astro = _web_src_astro()
+    assert len(astro) > 5
+    names = {p.name for p in astro}
+    assert {"index.astro", "dictation.astro", "welcome.astro"} <= names
 
 
 def test_voice_guard_patterns_catch_seeded_violations() -> None:
@@ -342,6 +400,7 @@ def test_voice_guard_patterns_catch_seeded_violations() -> None:
                  "every meeting, not just the visible page"):  # plain logic stays legal
         assert not _AI_VOCAB.search(keep), f"AI-vocab pattern should NOT flag {keep!r}"
     for hit in ("configure voice macros", "intelligent dictation mode",
+                "tune intelligent typing", "Intelligent typing (optional)",
                 "the Slack integration", "use the Slack export"):
         assert _BANNED_NAMES.search(hit), f"name pattern should flag {hit!r}"
     assert not _BANNED_NAMES.search("voice commands fire on keywords")

--- a/tests/unit/test_web_routes_sync.py
+++ b/tests/unit/test_web_routes_sync.py
@@ -61,14 +61,25 @@ def _fake_db(tmp_path, *, meetings=(), artifacts=None):
     artifacts = artifacts or {}
     summaries = [types.SimpleNamespace(id=m, started_at=datetime(2026, 1, 1)) for m in meetings]
     states = {m: _meeting_state(m) for m in meetings}
+    # Equilibrium 23-04: the push route now live-merges meetings/artifacts, so the
+    # fake repos record the merge calls (LWW reads return None → the push wins).
+    saved_meetings: list = []
+    recorded_artifacts: list = []
     return types.SimpleNamespace(
         db_path=tmp_path / "hs.db",
+        saved_meetings=saved_meetings,
+        recorded_artifacts=recorded_artifacts,
         meetings=types.SimpleNamespace(
             list_meetings=lambda limit=50: summaries[:limit],
             get_meeting=lambda mid: states.get(mid),
+            save_meeting=lambda state: saved_meetings.append(state),
+            delete_meeting=lambda mid: True,
         ),
         plugins=types.SimpleNamespace(
             list_artifacts=lambda mid: artifacts.get(mid, []),
+            get_artifact=lambda aid: None,
+            delete_artifact=lambda aid: True,
+            record_artifact=lambda **kw: recorded_artifacts.append(kw),
         ),
         notes=_empty_primitive_repo(),
         kbs=_empty_primitive_repo(),
@@ -101,7 +112,9 @@ def test_pull_serializes_meetings_and_artifacts(monkeypatch, tmp_path):
     assert a["value"]["meeting_id"] == "m1"
 
 
-def test_push_writes_changeset_to_inbox(monkeypatch, tmp_path):
+def test_push_live_merges_meeting_and_keeps_audit_inbox(monkeypatch, tmp_path):
+    # Equilibrium 23-04: a pushed meeting live-merges into the real table (a
+    # `save_meeting` call) AND a copy lands in the durable JSON audit inbox.
     fake = _fake_db(tmp_path)
     monkeypatch.setattr(hsdb, "get_database", lambda *a, **k: fake)
 
@@ -118,6 +131,11 @@ def test_push_writes_changeset_to_inbox(monkeypatch, tmp_path):
     assert body["received"]["meetings"] == 1
     assert body["received"]["artifacts"] == 0
 
+    # Live-merged into the meetings table (not just inboxed).
+    assert len(fake.saved_meetings) == 1
+    assert fake.saved_meetings[0].id == "m1"
+
+    # And a replayable audit copy still lands in the inbox.
     inbox = tmp_path / "sync_inbox"
     files = list(inbox.glob("inbox-*.json"))
     assert len(files) == 1

--- a/tests/unit/test_workflow_graph.py
+++ b/tests/unit/test_workflow_graph.py
@@ -10,7 +10,9 @@ from holdspeak.web.routes.workflow_graph import (
     apply_pure_transform,
     build_node_prompt,
     linearize,
+    on_node_error,
     parse_graph,
+    resolved_failure_policy,
     GraphNode,
 )
 
@@ -156,3 +158,69 @@ def test_apply_pure_transform() -> None:
     split = apply_pure_transform(GraphNode("s", "split_into_items", {}),
                                  " one \n\n two \n")
     assert split == "one\ntwo"
+
+
+# ── per-node provenance: failure_policy + runs_on are carried, not dropped ────
+def test_parse_graph_carries_failure_policy_and_runs_on() -> None:
+    g = {"nodes": [
+        {"id": "a", "kind": {"summarize": {}},
+         "failure_policy": "skip", "runs_on": "endpoint"},
+        {"id": "b", "kind": {"summarize": {}},
+         "failure_policy": "fallbackOnDevice", "runs_on": "onDevice"},
+    ]}
+    nodes = parse_graph(g)
+    assert nodes is not None
+    assert (nodes[0].failure_policy, nodes[0].runs_on) == ("skip", "endpoint")
+    assert (nodes[1].failure_policy, nodes[1].runs_on) == ("fallbackOnDevice", "onDevice")
+
+
+def test_parse_graph_unset_or_unknown_provenance_is_byte_identical_default() -> None:
+    # No keys, explicit null, and unknown strings all normalize to the inherit-default:
+    # failure_policy None (inherit the run default), runs_on "auto" (follow Settings).
+    g = {"nodes": [
+        {"id": "a", "kind": {"summarize": {}}},                      # absent
+        {"id": "b", "kind": {"summarize": {}}, "failure_policy": None, "runs_on": None},
+        {"id": "c", "kind": {"summarize": {}},
+         "failure_policy": "teleport", "runs_on": "moon"},           # unrecognised
+    ]}
+    nodes = parse_graph(g)
+    assert nodes is not None
+    for n in nodes:
+        assert n.failure_policy is None
+        assert n.runs_on == "auto"
+
+
+def test_resolved_failure_policy_falls_back_to_run_default() -> None:
+    # An explicit node policy wins; unset inherits the runner's default.
+    assert resolved_failure_policy(GraphNode("a", "llm", {}, failure_policy="skip")) == "skip"
+    assert resolved_failure_policy(GraphNode("a", "llm", {})) == "retryThenQueue"
+    assert resolved_failure_policy(GraphNode("a", "llm", {}), default="skip") == "skip"
+
+
+def test_on_node_error_honors_skip_and_fallback_but_surfaces_retry() -> None:
+    carried = "the resolved input"
+    # skip → carry the input straight through (the step is dropped, run survives).
+    assert on_node_error(GraphNode("a", "llm", {}, failure_policy="skip"), carried) == carried
+    # fallbackOnDevice → no separate hub fallback, so carry through (degrade, don't drop run).
+    assert on_node_error(
+        GraphNode("a", "llm", {}, failure_policy="fallbackOnDevice"), carried) == carried
+    # retryThenQueue and unset → None: the hub surfaces the failure (no silent recovery).
+    assert on_node_error(GraphNode("a", "llm", {}, failure_policy="retryThenQueue"), carried) is None
+    assert on_node_error(GraphNode("a", "llm", {}), carried) is None
+
+
+def test_linearize_preserves_provenance_through_ordering() -> None:
+    g = {
+        "nodes": [
+            {"id": "a", "kind": {"summarize": {}},
+             "failure_policy": "skip", "runs_on": "endpoint"},
+            {"id": "b", "kind": {"rewrite": {"tone": "calm"}},
+             "failure_policy": "fallbackOnDevice", "runs_on": "onDevice"},
+        ],
+        "exec_edges": [_exec("a", "b")],
+    }
+    plan = linearize(g)
+    assert plan.linearizable
+    a, b = plan.ordered
+    assert (a.id, a.failure_policy, a.runs_on) == ("a", "skip", "endpoint")
+    assert (b.id, b.failure_policy, b.runs_on) == ("b", "fallbackOnDevice", "onDevice")

--- a/web/src/components/dictation/HooksSection.astro
+++ b/web/src/components/dictation/HooksSection.astro
@@ -18,7 +18,7 @@
     </header>
     <p class="lede">
       Compress the latest captured Claude/Codex question into compact
-      context for intelligent typing. HoldSpeak uses safe read-only /
+      context for the dictation pipeline. HoldSpeak uses safe read-only /
       no-tools defaults and only runs this when you click the button.
     </p>
     <div class="row">

--- a/web/src/pages/desk.astro
+++ b/web/src/pages/desk.astro
@@ -605,6 +605,32 @@ const GROUPS = [
             <span x-text="runningKind === 'chain' ? 'Running the crew…' : (runningKind === 'workflow' ? 'Running the workflow…' : 'Running the persona…')">Running…</span>
           </div>
 
+          {/* honest hub notice — a graph it would not guess an order for ran the
+              prompt fallback; surface that verbatim so the run is never silent */}
+          <div class="run-notice" x-show="runWarning && !runBusy" x-cloak>
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><path d="M12 9v4M12 17h.01" /></svg>
+            <span x-text="runWarning"></span>
+          </div>
+
+          {/* workflow graph trail — the per-node execution path the hub ran */}
+          <div class="crew-result" x-show="runningKind === 'workflow' && workflowSteps && !runBusy" x-cloak>
+            <span class="run-result-label">Graph trail</span>
+            <ol class="crew-steps">
+              <template x-for="(step, i) in (workflowSteps || [])" {...{ ":key": "i" }}>
+                <li class="crew-step">
+                  <div class="crew-step-head">
+                    <span class="chain-num" x-text="i + 1"></span>
+                    <span class="crew-step-name" x-text="step.nodeId || step.kind"></span>
+                    <span class="crew-step-kind" x-show="step.kind" x-cloak x-text="step.kind" title="Node kind"></span>
+                    <span class="crew-step-provider" x-show="step.provider" x-cloak x-text="step.provider" title="Ran on"></span>
+                    <svg class="crew-step-arrow" x-show="i < (workflowSteps.length - 1)" x-cloak viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M19 12l-7 7-7-7" /></svg>
+                  </div>
+                  <pre class="crew-step-output" x-text="step.output"></pre>
+                </li>
+              </template>
+            </ol>
+          </div>
+
           {/* chain crew result — each step in sequence, then the final output */}
           <div class="crew-result" x-show="runningKind === 'chain' && chainSteps && !runBusy" x-cloak>
             <span class="run-result-label">Crew run</span>
@@ -626,7 +652,7 @@ const GROUPS = [
           {/* result — final output (all kinds) */}
           <div class="run-result" x-show="runResult && !runBusy" x-cloak>
             <div class="run-result-head">
-              <span class="run-result-label" x-text="runningKind === 'chain' ? 'Final output' : 'Output'">Output</span>
+              <span class="run-result-label" x-text="(runningKind === 'chain' || (runningKind === 'workflow' && workflowSteps)) ? 'Final output' : 'Output'">Output</span>
               <span class="egress" :class="runEgress().scope" :title="runEgress().label">
                 <svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
                 <span x-text="runEgress().scope === 'local' ? 'on-device' : (runEgress().scope === 'cloud' ? 'cloud' : 'egress')">egress</span>
@@ -1188,9 +1214,24 @@ const GROUPS = [
     background: var(--surface-3); border-radius: var(--radius-xs); padding: 0 5px;
     flex-shrink: 0; max-width: 10rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
+  .crew-step-kind {
+    font-family: var(--font-mono); font-size: 0.625rem; color: var(--ck, #A78BFA);
+    background: color-mix(in srgb, var(--ck, #A78BFA) 14%, var(--surface-3));
+    border-radius: var(--radius-xs); padding: 0 5px; flex-shrink: 0;
+  }
   .crew-step-arrow { margin-left: auto; color: #A78BFA; }
-  .crew-step-provider + .crew-step-arrow { margin-left: var(--space-2); }
+  .crew-step-provider + .crew-step-arrow,
+  .crew-step-kind + .crew-step-arrow { margin-left: var(--space-2); }
   .crew-step-output { margin: 0; padding: var(--space-3); font-family: var(--font-mono); font-size: var(--font-size-sm); line-height: var(--line-height-relaxed); color: var(--text-muted); white-space: pre-wrap; word-break: break-word; max-height: 22vh; overflow-y: auto; }
+  /* honest hub notice — a refused graph that fell back to the prompt */
+  .run-notice {
+    display: flex; align-items: flex-start; gap: var(--space-2);
+    margin: 0; padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm);
+    background: var(--warning-soft, color-mix(in srgb, #F59E0B 14%, var(--surface-2)));
+    color: var(--warning, #F59E0B); font-size: var(--font-size-sm);
+    border: 1px solid var(--warning-soft, color-mix(in srgb, #F59E0B 28%, transparent));
+  }
+  .run-notice svg { flex-shrink: 0; margin-top: 2px; }
 
   @media (max-width: 720px) {
     .desk { padding: var(--space-3); gap: var(--space-5); }

--- a/web/src/pages/dictation.astro
+++ b/web/src/pages/dictation.astro
@@ -48,7 +48,7 @@ import HooksSection from "../components/dictation/HooksSection.astro";
       <p class="cockpit-eyebrow">Dictation</p>
       <h1 class="cockpit-h">Dictation cockpit</h1>
       <p class="cockpit-lede">
-        Tune intelligent typing end-to-end — readiness, blocks, project
+        Tune the dictation pipeline end-to-end — readiness, blocks, project
         context, runtime, and a live dry-run — without hand-editing a single
         config file.
       </p>

--- a/web/src/pages/history.astro
+++ b/web/src/pages/history.astro
@@ -907,6 +907,61 @@ import AppLayout from "../layouts/AppLayout.astro";
                 </div>
               </div>
 
+              <!-- EQ-19: the persisted MIR intent timeline. Which intents were
+                   active across the meeting, window by window, plus a legend.
+                   Read-only; shows only when a timeline was recorded. -->
+              <div class="detail-card" x-show="selectedMeetingIntentTimeline" x-cloak>
+                <h4>Intent timeline</h4>
+                <p class="detail-sub">Which intents were active across the meeting, window by window.</p>
+                <div class="intent-legend" x-show="intentTimelineLegend().length" x-cloak>
+                  <template x-for="intent in intentTimelineLegend()" :key="intent">
+                    <span class="intent-chip" :class="`intent-c${intentColorSlot(intent)}`" x-text="intent"></span>
+                  </template>
+                </div>
+                <div class="intent-strip">
+                  <template x-for="cell in intentTimelineCells()" :key="cell.window_id">
+                    <div class="intent-cell" :title="cell.excerpt">
+                      <span class="intent-cell-time" x-text="cell.label"></span>
+                      <div class="intent-cell-bars">
+                        <template x-for="intent in cell.intents" :key="intent">
+                          <span class="intent-bar" :class="`intent-c${intentColorSlot(intent)}`" :title="intent" x-text="intent"></span>
+                        </template>
+                        <span class="intent-bar intent-bar--empty" x-show="!cell.intents.length" x-cloak>—</span>
+                      </div>
+                    </div>
+                  </template>
+                </div>
+              </div>
+
+              <!-- EQ-19: the persisted MIR plugin-run history — which plugins
+                   ran on which window, with status + timing. Read-only. -->
+              <div class="detail-card" x-show="selectedMeetingPluginRuns.length" x-cloak>
+                <h4>Plugin runs</h4>
+                <p class="detail-sub">The MIR plugins that ran on this meeting, with status and timing.</p>
+                <div class="plugin-run-table" role="table" aria-label="Plugin runs">
+                  <div class="plugin-run-row plugin-run-row--head" role="row">
+                    <span role="columnheader">Plugin</span>
+                    <span role="columnheader">Window</span>
+                    <span role="columnheader">Status</span>
+                    <span role="columnheader">Duration</span>
+                  </div>
+                  <template x-for="run in selectedMeetingPluginRuns" :key="run.id">
+                    <div class="plugin-run-row" role="row" :title="run.error || ''">
+                      <span role="cell" class="plugin-run-id">
+                        <span class="plugin-run-name" x-text="run.plugin_id"></span>
+                        <span class="plugin-run-version" x-show="run.plugin_version" x-cloak x-text="`v${run.plugin_version}`"></span>
+                        <span class="pill pill--small" x-show="run.deduped" x-cloak title="Skipped — an identical run already happened">Deduped</span>
+                      </span>
+                      <span role="cell" class="plugin-run-window" x-text="run.window_id || '—'"></span>
+                      <span role="cell">
+                        <span class="status-pill" :class="`run-${pluginRunStatusValue(run.status)}`" x-text="pluginRunStatusLabel(run.status)"></span>
+                      </span>
+                      <span role="cell" class="plugin-run-duration" x-text="pluginRunDurationLabel(run.duration_ms)"></span>
+                    </div>
+                  </template>
+                </div>
+              </div>
+
               <div class="detail-card" x-show="selectedMeeting?.intel?.summary" x-cloak>
                 <h4>Summary</h4>
                 <p x-text="selectedMeeting?.intel?.summary"></p>
@@ -2480,6 +2535,149 @@ import AppLayout from "../layouts/AppLayout.astro";
   .status-pill.proposal-rejected { background: var(--surface-3); color: var(--text-muted); }
   /* A decided/terminal proposal reads quieter than a pending one. */
   .proposal-card.accent-default { opacity: 0.85; }
+
+  /* === EQ-19: intent timeline + plugin runs ============== */
+  .detail-sub {
+    margin: 0 0 var(--space-1);
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+  }
+
+  /* Plugin-run terminal status reuses the status-pill scale. */
+  .status-pill.run-ok { color: var(--success); border-color: var(--success); background: var(--success-soft, var(--accent-soft)); }
+  .status-pill.run-error { color: var(--danger); border-color: var(--danger); background: var(--danger-soft, var(--canvas-raised)); }
+  .status-pill.run-skipped { color: var(--text-faint); }
+  .status-pill.run-running, .status-pill.run-queued, .status-pill.run-pending {
+    color: var(--accent); border-color: var(--accent); background: var(--accent-soft);
+  }
+
+  /* The intent legend names every distinct intent observed, color-keyed. */
+  .intent-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
+  }
+  .intent-chip {
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-pill);
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    border: 1px solid var(--intent-line, var(--line));
+    color: var(--intent-ink, var(--text-muted));
+    background: var(--intent-soft, var(--canvas-raised));
+  }
+
+  /* The strip is one column per window, scrolling left-to-right in time. */
+  .intent-strip {
+    display: flex;
+    gap: var(--space-1);
+    overflow-x: auto;
+    padding-bottom: var(--space-1);
+  }
+  .intent-cell {
+    flex: 0 0 auto;
+    min-width: 84px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding: var(--space-2);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-1);
+    background: var(--canvas-raised);
+  }
+  .intent-cell-time {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-faint);
+  }
+  .intent-cell-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .intent-bar {
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    padding: 2px var(--space-1);
+    border-radius: var(--radius-1);
+    border-left: 3px solid var(--intent-line, var(--accent));
+    color: var(--intent-ink, var(--text));
+    background: var(--intent-soft, var(--accent-soft));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .intent-bar--empty {
+    color: var(--text-faint);
+    border-left-color: var(--line);
+    background: transparent;
+  }
+
+  /* Eight stable hues so an intent keeps its color across strip + legend. */
+  .intent-c0 { --intent-ink: var(--accent); --intent-line: var(--accent); --intent-soft: var(--accent-soft); }
+  .intent-c1 { --intent-ink: var(--success); --intent-line: var(--success); --intent-soft: var(--success-soft, var(--accent-soft)); }
+  .intent-c2 { --intent-ink: var(--warn-signal, var(--accent)); --intent-line: var(--warn-signal, var(--accent)); --intent-soft: var(--warn-soft, var(--accent-soft)); }
+  .intent-c3 { --intent-ink: var(--info, var(--accent)); --intent-line: var(--info, var(--accent)); --intent-soft: var(--info-soft, var(--accent-soft)); }
+  .intent-c4 { --intent-ink: var(--danger); --intent-line: var(--danger); --intent-soft: var(--danger-soft, var(--accent-soft)); }
+  .intent-c5 { --intent-ink: color-mix(in srgb, var(--accent) 70%, var(--success)); --intent-line: color-mix(in srgb, var(--accent) 70%, var(--success)); --intent-soft: var(--accent-soft); }
+  .intent-c6 { --intent-ink: color-mix(in srgb, var(--accent) 50%, var(--danger)); --intent-line: color-mix(in srgb, var(--accent) 50%, var(--danger)); --intent-soft: var(--accent-soft); }
+  .intent-c7 { --intent-ink: var(--text-muted); --intent-line: var(--text-muted); --intent-soft: var(--canvas-raised); }
+
+  /* The plugin-run table: a 4-column CSS grid (plugin / window / status / duration). */
+  .plugin-run-table {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-2);
+    overflow: hidden;
+  }
+  .plugin-run-row {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 0.8fr);
+    gap: var(--space-2);
+    align-items: center;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--line);
+  }
+  .plugin-run-row:last-child { border-bottom: none; }
+  .plugin-run-row--head {
+    background: var(--canvas-raised);
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-loose);
+  }
+  .plugin-run-id {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    min-width: 0;
+  }
+  .plugin-run-name {
+    font-family: var(--font-mono);
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .plugin-run-version { color: var(--text-faint); font-family: var(--font-mono); font-size: var(--font-size-xs); }
+  .pill--small { padding: 0 var(--space-1); font-size: 10px; }
+  .plugin-run-window {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .plugin-run-duration {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+    text-align: right;
+  }
 
   .action-controls {
     display: flex;

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -141,7 +141,7 @@ import HoldMark from "../components/HoldMark.astro";
       <a class="home-card signal-card is-pressable" href="/dictation">
         <span class="home-card-glyph glyph-chip" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2M12 19v4M8 23h8"/></svg></span>
         <span class="home-card-t">Dictation cockpit</span>
-        <span class="home-card-d">Tune intelligent typing — blocks, project context, runtime</span>
+        <span class="home-card-d">Tune the dictation pipeline — blocks, project context, runtime</span>
         <span class="home-card-go" aria-hidden="true">→</span>
       </a>
       <a class="home-card signal-card is-pressable" href="/history">

--- a/web/src/pages/settings.astro
+++ b/web/src/pages/settings.astro
@@ -275,6 +275,20 @@ const WHISPER_LANGUAGES = [
               <input class="input" type="text" placeholder="https://hooks.slack.com/services/…" x-model="settings.meeting.slack_webhook_url" />
               <p class="hint">Adds a Send to Slack button to each meeting's aftercare. Sends exactly what you preview, after you approve each send, only to this URL's host. Leave empty to turn the feature off.</p>
             </div>
+            {/* HSM-14: the iPad desk's Webhook connector. Same consent posture as
+                Slack — setting the URL is the consent for exactly its host. */}
+            <div class="field full" x-show="fieldVisible('meetings','common','companion webhook url ipad desk connector discord zapier n8n')" x-cloak>
+              <label>Companion Webhook URL</label>
+              <input class="input" type="text" placeholder="https://hooks.example.com/…" x-model="settings.meeting.companion_webhook_url" />
+              <p class="hint">Powers the iPad desk's Webhook connector (Discord, Zapier, n8n, any endpoint). Sends exactly what you approve, only to this URL's host. Leave empty to turn the connector off.</p>
+            </div>
+            {/* HSM-14: the iPad desk's GitHub connector. Auth is the host's local
+                gh — no token is stored or crosses the wire. */}
+            <div class="field full" x-show="fieldVisible('meetings','common','companion github repo ipad desk connector issue')" x-cloak>
+              <label>Companion GitHub repo</label>
+              <input class="input" type="text" placeholder="owner/name" x-model="settings.meeting.companion_github_repo" />
+              <p class="hint">The default repo the iPad desk's GitHub connector files issues into via your host's signed-in gh. No token is stored or sent. Leave empty to turn the connector off.</p>
+            </div>
           </div>
           <div class="check-row" x-show="sectionVisible('meetings') || searching">
             <label class="check" x-show="fieldVisible('meetings','common','intel enabled meeting intelligence')" x-cloak><input type="checkbox" x-model="settings.meeting.intel_enabled" /> <span>Intel enabled</span></label>

--- a/web/src/pages/setup.astro
+++ b/web/src/pages/setup.astro
@@ -117,7 +117,7 @@ import AppLayout from "../layouts/AppLayout.astro";
         <!-- Model setup assistant (HS-42-06) -->
         <section class="model-assistant" id="runtime">
           <div class="ma-head">
-            <h2>Intelligent typing (optional)</h2>
+            <h2>The dictation pipeline (optional)</h2>
             <p>Add a model and HoldSpeak rewrites rough speech into clean, project-aware text. Pick a path — basic voice typing already works without one.</p>
           </div>
           <ul class="ma-choices">

--- a/web/src/pages/welcome.astro
+++ b/web/src/pages/welcome.astro
@@ -201,7 +201,7 @@ import "../styles/global.css";
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/></svg>
                 </span>
                 <span class="done-card-t">Tune the copilot</span>
-                <span class="done-card-d">Project-aware intelligent typing</span>
+                <span class="done-card-d">Project-aware dictation</span>
               </a>
             </div>
           </section>

--- a/web/src/scripts/desk-app.js
+++ b/web/src/scripts/desk-app.js
@@ -85,6 +85,11 @@ function DeskApp() {
     // ── chain / workflow run (capability execution, mirrors the agent run) ──
     runningKind: null, // "agent" | "chain" | "workflow" | null — which drawer
     chainSteps: null, // [{ agentId, agentName, output }] | null (crew result)
+    // Honest signals the hub lands on a workflow run:
+    //   `warning` (a graph it refused to guess an order for) and `steps`
+    //   (the per-node execution trail of a linearized graph). Both surfaced.
+    runWarning: "", // hub `data.warning` for the active run, or ""
+    workflowSteps: null, // [{ nodeId, kind, output, provider }] | null (graph trail)
 
     async init() {
       await this.loadAll();
@@ -460,6 +465,8 @@ function DeskApp() {
         name: w.name,
         prompt: w.prompt || "",
         hasGraph: Boolean(hasGraph),
+        // `graph_json` is a JSON OBJECT on the wire (Record<string, unknown> or
+        // null), never a string; kept as the object the graph editor reads.
         graphJson: graph,
       };
     },
@@ -801,7 +808,7 @@ function DeskApp() {
     // ── capability run — one drawer, three kinds ──
     //   agent    → POST /api/agents/{id}/run     → { output, provider }
     //   chain    → POST /api/chains/{id}/run      → { chain_id, steps:[{agent_id, output}], output }
-    //   workflow → POST /api/workflows/{id}/run   → { workflow_id, output, provider }
+    //   workflow → POST /api/workflows/{id}/run   → { workflow_id, output, provider[, steps][, warning] }
     openRun(target, kind = "agent") {
       this.running = target;
       this.runningKind = kind;
@@ -809,6 +816,8 @@ function DeskApp() {
       this.runError = "";
       this.runResult = null;
       this.chainSteps = null;
+      this.workflowSteps = null;
+      this.runWarning = "";
       this.runBusy = false;
     },
     closeRun() {
@@ -816,6 +825,8 @@ function DeskApp() {
       this.runningKind = null;
       this.runBusy = false;
       this.chainSteps = null;
+      this.workflowSteps = null;
+      this.runWarning = "";
     },
     /** The verb + display name for the active run drawer. */
     runTitle() {
@@ -910,12 +921,26 @@ function DeskApp() {
       this.runBusy = true;
       this.runError = "";
       this.runResult = null;
+      this.workflowSteps = null;
+      this.runWarning = "";
       try {
         const data = await this.fetchJson(`/api/workflows/${this.running.id}/run`, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ input }),
         });
+        // The hub is honest about a graph it would not guess an order for: it
+        // runs the prompt fallback and lands a `warning`. Surface it verbatim.
+        this.runWarning = data.warning || "";
+        // A linearized graph lands its per-node execution trail in `steps`
+        // ({node_id, kind, output, provider}); render it under the output.
+        this.workflowSteps = (data.steps || []).map((s) => ({
+          nodeId: s.node_id || "",
+          kind: s.kind || "",
+          output: s.output || "",
+          provider: s.provider || "",
+        }));
+        if (!this.workflowSteps.length) this.workflowSteps = null;
         this.runResult = {
           output: data.output || "",
           provider: data.provider || "",

--- a/web/src/scripts/history-app.js
+++ b/web/src/scripts/history-app.js
@@ -23,6 +23,11 @@ function historyApp() {
     selectedMeetingArtifacts: [],
     selectedMeetingProposals: [],
     selectedMeetingAftercare: null,
+    // EQ-19: the persisted MIR record for this meeting — the intent timeline
+    // (which intents were active per window, plus the transitions between them)
+    // and the plugin-run history. Read-only; viewing never re-runs anything.
+    selectedMeetingIntentTimeline: null,
+    selectedMeetingPluginRuns: [],
     highlightedSegmentIndex: null,
     selectedSpeakerId: "",
     selectedSpeaker: null,
@@ -180,6 +185,78 @@ function historyApp() {
       const rel = this.formatRelativeFromNow(job.requested_at);
       if (!rel) return `Retry ${this.formatDate(job.requested_at)}`;
       return `Retry ${this.formatDate(job.requested_at)} (${rel})`;
+    },
+
+    // EQ-19 helpers: present the persisted MIR record on the meeting detail.
+
+    // The intent timeline as ordered window cells. Each carries the window's
+    // active intents and a clock-style label so the strip reads left-to-right.
+    intentTimelineCells() {
+      const windows = this.selectedMeetingIntentTimeline?.windows || [];
+      return windows.map((window) => ({
+        window_id: window.window_id,
+        label: this.formatClockRange(window.start_seconds, window.end_seconds),
+        intents: Array.isArray(window.active_intents) ? window.active_intents : [],
+        excerpt: window.transcript_excerpt || "",
+      }));
+    },
+
+    // The distinct intents observed across the meeting, for the legend.
+    intentTimelineLegend() {
+      const seen = new Set();
+      for (const cell of this.intentTimelineCells()) {
+        for (const intent of cell.intents) seen.add(intent);
+      }
+      return Array.from(seen);
+    },
+
+    // Stable color slot (0-7) for an intent name, so the same intent keeps its
+    // hue across the strip and legend. Pure function of the name.
+    intentColorSlot(intent) {
+      const name = String(intent || "");
+      let hash = 0;
+      for (let i = 0; i < name.length; i++) {
+        hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+      }
+      return hash % 8;
+    },
+
+    pluginRunStatusLabel(status) {
+      const value = String(status || "").trim().toLowerCase();
+      if (value === "ok" || value === "success" || value === "succeeded") return "Succeeded";
+      if (value === "error" || value === "failed") return "Failed";
+      if (value === "skipped") return "Skipped";
+      if (value === "running") return "Running";
+      if (value === "queued") return "Queued";
+      return value ? value.charAt(0).toUpperCase() + value.slice(1) : "Pending";
+    },
+
+    pluginRunStatusValue(status) {
+      const value = String(status || "").trim().toLowerCase();
+      if (value === "ok" || value === "success" || value === "succeeded") return "ok";
+      if (value === "error" || value === "failed") return "error";
+      if (value === "skipped") return "skipped";
+      return value || "pending";
+    },
+
+    pluginRunDurationLabel(ms) {
+      const value = Number(ms);
+      if (!Number.isFinite(value) || value < 0) return "--";
+      if (value < 1000) return `${Math.round(value)} ms`;
+      return `${(value / 1000).toFixed(value < 10000 ? 2 : 1)} s`;
+    },
+
+    // mm:ss-style label for a window's start..end seconds.
+    formatClockRange(start, end) {
+      const fmt = (seconds) => {
+        const total = Math.max(0, Math.round(Number(seconds) || 0));
+        const m = Math.floor(total / 60);
+        const s = total % 60;
+        return `${m}:${String(s).padStart(2, "0")}`;
+      };
+      const a = fmt(start);
+      const b = fmt(end);
+      return a === b ? a : `${a}–${b}`;
     },
 
     intelFailureRateLabel() {
@@ -538,6 +615,8 @@ function historyApp() {
         this.selectedMeetingArtifacts = [];
         this.selectedMeetingProposals = [];
         this.selectedMeetingAftercare = null;
+        this.selectedMeetingIntentTimeline = null;
+        this.selectedMeetingPluginRuns = [];
         this.selectedMeeting = await this.apiJson(`/api/meetings/${id}`);
         // HS-49-01: the aftercare digest (open / decided / changed). Read-only;
         // stays quiet (is_empty) when there's nothing to act on.
@@ -562,6 +641,25 @@ function historyApp() {
         } catch (proposalError) {
           console.error("Failed to load meeting proposals:", proposalError);
           this.selectedMeetingProposals = [];
+        }
+        // EQ-19: the persisted MIR intent timeline — which intents were active
+        // per window, and the transitions between them. Read-only.
+        try {
+          const timeline = await this.apiJson(`/api/meetings/${id}/intent-timeline`);
+          this.selectedMeetingIntentTimeline =
+            timeline && (timeline.windows || []).length ? timeline : null;
+        } catch (timelineError) {
+          console.error("Failed to load meeting intent timeline:", timelineError);
+          this.selectedMeetingIntentTimeline = null;
+        }
+        // EQ-19: the persisted MIR plugin-run history (which plugins ran on
+        // which window, their status + timing). Read-only.
+        try {
+          const runs = await this.apiJson(`/api/meetings/${id}/plugin-runs`);
+          this.selectedMeetingPluginRuns = runs.runs || [];
+        } catch (runError) {
+          console.error("Failed to load meeting plugin runs:", runError);
+          this.selectedMeetingPluginRuns = [];
         }
       } catch (error) {
         console.error("Failed to load meeting:", error);


### PR DESCRIPTION
A **build flotilla of 6 worktree-isolated agents** each closed one disjoint equilibrium gap; this integrates them (clean cherry-picks, no conflicts) and verifies them together.

| Branch | Phase | What landed |
|--------|-------|-------------|
| graph-policy | 22 | the linear runner carries + applies per-node `failure_policy` (skip/fallback continue the chain, retry/unset fail fast) + `runs_on`, surfaced in the run steps; honestly documents what the hub does not yet enforce |
| banned-copy | 21 | "intelligent typing" → canonical names in web product copy; the voice guard now scans `web/src/**/*.astro` so a reintroduction fails CI |
| connectors-hub | 21 | the hub reads/writes `companion_webhook_url` + `companion_github_repo` (Slack-parity validation); web settings exposes them |
| sync-livemerge | 23 | `POST /api/sync/push` live-merges pushed meeting + artifact content into their real tables (was a JSON inbox), so they are immediately queryable like the other kinds |
| web-workflow-run | 22 | the web run UI surfaces the hub's honest `warning` + per-node `steps` trail; `primitives.ts` `graphJson` type corrected |
| web-intent-timeline | 19 | the web meeting-detail consumes the two persisted read routes (intent-timeline strip + plugin-run table) that had no consumer |

### Verification (integrated, not just per-agent)
- Full Python suite: **2924 passed, 0 failed** (`--ignore=tests/e2e/test_metal.py`).
- Web build: **complete**.
- Each agent also self-verified its slice (pytest / `npm run build`) before committing.

### Known follow-up
`docs/INTELLIGENT_TYPING_GUIDE.md` is a shipped doc asserted verbatim by a test, so the banned-name scope is **product copy only** until that doc is renamed in a later wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)