### PR TITLE
Phase 20 handover: executable front for the iPhone size-class pass

### DIFF
--- a/pm/roadmap/holdspeak-mobile/HANDOVER-2026-06-27-phase20-one-app-every-size.md
+++ b/pm/roadmap/holdspeak-mobile/HANDOVER-2026-06-27-phase20-one-app-every-size.md
@@ -1,0 +1,386 @@
+# HANDOVER — Phase 20 — One app, every size (the iPhone pass)
+
+> Read this top to bottom before touching a single view. It is built to make you ship
+> the whole pass without re-deriving anything. Every file:line below was **verified against
+> the working tree on 2026-06-27** (the parity-audit numbers were partly stale; the
+> corrections are inline). The design is already decided — your job is to build it, not
+> redesign it. Where this doc and an older note disagree, **this doc wins**; where this doc
+> and `EXPERIENCE-VISION-2026-06-27.md` disagree, **the vision wins** (it is the design canon).
+
+---
+
+## 0. The one sentence
+
+**Make every Apple surface reflow from the iPad diorama to a one-thumb iPhone "lane" through a
+single width authority (`DeskCamera`), losing no object, glyph, or in-world law — then prove it
+by hand on a cabled iPhone.** When the same desk, the same primitives, and the same long-press
+"Route this" twin work at 390pt as they do at 1024pt, and the intelligence pull-out physically
+migrates from the right edge to the bottom edge on a spring, the phase is done.
+
+This is **layout debt, not capability debt** (audit theme 1). You are not inventing features.
+Phases 18 and 19 built the surfaces; you make them fit through the doorway.
+
+---
+
+## 1. State of the world (you are starting clean)
+
+- **`main` is green and clean.** Last merges this session: #157 (companion README + null-read
+  guard), #161 (god-quality fixes), #162 (README steward), #158 (Fleet PYTHON). All landed.
+  Full Python suite 2924 passing; Swift package suite 381 passing.
+- **The Equilibrium program** (Phases 18–23) is the parent. Chart: `EQUILIBRIUM.md`. Phase 20 is
+  **the iPhone pass**, deliberately sequenced AFTER 18/19 because "you cannot lay out at compact
+  width what does not exist yet."
+- **One compact adaptation already ships** — `DeskDioramaStage.swift:3085` (`let compact = w < 500`,
+  the rail collapse + hidden decorative title). It is the **seed** of the pattern you generalize.
+  It is also a **stray** you consolidate into `DeskCamera` (§4).
+- **`@Environment(\.horizontalSizeClass)` is used in ZERO views today.** That is not a reason to
+  avoid it — read §4 carefully, this is the single most important decision in the phase.
+
+---
+
+## 2. The design north star — read `EXPERIENCE-VISION` §4.3 in full
+
+The vision (`EXPERIENCE-VISION-2026-06-27.md`, §4.3 "The adaptive iOS craft", lines 120–153) is
+the spec. The essence:
+
+> "The Desk is a place, and a place has to fit through a doorway. There is ONE doctrine, not two
+> builds: the desk has a camera and screen width is the lens. The phone never feels like a worse
+> iPad; it feels like the desk shrank to thumb-reach without losing a single object, glyph, or the
+> in-world law."
+
+**The three cameras (one authority, `DeskCamera`):**
+
+| Camera | When | Layout |
+|--------|------|--------|
+| `.wide` | iPad full width | the lit diorama — absolute-positioned, drag-to-arrange, lasso |
+| `.narrow` | iPad split-view / medium | the rail (the compact pattern that ships today, generalized) |
+| `.lane` | iPhone (<~500pt) | a single thumb-reachable card column — **a new layout engine**, not a free reflow |
+
+**The non-negotiable laws** (from §1 of the vision, "the rules that keep it one product"):
+
+1. **Nothing is hidden or removed between sizes.** The same primitives reflow because they were
+   all derived from one `DeskPrimitive` declaration. The lane *un-renders* the spatial arrangement;
+   rotating back to `.wide` **restores the exact arrangement** (`positions[id]` is never destroyed —
+   confirmed real state at `DeskDioramaStage.swift:2924`).
+2. **No new modals.** The two already-shipping full-screen sheets (a meeting recording, settings)
+   are sanctioned destinations. Everything else edits **in-world**. The rising bottom sheet on
+   iPhone is **a hand-built offset container over a transparent catcher, NOT a dimming `.sheet`**
+   ([[feedback_no_modals_in_world]]).
+3. **A speak-to-fill mic on every text field** survives the reflow ([[feedback_voice_mic_every_input]]).
+   `VoiceFillMic` already exists; do not drop it from any lane field.
+4. **The honest egress badge rides along**, never reassurance prose ([[feedback_no_privacy_novels]]).
+
+**The signature device moment (this is the screenshot/video that closes the phase):** in iPad
+split-view, drag the multitasking divider and watch `DioPullout` physically migrate from the
+right edge to the bottom edge **on a spring, in real time**. The pull-out content already travels
+cheaply — it is `maxWidth/maxHeight: .infinity` — so only the entry edge and a grab handle change.
+
+**The iPhone lane mock (from the vision, line 131):**
+
+```
+iPhone — DioStage, LANE camera (<500pt):
+┌───────────────────────────┐
+│ ⌶  ● synced 2m   ⚡Connect │  ← slim header: sync pill + connect
+├───────────────────────────┤
+│ ‹ ●meet ●models ●kb ●notes›│  ← sticky zone CHIP rail (tint pills)
+├───────────────────────────┤
+│ ┌───────────────────────┐ │
+│ │ 📼  Standup          › │ │  ← full-width .signalCard row
+│ │     CASSETTE · 3 decs  │ │     crisp pixel glyph @44pt
+│ └───────────────────────┘ │
+│ ┌───────────────────────┐ │
+│ │ 💎  Infra KB         › │ │
+│ └───────────────────────┘ │
+│                      ╭───╮ │
+│                      │ + │ │  ← accent FAB: New Note/KB/Zone
+│                      ╰───╯ │
+├═══════════════════════════┤  ← tap a row → sheet RISES from here
+│ ▦ Standup        🔒 local  │     (same DioPullout content, grab handle,
+│ ──────  ▁▁  ──────         │      over a transparent catcher, NOT a modal)
+└───────────────────────────┘
+```
+
+The iPhone dictation surface has its own vision beat (§ "iPhone" line 65): the dictation mic
+**promotes to a persistent bottom-edge HOLD BAR**; press-and-hold reflows to a bottom-up
+teleprompter ("you said" muted nearest the thumb, "→ Cursor" above, destination+egress pill at
+top), **no dim toward the bar** (a dim is a scrim). That is part of HSM-20-04's screen pass.
+
+---
+
+## 3. THE CRITICAL DOCTRINE CALL — `DeskCamera`, derived from `horizontalSizeClass` + width
+
+**This is the decision the whole phase hangs on. Get it right in story 20-01 and the rest is
+mechanical. Get it wrong and you will hand-hack twenty views and still ship something that breaks
+on rotate and split-view.**
+
+There is a tempting wrong answer: "the codebase uses `w < 500` width checks and doesn't use
+`horizontalSizeClass`, so just keep adding `w < 500` checks." **Do not do this.** The vision is
+explicit (line 128):
+
+> "`DeskCamera` is introduced as the ONE width authority and the scattered `w >= 500` and
+> `UIScreen.main.bounds` reads are folded into it (first story: 'DeskCamera is the only width
+> authority; delete the strays')."
+
+**The build:** introduce one `DeskCamera` enum (`.wide` / `.narrow` / `.lane`) derived from
+**`horizontalSizeClass` first, geometry width second** (size class is what correctly distinguishes
+an iPhone from an iPad in split-view; raw width alone lies on iPad multitasking). Plumb it once
+(an `@Environment` value or a value passed from the top `GeometryReader` + `@Environment(\.horizontalSizeClass)`
+read at the `DioStage` root) and **fold every stray width check into it.**
+
+**The strays to delete (verified, exact):**
+
+| File:line | Current stray | Folds into |
+|-----------|---------------|------------|
+| `DeskDioramaStage.swift:3085` | `let compact = w < 500` (rail collapse) | `camera != .wide` |
+| `DeskDioramaStage.swift:2977` | `... && w >= 500 ? 1 : 0` (hidden title) | `camera == .wide` |
+| `DeskDioramaStage.swift:2035` | `.frame(height: UIScreen.main.bounds.height * 0.62)` | geometry height, not `UIScreen` |
+| `DeskDioramaStage.swift:3546` | `let b = UIScreen.main.bounds` | the camera's geometry |
+
+After 20-01 there should be **exactly one** place that decides "how wide are we," and it returns a
+`DeskCamera`. Everything else asks the camera.
+
+---
+
+## 4. The verified code map — what overflows, where (your work list)
+
+All line numbers **verified 2026-06-27**. Where the parity-audit / status doc was wrong, the
+correction is called out.
+
+### 4a. The existing compact pattern (your seed — read it first)
+
+`DeskDioramaStage.swift:3085–3115`. `let compact = w < 500`. When `compact && !railOpen` the
+agent rail collapses to a slim trailing-edge tab (tap to expand); when `compact && railOpen` a
+transparent canvas overlay dismisses it on tap; rail padding tightens (`compact ? 6 : 10`). The
+decorative "HoldSpeak / drag a meeting" title is hidden via the `w >= 500` opacity at line 2977.
+**This is the quality bar and the migration seed — generalize it into `DeskCamera`, don't bypass it.**
+
+### 4b. Fixed dimensions that overflow ~390pt (the panels/cards/overlays)
+
+| Component | File:line | Fixed dim | Note |
+|-----------|-----------|-----------|------|
+| `DioZoneEditor` (hero) | `DeskDioramaStage.swift:641` | `width: 380` | status doc CORRECT |
+| `DioZoneEditor` (scroll wrap) | `DeskDioramaStage.swift:698` | `width: 380` | status doc CORRECT |
+| `DioConnectCard` | `DeskDioramaStage.swift:1009` | `width: 380` | in-world card; cap to width−pad |
+| `DioInlineNoteCard` | `DeskDioramaStage.swift:885` | `width: 304` | already near-safe; verify at 390 |
+| `DioInlineKBCard` | `DeskDioramaStage.swift:927` | `width: 288` | already near-safe; verify at 390 |
+| `DioRecordModePicker` | `DeskDioramaStage.swift:1400` | `width: 296` | safe-ish; center on lane |
+| `DioLiveIntelCard` | `DeskDioramaStage.swift:2137` | `maxWidth: 440` | clamp to width−pad |
+| `DioRunTargetSheet` | `DeskDioramaStage.swift:2137`-area | `maxWidth: 440` | clamp |
+| `DioRouteSheet` | `DeskDioramaStage.swift:2241` | `maxWidth: 460` | clamp |
+| `DioZoneEditor` (run result) | `DeskDioramaStage.swift:2315` | `maxWidth: 480, maxHeight: 520` | clamp |
+| `DioSendCard` | `DeskDioramaStage.swift:2442` | `maxWidth: 460` | clamp |
+| `DioActSheet` | `DeskDioramaStage.swift:2501` | `maxWidth: 460` | clamp |
+| `DioCoderSession` | **`DeskCoder.swift:183`** | `width: 480, height: 560` | **status doc said `DeskDioramaStage` — WRONG FILE.** It's `DeskCoder.swift` |
+| `DioCoderAnswer` | **`DeskCoder.swift:367`** | `width: 400` | **same correction — `DeskCoder.swift`** |
+| `AgentEditor` | `DeskAgents.swift:625` | `maxWidth: 560, maxHeight: 740` | the agent builder modal |
+| `ChainEditor` | `DeskAgents.swift:961` | `maxWidth: 560` | the chain builder modal |
+| `ChainEditor` member picker | `DeskAgents.swift:1015` | `maxWidth: 420` | clamp |
+
+`maxWidth: N` is *mostly* safe (it caps, doesn't force) but combined with horizontal padding it
+can still touch edges at 390pt; the rule for the lane is **`maxWidth: min(N, width − 2*margin)`**
+via the camera's helper. The hard `width: N` ones (380/480/400/304/288/296) are the real overflow.
+
+### 4c. The dim-scrim overlays (the "modal hells" — kill or reframe)
+
+Each is `ZStack { Color.black.opacity(...).ignoresSafeArea(); <fixed card> }`. The owner rejects
+this pattern ([[feedback_no_modals_in_world]]); 20-02 reframes them as in-world or as the
+hand-built rising bottom sheet (NOT `.sheet`):
+
+| Overlay | File:line | Scrim |
+|---------|-----------|-------|
+| `DioZoneEditor` | `DeskDioramaStage.swift:635` | 0.78 |
+| `DioRecordModePicker` | `DeskDioramaStage.swift:1394` | 0.40 |
+| `DioRunTargetSheet` | `DeskDioramaStage.swift:2110` | 0.60 |
+| `DioRouteSheet` | `DeskDioramaStage.swift:2191` | 0.55 |
+| `DioSendCard` | `DeskDioramaStage.swift:2413` | 0.70 |
+| `DioActSheet` | `DeskDioramaStage.swift:2463` | 0.70 |
+| `DioCoderSession` | `DeskCoder.swift:160` | 0.74 |
+| `DioCoderAnswer` | `DeskCoder.swift:322` | 0.78 |
+| `AgentEditor` | `DeskAgents.swift:618` | 0.62 |
+| `ChainEditor` | `DeskAgents.swift:906` | 0.62 |
+
+**Already in-world (no scrim — the GOOD pattern to copy):** `DioInlineNoteCard` (841–894),
+`DioInlineKBCard` (899–937), `DioConnectCard` (942–1017) — lift in place, dismiss on Done or
+tap-away over a transparent catcher. This is the template for reframing the scrim overlays.
+
+### 4d. The keystone: `DioPullout` (the migrating intelligence pane)
+
+`struct DioPullout` at `DeskDioramaStage.swift:1200`, rendered at `:3197`. Its content is already
+`maxWidth/maxHeight: .infinity` (the vision counted on this — confirmed). **It is the object that
+migrates right-edge→bottom-edge on a spring** in the signature moment. 20-02 changes only its
+entry edge + a grab handle by camera, not its content.
+
+### 4e. The capture canvas — the responsive exemplar (mostly already correct)
+
+`LiveCaptureCanvas` at `MeetingCaptureApp.swift:1137–1186`. Root is `GeometryReader`; tack zone is
+`min(264, size.width − 72)`; stream is an unconstrained `VStack`. **It already scales** — use it
+as the reference for how the lane should compute sizes. 20-03 mostly verifies it at 390pt and
+docks the floating recorder + wraps any chip rows; it is the *least* broken surface.
+
+### 4f. The connect screen + chip rows (HSM-20-04)
+
+- **CORRECTION:** the status doc cites the unwrapped Port+Token row at `MeetingCaptureApp.swift:1641`.
+  That is **the wrong location.** The real two-up row is `CompanionShellApp.swift:651–653`
+  (`field("Port", ...).frame(width: 130)` next to `field("Token", ...)` inside `maxWidth: 560`).
+  On lane, stack it vertically or make Port flexible.
+- The **good** wrapping layouts to copy: `FlowChips` (`CompanionShellApp.swift:738`),
+  `DioConstellationWeave` agent flow (`DeskDioramaStage.swift:1428`). Both wrap correctly.
+
+### 4g. The app targets (what actually renders)
+
+Two user-facing apps; the rest are harnesses. **Phase 20 owns the two below; ignore the harnesses
+except to keep them compiling.**
+
+- **`MeetingCaptureApp`** (`MeetingCaptureApp.swift:19`, `@main`) → `DioStage()` (the desk; the
+  main surface). This is 80% of the phase.
+- **`CompanionShellApp`** (`CompanionShellApp.swift:11`, `@main`) → `ShellView` (connect / meetings
+  / dictate / companion). The connect + dictate screens are HSM-20-04.
+- Harnesses (`HoldSpeakApp`, `SpeakHarnessApp`, `CompanionAnswerApp`, `InferenceHarnessApp`,
+  `LocalHarnessApp`, `CompanionProbeApp`) — not user-facing; do not redesign, just don't break.
+
+---
+
+## 5. The stories (this phase ships its stories with the chart — build in order)
+
+`20-01 leads` (the foundation). `20-02/03/04` are parallelizable once 20-01 lands (disjoint
+surfaces). `20-05` is the gate. Full per-story detail is in the story files
+(`story-01..05`); the one-liners:
+
+| ID | Title | The crux |
+|----|-------|----------|
+| HSM-20-01 | The `DeskCamera` foundation | one width authority from `horizontalSizeClass`+width; delete the 4 strays; the lane card-sizing helper |
+| HSM-20-02 | The desk at compact width | the lane card column; `DioPullout` migrates edge→edge on a spring; scrim overlays reframed; arrangement restored on rotate |
+| HSM-20-03 | The capture canvas at compact width | `LiveCaptureCanvas` verified at 390pt; docked recorder; wrapped chips |
+| HSM-20-04 | The forms + screens at compact width | connect (vertical Port/Token), settings, send/act sheets, the iPhone HOLD-BAR teleprompter |
+| HSM-20-05 | On-device proof | every compact screen walked on a real iPhone — **the only thing that closes a row** |
+
+---
+
+## 6. Build + screenshot pipeline (copy-paste; this is exactly how you iterate)
+
+**Toolchain caveat (load-bearing):** the Xcode-beta Swift 6.3 toolchain cannot build swift-syntax.
+Always sever the LLM.swift macro and disable package re-resolution
+([[reference_xcode_beta_swift_syntax_break]]).
+
+### Simulator build + screenshot (the iteration loop)
+
+```bash
+cd /Users/karol/dev/tools/HoldSpeak/apple
+
+# 1. Generate the flattened single-module xcodeproj (ONLY when you ADD a new .swift file;
+#    otherwise cp your edited file into build/meeting-capture-sources/ and skip this — a stale
+#    flattened tree will HIDE your compile errors, the #161 lesson).
+ruby scripts/gen-meeting-capture.rb
+
+# 2. Sever the LLM macro (idempotent).
+scripts/patch-llm-macro.sh "$PWD/build/meeting-capture-dd" \
+  build/HoldSpeakMeetingCapture.xcodeproj HoldSpeakMobile
+
+# 3. Build for the iPHONE simulator (the whole point of this phase — NOT the iPad sim).
+xcodebuild -project build/HoldSpeakMeetingCapture.xcodeproj -scheme HoldSpeakMobile \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -derivedDataPath build/meeting-capture-dd \
+  -skipMacroValidation -disableAutomaticPackageResolution build
+#   List available iPhone sims first: xcrun simctl list devices available | grep iPhone
+
+# 4. Install + launch on the iPhone sim with a seeded desk (so the lane has cards to lay out).
+DEV="iPhone 16 Pro"
+xcrun simctl boot "$DEV" 2>/dev/null || true
+xcrun simctl install "$DEV" \
+  build/meeting-capture-dd/Build/Products/Debug-iphonesimulator/HoldSpeakMobile.app
+SIMCTL_CHILD_HS_DEMO_HOME=1 xcrun simctl launch "$DEV" dev.holdspeak.mobile
+sleep 4
+xcrun simctl io "$DEV" screenshot /tmp/lane.png   # ABSOLUTE path required
+open /tmp/lane.png
+```
+
+**Seed env vars (via `SIMCTL_CHILD_<VAR>`), so the lane isn't empty:** `HS_DEMO_HOME=1` (seeds
+home content), `HS_DESK_CONNECT=1` (in-world Connect card), `HS_DESK_NOTE=1` (fresh note),
+`HS_DESK_RECORD=transcript`, `HS_DESK_ZONE=<n>`, `HS_DESK_SETTINGS=1`. For the companion shell:
+`HS_SHELL_TAB=<Tab>`, `HS_SHELL_DEMO=teleprompter|aftercare|artifacts`,
+`HS_DESKTOP_HOST/PORT/TOKEN`.
+
+### What `swift test` does and does NOT cover
+
+`cd apple && swift test` is host-hermetic and fast — it builds + tests **Contracts / RuntimeCore /
+Providers / InferenceLlama only**. It does **NOT** build the `Hosts` (SwiftUI app) target.
+**A green `swift test` is NOT proof your view compiles** — only the `xcodebuild` sim build above is
+([[feedback_verify_on_device_not_seeded]]). Run BOTH every iteration.
+
+### Where screenshots go
+
+`pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/screenshots/` (commit source + shots;
+`build/` is gitignored). Name them by surface + camera, e.g. `desk-lane.png`,
+`pullout-migrate-narrow.png`, `connect-lane.png`.
+
+### The device build (for 20-05 — the owner runs this, but know it)
+
+```bash
+# Real iPhone (NOT a sim). Requires the device cabled + UNLOCKED; clones packages, so run it
+# with the sandbox disabled.
+scripts/meeting-capture-device.sh <iphone-udid>   # xcrun devicectl list devices  → find the udid
+```
+
+---
+
+## 7. The hard-won lessons (internalize — these have bitten every prior mobile session)
+
+1. **Seeded Simulator ≠ device proof.** A sim screenshot is for *your* iteration, never a closeout
+   claim. Only the owner can walk the cabled iPhone, and **he will not send screenshots** — asking
+   has angered him before. Diagnose from CODE; let HSM-20-05 be his button.
+   ([[feedback_verify_on_device_not_seeded]]).
+2. **A stale flattened source tree hides compile errors.** If you add a new file and forget
+   `gen-meeting-capture.rb`, the build passes on the OLD sources and you ship something that won't
+   actually compile (the #161 god-quality bug). Re-gen on every NEW file.
+3. **No modals.** Reframing the scrim overlays in-world is half the phase's craft, not a footnote.
+   The rising bottom sheet is a hand-built offset container over a transparent catcher, never a
+   `.sheet`/`.fullScreenCover` ([[feedback_no_modals_in_world]]).
+4. **The mic stays on every field** through the reflow ([[feedback_voice_mic_every_input]]). A lane
+   text field with no `VoiceFillMic` is a regression.
+5. **Egress badge, never prose** ([[feedback_no_privacy_novels]]). The badge rides the migrating
+   pull-out; do not narrate privacy.
+6. **Nothing is removed between sizes.** If a primitive exists on `.wide` it exists on `.lane`. The
+   lane drops only *gestures the thumb can't do* (cross-desk drag → the long-press "Route this"
+   twin that already ships), never *objects*.
+7. **PMO gate every commit:** a fresh `.tmp/CONTRACT.md` with 7 honest `[x]` boxes per
+   `pm/roadmap/PMO-CONTRACT.md`. The `Tests ran` box means you actually ran `swift test` + the sim
+   build and read the output.
+8. **Merge the green:** branch off `main`, build a story (or a few), open a PR, watch CI, merge
+   with `--merge --delete-branch` ([[feedback_merge_phases_via_pr]]). Each story is mergeable alone.
+
+---
+
+## 8. Definition of done (the closeout bar)
+
+- [ ] `DeskCamera` is the **only** width authority; the 4 strays (§3) are gone; `grep` for
+      `UIScreen.main.bounds` and `w < 500`/`w >= 500` in the App targets returns only the camera.
+- [ ] Every fixed-dimension card/overlay in §4b/§4c fits inside 390pt with margins, at `.lane`.
+- [ ] The desk renders as the lane card column on iPhone; the FAB, the zone chip rail, and the
+      slim header match the vision mock (§2).
+- [ ] `DioPullout` migrates right-edge→bottom-edge on a spring (the signature moment), captured.
+- [ ] The scrim overlays are reframed in-world / as the hand-built rising sheet (no `.sheet` dims).
+- [ ] The connect Port/Token row and every chip row wrap/stack at 390pt; the iPhone HOLD-BAR
+      teleprompter reflows bottom-up.
+- [ ] `positions[id]` arrangement is restored exactly on rotate `.lane`→`.wide` (nothing destroyed).
+- [ ] `swift test` green AND the iPhone-sim `xcodebuild` green for both apps.
+- [ ] **HSM-20-05:** every compact screen walked on a real iPhone by the owner. **This is the only
+      thing that promotes an iPhone matrix cell from forward-constraint to proven.** Until then,
+      every cell stays `🟡`.
+
+---
+
+## 9. Pointers
+
+- **Design canon:** `EXPERIENCE-VISION-2026-06-27.md` §1 (the laws) + §4.3 (Phase 20).
+- **Program chart:** `EQUILIBRIUM.md` (Phase 20 row + the wave log).
+- **Audit evidence:** `PARITY-AUDIT-2026-06-27.md` (theme 1).
+- **Phase status + stories:** `phase-20-one-app-every-size/current-phase-status.md` + `story-01..05`.
+- **Primitive contract:** `apple/Sources/Contracts/{Primitives,Sync,Coding,Models}.swift`;
+  spec `contracts/THE_PRIMITIVE_FRAMEWORK.md`.
+- **Memories:** [[project_primitive_framework]], [[project_equilibrium_program]],
+  [[feedback_verify_on_device_not_seeded]], [[feedback_no_modals_in_world]],
+  [[feedback_voice_mic_every_input]], [[feedback_no_privacy_novels]],
+  [[reference_xcode_beta_swift_syntax_break]], [[reference_ios_simulator_screenshot]].
+</content>
+</invoke>

--- a/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/current-phase-status.md
@@ -1,52 +1,64 @@
 # Phase 20 — One app, every size (the iPhone pass)
 
 **Status:** planned — **follows 18 + 19** (you cannot lay out at compact width what does not
-exist yet). Stories detailed on open.
+exist yet). **Stories authored** (this is an executable front, lead-phase cadence).
 
-**Last updated:** 2026-06-27 (**authored** from the parity audit, theme 1.)
+**Last updated:** 2026-06-27 (authored from the parity audit theme 1; **refined into an
+executable front** with a full handover + 5 detailed stories + verified file:line corrections.)
+
+**Start here:** `../HANDOVER-2026-06-27-phase20-one-app-every-size.md` — the master orientation
+doc (verified code map, the build/screenshot pipeline, the doctrine call, the hard-won lessons,
+the definition of done). Read it before any code.
 
 ## Why this phase exists
 
-Audit theme 1: *iPhone is layout debt, not capability debt.* Compact-width adaptation exists
-in exactly one place (`DeskDioramaStage.swift:3085` — the rail collapse + hidden title,
-shipped this session). Every other Apple surface inherits the iPad layout:
+Audit theme 1: *iPhone is layout debt, not capability debt.* Compact-width adaptation exists in
+exactly one place (`DeskDioramaStage.swift:3085`, the rail collapse + hidden title, shipped this
+session). Every other Apple surface inherits the iPad layout:
 
 - Fixed `380pt` panels on the desk (`DeskDioramaStage.swift:641/698`) overflow ~390pt iPhone
   portrait, so meeting artifacts are unreachable.
-- Fixed-size dim-scrim overlays overflow a phone (`DioCoderSession` 480×560, `DioCoderAnswer`
-  400, `DioZoneEditor` 380, `DioSendCard`/`DioActSheet`).
-- The capture canvas (`LiveCaptureCanvas`, free-drag bubbles + floating recorder) assumes a
-  wide board.
-- Unwrapped chip rows (`MeetingCaptureApp.swift:1641`) overflow; the connect screen's two-up
-  Port+Token row is cramped (`CompanionShellApp.connectScreen`, fixed maxWidth 560).
+- Fixed-size dim-scrim overlays overflow a phone — `DioCoderSession` 480×560 + `DioCoderAnswer` 400
+  (**in `DeskCoder.swift:183/367`, not `DeskDioramaStage` — audit was wrong**), `DioZoneEditor`
+  380, `DioSendCard`/`DioActSheet` 460, the `DeskAgents.swift` editors 560/740.
+- The capture canvas (`LiveCaptureCanvas`, `MeetingCaptureApp.swift:1137`) assumes a wide board
+  (though it is the least broken — it is already `GeometryReader`-driven).
+- The companion connect screen's two-up Port+Token row is cramped
+  (`CompanionShellApp.swift:651–653`, **not** `MeetingCaptureApp.swift:1641` — audit was wrong).
 
-The audit's honest framing: most iPhone gaps are "the same finding twice" — the feature is
-absent on Apple, so there is nothing to lay out. That is **why this phase follows 18/19**:
-build the surfaces first, then make them reflow.
+The audit's honest framing: most iPhone gaps are "the same finding twice" — the feature is absent
+on Apple, so there is nothing to lay out. That is **why this phase follows 18/19**: build the
+surfaces first, then make them reflow.
 
-## The load-bearing design call
+## The load-bearing design call — `DeskCamera`, the one width authority
 
-**A real `horizontalSizeClass` pass with a shared compact pattern, then prove it on metal.**
-Not per-screen hacks: a single compact-layout convention (size-class plumbing, a width-relative
-card-sizing helper extending the in-world card pattern shipped this session, `presentationDetents`
-for any remaining sheets) applied across every Apple surface. Every `🟡`/`❌` iPhone cell in the
-matrix stays a *forward constraint* until it is walked on a physical iPhone
-([[feedback_verify_on_device_not_seeded]]) — seeded Simulator screenshots do not close a row.
+**Introduce a single `DeskCamera` (`.wide` / `.narrow` / `.lane`) derived from
+`horizontalSizeClass` FIRST and geometry width second, then fold every stray width check into it.**
+This is the vision's explicit first move (`../EXPERIENCE-VISION-2026-06-27.md:128`, §4.3): *"DeskCamera
+is the only width authority; delete the strays."* NOT per-screen `w < 500` hacks (that lies in iPad
+split-view and multiplies debt). The lane is a real card-column renderer, not a free reflow; the
+intelligence pull-out (`DioPullout`) migrates right-edge→bottom-edge on a spring (the signature
+device moment); nothing is hidden or removed between sizes, and the hand-arranged desk arrangement
+(`positions[id]`) is restored exactly on rotate. Every `🟡`/`❌` iPhone cell stays a *forward
+constraint* until walked on a physical iPhone ([[feedback_verify_on_device_not_seeded]]) — seeded
+Simulator screenshots do not close a row.
 
 ## Stories
 
 | ID | Title | Status |
 |----|-------|--------|
-| HSM-20-01 | The size-class foundation (shared compact pattern + helpers) — **leads** | todo |
-| HSM-20-02 | The desk at compact width (panels, cards, the overlays/scrims) | todo |
-| HSM-20-03 | The capture canvas at compact width (list + docked recorder + wrapped chips) | todo |
-| HSM-20-04 | The forms + screens at compact width (connect, settings, send/act sheets) | todo |
-| HSM-20-05 | On-device proof (every compact screen walked on a real iPhone) | todo |
+| HSM-20-01 | The `DeskCamera` foundation (one width authority + the lane helper) — **leads** | todo |
+| HSM-20-02 | The desk at compact width (the lane + the migrating pull-out) | todo |
+| HSM-20-03 | The capture canvas at compact width (docked recorder + wrapped chips) | todo |
+| HSM-20-04 | The forms + screens at compact width (connect, editors, sheets, hold-bar teleprompter) | todo |
+| HSM-20-05 | On-device proof (every compact screen walked on a real iPhone) — **the gate** | todo |
 
 ## Where we are
 
-Not started. **20-01 leads** (the shared pattern the rest apply). The desk overlays
-(`DioCoderSession`/`DioSendCard`/`DioZoneEditor`) are also the "modal hells" the owner rejects
-([[feedback_no_modals_in_world]]) — 20-02 reframes them as in-world or compact-aware cards,
-killing two birds. 20-05 is the gate and the only thing that promotes an iPhone cell from
+Not started; **fully storied and handed over.** **20-01 leads** (the `DeskCamera` authority the
+rest read). 20-02/03/04 parallelize once 20-01 lands (disjoint surfaces). The desk scrim overlays
+(`DioCoderSession`/`DioSendCard`/`DioZoneEditor`…) are also the "modal hells" the owner rejects
+([[feedback_no_modals_in_world]]) — 20-02/04 reframe them as in-world or hand-built rising sheets,
+killing two birds. **20-05 is the gate** and the only thing that promotes an iPhone cell from
 forward-constraint to proven.
+</content>

--- a/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-01-deskcamera-foundation.md
+++ b/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-01-deskcamera-foundation.md
@@ -1,0 +1,58 @@
+# HSM-20-01 — The `DeskCamera` foundation (one width authority + the lane helper)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 20
+- **Status:** todo — **leads the phase.** Every other story asks this story's camera.
+- **Depends on:** nothing (it consolidates what ships today).
+- **Unblocks:** 20-02 (the desk reads the camera), 20-03, 20-04 (forms read the camera).
+- **Owner:** unassigned
+
+## Problem
+
+There is no single answer to "how wide are we." Compact adaptation is one ad-hoc check
+(`DeskDioramaStage.swift:3085` `let compact = w < 500`), the hidden-title check is a second
+(`:2977` `... && w >= 500`), and two views read `UIScreen.main.bounds` directly (`:2035`, `:3546`)
+— which **lies in iPad split-view** (the screen is wide; your slice is narrow). Adding more
+`w < 500` checks per screen would multiply this debt across ~20 views and still break on
+split-view and rotate. The vision is explicit: introduce ONE width authority and *delete the
+strays* (`EXPERIENCE-VISION-2026-06-27.md:128`).
+
+## The design
+
+1. **`enum DeskCamera { case wide, narrow, lane }`** — the one authority.
+   - Derive it from **`@Environment(\.horizontalSizeClass)` FIRST, geometry width SECOND.**
+     `.compact` size class ⇒ `.lane` (this is the only correct iPhone-vs-iPad-split-view signal);
+     a `.regular` class with width below a tablet-split threshold ⇒ `.narrow`; otherwise `.wide`.
+     Width alone is a tiebreaker, never the primary signal.
+   - Plumb it once: read `horizontalSizeClass` + the top `GeometryReader` width at the `DioStage`
+     root and pass a `DeskCamera` down (an `@Environment` key or an explicit parameter — pick one
+     and use it everywhere). Do NOT re-derive width per view.
+2. **A lane card-sizing helper** that extends the in-world card pattern shipped this session:
+   a width-relative cap, e.g. `func laneWidth(_ ideal: CGFloat, in width: CGFloat, margin: CGFloat
+   = 16) -> CGFloat { min(ideal, width - 2*margin) }`, so a `width: 380` card becomes
+   `min(380, width − 32)` on lane and is unchanged on wide. This is the single helper 20-02/04 use
+   to clamp every fixed card.
+3. **Delete the strays** (verified targets):
+   - `:3085` `let compact = w < 500` → `camera != .wide`.
+   - `:2977` `... && w >= 500 ? 1 : 0` → `camera == .wide`.
+   - `:2035` `.frame(height: UIScreen.main.bounds.height * 0.62)` → use the `GeometryReader` height.
+   - `:3546` `let b = UIScreen.main.bounds` → the camera's geometry.
+   After this story, `grep -n "UIScreen.main.bounds\|w < 500\|w >= 500" App/**/*.swift` returns
+   **only** the `DeskCamera` derivation site.
+
+## Scope
+
+- **In:** the `DeskCamera` enum + its derivation + plumbing; the `laneWidth` helper; deleting the
+  four strays; the existing rail-collapse behavior re-expressed through the camera (byte-equivalent
+  rendering on iPad — no visual change at `.wide`/`.narrow`).
+- **Out:** the lane card column (20-02); the pull-out migration (20-02); any new screen layout.
+  This story changes *who decides width*, not *what the lane looks like*.
+
+## Proof
+
+- `swift test` green; the iPhone-sim AND iPad-sim `xcodebuild` both green (§6 of the handover).
+- iPad sim screenshot is **visually identical** to `main` at `.wide` and `.narrow` (this is a
+  pure consolidation — prove you broke nothing).
+- The `grep` above returns only the derivation site.
+- Device proof deferred to 20-05.
+</content>

--- a/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-02-desk-at-compact-width.md
+++ b/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-02-desk-at-compact-width.md
@@ -1,0 +1,62 @@
+# HSM-20-02 — The desk at compact width (the lane + the migrating pull-out)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 20
+- **Status:** todo — the heart of the phase (the signature device moment lives here).
+- **Depends on:** 20-01 (`DeskCamera` + `laneWidth`).
+- **Unblocks:** nothing downstream; it is the centerpiece.
+- **Owner:** unassigned
+
+## Problem
+
+`DioStage` is the front door on device, and it is built for the wide diorama:
+absolute-positioned primitives (`positions[id]`, `DeskDioramaStage.swift:2924`), drag-to-arrange,
+a right-edge intelligence pull-out (`DioPullout`, `:1200`/rendered `:3197`), and a stack of
+fixed-width dim-scrim overlays. On a 390pt iPhone the diorama does not fit, the 380pt panels
+overflow, and the scrim overlays are the "modal hells" the owner rejects.
+
+## The design
+
+Follow `EXPERIENCE-VISION-2026-06-27.md:120–153` (§4.3) and the lane mock at line 131.
+
+1. **The `.lane` card column** — a NEW layout engine gated on `camera == .lane` (the vision is
+   explicit this is a real renderer, not a free reflow): a single thumb-reachable column of
+   full-width `.signalCard` rows (crisp glyph @44pt, title, `CASSETTE · 3 decs` subtitle, chevron),
+   a sticky **zone chip rail** (`‹ ●meet ●models ●kb ●notes ›`), a slim header (sync pill +
+   Connect), and an accent **FAB** (New Note/KB/Zone). At `.wide` the diorama renders exactly as
+   today — the two layouts branch on the camera.
+2. **Nothing is destroyed.** The lane sorts by recency + zone; `positions[id]` is **never cleared**
+   when entering lane, and rotating back to `.wide` restores the exact hand-arranged desk. (Verify:
+   set positions on wide, rotate to lane, rotate back — identical arrangement.)
+3. **The migrating pull-out (the signature moment).** Tap a row → the same `DioPullout` content
+   (already `maxWidth/maxHeight: .infinity`) **rises from the bottom edge** as a hand-built offset
+   container over a transparent catcher (NOT a `.sheet`), with a grab handle. At `.wide`/`.narrow`
+   it enters from the right edge as today. Animate the entry edge change on a spring so that, in
+   iPad split-view, dragging the multitasking divider visibly migrates the pane right→bottom in
+   real time. **Only the entry edge + grab handle change by camera; the content is identical.**
+4. **Reframe the scrim overlays** (the modal-hells list, handover §4c) for lane: the in-world
+   editors (`DioInlineNoteCard`/`KB`/`ConnectCard`) already lift without a scrim — extend that
+   pattern; the action sheets (`DioSendCard`/`DioActSheet`/`DioRunTargetSheet`/`DioRouteSheet`)
+   become the same hand-built rising sheet, clamped via `laneWidth`. No `Color.black.opacity` dim
+   toward a fixed card on lane.
+5. **Clamp the fixed cards** with `laneWidth` (handover §4b): the 380/304/288/296 hard widths and
+   the 440/460/480 `maxWidth`s.
+6. **Cross-desk drag degrades to the twin.** The lane drops cross-desk drag-to-route (impossible
+   one-thumb) and leans on the already-shipping long-press "Route this to AI" twin — an INVARIANT
+   that survives the reflow, not a new feature.
+
+## Scope
+
+- **In:** the lane card column + zone chip rail + slim header + FAB; the pull-out bottom-edge
+  migration on a spring; reframing the desk scrim overlays as in-world/rising sheets; clamping the
+  fixed desk cards; arrangement-preservation on rotate.
+- **Out:** `LiveCaptureCanvas` (20-03); the connect/settings/teleprompter screens (20-04); the
+  agent/chain editors in `DeskAgents.swift` (20-04 unless trivially clamped here).
+
+## Proof
+
+- iPhone sim: the lane column matches the vision mock; the pull-out rises from the bottom.
+- iPad sim split-view: the pull-out migrates right→bottom on the divider drag (capture it).
+- Rotate lane↔wide: arrangement identical.
+- `swift test` + both sim builds green. Device walk = 20-05.
+</content>

--- a/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-03-capture-canvas-at-compact-width.md
+++ b/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-03-capture-canvas-at-compact-width.md
@@ -1,0 +1,45 @@
+# HSM-20-03 — The capture canvas at compact width (the live meeting board)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 20
+- **Status:** todo
+- **Depends on:** 20-01 (`DeskCamera`).
+- **Unblocks:** nothing downstream.
+- **Owner:** unassigned
+
+## Problem
+
+The live capture surface (`LiveCaptureCanvas`, `MeetingCaptureApp.swift:1137–1186`) assumes a wide
+board: free-drag utterance bubbles, a floating recorder orb, and a tack zone. It is the **least
+broken** surface — the root is a `GeometryReader`, the tack zone is already `min(264, size.width −
+72)`, and the utterance stream is an unconstrained `VStack` — but free-drag bubbles and a floating
+recorder are awkward one-thumb on a 390pt phone.
+
+## The design
+
+1. **Verify, then adapt — do not rewrite.** This canvas already scales; confirm it at 390pt first
+   (screenshot the seeded board on the iPhone sim). Use it as the reference for the lane's sizing
+   math elsewhere.
+2. **Lane: a docked recorder, not a floating orb.** On `camera == .lane`, dock the recorder to a
+   persistent bottom bar (thumb zone) instead of a free-floating orb; the live transcript stream
+   fills the column above it (it already flows top-to-bottom). The tack zone stays centered and
+   scales (it already does).
+3. **Wrap any chip rows.** The footer/status chips and any horizontal affordance must wrap or
+   scroll at 390pt (reuse the `FlowChips`/flow-layout pattern, handover §4f) — no clipped row.
+4. **Pinning survives.** The drag-to-tack "mark this moment" gesture (what feeds MIR) must still
+   work one-thumb; if free-drag is awkward, offer a tap-to-tack affordance on each bubble as the
+   lane equivalent, but **do not remove pinning** (it is a load-bearing capability, not decoration).
+5. At `.wide`/`.narrow` the canvas renders exactly as today.
+
+## Scope
+
+- **In:** the lane verification + the docked recorder bar; wrapped chip rows; a one-thumb tack
+  affordance if free-drag proves awkward at 390pt.
+- **Out:** the desk lane (20-02); forms/teleprompter (20-04).
+
+## Proof
+
+- iPhone sim: the capture board fits 390pt, the recorder is docked, chips wrap, a moment can be
+  tacked one-thumb.
+- `swift test` + both sim builds green. Device walk = 20-05.
+</content>

--- a/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-04-forms-and-screens-at-compact-width.md
+++ b/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-04-forms-and-screens-at-compact-width.md
@@ -1,0 +1,53 @@
+# HSM-20-04 — The forms + screens at compact width (connect, settings, sheets, the hold-bar teleprompter)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 20
+- **Status:** todo
+- **Depends on:** 20-01 (`DeskCamera` + `laneWidth`).
+- **Unblocks:** nothing downstream.
+- **Owner:** unassigned
+
+## Problem
+
+The non-desk screens inherit iPad widths and rows. The companion connect screen packs Port + Token
+two-up at a fixed maxWidth (`CompanionShellApp.swift:651–653`, inside `maxWidth: 560`); the
+agent/chain editors are 560/740 modals (`DeskAgents.swift:618/906`); the action sheets are
+460-wide; and the iPhone dictation surface has a **dedicated vision beat** (the HOLD BAR
+teleprompter, `EXPERIENCE-VISION-2026-06-27.md:65`) that does not exist yet.
+
+> **CORRECTION to the parity audit / status doc:** the unwrapped Port+Token row is at
+> `CompanionShellApp.swift:651–653`, **not** `MeetingCaptureApp.swift:1641` (that line is unrelated).
+
+## The design
+
+1. **Connect screen (lane):** stack Port and Token vertically (or make Port flexible) below
+   `camera == .lane`; clamp the `maxWidth: 560` container via `laneWidth`. Keep every field's
+   speak-to-fill mic (credentials/ports stay paste/number by design).
+2. **The agent/chain editors** (`DeskAgents.swift` `AgentEditor` 560×740, `ChainEditor` 560, member
+   picker 420): clamp via `laneWidth` and reframe the dim-scrim as the hand-built rising sheet on
+   lane (consistent with 20-02). The builder fields keep their mics.
+3. **The action sheets** (`DioSendCard`/`DioActSheet`/`DioRunTargetSheet`/`DioRouteSheet`,
+   460/440-wide) — if not already reframed in 20-02, clamp + rising-sheet them here.
+4. **The iPhone HOLD-BAR teleprompter** (the vision's signature dictation moment): the dictation
+   mic promotes to a persistent **bottom-edge hold bar** (accent-gradient capsule, thumb zone) on
+   the dictate screen; press-and-hold reflows to a **bottom-up** single-column teleprompter that
+   fills from the bar ("you said" muted nearest the thumb, "→ Cursor" full weight above, destination
+   + egress as one pill at the top). **No dim toward the bar** (a dim is a scrim); the bar's
+   elevation + the rising stack carry focus. Release commits (`.medium` haptic, `.success` on land);
+   "trace ›" pushes a full screen with a working back control.
+5. **Settings + the two sanctioned full-screen sheets** (a recording, settings) stay as full-screen
+   destinations — the no-modal law governs *primitive editing*, not these (vision §4.3 "honest
+   scope"). Just verify they fit 390pt.
+
+## Scope
+
+- **In:** the connect Port/Token stack; clamping + rising-sheet the agent/chain editors and action
+  sheets; the iPhone hold-bar teleprompter; verifying settings/full-screen sheets at 390pt.
+- **Out:** the desk lane (20-02); the capture canvas (20-03).
+
+## Proof
+
+- iPhone sim: connect stacks cleanly; editors fit; the hold-bar teleprompter reflows bottom-up with
+  no dim; every field keeps its mic; the egress pill is present (never prose).
+- `swift test` + both sim builds green. Device walk = 20-05.
+</content>

--- a/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-05-on-device-proof.md
+++ b/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-05-on-device-proof.md
@@ -1,0 +1,52 @@
+# HSM-20-05 — On-device proof (every compact screen walked on a real iPhone)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 20
+- **Status:** todo — **the gate.** The ONLY story that promotes an iPhone cell from
+  forward-constraint to proven.
+- **Depends on:** 20-01, 20-02, 20-03, 20-04 (everything reflows before it is walked).
+- **Unblocks:** the phase closeout + every `🟡` iPhone cell in the parity matrix.
+- **Owner:** **the owner** (only he can walk the cabled iPhone).
+
+## Problem
+
+Every prior mobile session that called a Simulator screenshot "proof" was wrong, and the owner
+walked a real device to find it broken ([[feedback_verify_on_device_not_seeded]], the device-gap
+handover). Simulator screenshots are for iteration; they do **not** close a row. A compact layout
+that is perfect in the iPhone sim can still break on real metal (safe-area insets, the notch/Dynamic
+Island, real rotation, real split-view drag, real keyboard avoidance).
+
+## The design
+
+This story is a **walk + capture protocol**, not new code (any bug it finds spawns a fix in the
+relevant story's surface):
+
+1. **Build to a real iPhone** (cabled, UNLOCKED): `scripts/meeting-capture-device.sh <iphone-udid>`
+   (run with the sandbox disabled — it clones packages; the build needs `patch-llm-macro.sh` +
+   `-disableAutomaticPackageResolution`, handover §6).
+2. **Walk every compact surface** and confirm against the vision:
+   - The desk **lane** column + zone chip rail + FAB + slim header.
+   - The pull-out **rising from the bottom edge** (and, on an iPad in split-view, migrating
+     right→bottom on the divider drag — the signature moment).
+   - Rotate lane↔wide: the hand-arranged desk arrangement is **restored exactly**.
+   - The capture canvas: docked recorder, a moment tacked one-thumb.
+   - Connect (Port/Token stacked), settings, the agent/chain editors.
+   - The **hold-bar teleprompter**: press-and-hold reflows bottom-up, no dim, release commits.
+   - Every text field still has its speak-to-fill mic; every output shows the egress badge.
+3. **The owner is the only walker.** Do not ask him for screenshots — diagnose any reported break
+   from CODE. The walk is his button; your job is to make it pass on the first walk by being
+   ruthless in the sim first.
+
+## Scope
+
+- **In:** the device build + the walk protocol + logging which cells are proven; fixes routed back
+  to 20-02/03/04 for anything the walk breaks.
+- **Out:** new layout work (lives in the other stories).
+
+## Proof
+
+- The owner confirms each surface on the cabled iPhone. Each confirmed surface promotes its matrix
+  cell from `🟡` (forward-constraint) to proven. **No sim screenshot closes this story.**
+- Phase closeout (the operating cadence: story headers, `current-phase-status.md`, the README "last
+  updated", the EQUILIBRIUM wave log) only after the walk passes.
+</content>


### PR DESCRIPTION
## What

Turns Phase 20 ("One app, every size" — the iPhone/compact pass) from a stub into a **world-class executable front** so a fresh agent can pick up story 20-01 and ship the whole pass without re-deriving anything.

Three artifacts:

1. **`HANDOVER-2026-06-27-phase20-one-app-every-size.md`** — the master orientation doc:
   - The one-sentence mission + state of the world (all PRs merged, main clean).
   - The design north star quoted from `EXPERIENCE-VISION` §4.3 (`DeskCamera`, the three cameras, the spring-migrating pull-out, the iPhone hold-bar teleprompter, the lane mock).
   - **The doctrine call** — introduce `DeskCamera` derived from `horizontalSizeClass`+width and fold the strays in; explicitly corrects the tempting "don't use horizontalSizeClass / keep adding `w<500`" trap.
   - A **verified code map**: every fixed dimension, every dim-scrim "modal hell", the 4 width-check strays, the responsive exemplar (`LiveCaptureCanvas`), and the keystone `DioPullout`.
   - The exact build + iPhone-sim screenshot pipeline (copy-paste), the `swift test` vs `xcodebuild` distinction, the seed env vars, where shots commit.
   - The hard-won lessons (seeded sim ≠ device proof; stale flattened tree hides errors; no modals; mic on every field; PMO gate) and a definition of done.

2. **Refined `current-phase-status.md`** — names `DeskCamera` as the design call, corrects the audit's stale pointers, aligns story titles, points at the handover.

3. **Five detailed story files** (`story-01..05`) in the Phase 18 format — each with Problem / The design / Scope / Proof, grounded in verified `file:line` evidence.

## Evidence / corrections

Two Explore passes verified every claim against the working tree and corrected the parity audit's stale pointers:
- `DioCoderSession` 480×560 + `DioCoderAnswer` 400 live in **`DeskCoder.swift:183/367`**, not `DeskDioramaStage`.
- The unwrapped Port+Token row is **`CompanionShellApp.swift:651–653`**, not `MeetingCaptureApp.swift:1641`.
- Confirmed the load-bearing symbols: `DioPullout` (`:1200`/`:3197`), `positions[id]` (`:2924`), the 4 strays to fold into `DeskCamera` (`:2035/:2977/:3085/:3546`).

## Verification

- Docs-only planning commit (no code touched).
- `uv run pytest -q tests/unit/test_doc_drift_guard.py` → **15 passed**.
- Through the PMO pre-commit gate (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)