### PR TITLE
Equilibrium Wave 4: iPad schema safety + activity client + a /desk null-guard

### DIFF
--- a/apple/Sources/Contracts/ActivityNudge.swift
+++ b/apple/Sources/Contracts/ActivityNudge.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+// Equilibrium 18-05 — the iPad's model of the desktop's source-cited pre-briefing
+// nudges (HoldSpeak Phase 53). Mirrors `Nudge.to_dict()` / `NudgeCitation.to_dict()`
+// in `holdspeak/activity_nudges.py` exactly: snake_case wire keys decode to these
+// camelCase properties via `.convertFromSnakeCase` (Coding.swift) — no manual
+// `CodingKeys`. Every optional matches a `None`-able Python field so a sparse card
+// still decodes (the codebase's robust-decode posture).
+
+/// A source citation for a nudge — names where the cited record came from, so the
+/// "Dictate with this" grounding is honest about its source (never fabricated).
+public struct NudgeCitation: Codable, Equatable, Sendable {
+    public var recordId: Int
+    public var sourceBrowser: String
+    public var sourceProfile: String
+    public var entityType: String?
+    public var entityId: String?
+    public var domain: String
+    public var title: String?
+    public var url: String
+    /// ISO-8601 instant kept as a wire string: it is `None`-able server-side, and
+    /// holding the raw string avoids coupling the decoder's date strategy to a field
+    /// the UI only displays.
+    public var lastSeenAt: String?
+    public var visitCount: Int
+
+    public init(recordId: Int, sourceBrowser: String, sourceProfile: String,
+                entityType: String? = nil, entityId: String? = nil, domain: String,
+                title: String? = nil, url: String, lastSeenAt: String? = nil,
+                visitCount: Int) {
+        self.recordId = recordId
+        self.sourceBrowser = sourceBrowser
+        self.sourceProfile = sourceProfile
+        self.entityType = entityType
+        self.entityId = entityId
+        self.domain = domain
+        self.title = title
+        self.url = url
+        self.lastSeenAt = lastSeenAt
+        self.visitCount = visitCount
+    }
+}
+
+/// A single source-cited pre-briefing nudge. The `key` is the deterministic id the
+/// dismiss route takes (e.g. `record:42` / `window:<iso>`); a `record`-kind nudge's
+/// first citation's `recordId` is what `selectNudge` parks for the next dictation.
+public struct ActivityNudge: Codable, Equatable, Sendable {
+    public var key: String
+    public var kind: String   // "window" | "record"
+    public var title: String
+    public var body: String
+    public var score: Double
+    public var citations: [NudgeCitation]
+    public var windowSince: String?
+    public var windowRecordCount: Int
+    /// Free-form server extras; kept as a typed blob so an evolving payload still
+    /// decodes. Defaults empty when the key is absent.
+    public var extras: [String: JSONValue]
+
+    public init(key: String, kind: String, title: String, body: String, score: Double,
+                citations: [NudgeCitation], windowSince: String? = nil,
+                windowRecordCount: Int = 0, extras: [String: JSONValue] = [:]) {
+        self.key = key
+        self.kind = kind
+        self.title = title
+        self.body = body
+        self.score = score
+        self.citations = citations
+        self.windowSince = windowSince
+        self.windowRecordCount = windowRecordCount
+        self.extras = extras
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.key = try c.decode(String.self, forKey: .key)
+        self.kind = try c.decode(String.self, forKey: .kind)
+        self.title = try c.decode(String.self, forKey: .title)
+        self.body = try c.decode(String.self, forKey: .body)
+        self.score = try c.decodeIfPresent(Double.self, forKey: .score) ?? 0
+        self.citations = try c.decodeIfPresent([NudgeCitation].self, forKey: .citations) ?? []
+        self.windowSince = try c.decodeIfPresent(String.self, forKey: .windowSince)
+        self.windowRecordCount = try c.decodeIfPresent(Int.self, forKey: .windowRecordCount) ?? 0
+        self.extras = try c.decodeIfPresent([String: JSONValue].self, forKey: .extras) ?? [:]
+    }
+}
+
+/// The desktop's project briefing surface (`GET /api/activity/briefing`): the most
+/// recent `meeting_context_briefing` annotation (markdown in `value`) when one
+/// exists, else `nil` — the iPad shows nothing rather than a fabricated digest.
+public struct ActivityBriefing: Codable, Equatable, Sendable {
+    public var id: Int
+    public var title: String?
+    public var value: String
+    public var updatedAt: String?
+
+    public init(id: Int, title: String? = nil, value: String, updatedAt: String? = nil) {
+        self.id = id
+        self.title = title
+        self.value = value
+        self.updatedAt = updatedAt
+    }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Activity.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Activity.swift
@@ -1,0 +1,129 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// Equilibrium 18-05 — the iPad's activity-nudge client. Until now the device never
+// called any `/api/activity/*` route, so the desktop's source-cited pre-briefing
+// nudges (and the "Dictate with this" grounding) were absent on mobile. This
+// extension closes that gap against the shapes in `holdspeak/web/routes/activity/`:
+//
+//   GET  /api/activity/nudges               → the cited cards (nudges.py)
+//   POST /api/activity/nudges/select        → park a record id for the next dictation
+//   POST /api/activity/nudges/{id}/dismiss  → persist a dismissal
+//   GET  /api/activity/briefing             → the project digest, when one exists
+//
+// Self-contained off the internal `config` (the file-private request helpers on the
+// base type are not reachable here): each request joins the Bearer token at call
+// time and never logs or echoes it (the Phase-61 credential discipline). Decoding
+// uses the shared `.convertFromSnakeCase` decoder so the contract types carry no
+// hand-written `CodingKeys` for the snake_case mapping.
+extension HTTPDesktopClient {
+
+    // MARK: - Activity nudges (Phase 53 → mobile)
+
+    /// `GET /api/activity/nudges` → the top source-cited nudges. Returns `[]` when
+    /// activity tracking is off (the desktop engine gates that); a non-2xx throws
+    /// `DesktopClientError.http` so the desk surfaces an honest failure.
+    public func activityNudges(projectId: String? = nil, limit: Int = 3) async throws -> [ActivityNudge] {
+        var path = "api/activity/nudges?limit=\(limit)"
+        if let projectId, !projectId.isEmpty,
+           let escaped = projectId.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) {
+            path += "&project_id=\(escaped)"
+        }
+        let data = try await activitySend(activityRequest(path: path))
+        do { return try HoldSpeakContracts.decoder().decode(NudgesEnvelope.self, from: data).nudges }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    /// `POST /api/activity/nudges/select` body `{record_id}` — parks the chosen
+    /// record id so the next dictation folds that activity record into its rewrite
+    /// context (the "Dictate with this" grounding). `record_id` MUST ride as a JSON
+    /// int: the desktop does `int(body.get("record_id"))` and 400s an unknown id.
+    public func selectNudge(recordId: Int) async throws {
+        _ = try await activitySend(activityJSONRequest(path: "api/activity/nudges/select",
+                                                       body: ["record_id": recordId]))
+    }
+
+    /// `POST /api/activity/nudges/{id}/dismiss` — persist a dismissal so the same
+    /// nudge does not return. `id` is the deterministic `ActivityNudge.key`
+    /// (e.g. `record:42` / `window:<iso>`), URL-escaped for the path.
+    public func dismissNudge(id: String) async throws {
+        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        _ = try await activitySend(activityRequest(path: "api/activity/nudges/\(escaped)/dismiss",
+                                                   method: "POST"))
+    }
+
+    /// `GET /api/activity/briefing` → the most-recent project briefing, or `nil` when
+    /// the desktop has none (the iPad shows nothing rather than a fabricated digest).
+    public func briefing() async throws -> ActivityBriefing? {
+        let data = try await activitySend(activityRequest(path: "api/activity/briefing"))
+        do { return try HoldSpeakContracts.decoder().decode(BriefingEnvelope.self, from: data).briefing }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    // MARK: - internals (self-contained; do not touch HTTPDesktopClient.swift)
+
+    struct NudgesEnvelope: Decodable {
+        var nudges: [ActivityNudge]
+        var activityEnabled: Bool?
+    }
+
+    /// The briefing route nests the digest under `briefing` (nullable) alongside a
+    /// `last_run` status row the mobile surface does not yet render.
+    struct BriefingEnvelope: Decodable {
+        var briefing: ActivityBriefing?
+    }
+
+    /// Run a request off the internal session, throwing `DesktopClientError.http` on
+    /// a non-2xx so the verb methods surface a real failure.
+    private func activitySend(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        return data
+    }
+
+    /// A GET/POST with no body, joining the Bearer token off `config` at call time.
+    private func activityRequest(path: String, method: String = "GET") -> URLRequest {
+        var request = URLRequest(url: activityURL(path: path))
+        request.httpMethod = method
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    /// A POST with a JSON body (a real int for `record_id`), Bearer joined off
+    /// `config` at call time.
+    private func activityJSONRequest(path: String, body: [String: Any]) -> URLRequest {
+        var request = URLRequest(url: activityURL(path: path))
+        request.httpMethod = "POST"
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func activityURL(path: String) -> URL {
+        let base = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        return URL(string: "\(base)/\(path)") ?? config.baseURL
+    }
+}
+
+private extension CharacterSet {
+    /// Query-value-safe set: alphanumerics plus the unreserved marks, so a value with
+    /// `&`/`=`/`/` is escaped rather than splitting the query.
+    static let urlQueryValueAllowed: CharacterSet = {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-._~")
+        return set
+    }()
+}

--- a/apple/Sources/Providers/Storage/SQLiteStorage.swift
+++ b/apple/Sources/Providers/Storage/SQLiteStorage.swift
@@ -7,6 +7,10 @@ private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.sel
 
 public enum StorageError: Error, Equatable {
     case open(String), exec(String), prepare(String)
+    /// The stored database is newer than this build understands. Raised instead
+    /// of touching the data, so an older build can never downgrade-stamp a
+    /// database written by a newer one (mirrors the desktop `SchemaVersionError`).
+    case tooNew(stored: Int32, build: Int32)
 }
 
 /// SQLite-backed `IStorage` + `ISyncStore` (HSM-4-01, HSM-10-01). Greenfield, WAL
@@ -31,6 +35,19 @@ public final class SQLiteStorage: IStorage, ISyncStore, @unchecked Sendable {
         guard sqlite3_open_v2(path, &db, flags, nil) == SQLITE_OK else {
             throw StorageError.open(lastError)
         }
+        // Read the stored version BEFORE migrating or stamping. A `user_version`
+        // greater than this build's schema means a NEWER build wrote it; refuse to
+        // open for writes (close the handle, throw) so we never downgrade-stamp it.
+        // This mirrors the desktop refuse-newer matrix (holdspeak/db/core.py
+        // `_ensure_schema` + `SchemaVersionError`). A fresh DB reads `user_version`
+        // as 0, which falls through to the create/equal paths unchanged.
+        let stored = (try? userVersion()) ?? 0
+        if stored > Self.schemaVersion {
+            sqlite3_close(db)
+            db = nil
+            throw StorageError.tooNew(stored: stored, build: Self.schemaVersion)
+        }
+
         try exec("PRAGMA journal_mode=WAL;")
         try exec("PRAGMA foreign_keys=ON;")
         try exec("""
@@ -42,14 +59,40 @@ public final class SQLiteStorage: IStorage, ISyncStore, @unchecked Sendable {
               modified_at TEXT, deleted INTEGER NOT NULL DEFAULT 0);
             CREATE INDEX IF NOT EXISTS idx_artifacts_meeting ON artifacts(meeting_id);
             """)
-        try migrateIfNeeded()
+        // An older DB (stored < build) is about to be ALTERed. Snapshot it first so
+        // an upgrade never changes data without leaving a recoverable copy. The
+        // equal/fresh path runs no ALTERs and takes no backup.
+        if stored > 0 && stored < Self.schemaVersion {
+            backupBeforeMigrate(path: path, stored: stored)
+        }
+        try migrateIfNeeded(stored: stored)
         try exec("PRAGMA user_version=\(Self.schemaVersion);")
+    }
+
+    /// Best-effort, logged copy of the SQLite file to a timestamped sibling before
+    /// an upgrade runs its ALTERs. A failed copy must not block opening the store,
+    /// so this never throws (mirrors the desktop `backup_database` safety net).
+    private func backupBeforeMigrate(path: String, stored: Int32) {
+        let timestamp = DateFormatter.backupTimestamp.string(from: Date())
+        var backup = "\(path).\(timestamp).bak"
+        let fm = FileManager.default
+        var counter = 1
+        while fm.fileExists(atPath: backup) {
+            backup = "\(path).\(timestamp)-\(counter).bak"
+            counter += 1
+        }
+        do {
+            try fm.copyItem(atPath: path, toPath: backup)
+            print("[SQLiteStorage] schema \(stored) < \(Self.schemaVersion); backed up to \(backup) before migrating")
+        } catch {
+            print("[SQLiteStorage] backup before migrate failed (continuing): \(error)")
+        }
     }
 
     /// v1 → v2: a pre-existing v1 DB lacks `modified_at`/`deleted`. Add them
     /// (guarded — ignore "duplicate column"). Greenfield, so this is the only step.
-    private func migrateIfNeeded() throws {
-        guard (try? userVersion()) ?? 0 < 2 else { return }
+    private func migrateIfNeeded(stored: Int32) throws {
+        guard stored < 2 else { return }
         for sql in [
             "ALTER TABLE meetings ADD COLUMN modified_at TEXT;",
             "ALTER TABLE meetings ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;",
@@ -218,4 +261,15 @@ public final class SQLiteStorage: IStorage, ISyncStore, @unchecked Sendable {
         }
         return out
     }
+}
+
+private extension DateFormatter {
+    /// `yyyyMMdd-HHmmss`, matching the desktop backup naming so a backup sibling
+    /// reads the same on both surfaces.
+    static let backupTimestamp: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyyMMdd-HHmmss"
+        return f
+    }()
 }

--- a/apple/Tests/ProvidersTests/ActivityClientTests.swift
+++ b/apple/Tests/ProvidersTests/ActivityClientTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// Equilibrium 18-05 — the iPad activity-nudge client. Network stubbed via
+/// `URLProtocol`; fully deterministic and offline (no real desktop). Proves: the
+/// source-cited cards decode against `Nudge.to_dict()` (snake_case via the shared
+/// decoder, no manual CodingKeys), the token rides as a Bearer header on every verb,
+/// `selectNudge` posts a real JSON int `record_id`, `dismissNudge` hits the keyed
+/// path, the briefing decodes (and `nil` when absent), and an HTTP error throws.
+final class ActivityClientTests: XCTestCase {
+
+    // MARK: stub (records body + auth + method + path)
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastMethod: String?
+        nonisolated(unsafe) static var lastPath: String?
+        nonisolated(unsafe) static var lastBody: Data?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastMethod = request.httpMethod
+            StubProtocol.lastPath = request.url?.path
+            StubProtocol.lastBody = request.httpBody ?? request.bodySteamData()
+            let path = request.url?.path ?? ""
+            guard let (status, body) = StubProtocol.routes[path] else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.lastMethod = nil
+        StubProtocol.lastPath = nil
+        StubProtocol.lastBody = nil
+    }
+
+    private func client(token: String? = nil) -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    // MARK: decode the source-cited cards
+
+    func testActivityNudgesDecodeServerShapeWithCitations() async throws {
+        StubProtocol.routes = ["/api/activity/nudges": (200, Data(#"""
+        {"nudges":[
+          {"key":"window:2026-06-27T12:00:00","kind":"window",
+           "title":"You touched 4 things since noon","body":"github.com, jira",
+           "score":0.91,"window_since":"2026-06-27T12:00:00","window_record_count":4,
+           "extras":{"headline":"recent"},
+           "citations":[
+             {"record_id":42,"source_browser":"chrome","source_profile":"Default",
+              "entity_type":"github_pull_request","entity_id":"7","domain":"github.com",
+              "title":"Fix the thing","url":"https://github.com/x/y/pull/7",
+              "last_seen_at":"2026-06-27T12:30:00Z","visit_count":3}
+           ]},
+          {"key":"record:99","kind":"record","title":"You were looking at a PR",
+           "body":"github.com","score":0.5,"window_since":null,"window_record_count":0,
+           "extras":{},"citations":[
+             {"record_id":99,"source_browser":"firefox","source_profile":"dev",
+              "entity_type":null,"entity_id":null,"domain":"example.com","title":null,
+              "url":"https://example.com","last_seen_at":null,"visit_count":1}
+           ]}
+        ],"activity_enabled":true}
+        """#.utf8))]
+
+        let nudges = try await client(token: "tok").activityNudges()
+        XCTAssertEqual(StubProtocol.lastMethod, "GET")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")   // Bearer joined at call time
+        XCTAssertEqual(nudges.count, 2)
+
+        let window = nudges[0]
+        XCTAssertEqual(window.key, "window:2026-06-27T12:00:00")
+        XCTAssertEqual(window.kind, "window")
+        XCTAssertEqual(window.score, 0.91, accuracy: 0.0001)
+        XCTAssertEqual(window.windowRecordCount, 4)
+        XCTAssertEqual(window.citations.count, 1)
+        let cite = window.citations[0]
+        XCTAssertEqual(cite.recordId, 42)                     // snake_case → camelCase, no CodingKeys
+        XCTAssertEqual(cite.sourceBrowser, "chrome")
+        XCTAssertEqual(cite.entityType, "github_pull_request")
+        XCTAssertEqual(cite.visitCount, 3)
+        XCTAssertEqual(cite.lastSeenAt, "2026-06-27T12:30:00Z")
+
+        let record = nudges[1]                                // a sparse record card still decodes
+        XCTAssertEqual(record.kind, "record")
+        XCTAssertNil(record.windowSince)
+        XCTAssertNil(record.citations[0].entityType)
+        XCTAssertNil(record.citations[0].title)
+        XCTAssertNil(record.citations[0].lastSeenAt)
+    }
+
+    func testActivityNudgesEmptyWhenTrackingOff() async throws {
+        StubProtocol.routes = ["/api/activity/nudges": (200,
+            Data(#"{"nudges":[],"activity_enabled":false}"#.utf8))]
+        let nudges = try await client().activityNudges()
+        XCTAssertTrue(nudges.isEmpty)
+    }
+
+    func testActivityNudgesHTTPErrorThrows() async {
+        StubProtocol.routes = ["/api/activity/nudges": (500, Data())]
+        do { _ = try await client().activityNudges(); XCTFail("expected throw") }
+        catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 500) }
+        catch { XCTFail("wrong error: \(error)") }
+    }
+
+    // MARK: select — the "Dictate with this" grounding (record_id as a JSON int)
+
+    func testSelectNudgePostsRealIntRecordId() async throws {
+        StubProtocol.routes = ["/api/activity/nudges/select": (200, Data(#"{"selected":42}"#.utf8))]
+        try await client(token: "tok").selectNudge(recordId: 42)
+        XCTAssertEqual(StubProtocol.lastMethod, "POST")
+        XCTAssertEqual(StubProtocol.lastPath, "/api/activity/nudges/select")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")
+        let body = try XCTUnwrap(StubProtocol.lastBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        // Must be a JSON number, not the string "42" — the desktop does int(...).
+        XCTAssertTrue(json["record_id"] is NSNumber)
+        XCTAssertEqual(json["record_id"] as? Int, 42)
+    }
+
+    func testSelectNudgeUnknownIdThrows() async {
+        StubProtocol.routes = ["/api/activity/nudges/select": (400,
+            Data(#"{"error":"unknown record_id 999"}"#.utf8))]
+        do { try await client().selectNudge(recordId: 999); XCTFail("expected throw") }
+        catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 400) }
+        catch { XCTFail("wrong error: \(error)") }
+    }
+
+    // MARK: dismiss — keyed path
+
+    func testDismissNudgeHitsKeyedPath() async throws {
+        StubProtocol.routes = ["/api/activity/nudges/record:42/dismiss": (200,
+            Data(#"{"dismissed":"record:42"}"#.utf8))]
+        try await client(token: "tok").dismissNudge(id: "record:42")
+        XCTAssertEqual(StubProtocol.lastMethod, "POST")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")
+        XCTAssertEqual(StubProtocol.lastPath, "/api/activity/nudges/record:42/dismiss")
+    }
+
+    // MARK: briefing — present and absent
+
+    func testBriefingDecodesDigest() async throws {
+        StubProtocol.routes = ["/api/activity/briefing": (200, Data(#"""
+        {"briefing":{"id":7,"title":"Arch review","value":"## Context\n- decided X",
+                     "updated_at":"2026-06-27T09:00:00Z"},
+         "last_run":{"status":"success"}}
+        """#.utf8))]
+        let briefing = try await client(token: "tok").briefing()
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")
+        let b = try XCTUnwrap(briefing)
+        XCTAssertEqual(b.id, 7)
+        XCTAssertEqual(b.title, "Arch review")
+        XCTAssertTrue(b.value.contains("decided X"))
+        XCTAssertEqual(b.updatedAt, "2026-06-27T09:00:00Z")
+    }
+
+    func testBriefingNilWhenAbsent() async throws {
+        StubProtocol.routes = ["/api/activity/briefing": (200,
+            Data(#"{"briefing":null,"last_run":null}"#.utf8))]
+        let briefing = try await client().briefing()
+        XCTAssertNil(briefing)   // the desk shows nothing rather than a fabricated digest
+    }
+}
+
+private extension URLRequest {
+    /// `URLProtocol` receives a streamed body for some posts; drain it so the test
+    /// can assert on `record_id`'s JSON type regardless of how URLSession framed it.
+    func bodySteamData() -> Data? {
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let size = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: size)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data.isEmpty ? nil : data
+    }
+}

--- a/apple/Tests/ProvidersTests/SQLiteStorageSchemaSafetyTests.swift
+++ b/apple/Tests/ProvidersTests/SQLiteStorageSchemaSafetyTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+import SQLite3
+import Contracts
+@testable import Providers
+
+/// Equilibrium 23-01/02: SQLiteStorage must mirror the desktop refuse-newer
+/// matrix (holdspeak/db/core.py `_ensure_schema` + `SchemaVersionError`):
+///
+/// - a DB written by a NEWER build (user_version > build schema) is REFUSED for
+///   writes and left byte-identical (never downgrade-stamped);
+/// - an OLDER DB is backed up to a timestamped sibling BEFORE the v1 → v2 ALTERs;
+/// - an equal-version DB is a no-op (no backup, no stamp change, data untouched).
+final class SQLiteStorageSchemaSafetyTests: XCTestCase {
+
+    private let SQLITE_TRANSIENT_T = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    private func tempPath() -> String {
+        NSTemporaryDirectory() + "hsm-safety-\(UUID().uuidString).sqlite"
+    }
+
+    /// Open a raw connection, run a script, set user_version, close. Models a DB
+    /// some other build left on disk.
+    private func seedRawDB(at path: String, userVersion: Int32, _ script: String) throws {
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        XCTAssertEqual(sqlite3_exec(db, script, nil, nil, nil), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(db, "PRAGMA user_version=\(userVersion);", nil, nil, nil), SQLITE_OK)
+    }
+
+    private func readUserVersionRaw(at path: String) -> Int32 {
+        var db: OpaquePointer?
+        guard sqlite3_open(path, &db) == SQLITE_OK else { return -1 }
+        defer { sqlite3_close(db) }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "PRAGMA user_version;", -1, &stmt, nil) == SQLITE_OK else { return -1 }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return -1 }
+        return sqlite3_column_int(stmt, 0)
+    }
+
+    // MARK: - Newer DB: refused, never downgrade-stamped, data untouched
+
+    func testNewerDatabaseIsRefusedAndLeftUntouched() throws {
+        let path = tempPath()
+        // A DB a FUTURE build wrote: schema version above our build.
+        let future = SQLiteStorage.schemaVersion + 5
+        try seedRawDB(at: path, userVersion: future, """
+            CREATE TABLE meetings(id TEXT PRIMARY KEY, started_at TEXT, json TEXT,
+              modified_at TEXT, deleted INTEGER NOT NULL DEFAULT 0, future_col TEXT);
+            INSERT INTO meetings(id, started_at, json) VALUES('mtg_future','t','{}');
+            """)
+
+        XCTAssertThrowsError(try SQLiteStorage(path: path)) { error in
+            guard case StorageError.tooNew(let stored, let build) = error else {
+                return XCTFail("expected StorageError.tooNew, got \(error)")
+            }
+            XCTAssertEqual(stored, future)
+            XCTAssertEqual(build, SQLiteStorage.schemaVersion)
+        }
+
+        // No downgrade-stamp: user_version is still the future version.
+        XCTAssertEqual(readUserVersionRaw(at: path), future)
+        // No data touched: the future-only column and its row survive intact.
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        var stmt: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(db, "SELECT future_col FROM meetings WHERE id='mtg_future';", -1, &stmt, nil), SQLITE_OK)
+        defer { sqlite3_finalize(stmt) }
+        XCTAssertEqual(sqlite3_step(stmt), SQLITE_ROW, "the future row must still be there")
+    }
+
+    // MARK: - Older DB: backed up, then migrated, data preserved
+
+    func testOlderDatabaseIsBackedUpThenMigrated() throws {
+        let path = tempPath()
+        // A v1 DB: meetings/artifacts WITHOUT modified_at/deleted, with a real row.
+        try seedRawDB(at: path, userVersion: 1, """
+            CREATE TABLE meetings(id TEXT PRIMARY KEY, started_at TEXT, json TEXT);
+            CREATE TABLE artifacts(id TEXT PRIMARY KEY, meeting_id TEXT, json TEXT);
+            INSERT INTO meetings(id, started_at, json)
+              VALUES('mtg_old','2024-01-01T00:00:00Z','{"id":"mtg_old"}');
+            """)
+
+        let dir = (path as NSString).deletingLastPathComponent
+        let stem = (path as NSString).lastPathComponent
+        let before = try FileManager.default.contentsOfDirectory(atPath: dir)
+            .filter { $0.hasPrefix(stem) && $0.hasSuffix(".bak") }
+        XCTAssertTrue(before.isEmpty, "no backup should exist before opening")
+
+        let db = try SQLiteStorage(path: path); defer { db.close() }
+
+        // Migrated: stamped to the current build version.
+        XCTAssertEqual(try db.userVersion(), SQLiteStorage.schemaVersion)
+        // The v1 row survives the migration AND the ALTERs landed (v2 columns now
+        // exist and the row reads back through them as a live, non-tombstoned row).
+        try db.saveArtifact(Artifact(id: "art_post", meetingId: "mtg_old",
+                                     artifactType: .decisions, title: "ok",
+                                     bodyMarkdown: "", structuredJson: .object([:]),
+                                     confidence: 0, status: .draft,
+                                     pluginId: "p", pluginVersion: "1"))
+        XCTAssertEqual(try db.loadArtifacts(meetingId: "mtg_old").map { $0.id }, ["art_post"])
+
+        // A timestamped backup sibling was written before the ALTERs ran.
+        let after = try FileManager.default.contentsOfDirectory(atPath: dir)
+            .filter { $0.hasPrefix(stem) && $0.hasSuffix(".bak") }
+        XCTAssertEqual(after.count, 1, "exactly one backup sibling should exist")
+
+        // And the backup is still the ORIGINAL v1 (user_version 1, no modified_at).
+        let backupPath = (dir as NSString).appendingPathComponent(after[0])
+        XCTAssertEqual(readUserVersionRaw(at: backupPath), 1, "backup must be the pre-migration copy")
+    }
+
+    // MARK: - Equal DB: no-op (no new backup, version unchanged, data intact)
+
+    func testEqualVersionDatabaseIsNoOp() throws {
+        let path = tempPath()
+        // First open creates the schema at the current version and lands a real row.
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<4 { url.deleteLastPathComponent() }
+        url.appendPathComponent("pm/roadmap/holdspeak-mobile/contracts/fixtures/meeting-sample.json")
+        struct Sample: Codable { let meeting: Meeting }
+        let sample = try HoldSpeakContracts.decoder().decode(Sample.self, from: Data(contentsOf: url))
+        do {
+            let db = try SQLiteStorage(path: path)
+            try db.saveMeeting(sample.meeting)
+            db.close()
+        }
+
+        let dir = (path as NSString).deletingLastPathComponent
+        let stem = (path as NSString).lastPathComponent
+        let before = try FileManager.default.contentsOfDirectory(atPath: dir)
+            .filter { $0.hasPrefix(stem) && $0.hasSuffix(".bak") }
+
+        // Reopen an already-current DB: equal-version path.
+        let db = try SQLiteStorage(path: path); defer { db.close() }
+        XCTAssertEqual(try db.userVersion(), SQLiteStorage.schemaVersion)
+        XCTAssertEqual(try db.loadMeeting(id: sample.meeting.id), sample.meeting, "data intact")
+
+        // No NEW backup was written for an equal-version open.
+        let after = try FileManager.default.contentsOfDirectory(atPath: dir)
+            .filter { $0.hasPrefix(stem) && $0.hasSuffix(".bak") }
+        XCTAssertEqual(after.count, before.count, "equal-version open takes no backup")
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
+++ b/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
@@ -131,4 +131,18 @@ Verified together: `swift build --target Providers` + all `*ClientTests` (**39 t
 the typed spine the Phase-19 SwiftUI screens (aftercare card, faceted archive, artifact ring, proposals
 review) consume next; the screens + the metal walk are hand-driven follow-ups.
 
+### Wave 4 (2026-06-27) — schema safety + the activity client + a hardening catch, 3 gaps
+
+Dispatched in the background while Waves 18-01/19 PRs merged (the machine never idles).
+
+| Gap | Phase | What landed |
+|-----|-------|-------------|
+| iPad schema safety | 23 | `SQLiteStorage` now reads `user_version` BEFORE migrate/stamp and REFUSES a newer-than-build DB (`StorageError.tooNew`, no downgrade-stamp), and takes a timestamped backup before migrating, mirroring the desktop refuse-newer matrix. The data-loss stopper, the highest-leverage Apple-side framework gap. (3 new + 5 existing Storage tests green.) |
+| Activity-nudge client | 18 | `activityNudges()` / `selectNudge(recordId:)` / `dismissNudge(id:)` / `briefing()` + the `ActivityNudge` type (source-cited cards, the "Dictate with this" grounding). New `+Activity.swift`; 8 tests. |
+| Web null-guard (hardening) | 21 | a latent-bug audit of every launch route found ONE more genuine null-read of the index class: `/desk` evaluated `filing.id` under an `x-show` when `filing` was null. Fixed (4 sites → `filing?.id`); the rest were already guarded. Route-preflight green. |
+
+Verified together: `swift test` (storage + activity + no regression), web build, and `route_preflight`
+all green. The web hardening proves the pattern: every wave's integration runs the browser preflight CI
+silently skips, so this class of bug keeps getting caught instead of shipped.
+
 See [[project_primitive_framework]], [[project_phase15_the_mesh]], [[project_phase17_agent_sync]].

--- a/web/src/pages/desk.astro
+++ b/web/src/pages/desk.astro
@@ -794,16 +794,16 @@ const GROUPS = [
           <ul class="file-list" x-show="items.directory.length" x-cloak>
             <template x-for="d in items.directory" {...{ ":key": "d.id" }}>
               <li>
-                <button type="button" class="file-option" :class="{ on: isFiledIn(filing.id, d.id) }" :disabled="filingBusy === d.id" @click="toggleFile(d)">
-                  <span class="file-check" :class="{ on: isFiledIn(filing.id, d.id) }">
-                    <svg x-show="isFiledIn(filing.id, d.id)" x-cloak viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
+                <button type="button" class="file-option" :class="{ on: isFiledIn(filing?.id, d.id) }" :disabled="filingBusy === d.id" @click="toggleFile(d)">
+                  <span class="file-check" :class="{ on: isFiledIn(filing?.id, d.id) }">
+                    <svg x-show="isFiledIn(filing?.id, d.id)" x-cloak viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
                   </span>
                   <span class="file-option-body">
                     <span class="file-option-name" x-text="d.name"></span>
                     <span class="file-option-meta" x-text="`${d.memberIds.length} item${d.memberIds.length === 1 ? '' : 's'}`"></span>
                   </span>
                   <span class="file-option-state" x-show="filingBusy === d.id" x-cloak>…</span>
-                  <span class="file-option-state filed" x-show="filingBusy !== d.id && isFiledIn(filing.id, d.id)" x-cloak>filed</span>
+                  <span class="file-option-state filed" x-show="filingBusy !== d.id && isFiledIn(filing?.id, d.id)" x-cloak>filed</span>
                 </button>
               </li>
             </template>


### PR DESCRIPTION
A **background** flotilla (3 worktree agents) dispatched while the Phase-18/19 PRs merged — the machine never idles.

| Gap | Phase | What landed |
|-----|-------|-------------|
| iPad schema safety | 23 | `SQLiteStorage` reads `user_version` **before** migrate/stamp and **refuses** a newer-than-build DB (`StorageError.tooNew`, no downgrade-stamp), and backs up to a timestamped sibling before migrating — mirroring the desktop refuse-newer matrix. The **data-loss stopper** (the highest-leverage Apple-side framework gap). 3 new + 5 existing Storage tests green. |
| Activity-nudge client | 18-05 | `activityNudges()` / `selectNudge(recordId:)` / `dismissNudge(id:)` / `briefing()` + the `ActivityNudge` type (source-cited cards, the "Dictate with this" grounding). New `+Activity.swift`; 8 tests. |
| Web null-guard (hardening) | 21 | the launch-route audit found one more genuine null-read of the index class — `/desk` evaluated `filing.id` under an `x-show` when `filing` was null. Fixed (`filing?.id` ×4); the rest were already guarded. |

**Verified together:** `swift test` (storage + activity, no regression) + web build + `route_preflight` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)