### PR TITLE
Equilibrium Wave 3 (Phase 19): the iPad meeting-contract client layer

### DIFF
--- a/apple/Sources/Contracts/Aftercare.swift
+++ b/apple/Sources/Contracts/Aftercare.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+// The aftercare digest contract (HS-49-01 / HSM client layer). Read-only "close
+// the loop" rollup the desktop returns from `GET /api/meetings/{id}/aftercare`:
+// what's still open (grouped by owner), what was decided, and a real diff vs the
+// chronologically previous meeting. Plus the `POST .../aftercare/file-issue`
+// result: an actuator *proposal* (proposed state) the user separately approves.
+//
+// Wire keys arrive snake_case and convert to these camelCase properties via the
+// shared decoder (`HoldSpeakContracts.decoder()`, `.convertFromSnakeCase`) — so
+// these types carry NO explicit CodingKeys for case conversion (matching
+// Models.swift / Providers.swift conventions). Every nested field the digest can
+// omit is optional, so the client tolerates the payload evolving and stays honest
+// (an empty digest renders nothing).
+
+/// A resolved "show me the moment" jump target — the transcript segment that
+/// justifies a decision or open item (`resolve_provenance_segment`). `nil` on the
+/// wire when the source had no usable timestamp (no fake jump is invented).
+public struct AftercareProvenance: Codable, Equatable, Sendable {
+    public var sourceTimestamp: Double?
+    public var segmentIndex: Int?
+    public var segmentStart: Double?
+    public var speaker: String?
+    public var textPreview: String?
+
+    public init(sourceTimestamp: Double? = nil, segmentIndex: Int? = nil,
+                segmentStart: Double? = nil, speaker: String? = nil, textPreview: String? = nil) {
+        self.sourceTimestamp = sourceTimestamp
+        self.segmentIndex = segmentIndex
+        self.segmentStart = segmentStart
+        self.speaker = speaker
+        self.textPreview = textPreview
+    }
+}
+
+/// One pending action item as the aftercare digest serializes it (an entry in an
+/// owner group's `items`). `id` + `meetingId` are load-bearing for the file-issue
+/// loop; everything else is best-effort.
+public struct AftercareOpenItem: Codable, Equatable, Sendable {
+    public var id: String
+    public var task: String
+    public var owner: String?
+    public var due: String?
+    public var reviewState: String?
+    public var sourceTimestamp: Double?
+    public var provenance: AftercareProvenance?
+    public var meetingId: String?
+
+    public init(id: String, task: String, owner: String? = nil, due: String? = nil,
+                reviewState: String? = nil, sourceTimestamp: Double? = nil,
+                provenance: AftercareProvenance? = nil, meetingId: String? = nil) {
+        self.id = id
+        self.task = task
+        self.owner = owner
+        self.due = due
+        self.reviewState = reviewState
+        self.sourceTimestamp = sourceTimestamp
+        self.provenance = provenance
+        self.meetingId = meetingId
+    }
+}
+
+/// Open items for one owner — the `open_items.by_owner[]` grouping (named owners
+/// A→Z, unassigned last, `owner == nil`).
+public struct AftercareOwnerGroup: Codable, Equatable, Sendable {
+    public var owner: String?
+    public var count: Int
+    public var items: [AftercareOpenItem]
+
+    public init(owner: String? = nil, count: Int, items: [AftercareOpenItem] = []) {
+        self.owner = owner
+        self.count = count
+        self.items = items
+    }
+}
+
+/// The `open_items` block: a total plus the by-owner grouping.
+public struct AftercareOpenItems: Codable, Equatable, Sendable {
+    public var total: Int
+    public var byOwner: [AftercareOwnerGroup]
+
+    public init(total: Int, byOwner: [AftercareOwnerGroup] = []) {
+        self.total = total
+        self.byOwner = byOwner
+    }
+}
+
+/// One decision captured for the meeting (deduped by normalized text). A
+/// `provenance` is present only when the decision carried a real source timestamp.
+public struct AftercareDecision: Codable, Equatable, Sendable {
+    public var decision: String
+    public var rationale: String?
+    public var sourceTimestamp: Double?
+    public var provenance: AftercareProvenance?
+
+    public init(decision: String, rationale: String? = nil,
+                sourceTimestamp: Double? = nil, provenance: AftercareProvenance? = nil) {
+        self.decision = decision
+        self.rationale = rationale
+        self.sourceTimestamp = sourceTimestamp
+        self.provenance = provenance
+    }
+}
+
+/// The chronologically-previous meeting the diff is computed against.
+public struct AftercarePreviousMeeting: Codable, Equatable, Sendable {
+    public var id: String
+    public var title: String?
+    public var date: String?
+
+    public init(id: String, title: String? = nil, date: String? = nil) {
+        self.id = id
+        self.title = title
+        self.date = date
+    }
+}
+
+/// An action item that has closed since the previous meeting (status done /
+/// dismissed). A thin shape — the diff carries less than the live open-item.
+public struct AftercareClosedAction: Codable, Equatable, Sendable {
+    public var id: String
+    public var task: String
+    public var owner: String?
+    public var status: String?
+    public var meetingId: String?
+
+    public init(id: String, task: String, owner: String? = nil,
+                status: String? = nil, meetingId: String? = nil) {
+        self.id = id
+        self.task = task
+        self.owner = owner
+        self.status = status
+        self.meetingId = meetingId
+    }
+}
+
+/// The real diff vs the previous meeting (`since_last_meeting`). `nil` on the wire
+/// when there is no prior meeting at all (no delta is invented).
+public struct AftercareSinceLastMeeting: Codable, Equatable, Sendable {
+    public var previousMeeting: AftercarePreviousMeeting?
+    public var newDecisions: [AftercareDecision]
+    public var newActions: [AftercareOpenItem]
+    public var closedActions: [AftercareClosedAction]
+    public var changed: Bool
+
+    public init(previousMeeting: AftercarePreviousMeeting? = nil,
+                newDecisions: [AftercareDecision] = [], newActions: [AftercareOpenItem] = [],
+                closedActions: [AftercareClosedAction] = [], changed: Bool = false) {
+        self.previousMeeting = previousMeeting
+        self.newDecisions = newDecisions
+        self.newActions = newActions
+        self.closedActions = closedActions
+        self.changed = changed
+    }
+}
+
+/// The full aftercare digest (`GET /api/meetings/{id}/aftercare`). `isEmpty` is the
+/// caller's cue to stay quiet (nothing open, decided, or changed). `slackConfigured`
+/// gates the Send-to-Slack affordance (HS-61-02) — a bool only, never the webhook URL.
+public struct Aftercare: Codable, Equatable, Sendable {
+    public var meetingId: String
+    public var meetingTitle: String?
+    public var meetingDate: String?
+    public var openItems: AftercareOpenItems
+    public var decisions: [AftercareDecision]
+    public var sinceLastMeeting: AftercareSinceLastMeeting?
+    public var isEmpty: Bool
+    public var slackConfigured: Bool?
+
+    public init(meetingId: String, meetingTitle: String? = nil, meetingDate: String? = nil,
+                openItems: AftercareOpenItems, decisions: [AftercareDecision] = [],
+                sinceLastMeeting: AftercareSinceLastMeeting? = nil,
+                isEmpty: Bool = false, slackConfigured: Bool? = nil) {
+        self.meetingId = meetingId
+        self.meetingTitle = meetingTitle
+        self.meetingDate = meetingDate
+        self.openItems = openItems
+        self.decisions = decisions
+        self.sinceLastMeeting = sinceLastMeeting
+        self.isEmpty = isEmpty
+        self.slackConfigured = slackConfigured
+    }
+}
+
+/// The actuator proposal returned by `POST .../aftercare/file-issue` (the
+/// `proposal` block of `{"success": true, "proposal": {...}}`). A *proposed* GitHub
+/// issue — nothing leaves the machine until it is separately approved + actuators
+/// are enabled. Decoded loosely; the `preview` is the human-readable summary the
+/// approval surface shows (never the machine payload's secrets).
+public struct AftercareIssueProposal: Codable, Equatable, Sendable {
+    public var id: String
+    public var meetingId: String?
+    public var windowId: String?
+    public var pluginId: String?
+    public var pluginVersion: String?
+    public var status: String?
+    public var target: String?
+    public var action: String?
+    public var preview: String?
+    public var reversible: Bool?
+    public var requiredCapabilities: [String]?
+    public var decidedBy: String?
+    public var error: String?
+    public var createdAt: Date?
+    public var decidedAt: Date?
+    public var executedAt: Date?
+
+    public init(id: String, meetingId: String? = nil, windowId: String? = nil,
+                pluginId: String? = nil, pluginVersion: String? = nil, status: String? = nil,
+                target: String? = nil, action: String? = nil, preview: String? = nil,
+                reversible: Bool? = nil, requiredCapabilities: [String]? = nil,
+                decidedBy: String? = nil, error: String? = nil,
+                createdAt: Date? = nil, decidedAt: Date? = nil, executedAt: Date? = nil) {
+        self.id = id
+        self.meetingId = meetingId
+        self.windowId = windowId
+        self.pluginId = pluginId
+        self.pluginVersion = pluginVersion
+        self.status = status
+        self.target = target
+        self.action = action
+        self.preview = preview
+        self.reversible = reversible
+        self.requiredCapabilities = requiredCapabilities
+        self.decidedBy = decidedBy
+        self.error = error
+        self.createdAt = createdAt
+        self.decidedAt = decidedAt
+        self.executedAt = executedAt
+    }
+}
+
+/// The full `POST .../aftercare/file-issue` envelope: `{"success", "proposal"?, "error"?}`.
+/// A 400/404 from the route returns `{"success": false, "error": "..."}` (no proposal).
+public struct AftercareFileIssueResult: Codable, Equatable, Sendable {
+    public var success: Bool
+    public var proposal: AftercareIssueProposal?
+    public var error: String?
+
+    public init(success: Bool, proposal: AftercareIssueProposal? = nil, error: String? = nil) {
+        self.success = success
+        self.proposal = proposal
+        self.error = error
+    }
+}

--- a/apple/Sources/Contracts/MeetingArtifact.swift
+++ b/apple/Sources/Contracts/MeetingArtifact.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+// EQ-W3 (iOS artifacts) — the read-side contract for a meeting's synthesized
+// artifacts, modelled faithfully against `GET /api/meetings/{id}/artifacts` in
+// holdspeak/web/routes/meetings.py. The audit finding this fixes: the iPad render
+// currently drops `confidence` and `sources` (the provenance the desk should
+// show), so this type carries them as first-class fields.
+//
+// Wire keys arrive snake_case; these camelCase properties map via the shared
+// decoder's `.convertFromSnakeCase` strategy (HoldSpeakContracts.decoder()),
+// matching the no-explicit-CodingKeys convention of `ArtifactSource` in Models.swift.
+//
+// INTEGRATOR NOTE — overlap with `Contracts/Models.swift::Artifact`:
+//   `Artifact` already exists and also carries `confidence` (non-optional Double)
+//   and `sources: [ArtifactSource]`. This `MeetingArtifact` is a deliberately
+//   leaner, decode-tolerant read model for the artifacts route: `artifactType`
+//   and `status` stay `String` (not the `ArtifactType`/`ArtifactStatus` enums) so
+//   a future wire value never fails the whole decode, `confidence` is `Double?`
+//   per the slice spec, and the lineage rows use a local
+//   `MeetingArtifactSource`. If the integrator prefers the richer `Artifact`,
+//   collapse these two — but keep the optional `confidence` + the source list so
+//   the iPad render can finally show provenance.
+
+/// One lineage row for a synthesized artifact. On the wire each `sources` entry is
+/// `{"source_type": ..., "source_ref": ...}` (see `ArtifactSummary.sources` in
+/// holdspeak/db/models.py — a `list[dict[str, str]]`). Decodes via the shared
+/// `.convertFromSnakeCase` decoder (sourceType ← source_type).
+public struct MeetingArtifactSource: Codable, Equatable, Sendable {
+    public var sourceType: String
+    public var sourceRef: String
+
+    public init(sourceType: String, sourceRef: String) {
+        self.sourceType = sourceType
+        self.sourceRef = sourceRef
+    }
+}
+
+/// A synthesized meeting artifact as returned by `GET /api/meetings/{id}/artifacts`.
+/// Carries the type/title/body/status the iPad already shows AND the `confidence`
+/// + `sources` provenance it currently drops. Decode is tolerant: `artifactType`
+/// and `status` are raw wire strings, and `confidence` is optional.
+public struct MeetingArtifact: Codable, Equatable, Sendable {
+    public var id: String
+    public var meetingId: String
+    /// Raw wire string (e.g. "action_items", "decisions"); matches `ArtifactType`
+    /// raw values but kept as `String` so an unknown type never fails the decode.
+    public var artifactType: String
+    public var title: String
+    public var bodyMarkdown: String
+    /// Type-specific structured payload (open shape). Kept as `JSONValue` so the
+    /// read model tolerates any plugin output.
+    public var structuredJson: JSONValue?
+    /// Synthesis confidence (0...1). Optional per the slice spec; the route always
+    /// sends a float today, but the iPad render must tolerate its absence.
+    public var confidence: Double?
+    /// Raw wire string (e.g. "draft", "needs_review", "accepted", "rejected").
+    public var status: String
+    public var pluginId: String?
+    public var pluginVersion: String?
+    /// The provenance list — `(source_type, source_ref)` lineage rows.
+    public var sources: [MeetingArtifactSource]
+    public var createdAt: Date?
+    public var updatedAt: Date?
+
+    public init(
+        id: String, meetingId: String, artifactType: String,
+        title: String, bodyMarkdown: String, structuredJson: JSONValue? = nil,
+        confidence: Double? = nil, status: String, pluginId: String? = nil,
+        pluginVersion: String? = nil, sources: [MeetingArtifactSource] = [],
+        createdAt: Date? = nil, updatedAt: Date? = nil
+    ) {
+        self.id = id
+        self.meetingId = meetingId
+        self.artifactType = artifactType
+        self.title = title
+        self.bodyMarkdown = bodyMarkdown
+        self.structuredJson = structuredJson
+        self.confidence = confidence
+        self.status = status
+        self.pluginId = pluginId
+        self.pluginVersion = pluginVersion
+        self.sources = sources
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+/// The envelope `GET /api/meetings/{id}/artifacts` returns: `{meeting_id, artifacts}`.
+public struct MeetingArtifactsEnvelope: Codable, Equatable, Sendable {
+    public var meetingId: String
+    public var artifacts: [MeetingArtifact]
+
+    public init(meetingId: String, artifacts: [MeetingArtifact]) {
+        self.meetingId = meetingId
+        self.artifacts = artifacts
+    }
+}

--- a/apple/Sources/Contracts/MeetingFacets.swift
+++ b/apple/Sources/Contracts/MeetingFacets.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The faceted-archive filter values (`GET /api/meetings/facets`, HS-55-04).
+///
+/// The hub returns the distinct *values* that can filter the history archive —
+/// every speaker that has spoken and every tag that has been applied — drawn in
+/// SQL across the whole archive (`db.meetings.list_facet_values()`). The wire
+/// shape is two plain string arrays:
+///
+/// ```json
+/// {"speakers": ["Alex", "Dana"], "tags": ["q3", "standup"]}
+/// ```
+///
+/// These are the chips the archive filter row offers; feeding a chosen value back
+/// as `speaker=`/`tag=` on `GET /api/meetings` narrows the list server-side.
+public struct MeetingFacets: Sendable, Equatable, Decodable {
+    /// Distinct speaker names across the archive, ordered case-insensitively by the
+    /// hub. Empty when no segments carry a speaker yet (honest at N=0).
+    public var speakers: [String]
+    /// Distinct meeting tags across the archive, ordered case-insensitively.
+    public var tags: [String]
+
+    public init(speakers: [String] = [], tags: [String] = []) {
+        self.speakers = speakers
+        self.tags = tags
+    }
+
+    /// Both arrays default to empty so a partial/evolving payload still decodes —
+    /// the client's robust-decode posture (a future field never breaks the existing
+    /// two, and an archive with no tags is a normal empty chip row, not an error).
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.speakers = try c.decodeIfPresent([String].self, forKey: .speakers) ?? []
+        self.tags = try c.decodeIfPresent([String].self, forKey: .tags) ?? []
+    }
+
+    /// Both keys already arrive as lower-case single words, so no snake_case mapping
+    /// is needed; the explicit map isolates this type from the shared decoder's
+    /// `.convertFromSnakeCase` strategy.
+    enum CodingKeys: String, CodingKey {
+        case speakers
+        case tags
+    }
+}

--- a/apple/Sources/Contracts/MeetingProposal.swift
+++ b/apple/Sources/Contracts/MeetingProposal.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+// HSM equilibrium wave 3 — the iPad's propose→review→approve client contract.
+// The desktop already SPLITS proposal generation from the human decision (the
+// actuator audit the iPad currently collapses): `GET /api/meetings/{id}/proposals`
+// is a pure read of `proposed`/decided proposals for review, and
+// `POST /api/meetings/{id}/proposals/{pid}/decision` is the separate approve/reject
+// gate. These types model exactly those two hub responses so the iPad can show the
+// review queue and act on it without conflating the two steps.
+
+/// One actuator proposal as the hub serializes it (`_proposal_to_dict` in
+/// `holdspeak/web/routes/meetings.py`). snake_case wire keys map to camelCase via
+/// the shared decoder's `.convertFromSnakeCase` (see `Coding.swift`); the timestamp
+/// fields decode as ISO-8601 UTC `Z` and are optional because `decided_at` /
+/// `executed_at` are `null` for an undecided proposal. Robust-decode posture: every
+/// nullable wire field is optional so the review queue tolerates the payload evolving.
+///
+/// This is the review-side view; it intentionally mirrors (but does not depend on)
+/// the existing `ActuatorProposal` so this wave's client slice lives entirely in
+/// new files.
+public struct MeetingProposal: Codable, Equatable, Sendable {
+    public var id: String
+    public var meetingId: String
+    public var windowId: String?
+    public var pluginId: String?
+    public var pluginVersion: String?
+    public var status: ActuatorStatus
+    public var target: String
+    public var action: String
+    public var preview: String
+    public var payload: JSONValue?
+    public var reversible: Bool
+    public var requiredCapabilities: [String]
+    public var decidedBy: String?
+    public var result: JSONValue?
+    public var error: String?
+    public var createdAt: Date?
+    public var decidedAt: Date?
+    public var executedAt: Date?
+
+    public init(
+        id: String, meetingId: String, windowId: String? = nil,
+        pluginId: String? = nil, pluginVersion: String? = nil,
+        status: ActuatorStatus, target: String, action: String, preview: String,
+        payload: JSONValue? = nil, reversible: Bool, requiredCapabilities: [String] = [],
+        decidedBy: String? = nil, result: JSONValue? = nil, error: String? = nil,
+        createdAt: Date? = nil, decidedAt: Date? = nil, executedAt: Date? = nil
+    ) {
+        self.id = id
+        self.meetingId = meetingId
+        self.windowId = windowId
+        self.pluginId = pluginId
+        self.pluginVersion = pluginVersion
+        self.status = status
+        self.target = target
+        self.action = action
+        self.preview = preview
+        self.payload = payload
+        self.reversible = reversible
+        self.requiredCapabilities = requiredCapabilities
+        self.decidedBy = decidedBy
+        self.result = result
+        self.error = error
+        self.createdAt = createdAt
+        self.decidedAt = decidedAt
+        self.executedAt = executedAt
+    }
+}
+
+/// The list-proposals envelope: `{ "meeting_id": ..., "proposals": [...] }`.
+public struct MeetingProposalsEnvelope: Codable, Equatable, Sendable {
+    public var meetingId: String
+    public var proposals: [MeetingProposal]
+
+    public init(meetingId: String, proposals: [MeetingProposal]) {
+        self.meetingId = meetingId
+        self.proposals = proposals
+    }
+}
+
+/// The decision route's response: `{ "success": ..., "proposal": {...} }` on a legal
+/// approve/reject, or `{ "success": false, "error": ... }` on an illegal decision
+/// (e.g. an already-executed proposal). `proposal` carries the transitioned record
+/// (a slack approval may already be `executed`); `error` is the human reason.
+public struct ProposalDecision: Codable, Equatable, Sendable {
+    public var success: Bool
+    public var proposal: MeetingProposal?
+    public var error: String?
+
+    public init(success: Bool, proposal: MeetingProposal? = nil, error: String? = nil) {
+        self.success = success
+        self.proposal = proposal
+        self.error = error
+    }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Aftercare.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Aftercare.swift
@@ -1,0 +1,81 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HSM client layer — Meeting Aftercare (HS-49 surface over the desktop's existing
+// HTTP API). Two read/close-the-loop verbs on the desktop client seam:
+//
+//   - aftercare(meetingId:)            GET  /api/meetings/{id}/aftercare
+//   - fileAftercareIssue(...)          POST /api/meetings/{id}/aftercare/file-issue
+//
+// New extension file by design (the equilibrium-wave conflict rule): no edits to
+// HTTPDesktopClient.swift or the shared seam. Reuses `self.config` (baseURL +
+// Bearer token) and the same request/decode posture as the rest of the client —
+// a non-2xx throws `DesktopClientError.http`; a decode miss throws `.malformed`.
+extension HTTPDesktopClient {
+
+    /// `GET /api/meetings/{id}/aftercare` → the read-only aftercare digest: what's
+    /// still open (by owner), what was decided, and the real diff vs the previous
+    /// meeting. Pure read, no side effects. `Aftercare.isEmpty` is the caller's cue
+    /// to stay quiet. A non-2xx (e.g. 404 unknown meeting) throws `.http(code)`.
+    public func aftercare(meetingId: String) async throws -> Aftercare {
+        let encoded = meetingId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? meetingId
+        let data = try await sendAftercare(makeAftercareRequest(path: "api/meetings/\(encoded)/aftercare"))
+        do { return try HoldSpeakContracts.decoder().decode(Aftercare.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    /// `POST /api/meetings/{id}/aftercare/file-issue` body `{action_item_id, repo}` →
+    /// an actuator *proposal* (proposed state) plus its human preview. Nothing leaves
+    /// the machine here: filing only records a proposal that the user must separately
+    /// approve (and actuators must be enabled). The route requires the target `repo`
+    /// ("owner/name") and that the action item already be `accepted`, so a 400 here
+    /// throws `.http(400)` and the caller surfaces the honest reason.
+    @discardableResult
+    public func fileAftercareIssue(
+        meetingId: String, actionItemId: String, repo: String
+    ) async throws -> AftercareFileIssueResult {
+        let encoded = meetingId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? meetingId
+        let request = makeAftercareRequest(
+            path: "api/meetings/\(encoded)/aftercare/file-issue",
+            method: "POST",
+            jsonBody: ["action_item_id": actionItemId, "repo": repo])
+        let data = try await sendAftercare(request)
+        do { return try HoldSpeakContracts.decoder().decode(AftercareFileIssueResult.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    // MARK: - internals (private to this extension — no dependency on the seam's
+    //         own private helpers, per the conflict rule; the request shape mirrors
+    //         HTTPDesktopClient.makeRequest / send exactly).
+
+    /// Run a request, throwing `DesktopClientError.http` on a non-2xx so the verbs
+    /// surface a real failure the view-model can render.
+    private func sendAftercare(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        return data
+    }
+
+    private func makeAftercareRequest(
+        path: String, method: String = "GET", jsonBody: [String: String]? = nil
+    ) -> URLRequest {
+        let base = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
+        request.httpMethod = method
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let jsonBody {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try? JSONSerialization.data(withJSONObject: jsonBody)
+        }
+        return request
+    }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Artifacts.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Artifacts.swift
@@ -1,0 +1,59 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// EQ-W3 (iOS artifacts) — the read client for a meeting's synthesized artifacts.
+// Additive extension on `HTTPDesktopClient`; lives in its own file so this slice
+// never touches the shared client (siblings + the integrator add their own verbs).
+//
+// Why this exists: the iPad currently renders meeting artifacts WITHOUT their
+// `confidence` or `sources` (the provenance the desk should show). This method
+// returns `[MeetingArtifact]`, which carries both — so the SwiftUI screen the
+// integrator builds can finally show how confident the synthesis was and what it
+// was grounded in.
+
+extension HTTPDesktopClient {
+
+    /// `GET /api/meetings/{meetingId}/artifacts` → the meeting's synthesized
+    /// artifacts (each with `confidence` + `sources` provenance). Reuses
+    /// `self.config` (baseURL + Bearer token + timeout); a non-2xx throws
+    /// `DesktopClientError.http`, a shape mismatch throws `.malformed`, so the
+    /// view-model surfaces an honest failure rather than a silently empty list.
+    public func meetingArtifacts(meetingId: String) async throws -> [MeetingArtifact] {
+        let request = artifactsRequest(meetingId: meetingId)
+
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        do {
+            return try HoldSpeakContracts.decoder()
+                .decode(MeetingArtifactsEnvelope.self, from: data)
+                .artifacts
+        } catch {
+            throw DesktopClientError.malformed
+        }
+    }
+
+    /// Build the artifacts GET request inline (no dependency on the shared client's
+    /// private helpers, per the no-shared-edits rule), mirroring the Bearer-auth
+    /// request pattern in HTTPDesktopClient.swift. `meetingId` is path-escaped so an
+    /// id with reserved characters never produces a junk URL.
+    private func artifactsRequest(meetingId: String) -> URLRequest {
+        let absolute = config.baseURL.absoluteString
+        let base = absolute.hasSuffix("/") ? String(absolute.dropLast()) : absolute
+        let escapedID = meetingId.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed) ?? meetingId
+        let url = URL(string: "\(base)/api/meetings/\(escapedID)/artifacts") ?? config.baseURL
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Facets.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Facets.swift
@@ -1,0 +1,90 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HS-55-04 (mobile) — the faceted meeting archive over the desktop's HTTP API.
+// The /history filter row on the iPad: read the distinct filter values the hub
+// offers (`/api/meetings/facets`), then narrow the archive server-side by feeding
+// a chosen speaker/tag (and/or a full-text query) back through `/api/meetings`.
+//
+// Kept in a SEPARATE extension file (no edits to HTTPDesktopClient.swift) so this
+// slice lands without colliding with the other client methods landing in the same
+// wave. The request + decode style mirrors the base client (Bearer auth, the shared
+// snake_case decoder, a non-2xx → `DesktopClientError.http`), built inline here so
+// this file owns no dependency on the base type's private helpers.
+extension HTTPDesktopClient {
+
+    /// `GET /api/meetings/facets` → the distinct speakers + tags that can filter the
+    /// archive (HS-55-04). Throws `DesktopClientError.http` on a non-2xx and
+    /// `.malformed` if the body is not the expected `{speakers, tags}` shape.
+    public func listFacets() async throws -> MeetingFacets {
+        let data = try await facetsSend(facetsRequest(path: "api/meetings/facets"))
+        do { return try HoldSpeakContracts.decoder().decode(MeetingFacets.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    /// `GET /api/meetings?search=&speaker=&tag=` → the faceted/searched summaries.
+    /// Every argument is optional; passing none returns the unfiltered archive (the
+    /// same summary shape `listMeetings()` returns — the hub routes search and facets
+    /// through one query so both branches share the `MeetingSummary` payload).
+    ///
+    /// - Parameters:
+    ///   - query: full-text transcript search (the hub's `search=` param).
+    ///   - speaker: narrow to meetings a given speaker spoke in (`speaker=`).
+    ///   - type: a facet value carried as the hub's `tag=` param (the archive's
+    ///     meeting "type" facet is a tag in the schema).
+    public func searchMeetings(query: String? = nil,
+                               speaker: String? = nil,
+                               type: String? = nil) async throws -> [MeetingSummary] {
+        var items: [URLQueryItem] = []
+        if let query, !query.isEmpty { items.append(URLQueryItem(name: "search", value: query)) }
+        if let speaker, !speaker.isEmpty { items.append(URLQueryItem(name: "speaker", value: speaker)) }
+        if let type, !type.isEmpty { items.append(URLQueryItem(name: "tag", value: type)) }
+
+        let data = try await facetsSend(facetsRequest(path: "api/meetings", query: items))
+        do {
+            return try HoldSpeakContracts.decoder()
+                .decode(FacetedMeetingsEnvelope.self, from: data).meetings
+        } catch { throw DesktopClientError.malformed }
+    }
+
+    // MARK: - internals (file-private to this slice; no shared-helper dependency)
+
+    /// The `/api/meetings` list envelope: the summaries plus an archive `total`. A
+    /// private mirror so this file never reaches into the base client's
+    /// `MeetingsEnvelope`.
+    private struct FacetedMeetingsEnvelope: Decodable {
+        var meetings: [MeetingSummary]
+        var total: Int?
+    }
+
+    /// Build a GET against the configured peer with optional query items, mirroring
+    /// the base client's Bearer-auth + timeout. Built inline so the slice carries no
+    /// dependency on the base type's private `makeRequest`.
+    private func facetsRequest(path: String, query: [URLQueryItem] = []) -> URLRequest {
+        let absolute = config.baseURL.absoluteString
+        let base = absolute.hasSuffix("/") ? String(absolute.dropLast()) : absolute
+        var components = URLComponents(string: "\(base)/\(path)")
+        if !query.isEmpty { components?.queryItems = query }
+        var request = URLRequest(url: components?.url ?? config.baseURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    /// Run a request, throwing `DesktopClientError.http` on a non-2xx (so the
+    /// view-model can render an honest unreachable/failed state). Mirrors the base
+    /// client's `send`.
+    private func facetsSend(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        return data
+    }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Proposals.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Proposals.swift
@@ -1,0 +1,102 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HSM equilibrium wave 3 — the propose→review→approve client slice. The iPad today
+// collapses "generate a proposal" and "approve it"; the desktop already keeps them
+// apart (actuator audit). These two methods give the iPad the SPLIT:
+//
+//   • `meetingProposals(meetingId:)` — a pure read of the proposals queued for
+//     review (`GET /api/meetings/{id}/proposals`). No side effect.
+//   • `decideProposal(meetingId:proposalId:approved:)` — the separate human gate
+//     (`POST /api/meetings/{id}/proposals/{pid}/decision`). Approving only flips DB
+//     state for most targets; a `slack` target executes immediately (the hub's
+//     consent model) — either way the transitioned proposal rides back.
+//
+// New file by design: no edit to HTTPDesktopClient.swift / IDesktopClient (siblings
+// add their own methods on the same type). The request/decode style is copied from
+// HTTPDesktopClient.swift (Bearer auth, shared decoder, throw on non-2xx) but built
+// inline here so it depends on no private helper.
+extension HTTPDesktopClient {
+
+    // MARK: - Proposals: review (HSM equilibrium wave 3)
+
+    /// `GET /api/meetings/{meetingId}/proposals` → the review queue. A pure read —
+    /// viewing a proposal performs no side effect on the hub. Throws
+    /// `DesktopClientError.http` on a non-2xx (e.g. 404 unknown meeting) and
+    /// `.malformed` if the envelope can't be decoded.
+    public func meetingProposals(meetingId: String) async throws -> [MeetingProposal] {
+        let request = proposalsRequest(
+            path: "api/meetings/\(escape(meetingId))/proposals", method: "GET")
+        let data = try await proposalsSend(request)
+        do {
+            return try HoldSpeakContracts.decoder()
+                .decode(MeetingProposalsEnvelope.self, from: data).proposals
+        } catch {
+            throw DesktopClientError.malformed
+        }
+    }
+
+    /// `POST /api/meetings/{meetingId}/proposals/{proposalId}/decision` with body
+    /// `{ "decision": "approved"|"rejected" }`. `approved` maps to the hub's two legal
+    /// strings; the route rejects anything else. Returns the decision envelope
+    /// (`success` + the transitioned `proposal`, or `error` on an illegal transition
+    /// such as deciding an already-executed proposal). A non-2xx (404 unknown
+    /// proposal, 400 illegal decision) throws `DesktopClientError.http`.
+    public func decideProposal(
+        meetingId: String, proposalId: String, approved: Bool
+    ) async throws -> ProposalDecision {
+        let body = ["decision": approved ? "approved" : "rejected"]
+        let request = proposalsRequest(
+            path: "api/meetings/\(escape(meetingId))/proposals/\(escape(proposalId))/decision",
+            method: "POST", jsonBody: body)
+        let data = try await proposalsSend(request)
+        do {
+            return try HoldSpeakContracts.decoder().decode(ProposalDecision.self, from: data)
+        } catch {
+            throw DesktopClientError.malformed
+        }
+    }
+
+    // MARK: - internals (self-contained; no dependency on private helpers)
+
+    /// Percent-encode a path segment so an id with reserved characters can't break
+    /// the URL. Falls back to the raw value if encoding somehow fails.
+    private func escape(_ segment: String) -> String {
+        segment.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? segment
+    }
+
+    /// Run a request against the hub, throwing `DesktopClientError.http` on a non-2xx
+    /// so the review view-model can render an honest failure (mirrors the
+    /// `send(_:)` discipline in HTTPDesktopClient.swift).
+    private func proposalsSend(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        return data
+    }
+
+    /// Build a Bearer-authed request the same way HTTPDesktopClient does, but inline
+    /// (no private-helper dependency). Trims a trailing slash off the base, attaches
+    /// the token when present, and JSON-encodes a string body for the decision POST.
+    private func proposalsRequest(
+        path: String, method: String, jsonBody: [String: String]? = nil
+    ) -> URLRequest {
+        let absolute = config.baseURL.absoluteString
+        let base = absolute.hasSuffix("/") ? String(absolute.dropLast()) : absolute
+        var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
+        request.httpMethod = method
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let jsonBody {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try? JSONSerialization.data(withJSONObject: jsonBody)
+        }
+        return request
+    }
+}

--- a/apple/Tests/ProvidersTests/AftercareClientTests.swift
+++ b/apple/Tests/ProvidersTests/AftercareClientTests.swift
@@ -1,0 +1,253 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HSM Aftercare client layer — decode round-trips + the client verbs over a stubbed
+/// network (URLProtocol, fully offline). Proves the digest from
+/// `GET /api/meetings/{id}/aftercare` decodes faithfully (open_items.by_owner,
+/// decisions, since_last_meeting, is_empty) and the `POST .../file-issue` envelope
+/// decodes to a proposal + preview. Mirrors DesktopClientTests' stub posture.
+final class AftercareClientTests: XCTestCase {
+
+    // MARK: stub (same shape as DesktopClientTests.StubProtocol)
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastMethod: String?
+        nonisolated(unsafe) static var lastBody: Data?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastMethod = request.httpMethod
+            StubProtocol.lastBody = request.httpBody
+                ?? request.httpBodyStream.map { stream -> Data in
+                    stream.open(); defer { stream.close() }
+                    var data = Data(); var buf = [UInt8](repeating: 0, count: 4096)
+                    while stream.hasBytesAvailable {
+                        let n = stream.read(&buf, maxLength: buf.count)
+                        if n <= 0 { break }
+                        data.append(buf, count: n)
+                    }
+                    return data
+                }
+            let path = request.url?.path ?? ""
+            guard let (status, body) = StubProtocol.routes[path] else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost)); return
+            }
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.lastMethod = nil
+        StubProtocol.lastBody = nil
+    }
+
+    private func client(token: String? = nil) -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    // A realistic, fully-populated digest (the shape compute_meeting_aftercare emits).
+    private let digestJSON = #"""
+    {
+      "meeting_id": "m1",
+      "meeting_title": "Arch review",
+      "meeting_date": "2026-06-20T10:00:00+00:00",
+      "open_items": {
+        "total": 3,
+        "by_owner": [
+          {
+            "owner": "Karol",
+            "count": 2,
+            "items": [
+              {"id": "a1", "task": "Wire the sync transport", "owner": "Karol",
+               "due": "2026-06-25", "review_state": "accepted", "source_timestamp": 12.5,
+               "provenance": {"source_timestamp": 12.5, "segment_index": 4, "segment_start": 11.0,
+                              "speaker": "Karol", "text_preview": "let's wire the transport next"},
+               "meeting_id": "m1"},
+              {"id": "a2", "task": "Draft the contract", "owner": "Karol",
+               "due": null, "review_state": "pending", "source_timestamp": null,
+               "provenance": null, "meeting_id": "m1"}
+            ]
+          },
+          {
+            "owner": null,
+            "count": 1,
+            "items": [
+              {"id": "a3", "task": "Book the room", "owner": null, "due": null,
+               "review_state": "pending", "source_timestamp": null, "provenance": null,
+               "meeting_id": "m1"}
+            ]
+          }
+        ]
+      },
+      "decisions": [
+        {"decision": "Ship the iPad companion", "rationale": "Track M gate achieved",
+         "source_timestamp": 30.0,
+         "provenance": {"source_timestamp": 30.0, "segment_index": 9, "segment_start": 29.5,
+                        "speaker": "Karol", "text_preview": "we ship the companion"}},
+        {"decision": "Defer Windows", "rationale": null, "source_timestamp": null, "provenance": null}
+      ],
+      "since_last_meeting": {
+        "previous_meeting": {"id": "m0", "title": "Kickoff", "date": "2026-06-19T09:00:00+00:00"},
+        "new_decisions": [
+          {"decision": "Ship the iPad companion", "rationale": "Track M gate achieved",
+           "source_timestamp": 30.0, "provenance": null}
+        ],
+        "new_actions": [
+          {"id": "a1", "task": "Wire the sync transport", "owner": "Karol", "due": "2026-06-25",
+           "review_state": "accepted", "source_timestamp": 12.5, "provenance": null, "meeting_id": "m1"}
+        ],
+        "closed_actions": [
+          {"id": "a0", "task": "Pick the engine", "owner": "Karol", "status": "done", "meeting_id": "m0"}
+        ],
+        "changed": true
+      },
+      "is_empty": false,
+      "slack_configured": true
+    }
+    """#
+
+    // MARK: digest decode round-trip (direct + through the client)
+
+    func testAftercareDigestDecodesFaithfully() throws {
+        let digest = try HoldSpeakContracts.decoder().decode(Aftercare.self, from: Data(digestJSON.utf8))
+
+        XCTAssertEqual(digest.meetingId, "m1")
+        XCTAssertEqual(digest.meetingTitle, "Arch review")
+        XCTAssertFalse(digest.isEmpty)
+        XCTAssertEqual(digest.slackConfigured, true)
+
+        // open_items.by_owner — named owner first, unassigned (nil) last.
+        XCTAssertEqual(digest.openItems.total, 3)
+        XCTAssertEqual(digest.openItems.byOwner.count, 2)
+        let karol = digest.openItems.byOwner[0]
+        XCTAssertEqual(karol.owner, "Karol")
+        XCTAssertEqual(karol.count, 2)
+        XCTAssertEqual(karol.items.first?.id, "a1")
+        XCTAssertEqual(karol.items.first?.reviewState, "accepted")
+        XCTAssertEqual(karol.items.first?.provenance?.segmentIndex, 4)
+        XCTAssertEqual(karol.items.first?.provenance?.textPreview, "let's wire the transport next")
+        XCTAssertNil(digest.openItems.byOwner[1].owner)   // unassigned group
+
+        // decisions
+        XCTAssertEqual(digest.decisions.count, 2)
+        XCTAssertEqual(digest.decisions[0].decision, "Ship the iPad companion")
+        XCTAssertEqual(digest.decisions[0].rationale, "Track M gate achieved")
+        XCTAssertNil(digest.decisions[1].rationale)
+
+        // since_last_meeting diff
+        let since = try XCTUnwrap(digest.sinceLastMeeting)
+        XCTAssertTrue(since.changed)
+        XCTAssertEqual(since.previousMeeting?.id, "m0")
+        XCTAssertEqual(since.previousMeeting?.title, "Kickoff")
+        XCTAssertEqual(since.newDecisions.count, 1)
+        XCTAssertEqual(since.newActions.first?.id, "a1")
+        XCTAssertEqual(since.closedActions.first?.status, "done")
+    }
+
+    func testEmptyDigestDecodes() throws {
+        let json = #"""
+        {"meeting_id": "m9", "meeting_title": null, "meeting_date": "2026-06-20T10:00:00+00:00",
+         "open_items": {"total": 0, "by_owner": []}, "decisions": [],
+         "since_last_meeting": null, "is_empty": true, "slack_configured": false}
+        """#
+        let digest = try HoldSpeakContracts.decoder().decode(Aftercare.self, from: Data(json.utf8))
+        XCTAssertTrue(digest.isEmpty)
+        XCTAssertEqual(digest.openItems.total, 0)
+        XCTAssertTrue(digest.openItems.byOwner.isEmpty)
+        XCTAssertNil(digest.sinceLastMeeting)            // no prior meeting → no delta invented
+        XCTAssertEqual(digest.slackConfigured, false)
+    }
+
+    func testAftercareClientGETsAndDecodes() async throws {
+        StubProtocol.routes = ["/api/meetings/m1/aftercare": (200, Data(digestJSON.utf8))]
+        let digest = try await client(token: "tok").aftercare(meetingId: "m1")
+        XCTAssertEqual(StubProtocol.lastMethod, "GET")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")   // Bearer token rides
+        XCTAssertEqual(digest.meetingId, "m1")
+        XCTAssertEqual(digest.openItems.byOwner.first?.items.first?.task, "Wire the sync transport")
+    }
+
+    func testAftercare404Throws() async {
+        StubProtocol.routes = ["/api/meetings/nope/aftercare": (404, Data(#"{"error":"Meeting not found"}"#.utf8))]
+        do { _ = try await client().aftercare(meetingId: "nope"); XCTFail("expected throw") }
+        catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 404) }
+        catch { XCTFail("wrong error: \(error)") }
+    }
+
+    // MARK: file-issue
+
+    func testFileAftercareIssuePostsAndDecodesProposal() async throws {
+        let body = #"""
+        {"success": true,
+         "proposal": {
+            "id": "p1", "meeting_id": "m1", "window_id": "m1:aftercare",
+            "plugin_id": "github_issue", "plugin_version": "1.0.0", "status": "proposed",
+            "target": "octo/repo", "action": "create_issue",
+            "preview": "Open issue in octo/repo: Wire the sync transport",
+            "reversible": false, "required_capabilities": ["github:issues:write"],
+            "decided_by": null, "error": null,
+            "created_at": "2026-06-27T12:00:00+00:00", "decided_at": null, "executed_at": null}}
+        """#
+        StubProtocol.routes = ["/api/meetings/m1/aftercare/file-issue": (200, Data(body.utf8))]
+
+        let result = try await client(token: "tok").fileAftercareIssue(
+            meetingId: "m1", actionItemId: "a1", repo: "octo/repo")
+
+        XCTAssertEqual(StubProtocol.lastMethod, "POST")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")
+        // The body carries both the action item id and the target repo verbatim.
+        let sent = try XCTUnwrap(StubProtocol.lastBody)
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: sent) as? [String: Any])
+        XCTAssertEqual(obj["action_item_id"] as? String, "a1")
+        XCTAssertEqual(obj["repo"] as? String, "octo/repo")
+
+        XCTAssertTrue(result.success)
+        let proposal = try XCTUnwrap(result.proposal)
+        XCTAssertEqual(proposal.id, "p1")
+        XCTAssertEqual(proposal.status, "proposed")            // proposed only — nothing sent
+        XCTAssertEqual(proposal.target, "octo/repo")
+        XCTAssertEqual(proposal.preview, "Open issue in octo/repo: Wire the sync transport")
+        XCTAssertEqual(proposal.requiredCapabilities, ["github:issues:write"])
+        XCTAssertNotNil(proposal.createdAt)                    // ISO date decodes
+        XCTAssertNil(proposal.executedAt)
+    }
+
+    func testFileAftercareIssueErrorEnvelopeDecodesOn400() throws {
+        // The route returns {"success": false, "error": "..."} with a 4xx for a
+        // non-accepted item; decode the envelope shape directly.
+        let body = #"{"success": false, "error": "Only an accepted action item can be filed as an issue"}"#
+        let result = try HoldSpeakContracts.decoder().decode(
+            AftercareFileIssueResult.self, from: Data(body.utf8))
+        XCTAssertFalse(result.success)
+        XCTAssertNil(result.proposal)
+        XCTAssertEqual(result.error, "Only an accepted action item can be filed as an issue")
+    }
+
+    func testFileAftercareIssue400Throws() async {
+        StubProtocol.routes = ["/api/meetings/m1/aftercare/file-issue":
+            (400, Data(#"{"success":false,"error":"A target repo (owner/name) is required"}"#.utf8))]
+        do {
+            _ = try await client().fileAftercareIssue(meetingId: "m1", actionItemId: "a1", repo: "x")
+            XCTFail("expected throw")
+        } catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 400) }
+        catch { XCTFail("wrong error: \(error)") }
+    }
+}

--- a/apple/Tests/ProvidersTests/ArtifactsClientTests.swift
+++ b/apple/Tests/ProvidersTests/ArtifactsClientTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import Contracts
+
+// EQ-W3 (iOS artifacts) — decode round-trip for the `GET /api/meetings/{id}/artifacts`
+// response. The load-bearing assertions: `confidence` and `sources` decode (the two
+// fields the iPad render currently drops), plus the type/title/body/status the
+// SwiftUI screen already shows. The JSON literal mirrors the exact shape
+// holdspeak/web/routes/meetings.py::api_get_meeting_artifacts returns.
+final class ArtifactsClientTests: XCTestCase {
+
+    private static let envelopeJSON = """
+    {
+      "meeting_id": "mtg-2026-06-27-a",
+      "artifacts": [
+        {
+          "id": "art-001",
+          "meeting_id": "mtg-2026-06-27-a",
+          "artifact_type": "decisions",
+          "title": "Decisions",
+          "body_markdown": "## Decisions\\n- Ship EQ-W3 client slices in parallel worktrees.",
+          "structured_json": {"decisions": ["ship the equilibrium wave"]},
+          "confidence": 0.82,
+          "status": "needs_review",
+          "plugin_id": "decisions.core",
+          "plugin_version": "1.0.0",
+          "sources": [
+            {"source_type": "intent_window", "source_ref": "win-7"},
+            {"source_type": "plugin_run", "source_ref": "run-42"}
+          ],
+          "created_at": "2026-06-27T10:00:00Z",
+          "updated_at": "2026-06-27T10:05:00Z"
+        }
+      ]
+    }
+    """
+
+    func testDecodesEnvelopeWithConfidenceAndSources() throws {
+        let data = Data(Self.envelopeJSON.utf8)
+        let envelope = try HoldSpeakContracts.decoder()
+            .decode(MeetingArtifactsEnvelope.self, from: data)
+
+        XCTAssertEqual(envelope.meetingId, "mtg-2026-06-27-a")
+        XCTAssertEqual(envelope.artifacts.count, 1)
+
+        let artifact = try XCTUnwrap(envelope.artifacts.first)
+        XCTAssertEqual(artifact.id, "art-001")
+        XCTAssertEqual(artifact.meetingId, "mtg-2026-06-27-a")
+        XCTAssertEqual(artifact.artifactType, "decisions")
+        XCTAssertEqual(artifact.title, "Decisions")
+        XCTAssertTrue(artifact.bodyMarkdown.contains("Ship EQ-W3"))
+        XCTAssertEqual(artifact.status, "needs_review")
+        XCTAssertEqual(artifact.pluginId, "decisions.core")
+
+        // The audit fix — confidence decodes (and is the right value).
+        XCTAssertEqual(try XCTUnwrap(artifact.confidence), 0.82, accuracy: 0.0001)
+
+        // The audit fix — the provenance list decodes with snake_case keys mapped.
+        XCTAssertEqual(artifact.sources.count, 2)
+        XCTAssertEqual(artifact.sources[0].sourceType, "intent_window")
+        XCTAssertEqual(artifact.sources[0].sourceRef, "win-7")
+        XCTAssertEqual(artifact.sources[1].sourceType, "plugin_run")
+        XCTAssertEqual(artifact.sources[1].sourceRef, "run-42")
+
+        XCTAssertNotNil(artifact.createdAt)
+        XCTAssertNotNil(artifact.updatedAt)
+    }
+
+    /// `confidence` is `Double?` per the slice spec: an artifact without it still
+    /// decodes (the iPad render must tolerate its absence), and `sources` defaults
+    /// to empty when omitted is NOT allowed by the route — but a present-empty list
+    /// decodes cleanly.
+    func testConfidenceIsOptionalAndEmptySourcesDecode() throws {
+        let json = """
+        {
+          "meeting_id": "m1",
+          "artifacts": [
+            {
+              "id": "a1",
+              "meeting_id": "m1",
+              "artifact_type": "action_items",
+              "title": "Action Items",
+              "body_markdown": "- do the thing",
+              "structured_json": {},
+              "confidence": null,
+              "status": "draft",
+              "plugin_id": "action_items.core",
+              "plugin_version": "1.0.0",
+              "sources": [],
+              "created_at": "2026-06-27T11:00:00Z",
+              "updated_at": "2026-06-27T11:00:00Z"
+            }
+          ]
+        }
+        """
+        let envelope = try HoldSpeakContracts.decoder()
+            .decode(MeetingArtifactsEnvelope.self, from: Data(json.utf8))
+        let artifact = try XCTUnwrap(envelope.artifacts.first)
+        XCTAssertNil(artifact.confidence)
+        XCTAssertTrue(artifact.sources.isEmpty)
+        XCTAssertEqual(artifact.artifactType, "action_items")
+    }
+}

--- a/apple/Tests/ProvidersTests/FacetsClientTests.swift
+++ b/apple/Tests/ProvidersTests/FacetsClientTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HS-55-04 (mobile) — the faceted meeting archive client. Network stubbed via
+/// `URLProtocol`; deterministic and offline. Proves: `/api/meetings/facets` decodes
+/// into `MeetingFacets`, the searched `/api/meetings` envelope decodes into
+/// `[MeetingSummary]`, the Bearer token rides, and the `MeetingFacets` contract type
+/// round-trips a realistic hub payload (incl. the empty-archive / partial cases).
+final class FacetsClientTests: XCTestCase {
+
+    // MARK: stub (matches on path; query string is stripped by `URLRequest.url.path`)
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastQuery: String?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastQuery = request.url?.query
+            let path = request.url?.path ?? ""
+            guard let (status, body) = StubProtocol.routes[path] else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.lastQuery = nil
+    }
+
+    private func client(token: String? = nil) -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    // MARK: - MeetingFacets contract decode round-trip
+
+    func testFacetsTypeDecodesRealisticPayload() throws {
+        let json = #"{"speakers":["Alex","Dana Lee"],"tags":["q3","standup"]}"#
+        let facets = try HoldSpeakContracts.decoder().decode(MeetingFacets.self, from: Data(json.utf8))
+        XCTAssertEqual(facets.speakers, ["Alex", "Dana Lee"])
+        XCTAssertEqual(facets.tags, ["q3", "standup"])
+    }
+
+    func testFacetsTypeToleratesEmptyArchive() throws {
+        let facets = try HoldSpeakContracts.decoder().decode(MeetingFacets.self, from: Data(#"{"speakers":[],"tags":[]}"#.utf8))
+        XCTAssertTrue(facets.speakers.isEmpty)
+        XCTAssertTrue(facets.tags.isEmpty)
+    }
+
+    func testFacetsTypeToleratesPartialPayload() throws {
+        // A future/partial payload missing one array still decodes (robust posture).
+        let facets = try HoldSpeakContracts.decoder().decode(MeetingFacets.self, from: Data(#"{"speakers":["Sam"]}"#.utf8))
+        XCTAssertEqual(facets.speakers, ["Sam"])
+        XCTAssertTrue(facets.tags.isEmpty)
+    }
+
+    // MARK: - listFacets() over the client
+
+    func testListFacetsDecodesAndSendsToken() async throws {
+        StubProtocol.routes = [
+            "/api/meetings/facets": (200, Data(#"{"speakers":["Alex","Dana"],"tags":["q3"]}"#.utf8)),
+        ]
+        let facets = try await client(token: "t0ken").listFacets()
+        XCTAssertEqual(facets.speakers, ["Alex", "Dana"])
+        XCTAssertEqual(facets.tags, ["q3"])
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer t0ken")
+    }
+
+    func testListFacetsThrowsHTTPOnNon2xx() async {
+        StubProtocol.routes = ["/api/meetings/facets": (500, Data())]
+        do {
+            _ = try await client().listFacets()
+            XCTFail("expected an http error")
+        } catch let HTTPDesktopClient.DesktopClientError.http(code) {
+            XCTAssertEqual(code, 500)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - searchMeetings(...) over the client
+
+    func testSearchMeetingsDecodesEnvelopeAndCarriesQuery() async throws {
+        // The hub's faceted /api/meetings envelope: summaries + a `total`.
+        let body = #"""
+        {"meetings":[
+          {"id":"m1","title":"Q3 Standup","started_at":"2026-06-27T09:00:00Z",
+           "ended_at":"2026-06-27T09:30:00Z","duration_seconds":1800.0,
+           "segment_count":42,"action_item_count":3,"tags":["q3","standup"],
+           "intel_status":"ready","intel_status_detail":null}
+        ],"total":1}
+        """#
+        StubProtocol.routes = ["/api/meetings": (200, Data(body.utf8))]
+
+        let meetings = try await client(token: "t0ken")
+            .searchMeetings(query: "roadmap", speaker: "Dana", type: "q3")
+
+        XCTAssertEqual(meetings.count, 1)
+        let m = try XCTUnwrap(meetings.first)
+        XCTAssertEqual(m.id, "m1")
+        XCTAssertEqual(m.title, "Q3 Standup")
+        XCTAssertEqual(m.segmentCount, 42)
+        XCTAssertEqual(m.actionItemCount, 3)
+        XCTAssertEqual(m.intelStatus, "ready")
+
+        // Every supplied facet rides as the hub's expected query param.
+        let q = try XCTUnwrap(StubProtocol.lastQuery)
+        XCTAssertTrue(q.contains("search=roadmap"), q)
+        XCTAssertTrue(q.contains("speaker=Dana"), q)
+        XCTAssertTrue(q.contains("tag=q3"), q)
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer t0ken")
+    }
+
+    func testSearchMeetingsWithNoFiltersSendsNoQuery() async throws {
+        StubProtocol.routes = ["/api/meetings": (200, Data(#"{"meetings":[],"total":0}"#.utf8))]
+        let meetings = try await client().searchMeetings()
+        XCTAssertTrue(meetings.isEmpty)
+        XCTAssertNil(StubProtocol.lastQuery)   // no params → bare path
+    }
+}

--- a/apple/Tests/ProvidersTests/ProposalsClientTests.swift
+++ b/apple/Tests/ProvidersTests/ProposalsClientTests.swift
@@ -1,0 +1,256 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HSM equilibrium wave 3 — the propose→review→approve client slice. A decode
+/// round-trip over a realistic hub payload (`_proposal_to_dict` in
+/// `holdspeak/web/routes/meetings.py`) plus a stubbed drive of the two client
+/// methods, proving the route paths, the Bearer header, the decision body shape,
+/// and that the responses decode into MeetingProposal / ProposalDecision.
+/// Fully offline (URLProtocol stub) — no real desktop.
+final class ProposalsClientTests: XCTestCase {
+
+    // MARK: stub (mirrors DesktopClientTests' StubProtocol; records last request)
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastMethod: String?
+        nonisolated(unsafe) static var lastPath: String?
+        nonisolated(unsafe) static var lastBody: Data?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastMethod = request.httpMethod
+            StubProtocol.lastPath = request.url?.path
+            // URLProtocol strips httpBody into httpBodyStream; read it back.
+            if let stream = request.httpBodyStream {
+                stream.open()
+                var data = Data()
+                let bufSize = 1024
+                let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+                while stream.hasBytesAvailable {
+                    let read = stream.read(buf, maxLength: bufSize)
+                    if read <= 0 { break }
+                    data.append(buf, count: read)
+                }
+                buf.deallocate()
+                stream.close()
+                StubProtocol.lastBody = data
+            } else {
+                StubProtocol.lastBody = request.httpBody
+            }
+            let path = request.url?.path ?? ""
+            guard let (status, body) = StubProtocol.routes[path] else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    private func client(token: String? = "t0ken") -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.lastMethod = nil
+        StubProtocol.lastPath = nil
+        StubProtocol.lastBody = nil
+    }
+
+    // A realistic GET /api/meetings/{id}/proposals envelope: one undecided slack
+    // proposal (null decided_at/executed_at/decided_by/result/error) — the exact
+    // shape `_proposal_to_dict` serializes.
+    private let proposalsJSON = #"""
+    {
+      "meeting_id": "m-42",
+      "proposals": [
+        {
+          "id": "p-1",
+          "meeting_id": "m-42",
+          "window_id": "w-7",
+          "plugin_id": "slack_export",
+          "plugin_version": "1.0.0",
+          "status": "proposed",
+          "target": "slack",
+          "action": "send_message",
+          "preview": "Posting the meeting digest to #standup",
+          "payload": {"channel": "#standup", "blocks": 3},
+          "reversible": false,
+          "required_capabilities": ["network.slack"],
+          "decided_by": null,
+          "result": null,
+          "error": null,
+          "created_at": "2026-06-27T14:03:11Z",
+          "decided_at": null,
+          "executed_at": null
+        }
+      ]
+    }
+    """#
+
+    // MARK: decode round-trip
+
+    func testProposalsEnvelopeDecodes() throws {
+        let env = try HoldSpeakContracts.decoder()
+            .decode(MeetingProposalsEnvelope.self, from: Data(proposalsJSON.utf8))
+        XCTAssertEqual(env.meetingId, "m-42")
+        XCTAssertEqual(env.proposals.count, 1)
+
+        let p = try XCTUnwrap(env.proposals.first)
+        XCTAssertEqual(p.id, "p-1")
+        XCTAssertEqual(p.meetingId, "m-42")
+        XCTAssertEqual(p.windowId, "w-7")
+        XCTAssertEqual(p.pluginId, "slack_export")
+        XCTAssertEqual(p.status, .proposed)
+        XCTAssertEqual(p.target, "slack")
+        XCTAssertEqual(p.action, "send_message")
+        XCTAssertEqual(p.preview, "Posting the meeting digest to #standup")
+        XCTAssertFalse(p.reversible)
+        XCTAssertEqual(p.requiredCapabilities, ["network.slack"])
+        XCTAssertNil(p.decidedBy)
+        XCTAssertNil(p.decidedAt)
+        XCTAssertNil(p.executedAt)
+        XCTAssertNotNil(p.createdAt)               // ISO-8601 Z decoded
+        XCTAssertEqual(p.payload, .object(["channel": .string("#standup"),
+                                           "blocks": .number(3)]))
+    }
+
+    func testDecisionEnvelopeDecodes() throws {
+        // An approved slack proposal executes immediately → comes back `executed`.
+        let json = #"""
+        {
+          "success": true,
+          "proposal": {
+            "id": "p-1",
+            "meeting_id": "m-42",
+            "window_id": "w-7",
+            "plugin_id": "slack_export",
+            "plugin_version": "1.0.0",
+            "status": "executed",
+            "target": "slack",
+            "action": "send_message",
+            "preview": "Posting the meeting digest to #standup",
+            "payload": {"channel": "#standup"},
+            "reversible": false,
+            "required_capabilities": ["network.slack"],
+            "decided_by": "ipad-user",
+            "result": {"ok": true},
+            "error": null,
+            "created_at": "2026-06-27T14:03:11Z",
+            "decided_at": "2026-06-27T14:05:00Z",
+            "executed_at": "2026-06-27T14:05:01Z"
+          }
+        }
+        """#
+        let decision = try HoldSpeakContracts.decoder()
+            .decode(ProposalDecision.self, from: Data(json.utf8))
+        XCTAssertTrue(decision.success)
+        XCTAssertNil(decision.error)
+        let p = try XCTUnwrap(decision.proposal)
+        XCTAssertEqual(p.status, .executed)
+        XCTAssertEqual(p.decidedBy, "ipad-user")
+        XCTAssertNotNil(p.decidedAt)
+        XCTAssertNotNil(p.executedAt)
+        XCTAssertEqual(p.result, .object(["ok": .bool(true)]))
+    }
+
+    func testIllegalDecisionEnvelopeDecodes() throws {
+        // The hub returns success:false + error on an illegal transition.
+        let json = #"{"success": false, "error": "proposal already executed"}"#
+        let decision = try HoldSpeakContracts.decoder()
+            .decode(ProposalDecision.self, from: Data(json.utf8))
+        XCTAssertFalse(decision.success)
+        XCTAssertNil(decision.proposal)
+        XCTAssertEqual(decision.error, "proposal already executed")
+    }
+
+    // MARK: stubbed client drive — route paths, Bearer, decision body
+
+    func testMeetingProposalsHitsRouteWithBearer() async throws {
+        StubProtocol.routes = ["/api/meetings/m-42/proposals": (200, Data(proposalsJSON.utf8))]
+        let proposals = try await client().meetingProposals(meetingId: "m-42")
+        XCTAssertEqual(proposals.count, 1)
+        XCTAssertEqual(proposals.first?.id, "p-1")
+        XCTAssertEqual(StubProtocol.lastMethod, "GET")
+        XCTAssertEqual(StubProtocol.lastPath, "/api/meetings/m-42/proposals")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer t0ken")
+    }
+
+    func testDecideProposalPostsApprovedDecision() async throws {
+        let okJSON = #"""
+        {"success": true, "proposal": {
+          "id": "p-1", "meeting_id": "m-42", "window_id": null,
+          "plugin_id": "slack_export", "plugin_version": "1.0.0",
+          "status": "approved", "target": "slack", "action": "send_message",
+          "preview": "x", "payload": null, "reversible": false,
+          "required_capabilities": [], "decided_by": "ipad-user",
+          "result": null, "error": null, "created_at": "2026-06-27T14:03:11Z",
+          "decided_at": "2026-06-27T14:05:00Z", "executed_at": null
+        }}
+        """#
+        StubProtocol.routes = [
+            "/api/meetings/m-42/proposals/p-1/decision": (200, Data(okJSON.utf8))
+        ]
+        let decision = try await client().decideProposal(
+            meetingId: "m-42", proposalId: "p-1", approved: true)
+        XCTAssertTrue(decision.success)
+        XCTAssertEqual(decision.proposal?.status, .approved)
+        XCTAssertEqual(StubProtocol.lastMethod, "POST")
+        XCTAssertEqual(StubProtocol.lastPath, "/api/meetings/m-42/proposals/p-1/decision")
+
+        // The body must carry decision:"approved" (approved=true → the hub string).
+        let body = try XCTUnwrap(StubProtocol.lastBody)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(obj["decision"], "approved")
+    }
+
+    func testDecideProposalRejectMapsToRejectedString() async throws {
+        let okJSON = #"""
+        {"success": true, "proposal": {
+          "id": "p-1", "meeting_id": "m-42", "window_id": null,
+          "plugin_id": "slack_export", "plugin_version": "1.0.0",
+          "status": "rejected", "target": "slack", "action": "send_message",
+          "preview": "x", "payload": null, "reversible": false,
+          "required_capabilities": [], "decided_by": "ipad-user",
+          "result": null, "error": null, "created_at": "2026-06-27T14:03:11Z",
+          "decided_at": "2026-06-27T14:05:00Z", "executed_at": null
+        }}
+        """#
+        StubProtocol.routes = [
+            "/api/meetings/m-42/proposals/p-1/decision": (200, Data(okJSON.utf8))
+        ]
+        _ = try await client().decideProposal(meetingId: "m-42", proposalId: "p-1", approved: false)
+        let body = try XCTUnwrap(StubProtocol.lastBody)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(obj["decision"], "rejected")
+    }
+
+    func testNon2xxThrowsHTTPError() async {
+        StubProtocol.routes = ["/api/meetings/nope/proposals": (404, Data())]
+        do {
+            _ = try await client().meetingProposals(meetingId: "nope")
+            XCTFail("expected a thrown HTTP error on 404")
+        } catch let HTTPDesktopClient.DesktopClientError.http(code) {
+            XCTAssertEqual(code, 404)
+        } catch {
+            XCTFail("expected DesktopClientError.http, got \(error)")
+        }
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
+++ b/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
@@ -114,4 +114,21 @@ Integrated + verified together: full Python suite **2924 passed**, web build gre
 
 Integrated + verified together: full Python suite green (route-preflight included, locally with Chromium), web build green. Cherry-pick note: the graph-builder + trust-chip both edited `desk.*` but git auto-merged them (additive, different regions).
 
+### Wave 3 (2026-06-27) — the iPad meeting-contract CLIENT layer (Phase 19), 4 gaps
+
+The first **iOS** build flotilla. Each agent built one typed `HTTPDesktopClient` client group in
+its OWN `+Feature.swift` extension file (+ Contracts type + a decode test), so they never collide
+with each other or the parallel teleprompter `+Dictation.swift`.
+
+| Gap | What landed |
+|-----|-------------|
+| Aftercare | `aftercare(meetingId:)` + `fileAftercareIssue(...)` + the `Aftercare` digest type (open items by owner, decisions, since-last diff). Agent caught that file-issue needs a `repo`. |
+| Faceted archive | `listFacets()` + `searchMeetings(query:speaker:type:)` + `MeetingFacets`. Agent read the real `db/meetings.py`: facets are `{speakers, tags}`, `type` maps to the `tag` param (corrected my brief). |
+| Artifact provenance | `meetingArtifacts(meetingId:)` + `MeetingArtifact` carrying the `confidence` + `sources` the iPad render currently drops. |
+| Proposals review | `meetingProposals(meetingId:)` + `decideProposal(...)` — the split propose→review→approve. |
+
+Verified together: `swift build --target Providers` + all `*ClientTests` (**39 tests**) green. This is
+the typed spine the Phase-19 SwiftUI screens (aftercare card, faceted archive, artifact ring, proposals
+review) consume next; the screens + the metal walk are hand-driven follow-ups.
+
 See [[project_primitive_framework]], [[project_phase15_the_mesh]], [[project_phase17_agent_sync]].


### PR DESCRIPTION
The first **iOS** build flotilla — 4 worktree agents, each a typed `HTTPDesktopClient` client group in its own `+Feature.swift` extension (+ Contracts type + decode test), so they never collide with each other or the teleprompter's `+Dictation.swift`.

| Client | What landed |
|--------|-------------|
| Aftercare | `aftercare(meetingId:)` + `fileAftercareIssue(...)` + the `Aftercare` digest (open items by owner, decisions, since-last diff). Agent caught file-issue needs a `repo`. |
| Faceted archive | `listFacets()` + `searchMeetings(query:speaker:type:)` + `MeetingFacets`. Agent read the real `db/meetings.py`: facets are `{speakers, tags}`, `type`→`tag` (corrected my brief). |
| Artifact provenance | `meetingArtifacts(meetingId:)` + `MeetingArtifact` carrying the `confidence` + `sources` the iPad render currently drops. |
| Proposals review | `meetingProposals(meetingId:)` + `decideProposal(...)` — the split propose→review→approve. |

**Verified together:** `swift build --target Providers` + all `*ClientTests` (**39 tests**) green, no cross-agent collisions. This is the typed spine the Phase-19 SwiftUI screens (aftercare card, faceted archive, artifact ring, proposals review) consume next — screens + the metal walk are hand-driven follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)