### PR TITLE
Equilibrium Wave 5 (docs): entry points + architecture catch up to the iPad client

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,28 @@ follow-up. It is read-only and local: nothing is sent, and nothing runs,
 without your approval. See the
 [Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md#meeting-aftercare-close-the-loop).
 
-## AIPI-Lite companion
+## Companions
+
+HoldSpeak runs as a desktop hub, and a companion on another device drives it
+over the same local HTTP API your browser uses, on your own network (LAN or
+Tailscale), with no hosted relay. Two companions exist today.
+
+### The iPad app
+
+The iPad is a first-class client of both modes, not a remote control for one.
+It talks to the hub through typed clients over the existing API: it dictates an
+answer into your desk (the hub runs that text through the full dictation
+pipeline, applying your corrections and routing, and types the result, and a
+matching voice command fires there too), pins your spoken language and your
+spoken-symbol dictionary on that dictation path, reads a meeting back with its
+artifacts, confidence, and sources, keeps proposing an action separate from
+approving it (the human gate stays its own step), reads the faceted archive, and
+pulls activity pre-briefing nudges. Its on-device storage is schema safe the
+same way the desktop is: it backs an older database up before migrating, and
+refuses to open one written by a newer build. The on-device screens for these
+are still coming together; the client layer they ride on is shipped and tested.
+
+### AIPI-Lite
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/aipi-lite-companion.png" alt="Pixel art AIPI-Lite companion device" width="220">
@@ -250,6 +271,7 @@ are in the [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpea
 | Map spoken keywords to real actions | [Voice Commands](https://github.com/karolswdev/HoldSpeak/blob/main/docs/VOICE_COMMANDS.md) |
 | Turn on Qlippy, the mascot | [Qlippy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md#qlippy-the-mascot-optional) |
 | Use meeting mode and configure AI intelligence | [Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md) |
+| Drive HoldSpeak from another device | [Companions](#companions) |
 | Wire up the AIPI-Lite companion | [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AIPI_LITE_DEV_WORKFLOW.md) |
 | Install Claude / Codex agent hooks | [Agent Hook Install](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AGENT_HOOK_INSTALL.md) |
 | Understand what's stored and what can leave my machine | [Security & Privacy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/SECURITY.md) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,11 +206,12 @@ The iPad keeps its own SQLite store
 (`apple/Sources/Providers/Storage/SQLiteStorage.swift`) for what it captures
 on device. It runs in WAL mode for crash safety: an integrity check on
 reopen confirms a committed write survives a crash, and an uncommitted write
-is rolled back. The schema carries a `user_version`, and a forward migration
-runs only when an older database is opened. This mirrors, on the mobile side,
-the same safe-by-default posture the desktop store takes. The desktop store
-is the one that also runs the four-way schema matrix below, where a database
-newer than the build is refused rather than rewritten.
+is rolled back. The schema carries a `user_version`, and the store reads it
+before it touches anything: a database newer than the build is refused (it
+throws rather than rewrite your data), an older one is backed up to a
+timestamped sibling and then migrated forward, and a current one is a no-op.
+That mirrors the desktop store's safe-by-default posture on the mobile side,
+the same four-way schema matrix described below.
 
 The desktop schema matrix:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,14 @@ approval, and the network crossings are enumerated in the
 [trust boundary](#the-trust-boundary) below and in
 [`SECURITY.md`](SECURITY.md).
 
+An iPad companion can join over your own network. It is a typed client of
+the same FastAPI routes the web UI calls, not a second runtime: it reads
+meetings, artifacts, aftercare, and faceted search, decides proposals, and
+sends dictation back to a focused app or a waiting coding agent. The desktop
+stays the hub; the iPad is an authoring port. Its piece of the
+[device path](#the-device-path) is the typed client layer, and the LAN
+crossing it opens is listed in the [trust boundary](#the-trust-boundary).
+
 ## The components
 
 How the major pieces connect. Boxes are subsystems, not classes; the module
@@ -60,6 +68,11 @@ flowchart TB
     CN["Gated connectors<br/>(plugins/gated_connector.py)"]
   end
 
+  subgraph ipad["iPad companion (apple/Sources/Providers/)"]
+    HC["Typed hub client<br/>(Desktop/HTTPDesktopClient*.swift)"]
+    LS[("On-device SQLite<br/>(Storage/SQLiteStorage.swift)")]
+  end
+
   DB[("SQLite<br/>(db/*)")]
   LLM(["LLM backend<br/>(local GGUF / MLX / OpenAI-compatible)"])
 
@@ -79,6 +92,8 @@ flowchart TB
   SRV --> UI
   runtime <--> DB
   SRV -. "WebSocket" .-> DEV
+  HC -. "meeting / dictation / proposal routes, LAN, Bearer token" .-> SRV
+  HC <--> LS
 ```
 
 The dictation and meeting flows are detailed in their own sections below.
@@ -147,6 +162,68 @@ sequenceDiagram
   end
 ```
 
+### The iPad companion
+
+The iPad joins the same hub over your own network (LAN or Tailscale, no
+hosted relay). It is a typed client of the FastAPI routes, built around one
+HTTP client (`apple/Sources/Providers/Desktop/HTTPDesktopClient.swift`)
+split into focused extensions, one per surface it reads or drives:
+
+- `HTTPDesktopClient+Aftercare.swift` reads the aftercare digest and files an
+  accepted action as a GitHub issue proposal (`GET .../aftercare`,
+  `POST .../aftercare/file-issue`).
+- `HTTPDesktopClient+Facets.swift` lists and searches meetings with the
+  server-side facets (`GET api/meetings/facets`, `GET api/meetings`).
+- `HTTPDesktopClient+Artifacts.swift` reads a meeting's typed artifacts
+  (`GET api/meetings/{id}/artifacts`).
+- `HTTPDesktopClient+Proposals.swift` reads pending proposals and submits an
+  approve or reject decision (`GET`/`POST .../proposals`); the executor still
+  runs on the hub, so the iPad approves but never acts on its own.
+- `HTTPDesktopClient+Dictation.swift` previews the dictation pipeline and
+  reports readiness (`POST api/dictation/dry-run`,
+  `GET api/dictation/readiness`); the base client sends the dictation itself
+  to a focused app or a waiting coding agent (`POST api/dictation/remote`).
+
+Every request carries the desktop's Bearer token, joined at call time and
+never stored in a payload. The hub is the only place state changes; the iPad
+is an authoring port onto it.
+
+```mermaid
+sequenceDiagram
+  participant IP as iPad companion
+  participant HC as Typed hub client
+  participant SRV as Web server + API
+  participant RT as WebRuntime
+  IP->>HC: read meeting, decide proposal, send dictation
+  HC->>SRV: route call over LAN, Bearer token
+  SRV->>RT: dispatch to the runtime
+  RT->>SRV: meetings, artifacts, aftercare, facets, decision result
+  SRV->>HC: typed response
+  HC->>IP: render on the authoring port
+```
+
+The iPad keeps its own SQLite store
+(`apple/Sources/Providers/Storage/SQLiteStorage.swift`) for what it captures
+on device. It runs in WAL mode for crash safety: an integrity check on
+reopen confirms a committed write survives a crash, and an uncommitted write
+is rolled back. The schema carries a `user_version`, and a forward migration
+runs only when an older database is opened. This mirrors, on the mobile side,
+the same safe-by-default posture the desktop store takes. The desktop store
+is the one that also runs the four-way schema matrix below, where a database
+newer than the build is refused rather than rewritten.
+
+The desktop schema matrix:
+
+- **Newer than this build:** refuse to touch it, and let `doctor` report the
+  mismatch, so a newer build never gets a downgrade rewrite from an older one.
+- **Older than this build:** back up first, then apply the migration, so the
+  pre-migration database is always recoverable.
+- **Already current:** no-op.
+- **Missing:** create a fresh database.
+
+Back up on demand with `holdspeak backup` and put a snapshot back with
+`holdspeak restore`. The matrix lives in `holdspeak/db/core.py`.
+
 ## The meeting pipeline
 
 How captured or imported audio becomes a transcript, typed artifacts, and an
@@ -192,4 +269,5 @@ flowchart LR
   RT -->|"opt-in; queue stats only, no transcript"| OPS(["Ops alert webhook"])
   RT -->|"one-time inbound fetch, about 7 MB"| WM(["Wake models, GitHub releases"])
   DEVCE(["Paired device, same LAN, PSK"]) -->|"audio in, status out"| RT
+  IPAD(["iPad companion, same LAN / Tailscale, Bearer token"]) -->|"meeting / dictation / proposal route calls"| RT
 ```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -209,6 +209,9 @@ Once hold-to-talk feels natural, the rest is one setting away each:
 - **Meetings**: [the Meeting Mode Guide](MEETING_MODE_GUIDE.md) covers live
   capture, importing recordings or transcripts you already have, and the
   aftercare that closes the loop.
+- **From another device**: an iPad [companion](USER_GUIDE.md#companions) drives
+  both modes over the hub's local API: dictate into your desk, read a meeting
+  back with its artifacts and sources, and approve a proposal.
 
 ## Troubleshooting
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -30,6 +30,7 @@ Use these guides depending on what you are setting up:
 | Agent hooks | Lets Claude Code and Codex report current cwd/session state to HoldSpeak | `/dictation` -> Agent Hooks |
 | Meeting mode | Captures microphone plus optional system audio | Dashboard, `holdspeak meeting` command |
 | Meeting intelligence | Produces transcript, topics, summaries, actions, artifacts | Dashboard and `/history` |
+| iPad companion | Drives both modes from another device over the hub's HTTP API: dictate into the desk, read a meeting back with its artifacts and sources, approve a proposal, browse the archive | [Companions](#companions) |
 | AIPI-Lite companion | Portable ESPHome device for meeting controls, status, and spoken replies to waiting Claude/Codex sessions | [AIPI-Lite Developer Workflow](AIPI_LITE_DEV_WORKFLOW.md), `/companion` |
 | Runtime setup | Configures local MLX, llama.cpp, or OpenAI-compatible endpoints | `/dictation` -> Runtime, `/docs/dictation-runtime` |
 
@@ -436,6 +437,47 @@ Example cloud/homelab config:
   }
 }
 ```
+
+## Companions
+
+HoldSpeak runs as a desktop hub. A companion on another device drives it over
+the same local HTTP API your browser uses, on your own network (LAN or
+Tailscale), with no hosted relay. Every request carries the hub's bearer token,
+exactly as the browser does when the runtime is bound off loopback.
+
+### The iPad app
+
+The iPad is a client of both modes, not a remote control for one. It reaches the
+hub through typed clients over the existing API, so the work happens on the desk
+and the iPad shows it:
+
+- **Dictate into your desk.** Speak an answer on the iPad and the hub runs that
+  text through the full dictation pipeline (your corrections, your blocks, your
+  routing) and types the result into the focused app or answers a waiting
+  Claude/Codex session. A configured voice command fires on this remote path
+  too, the same bounded action it would fire at the desk, so a keyword is not
+  dictated as prose. The spoken language setting and the spoken-symbol
+  dictionary apply on this path, the same as local dictation.
+- **Read a meeting back in full.** Pull a meeting's artifacts with their
+  confidence scores and the transcript sources each was grounded in, browse the
+  archive narrowed server-side by speaker, tag, or text (the same facets as
+  `/history`), and read its aftercare: what is open, decided, and changed.
+- **Approve, separately.** Proposing an action and approving it stay two steps,
+  the same human gate the desktop keeps. The iPad reads the proposals queued for
+  review and decides them one at a time; nothing runs without that approval.
+- **See what is grounded.** Activity pre-briefing nudges, source-cited, come
+  through to the iPad so you can pick a record to ground the next dictation in.
+
+The iPad's own storage is schema safe the way the desktop is: it backs an older
+database up before migrating it, and refuses to open one written by a newer
+build rather than risk your data. The on-device screens for these are still
+coming together; the client layer they ride on is shipped and tested.
+
+### AIPI-Lite
+
+AIPI-Lite is an optional portable device for meeting controls, status feedback,
+and spoken replies to a waiting Claude/Codex session. Firmware and bridge setup
+are in the [AIPI-Lite Developer Workflow](AIPI_LITE_DEV_WORKFLOW.md).
 
 ## Privacy Model
 


### PR DESCRIPTION
Background docs flotilla (2 worktree agents) + an integrator accuracy fix. README/GETTING_STARTED/USER_GUIDE now describe the iPad as a first-class client of both modes (SwiftUI screens honestly flagged in-progress); ARCHITECTURE.md's diagrams show the typed hub client. **Fix:** one agent branched just before #152 merged, so it wrote that only desktop refuses-newer; corrected to the shipped mobile refuse-newer + backup. Verified: doc-drift + mermaid render 17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)