### PR TITLE
Equilibrium Wave 2: honesty ban global + 3 web gaps + an index null-guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ comes back as typed, reviewable artifacts:
   it took. Fix a wrong result in one tap and the correction memory learns; the
   learning digest reports a real "learned from N similar" count, honest at
   zero; replay an old utterance through the updated pipeline and watch the
-  routing change. See [the learning loop](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay).
+  routing change. See [the learning loop](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md#12-dictation-journal-corrections--replay).
 - **Meetings end with their loops closed.** A meeting produces artifacts,
   an aftercare digest, and approval-gated actions where most tools stop at
   a transcript. Actuators are off by default, audited, and only ever run
@@ -245,10 +245,10 @@ are in the [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpea
 | Get it running and verify my setup | [Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) |
 | Choose / configure a model | [Models (bring your own)](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md) |
 | See speech become a project-grounded task | [The Dictation Copilot](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_COPILOT.md) |
-| Set up the dictation pipeline for Codex / Claude | [Intelligent Typing Setup](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md) |
-| Review, correct, and replay past dictations | [The dictation journal & replay](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay) |
+| Set up the dictation pipeline for Codex / Claude | [Dictation Pipeline Setup](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md) |
+| Review, correct, and replay past dictations | [The dictation journal & replay](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md#12-dictation-journal-corrections--replay) |
 | Map spoken keywords to real actions | [Voice Commands](https://github.com/karolswdev/HoldSpeak/blob/main/docs/VOICE_COMMANDS.md) |
-| Turn on Qlippy, the mascot | [Qlippy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INTELLIGENT_TYPING_GUIDE.md#qlippy-the-mascot-optional) |
+| Turn on Qlippy, the mascot | [Qlippy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md#qlippy-the-mascot-optional) |
 | Use meeting mode and configure AI intelligence | [Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md) |
 | Wire up the AIPI-Lite companion | [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AIPI_LITE_DEV_WORKFLOW.md) |
 | Install Claude / Codex agent hooks | [Agent Hook Install](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AGENT_HOOK_INSTALL.md) |

--- a/docs/AGENT_HOOK_INSTALL.md
+++ b/docs/AGENT_HOOK_INSTALL.md
@@ -351,7 +351,7 @@ Confirm HoldSpeak sees the expected project root and context files.
 
 ## See also
 
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md): how captured agent context
+- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md): how captured agent context
   shapes a rewrite.
 - [The Dictation Copilot](DICTATION_COPILOT.md): see the agent-grounded rewrite end
   to end.

--- a/docs/DICTATION_COPILOT.md
+++ b/docs/DICTATION_COPILOT.md
@@ -8,7 +8,7 @@ you how to turn it on and run the same demo yourself.
 
 > Everything here is **opt-in and off by default**. With the dictation pipeline
 > disabled, HoldSpeak types your transcript exactly as before. See
-> [Intelligent Typing Guide](./INTELLIGENT_TYPING_GUIDE.md) for the full setup
+> [Dictation Pipeline Guide](./DICTATION_PIPELINE_GUIDE.md) for the full setup
 > and [Models](./MODELS.md) for the bring-your-own-model contract.
 
 ## See it work
@@ -145,10 +145,10 @@ model-assist toggles, and a confidence threshold.](assets/cockpit/copilot-depth.
 
 Every feature above (① through ④) is a slider or toggle in **Runtime → Copilot depth**;
 the round-trip persists through the settings API. See the
-[Intelligent Typing Setup guide](./INTELLIGENT_TYPING_GUIDE.md) for the full
+[Dictation Pipeline Setup guide](./DICTATION_PIPELINE_GUIDE.md) for the full
 walk-through.
 
-Then add a project's [`.hs/` context](./INTELLIGENT_TYPING_GUIDE.md) (and,
+Then add a project's [`.hs/` context](./DICTATION_PIPELINE_GUIDE.md) (and,
 optionally, a `.holdspeak/blocks.yaml` taxonomy + `.holdspeak/project.yaml` KB)
 so the rewrite has facts to ground in.
 
@@ -201,9 +201,9 @@ hosted CI) and runs for real wherever your endpoint is reachable.
 
 ## See also
 
-- [Intelligent Typing Guide](./INTELLIGENT_TYPING_GUIDE.md): the full setup,
+- [Dictation Pipeline Guide](./DICTATION_PIPELINE_GUIDE.md): the full setup,
   `.hs/` conventions, target profiles, agent hooks, and every config knob.
-- [The learning loop](./INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay):
+- [The learning loop](./DICTATION_PIPELINE_GUIDE.md#12-dictation-journal-corrections--replay):
   what feature ② becomes over time. Correct a misfire in one tap, watch the "What
   HoldSpeak learned" digest count the honest reach, and replay to prove it improved.
 - [Models](./MODELS.md): choosing and pointing at a model.

--- a/docs/DICTATION_PIPELINE_GUIDE.md
+++ b/docs/DICTATION_PIPELINE_GUIDE.md
@@ -1,4 +1,4 @@
-# HoldSpeak Intelligent Typing Setup
+# HoldSpeak Dictation Pipeline Setup
 
 The gap between what you say and what you meant to type is where dictation
 tools usually stop; the dictation pipeline is HoldSpeak crossing it. It

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -121,7 +121,7 @@ focused and use the focused hold-to-talk fallback.
 > notification everywhere). It shows whether it's listening, transcribing, or typing
 > while you dictate into another app, and it never takes keyboard focus. For a
 > headless launch you can force it on with `HOLDSPEAK_DESKTOP_PRESENCE=1 holdspeak`.
-> See [Desktop Presence](INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
+> See [Desktop Presence](DICTATION_PIPELINE_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
 
 ## 6. Use Punctuation Commands
 
@@ -187,12 +187,12 @@ Good project markers include:
 - `.holdspeak/`
 - `.hs/`
 
-## 9. Enable Intelligent Typing Later
+## 9. Enable The Dictation Pipeline Later
 
 Do not enable the dictation LLM pipeline until basic typing is working.
 When ready, continue with:
 
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md)
+- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md)
 - [User Guide](USER_GUIDE.md)
 
 ## 10. Where To Go Next
@@ -222,7 +222,7 @@ Once hold-to-talk feels natural, the rest is one setting away each:
 
 ## See also
 
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md): once basic voice typing
+- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md): once basic voice typing
   works, turn on the project-aware copilot.
 - [Meeting Mode Guide](MEETING_MODE_GUIDE.md): meeting-specific setup and capture.
 - [Models (bring your own)](MODELS.md): pick and point at an LLM.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -128,7 +128,7 @@ makes the larger tiers practical.
 
 ## See also
 
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md): where the dictation model
+- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md): where the dictation model
   is used.
 - [Meeting Mode Guide](MEETING_MODE_GUIDE.md): where the meeting-intel model is used.
 - [Security & Privacy](SECURITY.md): what a cloud endpoint changes about egress.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,9 +24,9 @@ including the LLM. This page is the map. Pick a journey.
   how the two halves (typing and meetings) fit together. Also home to the wake
   word (hands-free entry, previewed before it types), the spoken language
   setting (any of Whisper's 99 languages), and the spoken-symbol dictionary.
-- **[Intelligent Typing Setup](./INTELLIGENT_TYPING_GUIDE.md)**: the project-aware
+- **[Dictation Pipeline Setup](./DICTATION_PIPELINE_GUIDE.md)**: the project-aware
   pipeline. Intent routing, project-facts enrichment, target profiles, LLM rewriting.
-- **[Project knowledge: facts + context](./INTELLIGENT_TYPING_GUIDE.md#5-set-up-project-knowledge)**:
+- **[Project knowledge: facts + context](./DICTATION_PIPELINE_GUIDE.md#5-set-up-project-knowledge)**:
   teach the copilot about a repo. Facts (the `project.yaml` KB, stamped in verbatim)
   and context (the `.hs/` files an optional rewrite reads) are two different things;
   this is what each is and how to set up both.
@@ -41,15 +41,15 @@ including the LLM. This page is the map. Pick a journey.
   dismissible, never acting on their own. One action pins a record so your next
   dictation can use it as context. Gated by the activity tracking toggle: off means
   no cards.
-- **[The learning loop: journal, correct, see what it learned, replay](./INTELLIGENT_TYPING_GUIDE.md#12-dictation-journal-corrections--replay)**:
+- **[The learning loop: journal, correct, see what it learned, replay](./DICTATION_PIPELINE_GUIDE.md#12-dictation-journal-corrections--replay)**:
   the local-only loop that gets better at your voice. Fix a misfire in one tap, see
   the honest "learned from N similar" count in the "What HoldSpeak learned" digest,
   and replay an utterance to watch the routing change. The proof, not the promise.
-- **[Desktop Presence](./INTELLIGENT_TYPING_GUIDE.md#11-desktop-presence-ambient-on-desktop-status)**:
+- **[Desktop Presence](./DICTATION_PIPELINE_GUIDE.md#11-desktop-presence-ambient-on-desktop-status)**:
   an opt-in, native, focus-safe status surface (a macOS HUD, a Linux tray and
   notification) that shows whether it's listening, transcribing, or typing while you
   dictate elsewhere. Optionally with
-  **[Qlippy, the mascot](./INTELLIGENT_TYPING_GUIDE.md#qlippy-the-mascot-optional)**:
+  **[Qlippy, the mascot](./DICTATION_PIPELINE_GUIDE.md#qlippy-the-mascot-optional)**:
   an ambient pixel-art dock plus one-at-a-time cards for the moments that need
   you (approvals, results, learning, meeting follow-ups), each carrying an
   egress badge that shows where its data goes. He never acts on his own.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -15,7 +15,7 @@ Use these guides depending on what you are setting up:
 | Goal | Guide |
 | --- | --- |
 | Install HoldSpeak and get basic voice typing working | [Getting Started](GETTING_STARTED.md) |
-| Configure project-aware intelligent typing | [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md) |
+| Configure the project-aware dictation pipeline | [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md) |
 | Record and review meetings | [Meeting Mode Guide](MEETING_MODE_GUIDE.md) |
 | Configure local/LAN dictation models | `/docs/dictation-runtime` in the local web UI |
 
@@ -202,7 +202,7 @@ def total(items):
 could you refactor it?
 ```
 
-## Intelligent Typing For Coding Assistants
+## The Dictation Pipeline For Coding Assistants
 
 HoldSpeak can do more than transcription. With the dictation pipeline enabled, it can transform a rough spoken thought into a useful prompt for Claude, Codex, a terminal, a browser, or another target.
 
@@ -241,7 +241,7 @@ holdspeak dictation runtime status
 holdspeak dictation dry-run "ask codex to inspect the failing test"
 ```
 
-For a full step-by-step setup, see [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md).
+For a full step-by-step setup, see [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md).
 
 ### OpenAI-Compatible Endpoints
 
@@ -499,7 +499,7 @@ Common issues:
 
 - [README](../README.md): install, platform notes, configuration reference.
 - [Getting Started](GETTING_STARTED.md): first-run setup and basic voice typing.
-- [Intelligent Typing Setup](INTELLIGENT_TYPING_GUIDE.md): dictation pipeline, project context, target override, OpenAI-compatible endpoints, and agent hooks.
+- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md): dictation pipeline, project context, target override, OpenAI-compatible endpoints, and agent hooks.
 - [Dictation runtime setup](../web/src/pages/docs/dictation-runtime.astro): source for the web runtime setup page.
 - [Meeting Mode Guide](MEETING_MODE_GUIDE.md): meeting-specific setup and troubleshooting.
 - [Firefox Extension Guide](FIREFOX_EXTENSION_GUIDE.md): local companion extension install.

--- a/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
+++ b/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
@@ -101,7 +101,17 @@ waves are how the backlog drains in parallel.
 | Intent-timeline + plugin-runs | 19 | the web meeting-detail consumes the two persisted read routes (an intent-timeline strip + a plugin-run table) that had no consumer |
 
 Integrated + verified together: full Python suite **2924 passed**, web build green.
-**Known follow-up:** the shipped `docs/INTELLIGENT_TYPING_GUIDE.md` (asserted verbatim by a
-test) still carries the old name; the ban is scoped to product copy until that doc is renamed.
+
+### Wave 2 (2026-06-27) — finish the honesty ban + more web, 4 gaps
+
+| Gap | Phase | What landed |
+|-----|-------|-------------|
+| Rename the guide + global ban | 21 | `docs/INTELLIGENT_TYPING_GUIDE.md` → `DICTATION_PIPELINE_GUIDE.md` (all refs + the verbatim test updated); `_BANNED_NAMES_DOCS` collapsed back so "intelligent typing" is now banned EVERYWHERE (docs + web). Closes the Wave 1 follow-up. |
+| Web proposals egress | 19 | the proposals review surface already existed (Phase 37); the real gap was its egress being a guard SENTENCE, replaced with the structured egress badge ({scope,label}) per canon |
+| Web linear graph builder | 22 | the web Desk authors a real minimal LINEAR `graph_json` (was hardcoded `{}`), in the exact shape `workflow_graph.linearize()` + the iPad Blueprint speak, so a web-authored chain round-trips |
+| Web ambient trust chip | 21 | an ambient egress/trust chip + a readiness line from `/api/setup/status` on the web Desk (reusing the egress component, never prose) |
+| Index page null-guard (bonus) | 21 | a pre-existing latent bug the integrated preflight caught: `index.astro` route-preview `x-text` read `routePreview.active_intents` un-guarded and threw on load when null; fixed with optional chaining (CI skips this e2e without Chromium, so it had hidden) |
+
+Integrated + verified together: full Python suite green (route-preflight included, locally with Chromium), web build green. Cherry-pick note: the graph-builder + trust-chip both edited `desk.*` but git auto-merged them (additive, different regions).
 
 See [[project_primitive_framework]], [[project_phase15_the_mesh]], [[project_phase17_agent_sync]].

--- a/tests/unit/test_doc_drift_guard.py
+++ b/tests/unit/test_doc_drift_guard.py
@@ -220,7 +220,7 @@ def test_qlippy_doc_states_the_guarantees_verbatim() -> None:
     """HS-56-06 / revised HS-62-01: the mascot doc keeps the never-acts
     guarantee, and the cards state egress with the BADGE, never a privacy
     paragraph (the owner's Quiet Trust direction — one symbol, no novels)."""
-    guide = (_REPO / "docs" / "INTELLIGENT_TYPING_GUIDE.md").read_text()
+    guide = (_REPO / "docs" / "DICTATION_PIPELINE_GUIDE.md").read_text()
     assert "Qlippy, the mascot" in guide
     assert "never acts on his own" in guide
     assert "the egress badge" in guide  # the documented contract
@@ -267,25 +267,14 @@ _AI_VOCAB = re.compile(
 
 # Banned synonyms for canonical feature names (POSITIONING.md table).
 #
-# "intelligent typing" is a banned synonym for the dictation pipeline in
-# user-facing *product copy* (the web/src astro templates). The historical
-# setup guide docs/INTELLIGENT_TYPING_GUIDE.md keeps that name as its own
-# established title and is referenced verbatim across the docs corpus (and by
-# test_qlippy_doc_states_the_guarantees_verbatim), so the docs scan below uses
-# _BANNED_NAMES_DOCS, which omits that one term. Renaming the guide is a
-# separate, larger move outside this guard's scope.
+# "intelligent typing" is a banned synonym for the dictation pipeline. The
+# setup guide it once titled is now docs/DICTATION_PIPELINE_GUIDE.md, so this
+# single guard bans the term EVERYWHERE: the user-facing docs *and* the web/src
+# product copy. There is no docs-corpus exception anymore.
 _BANNED_NAMES = re.compile(
     r"\bvoice macros?\b"               # canonical: voice commands
     r"|\bintelligent dictation\b"      # canonical: the dictation pipeline
     r"|\bintelligent typing\b"         # canonical: the dictation pipeline / dictation
-    r"|\bslack (?:integration|export)\b",  # canonical: Send to Slack
-    re.IGNORECASE,
-)
-
-# The docs-corpus variant: same table, minus "intelligent typing" (see above).
-_BANNED_NAMES_DOCS = re.compile(
-    r"\bvoice macros?\b"               # canonical: voice commands
-    r"|\bintelligent dictation\b"      # canonical: the dictation pipeline
     r"|\bslack (?:integration|export)\b",  # canonical: Send to Slack
     re.IGNORECASE,
 )
@@ -349,7 +338,7 @@ def test_no_user_facing_doc_uses_banned_feature_names() -> None:
     offenders = []
     for doc in _user_facing_docs():
         for lineno, line in _prose_lines(doc):
-            match = _BANNED_NAMES_DOCS.search(line)
+            match = _BANNED_NAMES.search(line)
             if match:
                 offenders.append(
                     f"{doc.relative_to(_REPO)}:{lineno}: {match.group(0)!r}"

--- a/web/src/pages/desk.astro
+++ b/web/src/pages/desk.astro
@@ -78,6 +78,18 @@ const GROUPS = [
         <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-3-6.7M21 3v5h-5" /></svg>
         <span x-text="`Synced ${updatedLabel()}`">not synced</span>
       </span>
+      {/* ── ambient trust: the canonical egress badge + a readiness line,
+            both sourced from GET /api/setup/status (no reassurance prose;
+            POSITIONING canon — ONE structured badge, never a sentence). ── */}
+      <a class="hub-egress egress-badge" :class="`is-${egressBadge().scope}`"
+         x-show="setupLoaded" x-cloak href="/setup"
+         :title="egressBadge().title" :aria-label="egressBadge().title"
+         x-text="egressBadge().text">Local</a>
+      <a class="hub-ready" :class="readyTone()" x-show="setupLoaded" x-cloak
+         href="/setup" :title="readyTitle()">
+        <span class="hub-ready-dot"></span>
+        <span x-text="readyLine()">Ready</span>
+      </a>
       <span class="hub-error" x-show="error" x-cloak x-text="error"></span>
     </div>
 
@@ -925,6 +937,23 @@ const GROUPS = [
   .hub-status.unreachable .hub-dot{ background: var(--danger-signal); }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
   .hub-synced { display: inline-flex; align-items: center; gap: var(--space-2); font-family: var(--font-mono); font-size: var(--font-size-xs); color: var(--text-faint); }
+  /* ambient trust: the egress badge (canonical .egress-badge styling) + a
+     one-line readiness chip, both linking through to /setup. */
+  .hub-egress { font-family: var(--font-mono); text-decoration: none; cursor: pointer; }
+  .hub-egress:hover { filter: brightness(1.15); }
+  .hub-egress:focus-visible { outline: var(--focus-outline-width) solid var(--accent); outline-offset: var(--focus-outline-offset); }
+  .hub-ready {
+    display: inline-flex; align-items: center; gap: var(--space-2);
+    font-family: var(--font-mono); font-size: var(--font-size-xs); text-decoration: none;
+    padding: var(--space-1) var(--space-3); border-radius: var(--radius-pill);
+    border: 1px solid var(--border-subtle); color: var(--text-faint);
+  }
+  .hub-ready:hover { border-color: var(--border-strong); color: var(--text-muted); }
+  .hub-ready:focus-visible { outline: var(--focus-outline-width) solid var(--accent); outline-offset: var(--focus-outline-offset); }
+  .hub-ready-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+  .hub-ready.ready   { color: var(--ok-strong); }
+  .hub-ready.warn    { color: var(--warn-strong); }
+  .hub-ready.blocked { color: var(--danger); }
   .hub-error { font-family: var(--font-mono); font-size: var(--font-size-xs); color: var(--danger); margin-left: auto; max-width: 50%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* ── group ── */

--- a/web/src/pages/desk.astro
+++ b/web/src/pages/desk.astro
@@ -540,8 +540,63 @@ const GROUPS = [
         <form class="drawer-body" @submit.prevent="submitWorkflow()">
           <p class="drawer-err" x-show="error" x-cloak x-text="error"></p>
           <label class="field"><span>Name</span><input type="text" x-model="workflowForm.name" placeholder="Weekly digest" /></label>
-          <label class="field"><span>Prompt</span><textarea rows="6" x-model="workflowForm.prompt" placeholder="Summarize this week's meetings into a digest…"></textarea></label>
-          <p class="field-note">A saved prompt that wires primitives into a run. Graph authoring lives in the Workbench. Saves to <code>POST /api/workflows</code>.</p>
+
+          {/* mode toggle — a saved prompt OR a linear chain */}
+          <div class="field">
+            <span>How it runs</span>
+            <div class="seg" role="tablist" aria-label="Workflow authoring mode">
+              <button type="button" class="seg-opt" :class="{ on: workflowForm.mode === 'prompt' }" @click="workflowForm.mode = 'prompt'" role="tab" :aria-selected="workflowForm.mode === 'prompt'">Prompt</button>
+              <button type="button" class="seg-opt" :class="{ on: workflowForm.mode === 'graph' }" @click="workflowForm.mode = 'graph'" role="tab" :aria-selected="workflowForm.mode === 'graph'">Linear chain</button>
+            </div>
+          </div>
+
+          {/* prompt mode */}
+          <template x-if="workflowForm.mode === 'prompt'">
+            <div class="field">
+              <span>Prompt</span>
+              <textarea rows="6" x-model="workflowForm.prompt" placeholder="Summarize this week's meetings into a digest…"></textarea>
+            </div>
+          </template>
+
+          {/* linear chain mode — ordered steps, entry → … → output */}
+          <template x-if="workflowForm.mode === 'graph'">
+            <div class="field">
+              <span>Steps — run top to bottom, each feeding the next</span>
+              <ol class="wf-chain" x-show="workflowForm.nodes.length" x-cloak>
+                <template x-for="(step, i) in workflowForm.nodes" {...{ ":key": "i" }}>
+                  <li class="wf-step">
+                    <div class="wf-step-head">
+                      <span class="wf-step-num" x-text="i + 1"></span>
+                      <select class="wf-step-kind" x-model="step.kind">
+                        <template x-for="k in workflowStepKinds" {...{ ":key": "k.kind" }}>
+                          <option :value="k.kind" x-text="k.label"></option>
+                        </template>
+                      </select>
+                      <div class="wf-step-ctl">
+                        <button type="button" class="wf-icon" :disabled="i === 0" @click="moveWorkflowStep(i, -1)" aria-label="Move step up">↑</button>
+                        <button type="button" class="wf-icon" :disabled="i === workflowForm.nodes.length - 1" @click="moveWorkflowStep(i, 1)" aria-label="Move step down">↓</button>
+                        <button type="button" class="wf-icon danger" @click="removeWorkflowStep(i)" aria-label="Remove step">✕</button>
+                      </div>
+                    </div>
+                    {/* per-kind payload */}
+                    <textarea class="wf-step-field" rows="2" x-show="step.kind === 'llm'" x-cloak x-model="step.prompt" placeholder="Your instruction. Use {input} for the prior step's text…"></textarea>
+                    <input class="wf-step-field" type="text" x-show="step.kind === 'rewrite'" x-cloak x-model="step.tone" placeholder="Tone (e.g. concise, formal)" />
+                    <input class="wf-step-field" type="text" x-show="step.kind === 'extract'" x-cloak x-model="step.artifactType" placeholder="Artifact (e.g. decisions, action_items)" />
+                  </li>
+                </template>
+              </ol>
+              <p class="wf-empty" x-show="!workflowForm.nodes.length" x-cloak>No steps yet. Add one to start the chain.</p>
+              <div class="wf-add">
+                <template x-for="k in workflowStepKinds" {...{ ":key": "k.kind" }}>
+                  <button type="button" class="btn sm ghost" @click="addWorkflowStep(k.kind)"><span aria-hidden="true">+</span> <span x-text="k.label"></span></button>
+                </template>
+              </div>
+            </div>
+          </template>
+
+          <p class="field-note" x-show="workflowForm.mode === 'prompt'" x-cloak>A saved prompt that wires primitives into a run. Saves to <code>POST /api/workflows</code>.</p>
+          <p class="field-note" x-show="workflowForm.mode === 'graph'" x-cloak>A <strong>linear chain</strong> (entry → steps → output) emitting the same <code>graph_json</code> the iPad Workbench produces and the hub linearizes. Branch and loop authoring lives in the Workbench; the web Desk ships the chain. Saves to <code>POST /api/workflows</code>.</p>
+
           <div class="drawer-foot">
             <button type="button" class="btn ghost" @click="closeCreate()">Cancel</button>
             <button type="submit" class="btn primary" :disabled="busy"><span x-text="busy ? 'Saving…' : 'Create workflow'">Create workflow</span></button>
@@ -1138,6 +1193,31 @@ const GROUPS = [
   .field-note code { font-family: var(--font-mono); color: var(--accent); }
   .field-note kbd { font-family: var(--font-mono); font-size: 0.6875rem; background: var(--surface-3); border: 1px solid var(--border); border-radius: var(--radius-xs); padding: 0 4px; color: var(--text-muted); }
   .drawer-foot { display: flex; justify-content: flex-end; gap: var(--space-2); padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-subtle); }
+
+  /* ── segmented mode toggle (prompt | linear chain) ── */
+  .seg { display: inline-flex; gap: 2px; padding: 2px; background: var(--surface-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); }
+  .seg-opt { flex: 1; font-family: var(--font-ui); font-size: var(--font-size-sm); color: var(--text-muted); background: transparent; border: none; border-radius: var(--radius-xs); padding: var(--space-1) var(--space-3); cursor: pointer; min-height: 1.9rem; }
+  .seg-opt:hover { color: var(--text); }
+  .seg-opt.on { color: var(--text-on-accent); background: var(--info); font-weight: 600; }
+  .seg-opt:focus-visible { outline: var(--focus-outline-width) solid var(--accent); outline-offset: var(--focus-outline-offset); }
+
+  /* ── linear chain builder ── */
+  .wf-chain { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-2); --ck: var(--info); }
+  .wf-step { position: relative; display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-3); background: var(--surface-2); border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); }
+  .wf-step:not(:last-child)::after { content: ""; position: absolute; left: 50%; bottom: calc(-1 * var(--space-2)); width: 1px; height: var(--space-2); background: var(--ck); opacity: 0.5; }
+  .wf-step-head { display: flex; align-items: center; gap: var(--space-2); }
+  .wf-step-num { flex: none; width: 1.4rem; height: 1.4rem; display: grid; place-items: center; font-family: var(--font-mono); font-size: var(--font-size-xs); color: var(--info); background: color-mix(in srgb, var(--info) 16%, var(--surface-3)); border-radius: var(--radius-pill); }
+  .wf-step-kind { flex: 1; font-family: var(--font-ui); font-size: var(--font-size-sm); color: var(--text); background: var(--field-bg); border: 1px solid var(--field-border); border-radius: var(--radius-sm); padding: var(--space-1) var(--space-2); }
+  .wf-step-kind:focus { outline: none; border-color: var(--field-focus-border); box-shadow: 0 0 0 2px var(--accent-tint); }
+  .wf-step-ctl { display: flex; gap: 2px; }
+  .wf-icon { width: 1.6rem; height: 1.6rem; display: grid; place-items: center; font-size: var(--font-size-sm); color: var(--text-muted); background: transparent; border: 1px solid var(--border-subtle); border-radius: var(--radius-xs); cursor: pointer; }
+  .wf-icon:hover { color: var(--text); border-color: var(--border-strong); }
+  .wf-icon.danger:hover { color: var(--danger, #F87171); border-color: var(--danger, #F87171); }
+  .wf-icon:disabled { opacity: 0.4; cursor: default; }
+  .wf-step-field { font-family: var(--font-mono); font-size: var(--font-size-sm); color: var(--text); background: var(--field-bg); border: 1px solid var(--field-border); border-radius: var(--radius-sm); padding: var(--space-2) var(--space-3); resize: vertical; }
+  .wf-step-field:focus { outline: none; border-color: var(--field-focus-border); box-shadow: 0 0 0 2px var(--accent-tint); }
+  .wf-empty { margin: 0; font-size: var(--font-size-sm); color: var(--text-faint); font-style: italic; }
+  .wf-add { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-1); }
 
   /* ── run drawer ── */
   .run-head-id { display: flex; gap: var(--space-3); align-items: flex-start; min-width: 0; }

--- a/web/src/pages/history.astro
+++ b/web/src/pages/history.astro
@@ -1247,6 +1247,9 @@ import AppLayout from "../layouts/AppLayout.astro";
                             <span class="status-pill" :class="`proposal-${p.status}`" x-text="proposalStatusLabel(p.status)"></span>
                             <span class="pill" x-text="p.reversible ? 'reversible' : 'irreversible'"></span>
                             <span class="pill" x-show="p.decided_by" x-cloak x-text="`by ${p.decided_by}`"></span>
+                            <!-- EQ-W2: the honest egress badge — one structured chip
+                                 (⌂ Local only / ☁ target), never a privacy sentence. -->
+                            <span class="egress-badge" :class="`is-${proposalEgress(p).scope}`" x-text="proposalEgressText(p)"></span>
                           </div>
                         </div>
                         <div class="artifact-card__actions">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -529,10 +529,10 @@ import HoldMark from "../components/HoldMark.astro";
               </button>
             </div>
             <p class="rail-muted" x-show="routePreview && routePreview.active_intents" x-cloak>
-              <strong>Active intents:</strong> <span x-text="(routePreview.active_intents || []).join(', ') || 'none'"></span>
+              <strong>Active intents:</strong> <span x-text="(routePreview?.active_intents || []).join(', ') || 'none'"></span>
             </p>
             <p class="rail-muted" x-show="routePreview && routePreview.plugin_chain" x-cloak>
-              <strong>Plugin chain:</strong> <span x-text="(routePreview.plugin_chain || []).join(' -> ') || 'none'"></span>
+              <strong>Plugin chain:</strong> <span x-text="(routePreview?.plugin_chain || []).join(' -> ') || 'none'"></span>
             </p>
           </div>
         </section>

--- a/web/src/scripts/desk-app.js
+++ b/web/src/scripts/desk-app.js
@@ -37,6 +37,12 @@ function DeskApp() {
     coderReady: false,
     coderBlockers: [],
 
+    // ── ambient trust (HS-21-04) — the canonical egress posture + readiness,
+    // both sourced from GET /api/setup/status. `setup` is the raw status block
+    // (or null when the adapter is unreachable — the chips simply hide).
+    setup: null,
+    setupLoaded: false,
+
     // ── the store, by kind ──
     items: {
       meeting: [],
@@ -97,8 +103,87 @@ function DeskApp() {
     async init() {
       await this.loadAll();
       this.loading = false;
+      this.loadSetup();
       this.refreshCoders();
       this.coderTimer = setInterval(() => this.refreshCoders(), 4000);
+    },
+
+    // ── ambient trust + readiness (HS-21-04) ─────────────────────────────────
+    // Read the live posture from the same adapter the /setup surface uses
+    // (GET /api/setup/status). Failures are silent: the chips stay hidden so we
+    // never assert a posture we couldn't confirm.
+    async loadSetup() {
+      try {
+        const res = await fetch("/api/setup/status");
+        if (!res.ok) return;
+        this.setup = await res.json();
+        this.setupLoaded = true;
+      } catch (_e) {
+        /* adapter unreachable — leave the ambient chips hidden (honest). */
+      }
+    },
+
+    /**
+     * The canonical egress badge for the live posture: `{scope, text, title}`.
+     * `scope` is the structured value the shared `.egress-badge` CSS keys on
+     * (local | mixed | cloud) — the ONE structured badge that replaces privacy
+     * prose (POSITIONING canon). The glyph + fallback word mirror the shared
+     * `EGRESS_SCOPES` map in egress-badge.js; this is a placement port, not a
+     * new visual language (desk-app.js is eval'd via ?raw, so no ES import).
+     */
+    egressBadge() {
+      const t = (this.setup && this.setup.trust) || {};
+      // Off-loopback bind with no auth token, or actuators on → external writes
+      // are possible: local + cloud.
+      const bind = t.web_bind;
+      const offLoopback = bind && bind !== "127.0.0.1" && bind !== "localhost" && bind !== "::1";
+      if (t.actuators_enabled || (offLoopback && !t.auth_token_set)) {
+        return { scope: "mixed", text: "⌂+☁ Local + cloud", title: "Local plus a configured cloud reach. Writes still need your approval." };
+      }
+      // A transcript can be sent to a configured endpoint → cloud.
+      if (t.transcript_egress && t.transcript_egress !== "none") {
+        const ep = (t.configured_endpoints && t.configured_endpoints[0]) || "";
+        const label = ep ? `Cloud · ${ep}` : "Configured endpoint";
+        return { scope: "cloud", text: `☁ ${label}`, title: "A transcript can be sent to a configured endpoint." };
+      }
+      // Nothing leaves the machine → local.
+      return { scope: "local", text: "⌂ Local only", title: "Everything stays on this machine." };
+    },
+
+    /** The /api/setup/status overall verdict: "ready" | "blocked" | other. */
+    setupOverall() {
+      return (this.setup && this.setup.overall) || "unknown";
+    },
+
+    /** The readiness chip tone class. */
+    readyTone() {
+      const o = this.setupOverall();
+      if (o === "ready") return "ready";
+      if (o === "blocked") return "blocked";
+      return "warn";
+    },
+
+    /** A one-line readiness indicator, e.g. "Ready · 6/6 checks". */
+    readyLine() {
+      const s = this.setup;
+      if (!s) return "";
+      const sections = s.sections || [];
+      const pass = sections.filter((x) => x.status === "pass").length;
+      const total = sections.length;
+      const counts = total ? ` · ${pass}/${total} checks` : "";
+      const o = this.setupOverall();
+      if (o === "ready") return `Ready${counts}`;
+      if (o === "blocked") {
+        const fails = sections.filter((x) => x.status === "fail").length;
+        return `${fails || 1} blocking${counts}`;
+      }
+      const advisory = sections.filter((x) => x.status === "warn").length;
+      return advisory ? `${advisory} to review${counts}` : `Almost ready${counts}`;
+    },
+
+    /** Hover title for the readiness chip — points at /setup for the detail. */
+    readyTitle() {
+      return `${this.readyLine()}. Open Setup for the full checklist.`;
     },
 
     // ── totals + grouping helpers (data-driven by the page descriptor) ──

--- a/web/src/scripts/desk-app.js
+++ b/web/src/scripts/desk-app.js
@@ -68,7 +68,10 @@ function DeskApp() {
     kbForm: { name: "", memberIds: "" },
     directoryForm: { name: "", parentId: "" },
     chainForm: { name: "", steps: "" },
-    workflowForm: { name: "", prompt: "" },
+    // A workflow is authored either as a saved prompt OR as a minimal LINEAR
+    // chain of steps (entry → … → output). `nodes` holds the ordered model-op
+    // steps the chain builder emits; `mode` toggles which the form ships.
+    workflowForm: { name: "", prompt: "", mode: "prompt", nodes: [] },
 
     // ── filing (membership picker) ──
     filing: null, // the primitive being filed: { kind, id, title } | null
@@ -774,6 +777,88 @@ function DeskApp() {
       }
     },
 
+    // ── authoring: the linear chain builder ──
+    //
+    // The web Desk authors a MINIMAL LINEAR workflow: entry → step → … → output.
+    // The kinds offered are the chain-safe ones the hub's `workflow_graph.linearize`
+    // accepts and the iPad Blueprint produces (no branch/loop/fan-out). Each step
+    // is one model op; `buildGraphJson` lowers them to the canonical snake_case
+    // `graph_json` wire (nodes with id + a single-key `kind` tag, ordered `exec_edges`
+    // on the "then" exec-out, and the `entry` id) — byte-shaped like the iPad's and
+    // accepted as-is by the hub linearizer.
+
+    /** The step kinds the linear builder offers (chain-safe model ops). */
+    workflowStepKinds: [
+      { kind: "llm", label: "Prompt", hint: "Your own instruction; {input} is the prior step's text." },
+      { kind: "summarize", label: "Summarize", hint: "Tighten the input into a faithful summary." },
+      { kind: "rewrite", label: "Rewrite", hint: "Restate the input in a tone you set." },
+      { kind: "extract", label: "Extract", hint: "Pull one artifact (decisions, actions…) out of the input." },
+    ],
+
+    /** Append a fresh step to the linear chain. */
+    addWorkflowStep(kind = "llm") {
+      this.workflowForm.nodes.push({
+        kind,
+        prompt: "",       // llm
+        tone: "concise",  // rewrite
+        artifactType: "decisions", // extract
+      });
+    },
+    /** Drop the step at `i` from the chain. */
+    removeWorkflowStep(i) {
+      this.workflowForm.nodes.splice(i, 1);
+    },
+    /** Move a step one slot toward the start (`dir=-1`) or end (`dir=+1`). */
+    moveWorkflowStep(i, dir) {
+      const j = i + dir;
+      const n = this.workflowForm.nodes;
+      if (j < 0 || j >= n.length) return;
+      [n[i], n[j]] = [n[j], n[i]];
+    },
+
+    /**
+     * Lower the ordered builder steps into the canonical snake_case `graph_json`.
+     *
+     * Shape (matches the iPad Blueprint + the hub `workflow_graph.linearize`):
+     *   nodes: [{ id, kind }]   kind is a single-key tag —
+     *     entry/summarize/output → {"entry":{}}, {"summarize":{}}, {"output":{}}
+     *     llm     → {"llm": {"name": .., "prompt": ..}}
+     *     rewrite → {"rewrite": {"tone": ..}}
+     *     extract → {"extract": "decisions"}   (bare-string payload)
+     *   exec_edges: [{ from: { node, name: "then" }, to }]  in chain order
+     *   entry: <entry node id>
+     *
+     * Web ships LINEAR-only by construction; it labels itself so (no control flow).
+     */
+    buildGraphJson(steps) {
+      const nodes = [{ id: "entry", kind: { entry: {} } }];
+      steps.forEach((s, i) => {
+        const id = `n${i + 1}`;
+        let kind;
+        if (s.kind === "llm") {
+          kind = { llm: { name: "Prompt", prompt: s.prompt || "" } };
+        } else if (s.kind === "rewrite") {
+          kind = { rewrite: { tone: s.tone || "concise" } };
+        } else if (s.kind === "extract") {
+          kind = { extract: s.artifactType || "decisions" };
+        } else {
+          kind = { summarize: {} };
+        }
+        nodes.push({ id, kind });
+      });
+      nodes.push({ id: "output", kind: { output: {} } });
+
+      // Wire one straight chain along the "then" exec-out, in node order.
+      const execEdges = [];
+      for (let i = 0; i < nodes.length - 1; i++) {
+        execEdges.push({
+          from: { node: nodes[i].id, name: "then" },
+          to: nodes[i + 1].id,
+        });
+      }
+      return { entry: "entry", nodes, exec_edges: execEdges, linear: true };
+    },
+
     // ── authoring: Workflow (LIVE POST /api/workflows) ──
     async submitWorkflow() {
       const f = this.workflowForm;
@@ -781,11 +866,22 @@ function DeskApp() {
         this.error = "A workflow needs a name.";
         return;
       }
+      const graphing = f.mode === "graph";
+      if (graphing && !f.nodes.length) {
+        this.error = "Add at least one step, or switch to a prompt.";
+        return;
+      }
+      if (!graphing && !f.prompt.trim()) {
+        this.error = "A prompt workflow needs a prompt, or switch to a chain.";
+        return;
+      }
       const payload = {
         name: f.name.trim(),
-        prompt: f.prompt,
-        // graph authoring lives in the Workbench; the web form ships a prompt.
-        graph_json: {},
+        // A graph workflow carries an empty prompt; the chain IS the run.
+        prompt: graphing ? "" : f.prompt,
+        // Prompt workflows ship no graph; chain workflows ship the linear graph_json
+        // the hub linearizer + the iPad both speak.
+        graph_json: graphing ? this.buildGraphJson(f.nodes) : {},
       };
       this.busy = true;
       try {
@@ -796,7 +892,7 @@ function DeskApp() {
         });
         this.items.workflow.unshift(this.fromWireWorkflow(data.workflow || data));
         this.status.workflow = "live";
-        this.workflowForm = { name: "", prompt: "" };
+        this.workflowForm = { name: "", prompt: "", mode: "prompt", nodes: [] };
         this.closeCreate();
       } catch (e) {
         this.error = `Save workflow: ${e.message}`;

--- a/web/src/scripts/history-app.js
+++ b/web/src/scripts/history-app.js
@@ -852,6 +852,23 @@ function historyApp() {
       return { github: "🐙", jira: "🧩", slack: "💬", webhook: "🔗" }[target] || "⚡";
     },
 
+    // EQ-W2: the honest egress badge for a proposal — the canonical structured
+    // {scope, label} chip (POSITIONING canon: ONE badge, never a sentence). A
+    // proposal whose target is an off-machine connector LEAVES the device on
+    // approve; anything else stays local (the decision only records DB state).
+    proposalEgress(proposal) {
+      const target = String(proposal?.target || "").toLowerCase();
+      const labels = { slack: "Slack", github: "GitHub", jira: "Jira", webhook: "Webhook" };
+      if (target in labels) return { scope: "cloud", label: labels[target] };
+      return { scope: "local", label: "Local only" };
+    },
+
+    proposalEgressText(proposal) {
+      const badge = this.proposalEgress(proposal);
+      const glyph = { local: "⌂", mixed: "⌂+☁", cloud: "☁" }[badge.scope] || "⌂";
+      return `${glyph} ${badge.label}`;
+    },
+
     // The reviewable preview: action → target, the human preview, then the
     // exact machine payload — the source of truth a reviewer is approving.
     proposalPreviewText(proposal) {


### PR DESCRIPTION
Second build flotilla (4 worktree agents) + integration.

| Branch | Phase | What landed |
|--------|-------|-------------|
| rename-guide | 21 | `INTELLIGENT_TYPING_GUIDE.md` → `DICTATION_PIPELINE_GUIDE.md` (all refs + verbatim test); `_BANNED_NAMES_DOCS` collapsed so "intelligent typing" is now banned **globally** (docs + web). Closes the Wave 1 follow-up. |
| web-proposals | 19 | the proposals review surface already existed (Phase 37); the real gap was its egress being a **sentence**, replaced with the structured egress badge per canon |
| web-graph-builder | 22 | the web Desk authors a real minimal **linear `graph_json`** (was hardcoded `{}`), in the shape `workflow_graph.linearize()` + the iPad Blueprint speak |
| web-trust-chip | 21 | an ambient egress/trust chip + a `/api/setup/status` readiness line on the web Desk (reusing the egress component, never prose) |

**Bonus — a pre-existing bug the integrated preflight caught:** `index.astro`'s route-preview `x-text` read `routePreview.active_intents` un-guarded and threw on load when null (`x-text` evaluates even under a false `x-show`). `main` fails it identically; CI skips this e2e without Chromium, so it had hidden. Fixed with optional chaining.

### Verification
- `route_preflight` + doc guard: **17 passed** (preflight now green).
- Full Python suite green; `npm run build` green.
- `graph-builder` + `trust-chip` both touched `desk.*` but git auto-merged (additive, different regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)