### PR TITLE
HSM-18-01 (spine): the dictation teleprompter's client + Contracts

### DIFF
--- a/apple/Sources/Contracts/DictationPreview.swift
+++ b/apple/Sources/Contracts/DictationPreview.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+// HSM-18-01 — the dictation teleprompter's data: the hub's dry-run preview (what WOULD be typed,
+// and where) and a readiness snapshot. Decoded with HoldSpeakContracts.decoder()
+// (.convertFromSnakeCase), so the snake_case wire (final_text, total_elapsed_ms) maps to these
+// camelCase properties automatically. Lenient (most fields optional) so a hub shape drift degrades
+// gracefully on the teleprompter rather than throwing.
+
+/// Where a dry-run says the dictation would land (the detected target profile / focused app).
+public struct DryRunTarget: Codable, Sendable, Equatable {
+    public var app: String?
+    public var window: String?
+    public var process: String?
+    public var profile: String?
+    public var confidence: Double?
+
+    /// The best human label for the destination column header ("→ Cursor"), or nil if unknown.
+    public var label: String? {
+        for candidate in [app, window, process, profile] {
+            if let c = candidate?.trimmingCharacters(in: .whitespaces), !c.isEmpty { return c }
+        }
+        return nil
+    }
+}
+
+/// The result of `POST /api/dictation/dry-run`: the routed + rewritten text the pipeline would
+/// produce, plus where it would go, so the user sees the receipt before a keystroke leaves the app.
+public struct DictationDryRun: Codable, Sendable, Equatable {
+    public var finalText: String
+    public var target: DryRunTarget?
+    public var warnings: [String]?
+    public var totalElapsedMs: Double?
+    public var status: String?
+    public var blocksCount: Int?
+    public var project: String?
+
+    public init(finalText: String, target: DryRunTarget? = nil, warnings: [String]? = nil,
+                totalElapsedMs: Double? = nil, status: String? = nil, blocksCount: Int? = nil,
+                project: String? = nil) {
+        self.finalText = finalText
+        self.target = target
+        self.warnings = warnings
+        self.totalElapsedMs = totalElapsedMs
+        self.status = status
+        self.blocksCount = blocksCount
+        self.project = project
+    }
+}
+
+/// A lean readiness snapshot for the dictate screen's status strip (`GET /api/dictation/readiness`).
+public struct DictationReadiness: Codable, Sendable, Equatable {
+    public var status: String?
+    public var modelExists: Bool?
+    public var runtimeStatus: String?
+    public var openaiCompatible: Bool?
+    public var project: String?
+
+    /// True when the snapshot reports a usable runtime (a model present or an endpoint reachable).
+    public var isReady: Bool {
+        if let s = status?.lowercased(), s == "ready" || s == "ok" { return true }
+        return (modelExists ?? false) || (openaiCompatible ?? false)
+    }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Dictation.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Dictation.swift
@@ -1,0 +1,49 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HSM-18-01 — the dictation-pipeline client (the teleprompter's spine). Typed calls to the hub's
+// dry-run + readiness routes so the iPad can show the rewrite AND its destination BEFORE a single
+// keystroke leaves the app. New file (no edits to HTTPDesktopClient.swift, so it never collides with
+// the parallel Phase-19 client work); builds its own Bearer-authed request from the internal `config`.
+public extension HTTPDesktopClient {
+    /// `POST /api/dictation/dry-run {utterance}` -> the routed + rewritten preview (what WOULD be
+    /// typed, and where). Preview-not-inject: this never delivers; the teleprompter shows it first.
+    func dictationDryRun(utterance: String) async throws -> DictationDryRun {
+        let data = try await dictationRequest(path: "api/dictation/dry-run",
+                                              method: "POST", body: ["utterance": utterance])
+        do { return try HoldSpeakContracts.decoder().decode(DictationDryRun.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    /// `GET /api/dictation/readiness` -> a setup snapshot for the dictate screen's status strip.
+    func dictationReadiness() async throws -> DictationReadiness {
+        let data = try await dictationRequest(path: "api/dictation/readiness", method: "GET", body: nil)
+        do { return try HoldSpeakContracts.decoder().decode(DictationReadiness.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    /// Self-contained authed request (the struct's own `send`/`makeRequest` are file-private; this
+    /// new file rebuilds the same Bearer pattern off the internal `config`/`session`).
+    private func dictationRequest(path: String, method: String, body: [String: Any]?) async throws -> Data {
+        let baseString = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        guard let url = URL(string: "\(baseString)/\(path)") else { throw DesktopClientError.malformed }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+        let (data, response) = try await session.data(for: request)
+        let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200..<300).contains(code) else { throw DesktopClientError.http(code) }
+        return data
+    }
+}

--- a/apple/Tests/ProvidersTests/DictationClientTests.swift
+++ b/apple/Tests/ProvidersTests/DictationClientTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import Contracts
+
+/// HSM-18-01 — the dictation teleprompter's data decodes from the hub's real `/api/dictation/dry-run`
+/// + `/api/dictation/readiness` JSON (snake_case wire -> camelCase via HoldSpeakContracts.decoder()).
+final class DictationClientTests: XCTestCase {
+
+    func testDryRunDecodesFinalTextAndDestination() throws {
+        let json = """
+        {
+          "final_text": "Use Redis with a 24 hour TTL.",
+          "target": { "app": "Cursor", "confidence": 0.91 },
+          "warnings": ["model fallback"],
+          "total_elapsed_ms": 380,
+          "status": "ok",
+          "blocks_count": 2,
+          "project": "holdspeak"
+        }
+        """.data(using: .utf8)!
+        let dry = try HoldSpeakContracts.decoder().decode(DictationDryRun.self, from: json)
+        XCTAssertEqual(dry.finalText, "Use Redis with a 24 hour TTL.")
+        XCTAssertEqual(dry.target?.label, "Cursor")          // the destination column header "-> Cursor"
+        XCTAssertEqual(dry.target?.confidence, 0.91)
+        XCTAssertEqual(dry.warnings, ["model fallback"])
+        XCTAssertEqual(dry.totalElapsedMs, 380)
+        XCTAssertEqual(dry.blocksCount, 2)
+    }
+
+    func testDryRunToleratesMissingOptionalFields() throws {
+        // a minimal hub response (only final_text) must still decode, not throw
+        let json = #"{"final_text": "hello"}"#.data(using: .utf8)!
+        let dry = try HoldSpeakContracts.decoder().decode(DictationDryRun.self, from: json)
+        XCTAssertEqual(dry.finalText, "hello")
+        XCTAssertNil(dry.target)
+        XCTAssertNil(dry.target?.label)
+    }
+
+    func testReadinessDecodesAndReportsReady() throws {
+        let json = """
+        { "status": "ready", "model_exists": true, "runtime_status": "ok", "openai_compatible": false }
+        """.data(using: .utf8)!
+        let r = try HoldSpeakContracts.decoder().decode(DictationReadiness.self, from: json)
+        XCTAssertTrue(r.isReady)
+        XCTAssertEqual(r.modelExists, true)
+        XCTAssertEqual(r.runtimeStatus, "ok")
+    }
+
+    func testReadinessNotReadyWhenNoModelAndNoEndpoint() throws {
+        let json = #"{"status": "incomplete", "model_exists": false, "openai_compatible": false}"#.data(using: .utf8)!
+        let r = try HoldSpeakContracts.decoder().decode(DictationReadiness.self, from: json)
+        XCTAssertFalse(r.isReady)
+    }
+}


### PR DESCRIPTION
The foundation the dictation teleprompter screen sits on. Typed calls to the hub's dry-run + readiness routes so the iPad can show the rewrite **and its destination before a keystroke leaves the app** (the Experience Vision's "watch the rewrite resolve" moment).

- `HTTPDesktopClient.dictationDryRun(utterance:) -> DictationDryRun` (`final_text` + the detected target + warnings + latency) and `dictationReadiness() -> DictationReadiness`. In a **new** `HTTPDesktopClient+Dictation.swift` extension (self-contained Bearer request off the internal `config`), so it never collides with the parallel Phase-19 client flotilla (each client group is its own `+Feature.swift`).
- `DictationDryRun` / `DictationReadiness` Contracts types, modeled from the real hub JSON, decoded `.convertFromSnakeCase`; lenient/optional so a shape drift degrades gracefully instead of throwing.

**Verified:** `swift test --filter DictationClientTests` **4/4** (decodes the real dry-run + readiness wire, incl. missing-optional tolerance; CI's swift-package job covers it).

Next: the teleprompter **screen** (push-to-talk → this dry-run → preview → send); the metal walk is the Phase-18 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)