### PR TITLE
Equilibrium Wave 6 (iOS): dictation client + a metal-readiness audit that caught a real bug

### DIFF
--- a/apple/Sources/Contracts/Aftercare.swift
+++ b/apple/Sources/Contracts/Aftercare.swift
@@ -187,6 +187,14 @@ public struct Aftercare: Codable, Equatable, Sendable {
 /// issue — nothing leaves the machine until it is separately approved + actuators
 /// are enabled. Decoded loosely; the `preview` is the human-readable summary the
 /// approval surface shows (never the machine payload's secrets).
+///
+/// METAL-READINESS (EQ-W6 audit): this is `_proposal_to_dict` in
+/// holdspeak/web/routes/meetings.py — the same serializer Proposals use, so the
+/// timestamp fields are RAW ISO STRINGS, not `Date`. The hub re-emits them with
+/// `datetime.now().isoformat()` (naive/local/microsecond, NO `Z`, e.g.
+/// `2026-06-27T18:08:21.337333`), which the shared decoder's `.iso8601` strategy
+/// would reject — failing the whole file-issue decode on real metal. Carried as
+/// `String?` to match the contract's "Timestamps are ISO strings" and stay format-safe.
 public struct AftercareIssueProposal: Codable, Equatable, Sendable {
     public var id: String
     public var meetingId: String?
@@ -201,16 +209,17 @@ public struct AftercareIssueProposal: Codable, Equatable, Sendable {
     public var requiredCapabilities: [String]?
     public var decidedBy: String?
     public var error: String?
-    public var createdAt: Date?
-    public var decidedAt: Date?
-    public var executedAt: Date?
+    /// Raw ISO wire strings (naive/local, no `Z`); see the type doc. Never `Date`.
+    public var createdAt: String?
+    public var decidedAt: String?
+    public var executedAt: String?
 
     public init(id: String, meetingId: String? = nil, windowId: String? = nil,
                 pluginId: String? = nil, pluginVersion: String? = nil, status: String? = nil,
                 target: String? = nil, action: String? = nil, preview: String? = nil,
                 reversible: Bool? = nil, requiredCapabilities: [String]? = nil,
                 decidedBy: String? = nil, error: String? = nil,
-                createdAt: Date? = nil, decidedAt: Date? = nil, executedAt: Date? = nil) {
+                createdAt: String? = nil, decidedAt: String? = nil, executedAt: String? = nil) {
         self.id = id
         self.meetingId = meetingId
         self.windowId = windowId

--- a/apple/Sources/Contracts/DictationBlocks.swift
+++ b/apple/Sources/Contracts/DictationBlocks.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+// HSM-18-01 — the rest of the dictation pipeline surface the iPad never called: blocks (CRUD),
+// block-templates, and project-context. Modeled faithfully against
+// holdspeak/web/routes/dictation/blocks.py + agent.py + _helpers.py. Decoded with
+// HoldSpeakContracts.decoder() (.convertFromSnakeCase), so the snake_case wire
+// (default_match_confidence, requires_project, sample_utterance, project_kb) maps to these camelCase
+// properties automatically. Lenient (most fields optional / open blobs) so a hub shape drift degrades
+// gracefully on the dictate screen rather than throwing.
+
+// MARK: - Blocks
+
+/// The match clause of a dictation block (`block.match` in blocks.yaml). Open-ended by design — the
+/// hub validates the real shape; the iPad keeps the known knobs typed and the rest as a raw blob so a
+/// richer match config still round-trips.
+public struct DictationBlockMatch: Codable, Sendable, Equatable {
+    public var examples: [String]?
+    public var negativeExamples: [String]?
+    public var threshold: Double?
+
+    public init(examples: [String]? = nil, negativeExamples: [String]? = nil, threshold: Double? = nil) {
+        self.examples = examples
+        self.negativeExamples = negativeExamples
+        self.threshold = threshold
+    }
+}
+
+/// The inject clause of a dictation block (`block.inject`). `mode` is "append" / "replace" / etc. on
+/// the hub; kept as a string so a new mode does not break decoding.
+public struct DictationBlockInject: Codable, Sendable, Equatable {
+    public var mode: String?
+    public var template: String?
+
+    public init(mode: String? = nil, template: String? = nil) {
+        self.mode = mode
+        self.template = template
+    }
+}
+
+/// One dictation block (an entry in `document.blocks`). `id` is the only field the hub guarantees;
+/// everything else is optional so a partial / future block still decodes.
+public struct DictationBlock: Codable, Sendable, Equatable, Identifiable {
+    public var id: String
+    public var description: String?
+    public var match: DictationBlockMatch?
+    public var inject: DictationBlockInject?
+
+    public init(id: String, description: String? = nil,
+                match: DictationBlockMatch? = nil, inject: DictationBlockInject? = nil) {
+        self.id = id
+        self.description = description
+        self.match = match
+        self.inject = inject
+    }
+}
+
+/// The raw blocks document (`document` in the blocks-list envelope): the YAML mapping the hub reads
+/// back, with the defaults it fills in (`version`, `default_match_confidence`, `blocks`).
+public struct DictationBlocksDocument: Codable, Sendable, Equatable {
+    public var version: Int?
+    public var defaultMatchConfidence: Double?
+    public var blocks: [DictationBlock]
+
+    public init(version: Int? = nil, defaultMatchConfidence: Double? = nil, blocks: [DictationBlock] = []) {
+        self.version = version
+        self.defaultMatchConfidence = defaultMatchConfidence
+        self.blocks = blocks
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case version, defaultMatchConfidence, blocks
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decodeIfPresent(Int.self, forKey: .version)
+        defaultMatchConfidence = try c.decodeIfPresent(Double.self, forKey: .defaultMatchConfidence)
+        blocks = try c.decodeIfPresent([DictationBlock].self, forKey: .blocks) ?? []
+    }
+}
+
+/// The `GET /api/dictation/blocks` envelope: the resolved scope/path, whether the file exists, the
+/// optional project context, and the parsed document.
+public struct DictationBlocksResult: Codable, Sendable, Equatable {
+    public var scope: String?
+    public var path: String?
+    public var exists: Bool?
+    public var project: DictationProjectInfo?
+    public var document: DictationBlocksDocument
+
+    public init(scope: String? = nil, path: String? = nil, exists: Bool? = nil,
+                project: DictationProjectInfo? = nil,
+                document: DictationBlocksDocument = .init()) {
+        self.scope = scope
+        self.path = path
+        self.exists = exists
+        self.project = project
+        self.document = document
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case scope, path, exists, project, document
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        scope = try c.decodeIfPresent(String.self, forKey: .scope)
+        path = try c.decodeIfPresent(String.self, forKey: .path)
+        exists = try c.decodeIfPresent(Bool.self, forKey: .exists)
+        project = try c.decodeIfPresent(DictationProjectInfo.self, forKey: .project)
+        document = try c.decodeIfPresent(DictationBlocksDocument.self, forKey: .document) ?? .init()
+    }
+}
+
+// MARK: - Block templates
+
+/// One starter block template (`GET /api/dictation/block-templates` -> `templates[]`). The metadata
+/// is typed; the `block` payload is the same open shape as a saved block.
+public struct DictationBlockTemplate: Codable, Sendable, Equatable, Identifiable {
+    public var id: String
+    public var title: String?
+    public var description: String?
+    public var sampleUtterance: String?
+    public var requiresProject: Bool?
+    public var block: DictationBlock?
+
+    public init(id: String, title: String? = nil, description: String? = nil,
+                sampleUtterance: String? = nil, requiresProject: Bool? = nil,
+                block: DictationBlock? = nil) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.sampleUtterance = sampleUtterance
+        self.requiresProject = requiresProject
+        self.block = block
+    }
+}
+
+// MARK: - Project context
+
+/// The detected/manual project the dictation APIs resolved (`project` in the responses). `anchor` is
+/// "manual" for a hand-picked root; otherwise the detector's anchor file.
+public struct DictationProjectInfo: Codable, Sendable, Equatable {
+    public var name: String?
+    public var root: String?
+    public var anchor: String?
+
+    public init(name: String? = nil, root: String? = nil, anchor: String? = nil) {
+        self.name = name
+        self.root = root
+        self.anchor = anchor
+    }
+}
+
+/// The on-disk config paths the hub reports for the active project
+/// (`GET /api/dictation/project-context` -> `paths`).
+public struct DictationProjectPaths: Codable, Sendable, Equatable {
+    public var blocks: String?
+    public var projectKb: String?
+
+    public init(blocks: String? = nil, projectKb: String? = nil) {
+        self.blocks = blocks
+        self.projectKb = projectKb
+    }
+}
+
+/// `GET /api/dictation/project-context`: the resolved project plus its config paths. Lets the iPad
+/// confirm which project the dictation pipeline is grounded in before it routes a single word.
+public struct DictationProjectContext: Codable, Sendable, Equatable {
+    public var project: DictationProjectInfo
+    public var paths: DictationProjectPaths?
+
+    public init(project: DictationProjectInfo = .init(), paths: DictationProjectPaths? = nil) {
+        self.project = project
+        self.paths = paths
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case project, paths
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        project = try c.decodeIfPresent(DictationProjectInfo.self, forKey: .project) ?? .init()
+        paths = try c.decodeIfPresent(DictationProjectPaths.self, forKey: .paths)
+    }
+}

--- a/apple/Sources/Contracts/DictationPreview.swift
+++ b/apple/Sources/Contracts/DictationPreview.swift
@@ -7,57 +7,160 @@ import Foundation
 // gracefully on the teleprompter rather than throwing.
 
 /// Where a dry-run says the dictation would land (the detected target profile / focused app).
+///
+/// This is the wire shape of `TargetProfile.to_dict()` in `holdspeak/target_profile.py`:
+/// `{id, label, confidence, source, app_name, process_name, window_title, details}`. The hub
+/// returns this object verbatim under `target` on both `/api/dictation/dry-run` and
+/// `/api/dictation/readiness`. snake_case (`app_name`, `process_name`, `window_title`) maps to
+/// these camelCase properties via `.convertFromSnakeCase` — no hand-written `CodingKeys`. Every
+/// field is optional so a sparse / drifted hub payload still decodes.
 public struct DryRunTarget: Codable, Sendable, Equatable {
-    public var app: String?
-    public var window: String?
-    public var process: String?
-    public var profile: String?
+    /// Stable profile id ("cursor", "claude_code", "browser", "unknown", ...).
+    public var id: String?
+    /// Human label the desk header renders ("Cursor", "Claude Code", ...).
+    public var label: String?
     public var confidence: Double?
+    /// How the profile was resolved ("explicit" | "hints" | "none" | ...).
+    public var source: String?
+    public var appName: String?
+    public var processName: String?
+    public var windowTitle: String?
+    /// Free-form server extras (e.g. `{"matched": "codex"}`); kept as a typed blob so an
+    /// evolving payload still decodes.
+    public var details: [String: JSONValue]?
+
+    public init(id: String? = nil, label: String? = nil, confidence: Double? = nil,
+                source: String? = nil, appName: String? = nil, processName: String? = nil,
+                windowTitle: String? = nil, details: [String: JSONValue]? = nil) {
+        self.id = id
+        self.label = label
+        self.confidence = confidence
+        self.source = source
+        self.appName = appName
+        self.processName = processName
+        self.windowTitle = windowTitle
+        self.details = details
+    }
 
     /// The best human label for the destination column header ("→ Cursor"), or nil if unknown.
-    public var label: String? {
-        for candidate in [app, window, process, profile] {
+    /// Prefers the hub's own `label`, then the app/window/process names; an "unknown" id is
+    /// treated as no destination so the teleprompter shows nothing rather than "unknown".
+    public var displayLabel: String? {
+        for candidate in [label, appName, windowTitle, processName] {
             if let c = candidate?.trimmingCharacters(in: .whitespaces), !c.isEmpty { return c }
+        }
+        if let id = id?.trimmingCharacters(in: .whitespaces),
+           !id.isEmpty, id.lowercased() != "unknown" {
+            return id
         }
         return nil
     }
 }
 
+/// The detected project context the hub attaches to a dry-run / readiness payload
+/// (`{name, root, anchor}` from `detect_project_for_cwd`). `null` when no project is detected.
+public struct DictationProject: Codable, Sendable, Equatable {
+    public var name: String?
+    public var root: String?
+    public var anchor: String?
+
+    public init(name: String? = nil, root: String? = nil, anchor: String? = nil) {
+        self.name = name
+        self.root = root
+        self.anchor = anchor
+    }
+}
+
 /// The result of `POST /api/dictation/dry-run`: the routed + rewritten text the pipeline would
 /// produce, plus where it would go, so the user sees the receipt before a keystroke leaves the app.
+///
+/// Mirrors `_run_dictation_dry_run_text` in
+/// `holdspeak/web/routes/dictation/_helpers.py`: `final_text` is the only always-present field;
+/// `target` is a `DryRunTarget` (the `TargetProfile.to_dict()` shape, NOT app/window/process),
+/// `project` is an object (`{name, root, anchor}`), `runtime_status`/`runtime_detail` describe the
+/// runtime, `blocks_count` counts the loaded blocks, and `warnings` is a list of strings. There is
+/// no top-level `status` field — that was a model guess; the runtime state lives in
+/// `runtimeStatus`. All but `finalText` are optional so a drifted / disabled-pipeline payload
+/// still decodes.
 public struct DictationDryRun: Codable, Sendable, Equatable {
     public var finalText: String
     public var target: DryRunTarget?
     public var warnings: [String]?
     public var totalElapsedMs: Double?
-    public var status: String?
+    public var runtimeStatus: String?
+    public var runtimeDetail: String?
     public var blocksCount: Int?
-    public var project: String?
+    public var project: DictationProject?
+    /// The deterministic doc-suggestion outcome ("stored" | "no_suggestion" | "dismissed" | ...).
+    public var suggestionStatus: String?
+    /// The journal row id this dry-run wrote (when journaling is on), for the in-the-moment fix.
+    public var journalId: Int?
 
     public init(finalText: String, target: DryRunTarget? = nil, warnings: [String]? = nil,
-                totalElapsedMs: Double? = nil, status: String? = nil, blocksCount: Int? = nil,
-                project: String? = nil) {
+                totalElapsedMs: Double? = nil, runtimeStatus: String? = nil,
+                runtimeDetail: String? = nil, blocksCount: Int? = nil,
+                project: DictationProject? = nil, suggestionStatus: String? = nil,
+                journalId: Int? = nil) {
         self.finalText = finalText
         self.target = target
         self.warnings = warnings
         self.totalElapsedMs = totalElapsedMs
-        self.status = status
+        self.runtimeStatus = runtimeStatus
+        self.runtimeDetail = runtimeDetail
         self.blocksCount = blocksCount
         self.project = project
+        self.suggestionStatus = suggestionStatus
+        self.journalId = journalId
     }
 }
 
-/// A lean readiness snapshot for the dictate screen's status strip (`GET /api/dictation/readiness`).
-public struct DictationReadiness: Codable, Sendable, Equatable {
+/// The runtime sub-object of the readiness snapshot (`runtime` in the real payload). Carries the
+/// availability `status` ("available" | "missing_model" | "unavailable" | "disabled"), whether a
+/// local model file exists, and the requested/resolved backend.
+public struct DictationRuntimeReadiness: Codable, Sendable, Equatable {
     public var status: String?
     public var modelExists: Bool?
-    public var runtimeStatus: String?
-    public var openaiCompatible: Bool?
-    public var project: String?
+    public var requestedBackend: String?
+    public var resolvedBackend: String?
+    public var detail: String?
 
-    /// True when the snapshot reports a usable runtime (a model present or an endpoint reachable).
+    public init(status: String? = nil, modelExists: Bool? = nil, requestedBackend: String? = nil,
+                resolvedBackend: String? = nil, detail: String? = nil) {
+        self.status = status
+        self.modelExists = modelExists
+        self.requestedBackend = requestedBackend
+        self.resolvedBackend = resolvedBackend
+        self.detail = detail
+    }
+}
+
+/// A readiness snapshot for the dictate screen's status strip (`GET /api/dictation/readiness`).
+///
+/// Mirrors `api_dictation_readiness` in `holdspeak/web/routes/dictation/pipeline.py`: the
+/// top-level keys are `ready` (the hub's own readiness verdict), `project`, `runtime`, and
+/// `target` (the `DryRunTarget` / `TargetProfile.to_dict()` shape). The earlier model invented a
+/// flat `status`/`model_exists`/`runtime_status`/`openai_compatible` — none of those are
+/// top-level; `model_exists` lives under `runtime`. All optional so a partial payload still
+/// decodes.
+public struct DictationReadiness: Codable, Sendable, Equatable {
+    /// The hub's own readiness verdict (pipeline enabled + project + valid blocks + runtime).
+    public var ready: Bool?
+    public var project: DictationProject?
+    public var runtime: DictationRuntimeReadiness?
+    public var target: DryRunTarget?
+
+    public init(ready: Bool? = nil, project: DictationProject? = nil,
+                runtime: DictationRuntimeReadiness? = nil, target: DryRunTarget? = nil) {
+        self.ready = ready
+        self.project = project
+        self.runtime = runtime
+        self.target = target
+    }
+
+    /// True when the snapshot reports a usable runtime. Trusts the hub's `ready` verdict first,
+    /// then falls back to "the runtime is available" (model present or endpoint reachable).
     public var isReady: Bool {
-        if let s = status?.lowercased(), s == "ready" || s == "ok" { return true }
-        return (modelExists ?? false) || (openaiCompatible ?? false)
+        if let ready { return ready }
+        return runtime?.status?.lowercased() == "available"
     }
 }

--- a/apple/Sources/Contracts/MeetingArtifact.swift
+++ b/apple/Sources/Contracts/MeetingArtifact.swift
@@ -59,15 +59,23 @@ public struct MeetingArtifact: Codable, Equatable, Sendable {
     public var pluginVersion: String?
     /// The provenance list — `(source_type, source_ref)` lineage rows.
     public var sources: [MeetingArtifactSource]
-    public var createdAt: Date?
-    public var updatedAt: Date?
+    /// METAL-READINESS (EQ-W6 audit): RAW ISO STRINGS, not `Date`. The route emits
+    /// `artifact.created_at.isoformat()` where `created_at` was loaded via
+    /// `datetime.fromisoformat(row[...])` from a value the DB stored with
+    /// `datetime.now().isoformat()` — a *naive/local/microsecond* instant with NO `Z`
+    /// (e.g. `2026-06-27T18:08:21.337333`). The shared decoder's `.iso8601` strategy
+    /// REQUIRES a timezone and would throw on that exact shape, failing the whole
+    /// artifact decode on real metal. Carried as `String?` to stay format-safe; the
+    /// route always sends both, but optional keeps the read model tolerant.
+    public var createdAt: String?
+    public var updatedAt: String?
 
     public init(
         id: String, meetingId: String, artifactType: String,
         title: String, bodyMarkdown: String, structuredJson: JSONValue? = nil,
         confidence: Double? = nil, status: String, pluginId: String? = nil,
         pluginVersion: String? = nil, sources: [MeetingArtifactSource] = [],
-        createdAt: Date? = nil, updatedAt: Date? = nil
+        createdAt: String? = nil, updatedAt: String? = nil
     ) {
         self.id = id
         self.meetingId = meetingId

--- a/apple/Sources/Contracts/MeetingProposal.swift
+++ b/apple/Sources/Contracts/MeetingProposal.swift
@@ -10,10 +10,19 @@ import Foundation
 
 /// One actuator proposal as the hub serializes it (`_proposal_to_dict` in
 /// `holdspeak/web/routes/meetings.py`). snake_case wire keys map to camelCase via
-/// the shared decoder's `.convertFromSnakeCase` (see `Coding.swift`); the timestamp
-/// fields decode as ISO-8601 UTC `Z` and are optional because `decided_at` /
-/// `executed_at` are `null` for an undecided proposal. Robust-decode posture: every
-/// nullable wire field is optional so the review queue tolerates the payload evolving.
+/// the shared decoder's `.convertFromSnakeCase` (see `Coding.swift`).
+///
+/// METAL-READINESS (EQ-W6 audit): the timestamp fields are RAW ISO STRINGS, not
+/// `Date`. The hub stores + re-emits them with `datetime.now().isoformat()` — a
+/// *naive, local, microsecond* instant with NO `Z` and NO offset (e.g.
+/// `2026-06-27T18:08:21.337333`). The shared decoder's `.iso8601` strategy REQUIRES
+/// a timezone and would throw on that exact shape, failing the WHOLE proposal decode
+/// on real metal. The contract's own model doc says "Timestamps are ISO strings"
+/// (`ActuatorProposalRecord` in holdspeak/db/models.py), so this read model carries
+/// them verbatim as `String?` and never couples to a strict instant format. They are
+/// optional because `decided_at` / `executed_at` are `null` for an undecided
+/// proposal. Robust-decode posture: every nullable wire field is optional so the
+/// review queue tolerates the payload evolving.
 ///
 /// This is the review-side view; it intentionally mirrors (but does not depend on)
 /// the existing `ActuatorProposal` so this wave's client slice lives entirely in
@@ -34,9 +43,10 @@ public struct MeetingProposal: Codable, Equatable, Sendable {
     public var decidedBy: String?
     public var result: JSONValue?
     public var error: String?
-    public var createdAt: Date?
-    public var decidedAt: Date?
-    public var executedAt: Date?
+    /// Raw ISO wire string (naive/local, no `Z`); see the type doc. Never a `Date`.
+    public var createdAt: String?
+    public var decidedAt: String?
+    public var executedAt: String?
 
     public init(
         id: String, meetingId: String, windowId: String? = nil,
@@ -44,7 +54,7 @@ public struct MeetingProposal: Codable, Equatable, Sendable {
         status: ActuatorStatus, target: String, action: String, preview: String,
         payload: JSONValue? = nil, reversible: Bool, requiredCapabilities: [String] = [],
         decidedBy: String? = nil, result: JSONValue? = nil, error: String? = nil,
-        createdAt: Date? = nil, decidedAt: Date? = nil, executedAt: Date? = nil
+        createdAt: String? = nil, decidedAt: String? = nil, executedAt: String? = nil
     ) {
         self.id = id
         self.meetingId = meetingId

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+DictationBlocks.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+DictationBlocks.swift
@@ -1,0 +1,129 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HSM-18-01 — the rest of the dictation-pipeline client the iPad never had: blocks (read + full CRUD),
+// block-templates, and project-context. Typed calls to the hub's
+// `/api/dictation/blocks*`, `/api/dictation/block-templates`, `/api/dictation/project-context`
+// (modeled in Contracts/DictationBlocks.swift). New file (no edits to HTTPDesktopClient.swift, so it
+// never collides with the parallel client work); builds its own Bearer-authed request off the internal
+// `config`, mirroring +Dictation.swift's pattern.
+//
+// CRUD parity with blocks.py: GET (list) / POST {block} (create) / PUT /{id} {block} (update) /
+// DELETE /{id}. The hub also exposes POST /blocks/from-template (with an optional dry-run); the iPad
+// builds from a template by reading block-templates + create, so it is not surfaced here.
+public extension HTTPDesktopClient {
+
+    /// `GET /api/dictation/blocks?scope=&project_root=` -> the resolved blocks document (the YAML the
+    /// hub reads back) plus scope/path/exists/project envelope.
+    func dictationBlocks(scope: String = "global", projectRoot: String? = nil) async throws -> DictationBlocksResult {
+        var query = [URLQueryItem(name: "scope", value: scope)]
+        if let projectRoot, !projectRoot.isEmpty { query.append(URLQueryItem(name: "project_root", value: projectRoot)) }
+        let data = try await blocksRequest(path: "api/dictation/blocks", method: "GET", query: query, body: nil)
+        return try decodeBlocks(DictationBlocksResult.self, from: data)
+    }
+
+    /// `GET /api/dictation/block-templates` -> the starter templates (`templates[]`).
+    func blockTemplates() async throws -> [DictationBlockTemplate] {
+        let data = try await blocksRequest(path: "api/dictation/block-templates", method: "GET", query: [], body: nil)
+        let envelope = try decodeBlocks(BlockTemplatesEnvelope.self, from: data)
+        return envelope.templates
+    }
+
+    /// `GET /api/dictation/project-context?project_root=` -> the resolved project + its config paths.
+    func projectContext(projectRoot: String? = nil) async throws -> DictationProjectContext {
+        var query: [URLQueryItem] = []
+        if let projectRoot, !projectRoot.isEmpty { query.append(URLQueryItem(name: "project_root", value: projectRoot)) }
+        let data = try await blocksRequest(path: "api/dictation/project-context", method: "GET", query: query, body: nil)
+        return try decodeBlocks(DictationProjectContext.self, from: data)
+    }
+
+    // MARK: - CRUD (blocks.py exposes POST / PUT /{id} / DELETE /{id})
+
+    /// `POST /api/dictation/blocks {block}` -> the updated document. 409 (id already exists) surfaces
+    /// as `DesktopClientError.http(409)`.
+    @discardableResult
+    func createBlock(_ block: DictationBlock, scope: String = "global", projectRoot: String? = nil) async throws -> DictationBlocksResult {
+        let data = try await blocksRequest(path: "api/dictation/blocks", method: "POST",
+                                           query: blocksQuery(scope: scope, projectRoot: projectRoot),
+                                           body: ["block": try encodeBlock(block)])
+        return try decodeBlocks(DictationBlocksResult.self, from: data)
+    }
+
+    /// `PUT /api/dictation/blocks/{blockId} {block}` -> the updated document. Unknown id surfaces as a
+    /// 404; an id collision on rename as a 409.
+    @discardableResult
+    func updateBlock(_ blockId: String, with block: DictationBlock, scope: String = "global", projectRoot: String? = nil) async throws -> DictationBlocksResult {
+        let encoded = blockId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? blockId
+        let data = try await blocksRequest(path: "api/dictation/blocks/\(encoded)", method: "PUT",
+                                           query: blocksQuery(scope: scope, projectRoot: projectRoot),
+                                           body: ["block": try encodeBlock(block)])
+        return try decodeBlocks(DictationBlocksResult.self, from: data)
+    }
+
+    /// `DELETE /api/dictation/blocks/{blockId}` -> the updated document. Note: the hub rejects deleting
+    /// the last block (save requires >= 1) with a 422, surfaced as `DesktopClientError.http(422)`.
+    @discardableResult
+    func deleteBlock(_ blockId: String, scope: String = "global", projectRoot: String? = nil) async throws -> DictationBlocksResult {
+        let encoded = blockId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? blockId
+        let data = try await blocksRequest(path: "api/dictation/blocks/\(encoded)", method: "DELETE",
+                                           query: blocksQuery(scope: scope, projectRoot: projectRoot), body: nil)
+        return try decodeBlocks(DictationBlocksResult.self, from: data)
+    }
+
+    // MARK: - internals
+
+    /// The `GET /api/dictation/block-templates` envelope.
+    private struct BlockTemplatesEnvelope: Codable {
+        var templates: [DictationBlockTemplate]
+    }
+
+    private func blocksQuery(scope: String, projectRoot: String?) -> [URLQueryItem] {
+        var query = [URLQueryItem(name: "scope", value: scope)]
+        if let projectRoot, !projectRoot.isEmpty { query.append(URLQueryItem(name: "project_root", value: projectRoot)) }
+        return query
+    }
+
+    private func decodeBlocks<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do { return try HoldSpeakContracts.decoder().decode(T.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    /// Round-trip a `DictationBlock` back to a JSON object for the create/update bodies (the hub wants
+    /// `{"block": {...}}` with snake_case keys, matching the decoder's `.convertFromSnakeCase`).
+    private func encodeBlock(_ block: DictationBlock) throws -> [String: Any] {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(block)
+        guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DesktopClientError.malformed
+        }
+        return obj
+    }
+
+    /// Self-contained authed request (the struct's own `send`/`makeRequest` are file-private; this new
+    /// file rebuilds the same Bearer pattern off the internal `config`/`session`).
+    private func blocksRequest(path: String, method: String, query: [URLQueryItem], body: [String: Any]?) async throws -> Data {
+        let baseString = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        guard var components = URLComponents(string: "\(baseString)/\(path)") else { throw DesktopClientError.malformed }
+        if !query.isEmpty { components.queryItems = query }
+        guard let url = components.url else { throw DesktopClientError.malformed }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+        let (data, response) = try await session.data(for: request)
+        let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200..<300).contains(code) else { throw DesktopClientError.http(code) }
+        return data
+    }
+}

--- a/apple/Tests/ProvidersTests/ActivityClientTests.swift
+++ b/apple/Tests/ProvidersTests/ActivityClientTests.swift
@@ -109,6 +109,46 @@ final class ActivityClientTests: XCTestCase {
         XCTAssertNil(record.citations[0].lastSeenAt)
     }
 
+    /// Audit guard: every field of `Nudge.to_dict()` / `NudgeCitation.to_dict()`
+    /// (`holdspeak/activity_nudges.py`) decodes into the contract, at the type level. The
+    /// metal-readiness audit confirmed the activity client carries NO drift from these shapes; this
+    /// case pins that so a server-side field rename is caught here, not in the field.
+    func testActivityNudgeContractDecodesEveryServerField() throws {
+        let json = #"""
+        {"key":"record:42","kind":"record","title":"You were reading a PR",
+         "body":"github.com/x/y/pull/7","score":0.8765,
+         "window_since":"2026-06-27T12:00:00","window_record_count":3,
+         "extras":{"headline":"recent","n":2},
+         "citations":[
+           {"record_id":42,"source_browser":"chrome","source_profile":"Default",
+            "entity_type":"github_pull_request","entity_id":"7","domain":"github.com",
+            "title":"Fix the thing","url":"https://github.com/x/y/pull/7",
+            "last_seen_at":"2026-06-27T12:30:00Z","visit_count":3}
+         ]}
+        """#.data(using: .utf8)!
+        let nudge = try HoldSpeakContracts.decoder().decode(ActivityNudge.self, from: json)
+        XCTAssertEqual(nudge.key, "record:42")
+        XCTAssertEqual(nudge.kind, "record")
+        XCTAssertEqual(nudge.title, "You were reading a PR")
+        XCTAssertEqual(nudge.body, "github.com/x/y/pull/7")
+        XCTAssertEqual(nudge.score, 0.8765, accuracy: 0.0001)   // server rounds to 4 places
+        XCTAssertEqual(nudge.windowSince, "2026-06-27T12:00:00")
+        XCTAssertEqual(nudge.windowRecordCount, 3)
+        XCTAssertEqual(nudge.extras["headline"], .string("recent"))
+        XCTAssertEqual(nudge.extras["n"], .number(2))
+        let c = try XCTUnwrap(nudge.citations.first)
+        XCTAssertEqual(c.recordId, 42)
+        XCTAssertEqual(c.sourceBrowser, "chrome")
+        XCTAssertEqual(c.sourceProfile, "Default")
+        XCTAssertEqual(c.entityType, "github_pull_request")
+        XCTAssertEqual(c.entityId, "7")
+        XCTAssertEqual(c.domain, "github.com")
+        XCTAssertEqual(c.title, "Fix the thing")
+        XCTAssertEqual(c.url, "https://github.com/x/y/pull/7")
+        XCTAssertEqual(c.lastSeenAt, "2026-06-27T12:30:00Z")
+        XCTAssertEqual(c.visitCount, 3)
+    }
+
     func testActivityNudgesEmptyWhenTrackingOff() async throws {
         StubProtocol.routes = ["/api/activity/nudges": (200,
             Data(#"{"nudges":[],"activity_enabled":false}"#.utf8))]

--- a/apple/Tests/ProvidersTests/AftercareClientTests.swift
+++ b/apple/Tests/ProvidersTests/AftercareClientTests.swift
@@ -195,16 +195,21 @@ final class AftercareClientTests: XCTestCase {
     // MARK: file-issue
 
     func testFileAftercareIssuePostsAndDecodesProposal() async throws {
+        // The REAL `_proposal_to_dict` shape: it ALSO carries `payload` + `result`
+        // (which the loose AftercareIssueProposal model does not declare and harmlessly
+        // ignores), and the timestamps are the hub's naive/no-`Z` `isoformat()` (the
+        // EQ-W6 fix — they decode as raw strings, not `Date`).
         let body = #"""
         {"success": true,
          "proposal": {
             "id": "p1", "meeting_id": "m1", "window_id": "m1:aftercare",
             "plugin_id": "github_issue", "plugin_version": "1.0.0", "status": "proposed",
-            "target": "octo/repo", "action": "create_issue",
+            "target": "github", "action": "create_issue",
             "preview": "Open issue in octo/repo: Wire the sync transport",
+            "payload": {"repo": "octo/repo", "title": "Wire the sync transport"},
             "reversible": false, "required_capabilities": ["github:issues:write"],
-            "decided_by": null, "error": null,
-            "created_at": "2026-06-27T12:00:00+00:00", "decided_at": null, "executed_at": null}}
+            "decided_by": null, "result": null, "error": null,
+            "created_at": "2026-06-27T12:00:00.789654", "decided_at": null, "executed_at": null}}
         """#
         StubProtocol.routes = ["/api/meetings/m1/aftercare/file-issue": (200, Data(body.utf8))]
 
@@ -223,10 +228,11 @@ final class AftercareClientTests: XCTestCase {
         let proposal = try XCTUnwrap(result.proposal)
         XCTAssertEqual(proposal.id, "p1")
         XCTAssertEqual(proposal.status, "proposed")            // proposed only — nothing sent
-        XCTAssertEqual(proposal.target, "octo/repo")
+        XCTAssertEqual(proposal.target, "github")
         XCTAssertEqual(proposal.preview, "Open issue in octo/repo: Wire the sync transport")
         XCTAssertEqual(proposal.requiredCapabilities, ["github:issues:write"])
-        XCTAssertNotNil(proposal.createdAt)                    // ISO date decodes
+        // The real naive/no-`Z` timestamp carried verbatim (it threw as `Date` before).
+        XCTAssertEqual(proposal.createdAt, "2026-06-27T12:00:00.789654")
         XCTAssertNil(proposal.executedAt)
     }
 

--- a/apple/Tests/ProvidersTests/ArtifactsClientTests.swift
+++ b/apple/Tests/ProvidersTests/ArtifactsClientTests.swift
@@ -6,6 +6,14 @@ import XCTest
 // fields the iPad render currently drops), plus the type/title/body/status the
 // SwiftUI screen already shows. The JSON literal mirrors the exact shape
 // holdspeak/web/routes/meetings.py::api_get_meeting_artifacts returns.
+//
+// METAL-READINESS (EQ-W6 audit): the `created_at`/`updated_at` literals use the REAL
+// wire shape — the route emits `artifact.created_at.isoformat()` where the value was
+// loaded via `datetime.fromisoformat(...)` from a DB string written by
+// `datetime.now().isoformat()`: naive/local, microseconds, NO `Z`. The contract
+// decoded these as `Date` via the shared `.iso8601` strategy, which THROWS on a
+// zone-less string — failing the whole artifact decode on real metal. Now carried as
+// raw `String?`.
 final class ArtifactsClientTests: XCTestCase {
 
     private static let envelopeJSON = """
@@ -27,8 +35,8 @@ final class ArtifactsClientTests: XCTestCase {
             {"source_type": "intent_window", "source_ref": "win-7"},
             {"source_type": "plugin_run", "source_ref": "run-42"}
           ],
-          "created_at": "2026-06-27T10:00:00Z",
-          "updated_at": "2026-06-27T10:05:00Z"
+          "created_at": "2026-06-27T10:00:00.123456",
+          "updated_at": "2026-06-27T10:05:00.654321"
         }
       ]
     }
@@ -61,8 +69,9 @@ final class ArtifactsClientTests: XCTestCase {
         XCTAssertEqual(artifact.sources[1].sourceType, "plugin_run")
         XCTAssertEqual(artifact.sources[1].sourceRef, "run-42")
 
-        XCTAssertNotNil(artifact.createdAt)
-        XCTAssertNotNil(artifact.updatedAt)
+        // Real naive/no-`Z` timestamps carried verbatim (they threw as `Date` before).
+        XCTAssertEqual(artifact.createdAt, "2026-06-27T10:00:00.123456")
+        XCTAssertEqual(artifact.updatedAt, "2026-06-27T10:05:00.654321")
     }
 
     /// `confidence` is `Double?` per the slice spec: an artifact without it still
@@ -86,8 +95,8 @@ final class ArtifactsClientTests: XCTestCase {
               "plugin_id": "action_items.core",
               "plugin_version": "1.0.0",
               "sources": [],
-              "created_at": "2026-06-27T11:00:00Z",
-              "updated_at": "2026-06-27T11:00:00Z"
+              "created_at": "2026-06-27T11:00:00.000000",
+              "updated_at": "2026-06-27T11:00:00.000000"
             }
           ]
         }

--- a/apple/Tests/ProvidersTests/DictationBlocksClientTests.swift
+++ b/apple/Tests/ProvidersTests/DictationBlocksClientTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HSM-18-01 — the rest of the dictation-pipeline client: blocks (read + CRUD), block-templates,
+/// project-context. Network stubbed via `URLProtocol`; deterministic and offline. Proves the
+/// snake_case hub wire decodes into the Contracts types, the Bearer token rides, the query params
+/// (scope / project_root) are carried, the CRUD verbs/paths are right, and the create/update bodies
+/// round-trip a block back to snake_case JSON.
+final class DictationBlocksClientTests: XCTestCase {
+
+    // MARK: stub (matches on path; query carried separately)
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastQuery: String?
+        nonisolated(unsafe) static var lastMethod: String?
+        nonisolated(unsafe) static var lastBody: [String: Any]?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastQuery = request.url?.query
+            StubProtocol.lastMethod = request.httpMethod
+            // URLProtocol strips httpBody onto the body stream; read it back.
+            if let stream = request.httpBodyStream {
+                stream.open()
+                var data = Data()
+                let bufSize = 4096
+                let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+                while stream.hasBytesAvailable {
+                    let read = stream.read(buf, maxLength: bufSize)
+                    if read <= 0 { break }
+                    data.append(buf, count: read)
+                }
+                buf.deallocate()
+                stream.close()
+                StubProtocol.lastBody = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            } else if let body = request.httpBody {
+                StubProtocol.lastBody = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any]
+            } else {
+                StubProtocol.lastBody = nil
+            }
+            let path = request.url?.path ?? ""
+            guard let (status, body) = StubProtocol.routes[path] else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.lastQuery = nil
+        StubProtocol.lastMethod = nil
+        StubProtocol.lastBody = nil
+    }
+
+    private func client(token: String? = nil) -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    // MARK: - contract decode round-trips (faithful to blocks.py / agent.py)
+
+    func testBlocksResultDecodesRealEnvelope() throws {
+        let json = #"""
+        {
+          "scope": "global",
+          "path": "/home/me/.holdspeak/blocks.yaml",
+          "exists": true,
+          "project": null,
+          "document": {
+            "version": 1,
+            "default_match_confidence": 0.6,
+            "blocks": [
+              {
+                "id": "action_item",
+                "description": "User is capturing a task.",
+                "match": {
+                  "examples": ["follow up with Sam"],
+                  "negative_examples": ["write a paragraph"],
+                  "threshold": 0.7
+                },
+                "inject": { "mode": "replace", "template": "Action item: {raw_text}" }
+              }
+            ]
+          }
+        }
+        """#
+        let result = try HoldSpeakContracts.decoder().decode(DictationBlocksResult.self, from: Data(json.utf8))
+        XCTAssertEqual(result.scope, "global")
+        XCTAssertEqual(result.exists, true)
+        XCTAssertEqual(result.document.version, 1)
+        XCTAssertEqual(result.document.defaultMatchConfidence, 0.6)
+        XCTAssertEqual(result.document.blocks.count, 1)
+        let block = try XCTUnwrap(result.document.blocks.first)
+        XCTAssertEqual(block.id, "action_item")
+        XCTAssertEqual(block.match?.examples, ["follow up with Sam"])
+        XCTAssertEqual(block.match?.negativeExamples, ["write a paragraph"])
+        XCTAssertEqual(block.match?.threshold, 0.7)
+        XCTAssertEqual(block.inject?.mode, "replace")
+        XCTAssertEqual(block.inject?.template, "Action item: {raw_text}")
+    }
+
+    func testBlocksDocumentToleratesMissingDefaults() throws {
+        // A bare document (only blocks) still decodes — robust against shape drift.
+        let json = #"{"document": {"blocks": [{"id": "only"}]}}"#
+        let result = try HoldSpeakContracts.decoder().decode(DictationBlocksResult.self, from: Data(json.utf8))
+        XCTAssertNil(result.document.version)
+        XCTAssertEqual(result.document.blocks.first?.id, "only")
+        XCTAssertNil(result.document.blocks.first?.match)
+    }
+
+    func testBlockTemplateDecodesMetadataAndBlock() throws {
+        let json = #"""
+        {"templates": [
+          {
+            "id": "action_item",
+            "title": "Action item",
+            "description": "Turn task dictation into a line.",
+            "sample_utterance": "follow up with Sam about the launch checklist",
+            "requires_project": false,
+            "block": { "id": "action_item", "inject": { "mode": "replace", "template": "Action item: {raw_text}" } }
+          }
+        ]}
+        """#
+        struct Envelope: Codable { var templates: [DictationBlockTemplate] }
+        let env = try HoldSpeakContracts.decoder().decode(Envelope.self, from: Data(json.utf8))
+        let t = try XCTUnwrap(env.templates.first)
+        XCTAssertEqual(t.id, "action_item")
+        XCTAssertEqual(t.title, "Action item")
+        XCTAssertEqual(t.sampleUtterance, "follow up with Sam about the launch checklist")
+        XCTAssertEqual(t.requiresProject, false)
+        XCTAssertEqual(t.block?.inject?.mode, "replace")
+    }
+
+    func testProjectContextDecodesProjectAndPaths() throws {
+        let json = #"""
+        {
+          "project": { "name": "holdspeak", "root": "/Users/me/holdspeak", "anchor": ".git" },
+          "paths": {
+            "blocks": "/Users/me/holdspeak/.holdspeak/blocks.yaml",
+            "project_kb": "/Users/me/holdspeak/.holdspeak/project.yaml"
+          }
+        }
+        """#
+        let ctx = try HoldSpeakContracts.decoder().decode(DictationProjectContext.self, from: Data(json.utf8))
+        XCTAssertEqual(ctx.project.name, "holdspeak")
+        XCTAssertEqual(ctx.project.root, "/Users/me/holdspeak")
+        XCTAssertEqual(ctx.project.anchor, ".git")
+        XCTAssertEqual(ctx.paths?.blocks, "/Users/me/holdspeak/.holdspeak/blocks.yaml")
+        XCTAssertEqual(ctx.paths?.projectKb, "/Users/me/holdspeak/.holdspeak/project.yaml")
+    }
+
+    // MARK: - over the client (Bearer + query + verb/path)
+
+    func testDictationBlocksSendsTokenScopeAndDecodes() async throws {
+        StubProtocol.routes = [
+            "/api/dictation/blocks": (200, Data(#"{"scope":"project","document":{"blocks":[{"id":"b1"}]}}"#.utf8)),
+        ]
+        let result = try await client(token: "t0ken").dictationBlocks(scope: "project", projectRoot: "/Users/me/app")
+        XCTAssertEqual(result.scope, "project")
+        XCTAssertEqual(result.document.blocks.first?.id, "b1")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer t0ken")
+        XCTAssertEqual(StubProtocol.lastMethod, "GET")
+        let q = try XCTUnwrap(StubProtocol.lastQuery)
+        XCTAssertTrue(q.contains("scope=project"), q)
+        XCTAssertTrue(q.contains("project_root=") && q.contains("app"), q)
+    }
+
+    func testBlockTemplatesUnwrapsEnvelope() async throws {
+        StubProtocol.routes = [
+            "/api/dictation/block-templates": (200, Data(#"{"templates":[{"id":"action_item","title":"Action item"}]}"#.utf8)),
+        ]
+        let templates = try await client(token: "abc").blockTemplates()
+        XCTAssertEqual(templates.count, 1)
+        XCTAssertEqual(templates.first?.id, "action_item")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer abc")
+    }
+
+    func testProjectContextSendsProjectRootQuery() async throws {
+        StubProtocol.routes = [
+            "/api/dictation/project-context": (200, Data(#"{"project":{"name":"holdspeak","root":"/r"}}"#.utf8)),
+        ]
+        let ctx = try await client(token: "xyz").projectContext(projectRoot: "/r")
+        XCTAssertEqual(ctx.project.name, "holdspeak")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer xyz")
+        XCTAssertEqual(try XCTUnwrap(StubProtocol.lastQuery), "project_root=/r")
+    }
+
+    func testCreateBlockPostsSnakeCaseBlockBody() async throws {
+        StubProtocol.routes = [
+            "/api/dictation/blocks": (201, Data(#"{"scope":"global","document":{"blocks":[{"id":"new"}]}}"#.utf8)),
+        ]
+        let block = DictationBlock(
+            id: "new",
+            description: "a new block",
+            match: .init(examples: ["hi"], negativeExamples: ["bye"], threshold: 0.7),
+            inject: .init(mode: "append", template: "x")
+        )
+        let result = try await client(token: "t").createBlock(block)
+        XCTAssertEqual(result.document.blocks.first?.id, "new")
+        XCTAssertEqual(StubProtocol.lastMethod, "POST")
+        let body = try XCTUnwrap(StubProtocol.lastBody)
+        let sent = try XCTUnwrap(body["block"] as? [String: Any])
+        XCTAssertEqual(sent["id"] as? String, "new")
+        // .convertToSnakeCase: negativeExamples -> negative_examples on the wire.
+        let match = try XCTUnwrap(sent["match"] as? [String: Any])
+        XCTAssertNotNil(match["negative_examples"])
+        XCTAssertNil(match["negativeExamples"])
+    }
+
+    func testUpdateBlockUsesPutAndIdInPath() async throws {
+        StubProtocol.routes = [
+            "/api/dictation/blocks/action_item": (200, Data(#"{"document":{"blocks":[{"id":"action_item"}]}}"#.utf8)),
+        ]
+        let result = try await client(token: "t").updateBlock("action_item",
+                                                               with: DictationBlock(id: "action_item", description: "edited"))
+        XCTAssertEqual(result.document.blocks.first?.id, "action_item")
+        XCTAssertEqual(StubProtocol.lastMethod, "PUT")
+        XCTAssertNotNil(StubProtocol.lastBody?["block"])
+    }
+
+    func testDeleteBlockUsesDeleteVerb() async throws {
+        StubProtocol.routes = [
+            "/api/dictation/blocks/stale": (200, Data(#"{"document":{"blocks":[{"id":"keep"}]}}"#.utf8)),
+        ]
+        let result = try await client(token: "t").deleteBlock("stale", scope: "project", projectRoot: "/p")
+        XCTAssertEqual(result.document.blocks.first?.id, "keep")
+        XCTAssertEqual(StubProtocol.lastMethod, "DELETE")
+        let q = try XCTUnwrap(StubProtocol.lastQuery)
+        XCTAssertTrue(q.contains("scope=project"), q)
+    }
+
+    func testDeleteLastBlock422SurfacesAsHTTPError() async {
+        // blocks.py rejects deleting the last block (save requires >= 1) with a 422.
+        StubProtocol.routes = ["/api/dictation/blocks/only": (422, Data(#"{"error":"at least one block required"}"#.utf8))]
+        do {
+            _ = try await client(token: "t").deleteBlock("only")
+            XCTFail("expected an http error")
+        } catch let HTTPDesktopClient.DesktopClientError.http(code) {
+            XCTAssertEqual(code, 422)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testBlocksThrowsMalformedOnBadJSON() async {
+        StubProtocol.routes = ["/api/dictation/blocks": (200, Data(#"{ not json"#.utf8))]
+        do {
+            _ = try await client().dictationBlocks()
+            XCTFail("expected malformed")
+        } catch HTTPDesktopClient.DesktopClientError.malformed {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/apple/Tests/ProvidersTests/DictationClientTests.swift
+++ b/apple/Tests/ProvidersTests/DictationClientTests.swift
@@ -1,53 +1,145 @@
 import XCTest
 import Contracts
 
-/// HSM-18-01 — the dictation teleprompter's data decodes from the hub's real `/api/dictation/dry-run`
-/// + `/api/dictation/readiness` JSON (snake_case wire -> camelCase via HoldSpeakContracts.decoder()).
+/// HSM-18-01 — the dictation teleprompter's data decodes from the hub's REAL
+/// `/api/dictation/dry-run` + `/api/dictation/readiness` JSON. The JSON below is the actual wire
+/// shape produced by `_run_dictation_dry_run_text` (`holdspeak/web/routes/dictation/_helpers.py`)
+/// and `api_dictation_readiness` (`.../pipeline.py`): `target` is `TargetProfile.to_dict()`
+/// (`id`/`label`/`confidence`/`source`/`app_name`/`process_name`/`window_title`/`details`), NOT
+/// the earlier guessed `app`/`window`/`process`/`profile`. snake_case -> camelCase via
+/// `HoldSpeakContracts.decoder()`.
 final class DictationClientTests: XCTestCase {
 
-    func testDryRunDecodesFinalTextAndDestination() throws {
+    // MARK: dry-run — the real `_run_dictation_dry_run_text` shape
+
+    func testDryRunDecodesRealServerShape() throws {
+        // A verbatim dry-run payload: `target` is the TargetProfile dict, `project` is an object,
+        // `runtime_status`/`runtime_detail`/`blocks_count`/`suggestion_status`/`journal_id` ride
+        // alongside the rewritten `final_text`. There is NO top-level `status`.
         let json = """
         {
-          "final_text": "Use Redis with a 24 hour TTL.",
-          "target": { "app": "Cursor", "confidence": 0.91 },
-          "warnings": ["model fallback"],
-          "total_elapsed_ms": 380,
-          "status": "ok",
+          "project": {"name": "holdspeak", "root": "/Users/k/dev/holdspeak", "anchor": "git"},
+          "target": {
+            "id": "cursor", "label": "Cursor", "confidence": 0.78, "source": "hints",
+            "app_name": "Cursor", "process_name": "Cursor", "window_title": "main.swift",
+            "details": {"matched": "editor_app"}
+          },
+          "suggestion_status": "no_suggestion",
+          "journal_id": 17,
+          "learning": null,
+          "runtime_status": "available",
+          "runtime_detail": "mlx model present",
           "blocks_count": 2,
-          "project": "holdspeak"
+          "stages": [],
+          "final_text": "Use Redis with a 24 hour TTL.",
+          "total_elapsed_ms": 380.0,
+          "warnings": ["model fallback"]
         }
         """.data(using: .utf8)!
         let dry = try HoldSpeakContracts.decoder().decode(DictationDryRun.self, from: json)
         XCTAssertEqual(dry.finalText, "Use Redis with a 24 hour TTL.")
-        XCTAssertEqual(dry.target?.label, "Cursor")          // the destination column header "-> Cursor"
-        XCTAssertEqual(dry.target?.confidence, 0.91)
+        // target is the TargetProfile shape — app_name etc. populate now (they decoded to nil
+        // against the old app/window/process model, the bug this audit fixed).
+        XCTAssertEqual(dry.target?.id, "cursor")
+        XCTAssertEqual(dry.target?.label, "Cursor")
+        XCTAssertEqual(dry.target?.confidence, 0.78)
+        XCTAssertEqual(dry.target?.source, "hints")
+        XCTAssertEqual(dry.target?.appName, "Cursor")
+        XCTAssertEqual(dry.target?.processName, "Cursor")
+        XCTAssertEqual(dry.target?.windowTitle, "main.swift")
+        XCTAssertEqual(dry.target?.details?["matched"], .string("editor_app"))
+        XCTAssertEqual(dry.target?.displayLabel, "Cursor")     // the "-> Cursor" header
+        // project is an object, not a string
+        XCTAssertEqual(dry.project?.name, "holdspeak")
+        XCTAssertEqual(dry.project?.root, "/Users/k/dev/holdspeak")
+        XCTAssertEqual(dry.project?.anchor, "git")
+        XCTAssertEqual(dry.runtimeStatus, "available")
+        XCTAssertEqual(dry.runtimeDetail, "mlx model present")
+        XCTAssertEqual(dry.blocksCount, 2)
+        XCTAssertEqual(dry.suggestionStatus, "no_suggestion")
+        XCTAssertEqual(dry.journalId, 17)
         XCTAssertEqual(dry.warnings, ["model fallback"])
         XCTAssertEqual(dry.totalElapsedMs, 380)
-        XCTAssertEqual(dry.blocksCount, 2)
     }
 
-    func testDryRunToleratesMissingOptionalFields() throws {
-        // a minimal hub response (only final_text) must still decode, not throw
-        let json = #"{"final_text": "hello"}"#.data(using: .utf8)!
+    /// An "unknown" target (the `_profile("unknown", 0.0, ...)` path) with no usable name has no
+    /// destination — the header shows nothing rather than the literal "unknown".
+    func testDryRunUnknownTargetHasNoDestinationLabel() throws {
+        let json = """
+        {"final_text": "hi",
+         "target": {"id": "unknown", "confidence": 0.0, "source": "none",
+                    "app_name": null, "process_name": null, "window_title": null, "details": {}}}
+        """.data(using: .utf8)!
+        let dry = try HoldSpeakContracts.decoder().decode(DictationDryRun.self, from: json)
+        XCTAssertEqual(dry.target?.id, "unknown")
+        // no label, no app/window/process, and the id is "unknown" -> nothing to show.
+        XCTAssertNil(dry.target?.displayLabel)
+    }
+
+    /// A disabled-pipeline dry-run returns no `target`/`blocks_count` extras; only `final_text` is
+    /// guaranteed. It must still decode, not throw.
+    func testDryRunToleratesMinimalPayload() throws {
+        let json = #"{"final_text": "hello", "runtime_status": "disabled"}"#.data(using: .utf8)!
         let dry = try HoldSpeakContracts.decoder().decode(DictationDryRun.self, from: json)
         XCTAssertEqual(dry.finalText, "hello")
+        XCTAssertEqual(dry.runtimeStatus, "disabled")
         XCTAssertNil(dry.target)
-        XCTAssertNil(dry.target?.label)
+        XCTAssertNil(dry.project)
+        XCTAssertNil(dry.target?.displayLabel)
     }
 
-    func testReadinessDecodesAndReportsReady() throws {
+    // MARK: readiness — the real `api_dictation_readiness` shape
+
+    func testReadinessDecodesRealServerShape() throws {
+        // The real top-level: `ready` (the hub's verdict), `project`, `runtime` (model_exists lives
+        // HERE, not top-level), and `target`. The earlier flat status/model_exists/runtime_status/
+        // openai_compatible model decoded none of this.
         let json = """
-        { "status": "ready", "model_exists": true, "runtime_status": "ok", "openai_compatible": false }
+        {
+          "ready": true,
+          "project": {"name": "holdspeak", "root": "/Users/k/dev/holdspeak", "anchor": "git"},
+          "config": {"pipeline_enabled": true, "backend": "mlx"},
+          "runtime": {
+            "status": "available", "requested_backend": "mlx", "resolved_backend": "mlx",
+            "detail": "model present", "model_exists": true
+          },
+          "target": {
+            "id": "claude_code", "label": "Claude Code", "confidence": 0.92, "source": "hints",
+            "app_name": "Terminal", "process_name": "claude", "window_title": null,
+            "details": {"matched": "claude"}
+          },
+          "warnings": []
+        }
         """.data(using: .utf8)!
         let r = try HoldSpeakContracts.decoder().decode(DictationReadiness.self, from: json)
         XCTAssertTrue(r.isReady)
-        XCTAssertEqual(r.modelExists, true)
-        XCTAssertEqual(r.runtimeStatus, "ok")
+        XCTAssertEqual(r.ready, true)
+        XCTAssertEqual(r.project?.name, "holdspeak")
+        XCTAssertEqual(r.runtime?.status, "available")
+        XCTAssertEqual(r.runtime?.modelExists, true)
+        XCTAssertEqual(r.runtime?.requestedBackend, "mlx")
+        XCTAssertEqual(r.runtime?.resolvedBackend, "mlx")
+        XCTAssertEqual(r.target?.id, "claude_code")
+        XCTAssertEqual(r.target?.displayLabel, "Claude Code")
     }
 
-    func testReadinessNotReadyWhenNoModelAndNoEndpoint() throws {
-        let json = #"{"status": "incomplete", "model_exists": false, "openai_compatible": false}"#.data(using: .utf8)!
+    func testReadinessNotReadyWhenRuntimeUnavailable() throws {
+        // ready:false + an unavailable runtime -> not ready, and isReady honors the hub verdict.
+        let json = """
+        {"ready": false, "project": null,
+         "runtime": {"status": "missing_model", "model_exists": false}}
+        """.data(using: .utf8)!
         let r = try HoldSpeakContracts.decoder().decode(DictationReadiness.self, from: json)
         XCTAssertFalse(r.isReady)
+        XCTAssertEqual(r.runtime?.modelExists, false)
+        XCTAssertNil(r.project)
+    }
+
+    /// With no `ready` field, isReady falls back to "the runtime is available".
+    func testReadinessFallsBackToRuntimeStatusWhenNoVerdict() throws {
+        let json = #"{"runtime": {"status": "available", "model_exists": true}}"#.data(using: .utf8)!
+        let r = try HoldSpeakContracts.decoder().decode(DictationReadiness.self, from: json)
+        XCTAssertNil(r.ready)
+        XCTAssertTrue(r.isReady)
     }
 }

--- a/apple/Tests/ProvidersTests/ProposalsClientTests.swift
+++ b/apple/Tests/ProvidersTests/ProposalsClientTests.swift
@@ -77,6 +77,13 @@ final class ProposalsClientTests: XCTestCase {
     // A realistic GET /api/meetings/{id}/proposals envelope: one undecided slack
     // proposal (null decided_at/executed_at/decided_by/result/error) — the exact
     // shape `_proposal_to_dict` serializes.
+    //
+    // METAL-READINESS (EQ-W6 audit): `created_at` is the REAL wire shape the hub
+    // emits — `datetime.now().isoformat()`: naive/local, microseconds, NO `Z`
+    // (`2026-06-27T14:03:11.337333`). Before the fix the contract decoded these as
+    // `Date` via the shared `.iso8601` strategy, which throws on a zone-less string —
+    // so on real metal the whole envelope decode failed `.malformed`. The contract
+    // now carries the timestamps as raw `String?`, so this real shape decodes.
     private let proposalsJSON = #"""
     {
       "meeting_id": "m-42",
@@ -97,7 +104,7 @@ final class ProposalsClientTests: XCTestCase {
           "decided_by": null,
           "result": null,
           "error": null,
-          "created_at": "2026-06-27T14:03:11Z",
+          "created_at": "2026-06-27T14:03:11.337333",
           "decided_at": null,
           "executed_at": null
         }
@@ -127,7 +134,8 @@ final class ProposalsClientTests: XCTestCase {
         XCTAssertNil(p.decidedBy)
         XCTAssertNil(p.decidedAt)
         XCTAssertNil(p.executedAt)
-        XCTAssertNotNil(p.createdAt)               // ISO-8601 Z decoded
+        // The REAL naive/no-`Z` timestamp the hub emits, carried verbatim (not a Date).
+        XCTAssertEqual(p.createdAt, "2026-06-27T14:03:11.337333")
         XCTAssertEqual(p.payload, .object(["channel": .string("#standup"),
                                            "blocks": .number(3)]))
     }
@@ -153,9 +161,9 @@ final class ProposalsClientTests: XCTestCase {
             "decided_by": "ipad-user",
             "result": {"ok": true},
             "error": null,
-            "created_at": "2026-06-27T14:03:11Z",
-            "decided_at": "2026-06-27T14:05:00Z",
-            "executed_at": "2026-06-27T14:05:01Z"
+            "created_at": "2026-06-27T14:03:11.337333",
+            "decided_at": "2026-06-27T14:05:00.111222",
+            "executed_at": "2026-06-27T14:05:01.999000"
           }
         }
         """#
@@ -166,8 +174,9 @@ final class ProposalsClientTests: XCTestCase {
         let p = try XCTUnwrap(decision.proposal)
         XCTAssertEqual(p.status, .executed)
         XCTAssertEqual(p.decidedBy, "ipad-user")
-        XCTAssertNotNil(p.decidedAt)
-        XCTAssertNotNil(p.executedAt)
+        // Real naive/no-`Z` timestamps decode (they threw as `Date` before the fix).
+        XCTAssertEqual(p.decidedAt, "2026-06-27T14:05:00.111222")
+        XCTAssertEqual(p.executedAt, "2026-06-27T14:05:01.999000")
         XCTAssertEqual(p.result, .object(["ok": .bool(true)]))
     }
 
@@ -201,8 +210,8 @@ final class ProposalsClientTests: XCTestCase {
           "status": "approved", "target": "slack", "action": "send_message",
           "preview": "x", "payload": null, "reversible": false,
           "required_capabilities": [], "decided_by": "ipad-user",
-          "result": null, "error": null, "created_at": "2026-06-27T14:03:11Z",
-          "decided_at": "2026-06-27T14:05:00Z", "executed_at": null
+          "result": null, "error": null, "created_at": "2026-06-27T14:03:11.337333",
+          "decided_at": "2026-06-27T14:05:00.111222", "executed_at": null
         }}
         """#
         StubProtocol.routes = [
@@ -229,8 +238,8 @@ final class ProposalsClientTests: XCTestCase {
           "status": "rejected", "target": "slack", "action": "send_message",
           "preview": "x", "payload": null, "reversible": false,
           "required_capabilities": [], "decided_by": "ipad-user",
-          "result": null, "error": null, "created_at": "2026-06-27T14:03:11Z",
-          "decided_at": "2026-06-27T14:05:00Z", "executed_at": null
+          "result": null, "error": null, "created_at": "2026-06-27T14:03:11.337333",
+          "decided_at": "2026-06-27T14:05:00.111222", "executed_at": null
         }}
         """#
         StubProtocol.routes = [
@@ -252,5 +261,42 @@ final class ProposalsClientTests: XCTestCase {
         } catch {
             XCTFail("expected DesktopClientError.http, got \(error)")
         }
+    }
+
+    // MARK: metal-readiness regression (EQ-W6 audit)
+
+    /// The exact wire shape the hub produces for the proposal timestamps —
+    /// `datetime.now().isoformat()` (naive/local, microseconds, NO `Z`). Before the
+    /// audit fix, `created_at`/`decided_at`/`executed_at` decoded as `Date` via the
+    /// shared `.iso8601` strategy, which throws on a zone-less string — so the WHOLE
+    /// envelope failed `.malformed` on real metal even though every other field was
+    /// fine. This proves the contract now carries them as raw strings and decodes the
+    /// real shape. (A `+00:00` offset variant is included to prove offsets survive too.)
+    func testRealNaiveTimestampsDecodeAsRawStrings() throws {
+        let json = #"""
+        {
+          "meeting_id": "m-1",
+          "proposals": [
+            {
+              "id": "p-1", "meeting_id": "m-1", "window_id": null,
+              "plugin_id": "github_issue", "plugin_version": "1.0.0",
+              "status": "approved", "target": "github", "action": "create_issue",
+              "preview": "Open issue", "payload": null, "reversible": true,
+              "required_capabilities": ["github:issues:write"], "decided_by": "ipad-user",
+              "result": null, "error": null,
+              "created_at": "2026-06-27T18:08:21.337333",
+              "decided_at": "2026-06-27T18:09:00.000001",
+              "executed_at": "2026-06-27T18:10:42.500000+00:00"
+            }
+          ]
+        }
+        """#
+        let env = try HoldSpeakContracts.decoder()
+            .decode(MeetingProposalsEnvelope.self, from: Data(json.utf8))
+        let p = try XCTUnwrap(env.proposals.first)
+        XCTAssertEqual(p.status, .approved)
+        XCTAssertEqual(p.createdAt, "2026-06-27T18:08:21.337333")
+        XCTAssertEqual(p.decidedAt, "2026-06-27T18:09:00.000001")
+        XCTAssertEqual(p.executedAt, "2026-06-27T18:10:42.500000+00:00")
     }
 }

--- a/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
+++ b/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
@@ -145,4 +145,18 @@ Verified together: `swift test` (storage + activity + no regression), web build,
 all green. The web hardening proves the pattern: every wave's integration runs the browser preflight CI
 silently skips, so this class of bug keeps getting caught instead of shipped.
 
+### Wave 6 (2026-06-27) — finish the dictation client + a metal-readiness audit that earned its keep
+
+The first audit-and-fix iOS fleet, run before the device walk. 3 agents:
+
+| Slice | What landed |
+|-------|-------------|
+| Dictation client completion | `dictationBlocks` (+ full CRUD), `blockTemplates`, `projectContext` + Contracts types (the rest of the HSM-18-01 routes the iPad never called). 12 tests. |
+| **Meeting-client audit (caught a real metal-breaking bug)** | The hub serializes proposal/artifact timestamps with `datetime.now().isoformat()` (naive, no `Z`/offset). Swift's `.iso8601` decode strategy REQUIRES a timezone and THROWS on a zone-less string, so the WHOLE response decode failed (`.malformed`) the instant any timestamp was present, breaking Proposals + Aftercare-file-issue + Artifacts on real metal. The existing tests masked it with idealized `...Z` literals. Fix: carry those timestamps as raw `String?` (the contract's own rule), no edit to the shared decoder. |
+| Dictation/activity audit | dictation (dry-run/readiness) + activity verified field-by-field vs the real routes; tests strengthened. |
+
+Integrated: `swift build --target Providers` + the full package suite **366 tests, 0 failures**. The
+audit is the highest-value pre-metal move: it caught, in a worktree, a bug that would have failed three
+of the owner's device-walk features.
+
 See [[project_primitive_framework]], [[project_phase15_the_mesh]], [[project_phase17_agent_sync]].


### PR DESCRIPTION
First audit-and-fix iOS fleet, run **before** the device walk.

- **Dictation client completion:** `dictationBlocks` (+ CRUD), `blockTemplates`, `projectContext` + types (the rest of HSM-18-01). 12 tests.
- **Meeting-client audit → caught a real metal-breaking bug:** the hub serializes timestamps with `datetime.now().isoformat()` (naive, no `Z`/offset); Swift's `.iso8601` decode **requires** a timezone, so the **whole response decode threw** (`.malformed`) whenever any timestamp was present — breaking Proposals + Aftercare-file-issue + Artifacts on metal. Existing tests masked it with idealized `...Z` literals. Fixed: carry them as `String?` (the contract's own rule), no shared-decoder change.
- **Dictation/activity audit:** verified field-by-field vs the real routes.

Integrated: `swift build --target Providers` + full package suite **366 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)