### PR TITLE
Armada Wave 7 (iOS): meeting-import + learning-loop clients (the last Phase-19 clients)

### DIFF
--- a/apple/Sources/Contracts/LearningJournal.swift
+++ b/apple/Sources/Contracts/LearningJournal.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+// HSM Contracts — the dictation learning loop, read side (Phase 19-06).
+//
+// Faithful Swift models for the desktop hub's two read-only learning routes:
+//
+//   - GET /api/dictation/journal          → JournalResponse  (newest-first entries
+//                                            + the local-only toggle/retention/count)
+//   - GET /api/dictation/learning-digest  → LearningDigest    (windowed "what HoldSpeak
+//                                            learned" counts + per-correction reach)
+//
+// These are READ-ONLY on the iPad: no on-device journaling, no correction writes —
+// that's Phase 9. The write/delete/correct routes on the hub are intentionally not
+// modelled here.
+//
+// CRITICAL — naive timestamps. The hub stamps `created_at` via
+// `datetime.now().isoformat()` (no `Z`, no offset) and the digest's `generated_at`
+// the same way. The shared `HoldSpeakContracts.decoder()` uses `.iso8601`, which
+// THROWS on a naive string. So every timestamp here is a raw `String?`, never a
+// `Date` — exactly the bug just fixed in the meeting clients. Carry the string;
+// the view layer formats it.
+
+// MARK: - Journal (GET /api/dictation/journal)
+
+/// One journaled dictation run, as `_journal_to_dict` serializes it. A pure record
+/// of a single utterance's trip through the pipeline — what was said, what it became,
+/// where it routed, and how long it took.
+public struct JournalEntry: Codable, Sendable, Equatable, Identifiable {
+    public let id: Int
+    /// Naive ISO from `datetime.now().isoformat()` — String, never Date (decoder would throw).
+    public let createdAt: String?
+    /// "dictation" or "dry_run".
+    public let source: String
+    public let transcript: String
+    public let finalText: String
+    public let projectRoot: String?
+    public let intent: String?
+    public let blockId: String?
+    public let targetProfile: String?
+    /// Per-stage timings (stage id → ms). May be absent/empty on a bare run.
+    public let stageMs: [String: Double]?
+    public let totalMs: Double?
+    /// Rewriter pass timings, when a rewrite happened.
+    public let rewritePassMs: [Double]?
+    public let confidence: Double?
+    public let warnings: [String]?
+    public let corrected: Bool
+    public let correctionId: Int?
+    /// HS-48-02 inline "learned from N similar" signal — the correction the live
+    /// router would apply to this utterance, or `nil` when corrections are off /
+    /// nothing matches (the hub stays honest rather than claim learning).
+    public let learning: CorrectionSignal?
+
+    public init(
+        id: Int, createdAt: String?, source: String, transcript: String, finalText: String,
+        projectRoot: String?, intent: String?, blockId: String?, targetProfile: String?,
+        stageMs: [String: Double]?, totalMs: Double?, rewritePassMs: [Double]?,
+        confidence: Double?, warnings: [String]?, corrected: Bool, correctionId: Int?,
+        learning: CorrectionSignal?
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.source = source
+        self.transcript = transcript
+        self.finalText = finalText
+        self.projectRoot = projectRoot
+        self.intent = intent
+        self.blockId = blockId
+        self.targetProfile = targetProfile
+        self.stageMs = stageMs
+        self.totalMs = totalMs
+        self.rewritePassMs = rewritePassMs
+        self.confidence = confidence
+        self.warnings = warnings
+        self.corrected = corrected
+        self.correctionId = correctionId
+        self.learning = learning
+    }
+}
+
+/// The inline correction signal carried on a journal entry (and the digest's match
+/// shape) — `best_correction_signal`'s output. `nil` on an entry means the router
+/// would nudge nothing.
+public struct CorrectionSignal: Codable, Sendable, Equatable {
+    public let matched: Bool
+    /// "intent" or "target".
+    public let kind: String
+    public let value: String
+    /// The gist (key) the correction is anchored on.
+    public let gist: String
+    /// How many journal utterances this correction reaches (Jaccard count).
+    public let similar: Int
+
+    public init(matched: Bool, kind: String, value: String, gist: String, similar: Int) {
+        self.matched = matched
+        self.kind = kind
+        self.value = value
+        self.gist = gist
+        self.similar = similar
+    }
+}
+
+/// The full `GET /api/dictation/journal` envelope: the entries plus the local-only
+/// trust facts the UI shows (is journaling on, how many we keep, the true total).
+/// On a bare server `items` is empty and `count` is 0 — never an error.
+public struct JournalResponse: Codable, Sendable, Equatable {
+    /// Whether journaling is enabled (config `journal_enabled`, default true).
+    public let enabled: Bool
+    /// How many entries are retained (config `journal_retention`).
+    public let retention: Int
+    /// The true total in the durable journal (may exceed `items.count` under a limit).
+    public let count: Int
+    public let items: [JournalEntry]
+
+    public init(enabled: Bool, retention: Int, count: Int, items: [JournalEntry]) {
+        self.enabled = enabled
+        self.retention = retention
+        self.count = count
+        self.items = items
+    }
+}
+
+// MARK: - Learning digest (GET /api/dictation/learning-digest)
+
+/// The "What HoldSpeak learned" digest from `build_learning_digest`. Window scopes
+/// the *activity* (corrections made, dictations corrected, breakdowns); per-correction
+/// reach ("N similar") is over the whole journal because a correction nudges every
+/// matching utterance regardless of when it was said.
+public struct LearningDigest: Codable, Sendable, Equatable {
+    /// "week" (last 7 days) or "all".
+    public let window: String
+    /// Whether `corrections_enabled` is on. Counts are real either way; this lets the
+    /// view phrase coverage honestly ("now nudged" only when corrections actually route).
+    public let enabled: Bool
+    /// Naive ISO (`now.isoformat()`) — String, never Date.
+    public let generatedAt: String?
+    public let totals: Totals
+    public let byKind: ByKind
+    public let byBlock: [BlockCount]
+    public let byTarget: [TargetCount]
+    public let corrections: [CorrectionRow]
+
+    public struct Totals: Codable, Sendable, Equatable {
+        public let correctionsMade: Int
+        public let dictationsCorrected: Int
+        public let similarNudged: Int
+        public let journalCount: Int
+
+        public init(correctionsMade: Int, dictationsCorrected: Int, similarNudged: Int, journalCount: Int) {
+            self.correctionsMade = correctionsMade
+            self.dictationsCorrected = dictationsCorrected
+            self.similarNudged = similarNudged
+            self.journalCount = journalCount
+        }
+    }
+
+    public struct ByKind: Codable, Sendable, Equatable {
+        public let intent: Int
+        public let target: Int
+
+        public init(intent: Int, target: Int) {
+            self.intent = intent
+            self.target = target
+        }
+    }
+
+    /// A ranked `{block_id, count}` row (corrections that re-route intent to a block).
+    public struct BlockCount: Codable, Sendable, Equatable {
+        public let blockId: String
+        public let count: Int
+
+        public init(blockId: String, count: Int) {
+            self.blockId = blockId
+            self.count = count
+        }
+    }
+
+    /// A ranked `{target_profile, count}` row (corrections that re-target output).
+    public struct TargetCount: Codable, Sendable, Equatable {
+        public let targetProfile: String
+        public let count: Int
+
+        public init(targetProfile: String, count: Int) {
+            self.targetProfile = targetProfile
+            self.count = count
+        }
+    }
+
+    /// One windowed correction with its whole-journal reach.
+    public struct CorrectionRow: Codable, Sendable, Equatable, Identifiable {
+        /// `null` when the store is non-durable (in-memory only).
+        public let id: Int?
+        /// "intent" or "target".
+        public let kind: String
+        public let gist: String
+        public let value: String
+        /// Naive ISO or `null` — String, never Date.
+        public let createdAt: String?
+        /// How many journal utterances this correction reaches.
+        public let similar: Int
+
+        public init(id: Int?, kind: String, gist: String, value: String, createdAt: String?, similar: Int) {
+            self.id = id
+            self.kind = kind
+            self.gist = gist
+            self.value = value
+            self.createdAt = createdAt
+            self.similar = similar
+        }
+    }
+
+    public init(
+        window: String, enabled: Bool, generatedAt: String?, totals: Totals, byKind: ByKind,
+        byBlock: [BlockCount], byTarget: [TargetCount], corrections: [CorrectionRow]
+    ) {
+        self.window = window
+        self.enabled = enabled
+        self.generatedAt = generatedAt
+        self.totals = totals
+        self.byKind = byKind
+        self.byBlock = byBlock
+        self.byTarget = byTarget
+        self.corrections = corrections
+    }
+}

--- a/apple/Sources/Contracts/MeetingImport.swift
+++ b/apple/Sources/Contracts/MeetingImport.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// The result of `POST /api/meetings/import` (HS-19-03, mobile).
+///
+/// The hub creates the meeting row **immediately** in a visible `importing`
+/// state and runs Whisper/parse on a background thread, so the upload returns
+/// `202 Accepted` with just the freshly-minted id and that initial status:
+///
+/// ```json
+/// {"meeting_id": "a1b2c3d4", "status": "importing"}
+/// ```
+///
+/// The id is the handle the iPad polls (`/history`, `/api/meetings/{id}`) to
+/// watch the import move `importing` → `queued`/`disabled` (success) or
+/// `import_failed` (the actionable failure stays, honestly labeled). The created
+/// meeting carries no timestamps in this response; any timestamp that later
+/// rides on the meeting summary is a raw `String?` (the hub emits naive
+/// `datetime.now().isoformat()` with no `Z`, which the `.iso8601` decoder
+/// rejects — never decode it as a `Date`).
+public struct MeetingImportResult: Sendable, Equatable, Decodable {
+    /// The id of the meeting row the hub created for this upload — the handle the
+    /// client polls to follow the import to completion.
+    public var meetingID: String
+    /// The lifecycle state at acceptance — `"importing"` on the happy path. Carried
+    /// verbatim so a future state never breaks the decode.
+    public var status: String
+
+    public init(meetingID: String, status: String) {
+        self.meetingID = meetingID
+        self.status = status
+    }
+
+    /// The hub sends `meeting_id` (snake_case) and `status`. The shared decoder runs
+    /// `.convertFromSnakeCase`, which rewrites the wire key `meeting_id` to
+    /// `meetingId` BEFORE matching — so the CodingKey is the camelCase `meetingId`,
+    /// not the literal `meeting_id` (matching the wire key directly would never
+    /// hit). A missing `status` decodes to the honest `importing` default rather
+    /// than throwing.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.meetingID = try c.decode(String.self, forKey: .meetingID)
+        self.status = try c.decodeIfPresent(String.self, forKey: .status) ?? "importing"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case meetingID = "meetingId"
+        case status
+    }
+}
+
+/// The error body the hub returns on a rejected upload (a non-2xx) — an
+/// unsupported format, an empty file, or the honest missing-ffmpeg message:
+///
+/// ```json
+/// {"error": "Unsupported format: .pages"}
+/// ```
+///
+/// Decoded only on the failure path so the client can surface the hub's own
+/// actionable message instead of a bare status code.
+public struct MeetingImportErrorBody: Sendable, Equatable, Decodable {
+    public var error: String
+    public init(error: String) { self.error = error }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Learning.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Learning.swift
@@ -1,0 +1,82 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HSM client layer — the dictation learning loop, READ side (Phase 19-06). Two
+// read-only verbs over the desktop hub's existing HTTP API:
+//
+//   - journalEntries(limit:source:)  GET /api/dictation/journal          → JournalResponse
+//   - learningDigest(window:)        GET /api/dictation/learning-digest  → LearningDigest
+//
+// Read-only by design: the iPad does NOT journal on-device and does NOT write
+// corrections here — that's Phase 9. The hub's POST/DELETE/correct routes are not
+// surfaced on this seam.
+//
+// New extension file by design (the equilibrium-wave conflict rule): no edits to
+// HTTPDesktopClient.swift or any shared file. Reuses `self.config` (baseURL + Bearer
+// token) and the same request/decode posture as the rest of the client — a non-2xx
+// throws `DesktopClientError.http`; a decode miss throws `.malformed`.
+extension HTTPDesktopClient {
+
+    /// `GET /api/dictation/journal?limit=&source=` → the dictation journal newest-first
+    /// plus the local-only trust facts (enabled / retention / true count). Pure read,
+    /// no side effects. On a bare server (no durable journal) `items` is empty and
+    /// `count` is 0 — never an error. A non-2xx throws `.http(code)`.
+    ///
+    /// - Parameters:
+    ///   - limit: max entries to return (hub default 200).
+    ///   - source: filter to "dictation" or "dry_run"; anything else the hub treats as
+    ///             "no filter". `nil` returns all sources.
+    public func journalEntries(limit: Int = 200, source: String? = nil) async throws -> JournalResponse {
+        var query = "limit=\(limit)"
+        if let source, !source.isEmpty {
+            let encoded = source.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? source
+            query += "&source=\(encoded)"
+        }
+        let data = try await sendLearning(makeLearningRequest(path: "api/dictation/journal?\(query)"))
+        do { return try HoldSpeakContracts.decoder().decode(JournalResponse.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    /// `GET /api/dictation/learning-digest?window=` → the windowed "what HoldSpeak
+    /// learned" digest (corrections made, dictations corrected, by-kind/block/target
+    /// breakdowns, per-correction whole-journal reach). Pure read. The hub coerces an
+    /// unknown window to "week", so this always decodes to a digest on a 2xx; a non-2xx
+    /// throws `.http(code)`.
+    ///
+    /// - Parameter window: "week" (last 7 days) or "all".
+    public func learningDigest(window: String = "week") async throws -> LearningDigest {
+        let encoded = window.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? window
+        let data = try await sendLearning(makeLearningRequest(path: "api/dictation/learning-digest?window=\(encoded)"))
+        do { return try HoldSpeakContracts.decoder().decode(LearningDigest.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    // MARK: - internals (private to this extension — no dependency on the seam's own
+    //         private helpers, per the conflict rule; the request shape mirrors
+    //         HTTPDesktopClient.makeRequest / send exactly).
+
+    /// Run a request, throwing `DesktopClientError.http` on a non-2xx so the verbs
+    /// surface a real failure the view-model can render.
+    private func sendLearning(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        return data
+    }
+
+    private func makeLearningRequest(path: String) -> URLRequest {
+        let base = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = config.timeout
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+}

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+MeetingImport.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+MeetingImport.swift
@@ -1,0 +1,101 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Contracts
+
+// HS-19-03 (mobile) — import a recording or transcript from the iPad into the
+// desktop hub's full intel pipeline (`POST /api/meetings/import`). The hub's
+// route reads ONE multipart field named `file` (`file: UploadFile = File(...)`),
+// refuses unsupported formats up front, creates the meeting row immediately in a
+// visible `importing` state, and returns `202 {meeting_id, status}` while Whisper
+// (audio) or the parser (.vtt/.srt/.txt) runs on a background thread.
+//
+// Kept in a SEPARATE extension file (no edits to HTTPDesktopClient.swift) so this
+// slice lands without colliding with the other client methods in the same wave.
+// The Bearer auth + non-2xx → `DesktopClientError.http` mirror the base client, but
+// the multipart body is built inline here so this file owns no dependency on the
+// base type's private JSON helpers.
+extension HTTPDesktopClient {
+
+    /// `POST /api/meetings/import` — upload an on-device recording or transcript file
+    /// as `multipart/form-data` (the single hub field `file`) and get back the
+    /// created meeting's id + initial status.
+    ///
+    /// - Parameters:
+    ///   - fileURL: a readable local file (the picked recording / transcript).
+    ///   - filename: the name the hub sees in `Content-Disposition` — its suffix
+    ///     drives format validation (audio vs `.vtt`/`.srt`/`.txt`) and the default
+    ///     meeting title, so pass the real on-device name, not the temp path.
+    ///   - mimeType: the part's `Content-Type` (e.g. `audio/wav`, `text/vtt`); the
+    ///     hub validates by suffix, but a faithful type keeps the part well-formed.
+    /// - Returns: `MeetingImportResult` with the `meeting_id` to poll and the
+    ///   `importing` status.
+    /// - Throws: `DesktopClientError.http(code)` on a non-2xx (the hub's rejection —
+    ///   unsupported format / empty file), `.malformed` if the 2xx body is not the
+    ///   `{meeting_id, status}` shape.
+    public func importMeeting(fileURL: URL,
+                              filename: String,
+                              mimeType: String) async throws -> MeetingImportResult {
+        let fileData = try Data(contentsOf: fileURL)
+        let boundary = "Boundary-\(UUID().uuidString)"
+        let body = Self.multipartBody(fieldName: "file",
+                                      filename: filename,
+                                      mimeType: mimeType,
+                                      fileData: fileData,
+                                      boundary: boundary)
+
+        let request = importRequest(path: "api/meetings/import", boundary: boundary, body: body)
+        let data = try await importSend(request)
+        do { return try HoldSpeakContracts.decoder().decode(MeetingImportResult.self, from: data) }
+        catch { throw DesktopClientError.malformed }
+    }
+
+    // MARK: - internals (file-private to this slice; no shared-helper dependency)
+
+    /// Build a single-file `multipart/form-data` body for `fieldName`. Each line is
+    /// CRLF-terminated per RFC 7578; the closing boundary carries the trailing `--`.
+    static func multipartBody(fieldName: String,
+                              filename: String,
+                              mimeType: String,
+                              fileData: Data,
+                              boundary: String) -> Data {
+        var body = Data()
+        let crlf = "\r\n"
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append(("Content-Disposition: form-data; name=\"\(fieldName)\"; " +
+                     "filename=\"\(filename)\"\(crlf)").data(using: .utf8)!)
+        body.append("Content-Type: \(mimeType)\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(fileData)
+        body.append("\(crlf)--\(boundary)--\(crlf)".data(using: .utf8)!)
+        return body
+    }
+
+    /// A POST against the configured peer carrying the multipart body, mirroring the
+    /// base client's Bearer-auth + timeout. Built inline so the slice carries no
+    /// dependency on the base type's private `makeRequest`.
+    private func importRequest(path: String, boundary: String, body: Data) -> URLRequest {
+        let absolute = config.baseURL.absoluteString
+        let base = absolute.hasSuffix("/") ? String(absolute.dropLast()) : absolute
+        var request = URLRequest(url: URL(string: "\(base)/\(path)") ?? config.baseURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = config.timeout
+        request.setValue("multipart/form-data; boundary=\(boundary)",
+                         forHTTPHeaderField: "Content-Type")
+        if let token = config.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = body
+        return request
+    }
+
+    /// Run the upload, throwing `DesktopClientError.http` on a non-2xx (so the
+    /// view-model can render the hub's rejection). Mirrors the base client's `send`.
+    private func importSend(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw DesktopClientError.http(http.statusCode)
+        }
+        return data
+    }
+}

--- a/apple/Tests/ProvidersTests/LearningClientTests.swift
+++ b/apple/Tests/ProvidersTests/LearningClientTests.swift
@@ -1,0 +1,282 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HSM learning-loop client (read side, Phase 19-06) — decode round-trips + the client
+/// verbs over a stubbed network (URLProtocol, fully offline). Proves:
+///   - GET /api/dictation/journal          → JournalResponse decodes faithfully, incl.
+///     the inline `learning` signal, the local-only toggle/retention/count, and NAIVE
+///     `created_at` carried as a String (the .iso8601 decoder would throw on a Date).
+///   - GET /api/dictation/learning-digest  → LearningDigest decodes (totals, by_kind,
+///     by_block/by_target ranks, per-correction reach, naive generated_at).
+///   - Bearer token rides, query params (limit/source/window) are sent, non-2xx throws.
+/// Mirrors AftercareClientTests' stub posture.
+final class LearningClientTests: XCTestCase {
+
+    // MARK: stub (same shape as DesktopClientTests.StubProtocol)
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastMethod: String?
+        nonisolated(unsafe) static var lastURL: URL?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastMethod = request.httpMethod
+            StubProtocol.lastURL = request.url
+            // Match on path only (the verbs append a query string).
+            let path = request.url?.path ?? ""
+            guard let (status, body) = StubProtocol.routes[path] else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost)); return
+            }
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.lastMethod = nil
+        StubProtocol.lastURL = nil
+    }
+
+    private func client(token: String? = nil) -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    // A realistic, fully-populated journal envelope. NOTE the naive created_at
+    // ("2026-06-27T12:00:00.123456", no Z / offset) — the .iso8601 decoder throws on
+    // a Date, so the contract carries it as a String. One entry has a learning signal,
+    // one is bare (learning: null).
+    private let journalJSON = #"""
+    {
+      "enabled": true,
+      "retention": 500,
+      "count": 7,
+      "items": [
+        {
+          "id": 42,
+          "created_at": "2026-06-27T12:00:00.123456",
+          "source": "dictation",
+          "transcript": "fix the sync transport bug",
+          "final_text": "Fix the sync transport bug.",
+          "project_root": "/Users/karol/dev/holdspeak",
+          "intent": "code",
+          "block_id": "code-fix",
+          "target_profile": "editor",
+          "stage_ms": {"transcribe": 120.5, "route": 4.0, "project-rewriter": 88.0},
+          "total_ms": 212.5,
+          "rewrite_pass_ms": [88.0],
+          "confidence": 0.91,
+          "warnings": [],
+          "corrected": false,
+          "correction_id": null,
+          "learning": {
+            "matched": true, "kind": "intent", "value": "code-fix",
+            "gist": "fix the sync transport bug", "similar": 3
+          }
+        },
+        {
+          "id": 41,
+          "created_at": "2026-06-27T11:58:30.000001",
+          "source": "dry_run",
+          "transcript": "book the room",
+          "final_text": "Book the room.",
+          "project_root": null,
+          "intent": null,
+          "block_id": null,
+          "target_profile": null,
+          "stage_ms": {},
+          "total_ms": 0.0,
+          "rewrite_pass_ms": [],
+          "confidence": null,
+          "warnings": ["no project context"],
+          "corrected": true,
+          "correction_id": 9,
+          "learning": null
+        }
+      ]
+    }
+    """#
+
+    // The digest shape build_learning_digest emits.
+    private let digestJSON = #"""
+    {
+      "window": "week",
+      "enabled": true,
+      "generated_at": "2026-06-27T12:01:00.500000",
+      "totals": {
+        "corrections_made": 4,
+        "dictations_corrected": 2,
+        "similar_nudged": 5,
+        "journal_count": 7
+      },
+      "by_kind": {"intent": 3, "target": 1},
+      "by_block": [
+        {"block_id": "code-fix", "count": 2},
+        {"block_id": "note", "count": 1}
+      ],
+      "by_target": [
+        {"target_profile": "editor", "count": 1}
+      ],
+      "corrections": [
+        {"id": 9, "kind": "intent", "gist": "fix the sync transport bug",
+         "value": "code-fix", "created_at": "2026-06-26T09:00:00.000000", "similar": 3},
+        {"id": null, "kind": "target", "gist": "send to slack",
+         "value": "editor", "created_at": null, "similar": 0}
+      ]
+    }
+    """#
+
+    // MARK: journal decode + client GET
+
+    func testJournalResponseDecodesFaithfully() throws {
+        let resp = try HoldSpeakContracts.decoder().decode(JournalResponse.self, from: Data(journalJSON.utf8))
+
+        XCTAssertTrue(resp.enabled)
+        XCTAssertEqual(resp.retention, 500)
+        XCTAssertEqual(resp.count, 7)               // true total can exceed items.count
+        XCTAssertEqual(resp.items.count, 2)
+
+        let first = resp.items[0]
+        XCTAssertEqual(first.id, 42)
+        // Naive timestamp survives as a raw String (the whole point — Date would throw).
+        XCTAssertEqual(first.createdAt, "2026-06-27T12:00:00.123456")
+        XCTAssertEqual(first.source, "dictation")
+        XCTAssertEqual(first.finalText, "Fix the sync transport bug.")
+        XCTAssertEqual(first.intent, "code")
+        XCTAssertEqual(first.blockId, "code-fix")
+        XCTAssertEqual(first.targetProfile, "editor")
+        XCTAssertEqual(first.stageMs?["transcribe"], 120.5)
+        XCTAssertEqual(first.totalMs, 212.5)
+        XCTAssertEqual(first.rewritePassMs, [88.0])
+        XCTAssertEqual(first.confidence, 0.91)
+        XCTAssertEqual(first.warnings, [])
+        XCTAssertFalse(first.corrected)
+        XCTAssertNil(first.correctionId)
+        // inline learning signal decoded
+        let learning = try XCTUnwrap(first.learning)
+        XCTAssertTrue(learning.matched)
+        XCTAssertEqual(learning.kind, "intent")
+        XCTAssertEqual(learning.value, "code-fix")
+        XCTAssertEqual(learning.similar, 3)
+
+        // The bare entry — nullables become nil, learning is absent (router nudges nothing).
+        let second = resp.items[1]
+        XCTAssertEqual(second.source, "dry_run")
+        XCTAssertNil(second.projectRoot)
+        XCTAssertNil(second.intent)
+        XCTAssertNil(second.confidence)
+        XCTAssertEqual(second.warnings, ["no project context"])
+        XCTAssertTrue(second.corrected)
+        XCTAssertEqual(second.correctionId, 9)
+        XCTAssertNil(second.learning)
+    }
+
+    func testEmptyJournalDecodes() throws {
+        // A bare server: journaling on, nothing recorded yet — empty, never an error.
+        let json = #"{"enabled": true, "retention": 500, "count": 0, "items": []}"#
+        let resp = try HoldSpeakContracts.decoder().decode(JournalResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(resp.count, 0)
+        XCTAssertTrue(resp.items.isEmpty)
+    }
+
+    func testJournalClientGETsWithLimitAndBearer() async throws {
+        StubProtocol.routes = ["/api/dictation/journal": (200, Data(journalJSON.utf8))]
+        let resp = try await client(token: "tok").journalEntries(limit: 50)
+        XCTAssertEqual(StubProtocol.lastMethod, "GET")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")          // Bearer token rides
+        XCTAssertEqual(StubProtocol.lastURL?.query, "limit=50")      // limit param sent
+        XCTAssertEqual(resp.items.first?.id, 42)
+        XCTAssertEqual(resp.items.first?.transcript, "fix the sync transport bug")
+    }
+
+    func testJournalClientSendsSourceFilter() async throws {
+        StubProtocol.routes = ["/api/dictation/journal": (200, Data(journalJSON.utf8))]
+        _ = try await client(token: "tok").journalEntries(limit: 10, source: "dictation")
+        let query = try XCTUnwrap(StubProtocol.lastURL?.query)
+        XCTAssertTrue(query.contains("limit=10"))
+        XCTAssertTrue(query.contains("source=dictation"))
+    }
+
+    func testJournalNoTokenSendsNoAuthHeader() async throws {
+        StubProtocol.routes = ["/api/dictation/journal": (200, Data(journalJSON.utf8))]
+        _ = try await client().journalEntries()
+        // No token configured → no Authorization header at all.
+        XCTAssertEqual(StubProtocol.lastAuth, .some(.none))
+    }
+
+    func testJournal500Throws() async {
+        StubProtocol.routes = ["/api/dictation/journal": (500, Data(#"{"error":"boom"}"#.utf8))]
+        do { _ = try await client().journalEntries(); XCTFail("expected throw") }
+        catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 500) }
+        catch { XCTFail("wrong error: \(error)") }
+    }
+
+    // MARK: digest decode + client GET
+
+    func testLearningDigestDecodesFaithfully() throws {
+        let digest = try HoldSpeakContracts.decoder().decode(LearningDigest.self, from: Data(digestJSON.utf8))
+
+        XCTAssertEqual(digest.window, "week")
+        XCTAssertTrue(digest.enabled)
+        // naive generated_at carried as String
+        XCTAssertEqual(digest.generatedAt, "2026-06-27T12:01:00.500000")
+
+        XCTAssertEqual(digest.totals.correctionsMade, 4)
+        XCTAssertEqual(digest.totals.dictationsCorrected, 2)
+        XCTAssertEqual(digest.totals.similarNudged, 5)
+        XCTAssertEqual(digest.totals.journalCount, 7)
+
+        XCTAssertEqual(digest.byKind.intent, 3)
+        XCTAssertEqual(digest.byKind.target, 1)
+
+        XCTAssertEqual(digest.byBlock.count, 2)
+        XCTAssertEqual(digest.byBlock.first?.blockId, "code-fix")
+        XCTAssertEqual(digest.byBlock.first?.count, 2)
+        XCTAssertEqual(digest.byTarget.first?.targetProfile, "editor")
+
+        XCTAssertEqual(digest.corrections.count, 2)
+        let durable = digest.corrections[0]
+        XCTAssertEqual(durable.id, 9)
+        XCTAssertEqual(durable.kind, "intent")
+        XCTAssertEqual(durable.gist, "fix the sync transport bug")
+        XCTAssertEqual(durable.similar, 3)
+        XCTAssertEqual(durable.createdAt, "2026-06-26T09:00:00.000000")
+        // The in-memory (non-durable) correction: null id, null created_at.
+        let inMemory = digest.corrections[1]
+        XCTAssertNil(inMemory.id)
+        XCTAssertNil(inMemory.createdAt)
+        XCTAssertEqual(inMemory.similar, 0)
+    }
+
+    func testLearningDigestClientGETsWithWindowAndBearer() async throws {
+        StubProtocol.routes = ["/api/dictation/learning-digest": (200, Data(digestJSON.utf8))]
+        let digest = try await client(token: "tok").learningDigest(window: "all")
+        XCTAssertEqual(StubProtocol.lastMethod, "GET")
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer tok")
+        XCTAssertEqual(StubProtocol.lastURL?.query, "window=all")    // window param sent
+        XCTAssertEqual(digest.totals.correctionsMade, 4)
+    }
+
+    func testLearningDigest503Throws() async {
+        StubProtocol.routes = ["/api/dictation/learning-digest": (503, Data(#"{"error":"down"}"#.utf8))]
+        do { _ = try await client().learningDigest(); XCTFail("expected throw") }
+        catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 503) }
+        catch { XCTFail("wrong error: \(error)") }
+    }
+}

--- a/apple/Tests/ProvidersTests/MeetingImportClientTests.swift
+++ b/apple/Tests/ProvidersTests/MeetingImportClientTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+/// HS-19-03 (mobile) — the meeting-import client. Network stubbed via `URLProtocol`;
+/// deterministic and offline. Proves: `importMeeting(...)` POSTs a well-formed
+/// `multipart/form-data` body with the hub's single `file` field and the declared
+/// boundary, the Bearer token rides, the `202 {meeting_id, status}` decodes into
+/// `MeetingImportResult`, a non-2xx rejection throws `.http`, and the contract type
+/// round-trips realistic + partial hub payloads.
+final class MeetingImportClientTests: XCTestCase {
+
+    // MARK: stub — captures the auth header, Content-Type, and the full request body.
+    // `URLProtocol` exposes a non-stream `httpBody` as `httpBodyStream`, so the body
+    // is read off the stream to assert the multipart parts.
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var routes: [String: (Int, Data)] = [:]
+        nonisolated(unsafe) static var lastAuth: String??
+        nonisolated(unsafe) static var lastContentType: String??
+        nonisolated(unsafe) static var lastBody: Data?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for r: URLRequest) -> URLRequest { r }
+        override func startLoading() {
+            StubProtocol.lastAuth = request.value(forHTTPHeaderField: "Authorization")
+            StubProtocol.lastContentType = request.value(forHTTPHeaderField: "Content-Type")
+            StubProtocol.lastBody = Self.readBody(from: request)
+            let path = request.url?.path ?? ""
+            guard let (status, body) = StubProtocol.routes[path] else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+
+        private static func readBody(from request: URLRequest) -> Data? {
+            if let body = request.httpBody { return body }
+            guard let stream = request.httpBodyStream else { return nil }
+            stream.open()
+            defer { stream.close() }
+            var data = Data()
+            let size = 4096
+            var buffer = [UInt8](repeating: 0, count: size)
+            while stream.hasBytesAvailable {
+                let read = stream.read(&buffer, maxLength: size)
+                if read <= 0 { break }
+                data.append(buffer, count: read)
+            }
+            return data
+        }
+    }
+
+    private func stubbedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    override func setUp() {
+        super.setUp()
+        StubProtocol.routes = [:]
+        StubProtocol.lastAuth = nil
+        StubProtocol.lastContentType = nil
+        StubProtocol.lastBody = nil
+    }
+
+    private func client(token: String? = nil) -> HTTPDesktopClient {
+        HTTPDesktopClient(config: .init(baseURL: URL(string: "http://desk.tailnet:8000")!, token: token),
+                          session: stubbedSession())
+    }
+
+    /// Write a small payload to a temp file and return its URL (the picked recording).
+    private func tempFile(_ bytes: Data, ext: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hsimport-\(UUID().uuidString).\(ext)")
+        try bytes.write(to: url)
+        return url
+    }
+
+    // MARK: - MeetingImportResult contract decode
+
+    func testResultDecodesRealisticPayload() throws {
+        let json = #"{"meeting_id":"a1b2c3d4","status":"importing"}"#
+        let result = try HoldSpeakContracts.decoder().decode(MeetingImportResult.self, from: Data(json.utf8))
+        XCTAssertEqual(result.meetingID, "a1b2c3d4")
+        XCTAssertEqual(result.status, "importing")
+    }
+
+    func testResultDefaultsStatusWhenMissing() throws {
+        // A partial payload (only the id) still decodes, defaulting to `importing`.
+        let result = try HoldSpeakContracts.decoder().decode(MeetingImportResult.self, from: Data(#"{"meeting_id":"x9"}"#.utf8))
+        XCTAssertEqual(result.meetingID, "x9")
+        XCTAssertEqual(result.status, "importing")
+    }
+
+    func testErrorBodyDecodes() throws {
+        let body = try HoldSpeakContracts.decoder().decode(MeetingImportErrorBody.self, from: Data(#"{"error":"Unsupported format: .pages"}"#.utf8))
+        XCTAssertEqual(body.error, "Unsupported format: .pages")
+    }
+
+    // MARK: - importMeeting(...) over the client
+
+    func testImportMeetingSendsMultipartFieldBoundaryAndBearer() async throws {
+        StubProtocol.routes = [
+            "/api/meetings/import": (202, Data(#"{"meeting_id":"a1b2c3d4","status":"importing"}"#.utf8)),
+        ]
+        let fileURL = try tempFile(Data("RIFFfake-wav-bytes".utf8), ext: "wav")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let result = try await client(token: "t0ken")
+            .importMeeting(fileURL: fileURL, filename: "standup.wav", mimeType: "audio/wav")
+
+        // Response decodes faithfully.
+        XCTAssertEqual(result.meetingID, "a1b2c3d4")
+        XCTAssertEqual(result.status, "importing")
+
+        // Bearer rides.
+        XCTAssertEqual(StubProtocol.lastAuth, "Bearer t0ken")
+
+        // Content-Type is multipart and declares a boundary the body uses.
+        let contentType = try XCTUnwrap(StubProtocol.lastContentType ?? nil)
+        XCTAssertTrue(contentType.hasPrefix("multipart/form-data; boundary="), contentType)
+        let boundary = String(contentType.dropFirst("multipart/form-data; boundary=".count))
+        XCTAssertFalse(boundary.isEmpty)
+
+        // The body carries exactly the hub's `file` field, the filename, the part's
+        // declared boundary (open + close), and the file bytes verbatim.
+        let body = try XCTUnwrap(StubProtocol.lastBody)
+        let text = String(decoding: body, as: UTF8.self)
+        XCTAssertTrue(text.contains("--\(boundary)\r\n"), "open boundary missing")
+        XCTAssertTrue(text.contains("--\(boundary)--"), "close boundary missing")
+        XCTAssertTrue(text.contains("name=\"file\""), "hub field name must be `file`")
+        XCTAssertTrue(text.contains("filename=\"standup.wav\""), "filename missing")
+        XCTAssertTrue(text.contains("Content-Type: audio/wav"), "part content-type missing")
+        XCTAssertTrue(text.contains("RIFFfake-wav-bytes"), "file bytes missing from body")
+    }
+
+    func testImportMeetingTranscriptUsesGivenMimeAndFilename() async throws {
+        StubProtocol.routes = [
+            "/api/meetings/import": (202, Data(#"{"meeting_id":"vtt001","status":"importing"}"#.utf8)),
+        ]
+        let fileURL = try tempFile(Data("WEBVTT\n\n00:00.000 --> 00:01.000\nhi".utf8), ext: "vtt")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let result = try await client()
+            .importMeeting(fileURL: fileURL, filename: "call.vtt", mimeType: "text/vtt")
+
+        XCTAssertEqual(result.meetingID, "vtt001")
+        let text = String(decoding: try XCTUnwrap(StubProtocol.lastBody), as: UTF8.self)
+        XCTAssertTrue(text.contains("filename=\"call.vtt\""))
+        XCTAssertTrue(text.contains("Content-Type: text/vtt"))
+    }
+
+    func testImportMeetingThrowsHTTPOnRejection() async throws {
+        // The hub rejects an unsupported format with a 400 + error body.
+        StubProtocol.routes = ["/api/meetings/import": (400, Data(#"{"error":"Unsupported format: .pages"}"#.utf8))]
+        let fileURL = try tempFile(Data("nope".utf8), ext: "pages")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        do {
+            _ = try await client().importMeeting(fileURL: fileURL, filename: "doc.pages", mimeType: "application/octet-stream")
+            XCTFail("expected an http error")
+        } catch let HTTPDesktopClient.DesktopClientError.http(code) {
+            XCTAssertEqual(code, 400)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
+++ b/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
@@ -159,4 +159,13 @@ Integrated: `swift build --target Providers` + the full package suite **366 test
 audit is the highest-value pre-metal move: it caught, in a worktree, a bug that would have failed three
 of the owner's device-walk features.
 
+### Armada Wave 7 (2026-06-27) — the last remaining Phase-19 iPad clients, 2 gaps
+
+| Slice | What landed |
+|-------|-------------|
+| Meeting import client | `importMeeting(fileURL:filename:mimeType:)` (multipart POST to /api/meetings/import) + `MeetingImport` types. The clients now cover the full Phase-19 meeting surface. |
+| Learning-loop read client | `journalEntries` + `learningDigest` (read-only; on-device journaling stays Phase 9) + `LearningJournal` types. |
+
+Both carry `String?` timestamps by construction (the Wave-6 naive-timestamp lesson, told to the agents up front). Integrated: 15 tests green, no regression. Gotcha flagged for future agents: under `.convertFromSnakeCase`, a snake_case literal CodingKey never matches, use the camelCase key.
+
 See [[project_primitive_framework]], [[project_phase15_the_mesh]], [[project_phase17_agent_sync]].


### PR DESCRIPTION
Two worktree agents complete the Phase-19 client surface: the meeting-import client (multipart POST to /api/meetings/import, 6 tests) + the read-first learning-loop client (journal + digest, 9 tests). Both carry String? timestamps by construction (the Wave-6 naive-timestamp lesson). 15 tests green, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)