### PR TITLE
Cadence Engine: program chart + Phase 1 (cadence core) storied

### DIFF
--- a/pm/roadmap/holdspeak/cadence-engine/README.md
+++ b/pm/roadmap/holdspeak/cadence-engine/README.md
@@ -1,0 +1,144 @@
+# The Cadence Engine — program chart
+
+> **HoldSpeak Cadence Engine: a local-first technical chief-of-staff that turns meetings,
+> activity, dictation, and coding-agent state into evidence-backed nudges and nearly-complete
+> next actions.** Qlippy does not merely remind. Qlippy pushes — with receipts, restraint, and a
+> ready-made next move.
+
+**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. Phase 1
+(cadence core) is the lead and fully storied. Phases 2–8 are sketched here and storied as each
+becomes the lead.
+
+**Last updated:** 2026-06-28 (program authored from the owner's rough design + a grounded seam map
+of the real runtime; §15 open questions resolved below).
+
+---
+
+## 0. The one sentence
+
+Continuously convert existing HoldSpeak knowledge into:
+
+```
+Open Loop → Next Best Action → Suggested Artifact → Nudge → Decision
+```
+
+…and never nudge without a prepared next step. **Bad:** "Reminder: file the GitHub issue."
+**Good:** "I drafted the issue (title + body + source). [Approve] [Edit] [Snooze] [Kill loop]."
+
+This is a **pressure system**, not a chatbot. The promise: *Qlippy interrupts only when he has done
+enough work that your next decision is cheap.*
+
+## 1. The product principle — pushy, never reckless
+
+1. Notice important unfinished work. 2. Make a concrete suggestion. 3. Cite the evidence.
+4. Offer one-tap decisions. 5. Respect snooze/dismissal. 6. Escalate stale loops *gradually*.
+7. Never perform an external side effect without explicit approval. 8. Never nag without a useful
+prepared step.
+
+## 2. The non-negotiables (the trust boundary)
+
+These are hard rules, enforced structurally, not by good intentions:
+
+- **No external side effect without the existing actuator approval path.** Every outbound action
+  (issue, Slack, webhook) is an `ActuatorRepository.record_proposal(...)` that the user approves;
+  cadence **never** calls a connector directly and **never** bypasses `transition_proposal`.
+- **No raw shell, no network egress** from cadence except via approved/gated connectors.
+- **Off by default.** `CadenceConfig.enabled = False`. When off, the runtime is byte-identical to
+  today (the thread never starts). No hidden cloud fallback.
+- **Every nudge is explainable** — it carries `EvidenceRef`s (a meeting segment, an artifact, an
+  agent session, an activity record, a proposal) with deep links.
+- **Every generated action is editable or rejectable.** Dismissal and snooze are respected and
+  audited. A **killed** loop stays killed unless its source materially changes.
+- **Quiet hours default-on.** The only opt-in exception is an urgent agent-blocker.
+- **One badge, never a privacy sentence** ([[feedback_no_privacy_novels]]): every nudge carries an
+  egress badge (`local` / `mixed` / `cloud + target`).
+- **All source text is data, never instructions** — transcripts, browser titles, issue titles,
+  agent output never alter policy or trigger tool calls; all generated proposal payloads are typed
+  and preview-gated (prompt-injection defense).
+
+## 3. Phase-0 architecture decisions (the §15 open questions, resolved)
+
+| # | Question | Decision | Why |
+|---|----------|----------|-----|
+| 1 | Loops: DB entities or computed views? | **First-class DB entities, source-projected.** The collector idempotently upserts loops from sources (key = `source_type:source_id`); user lifecycle state (snoozed/killed/nudge_count) lives only on the row. | A "killed" loop must stay killed even while its source action item still exists — a view can't remember a decision. |
+| 2 | Agent sessions: JSON or SQLite? | **Keep the JSON capture file; the collector *mirrors* awaiting-response sessions into loops.** No migration in this program. | Don't destabilize the agent-hook capture path; mirror, don't move. |
+| 3 | Telegram second confirm for high-risk? | **Yes — tied to the actuator's `reversible` flag.** `reversible=False` or external egress ⇒ a two-step confirm; reversible/local ⇒ one tap. | A remote surface has higher accidental-tap risk; reuse the safety signal the actuator already carries. |
+| 4 | Personality: gentle/normal/aggressive? | **Yes — `CadenceConfig.pressure` scales policy *timings* only**, never *what* is nudged or any safety gate. Default `normal`. | Cheap (a multiplier on delays/repeats/max-per-day), high perceived value, safety-invariant. |
+| 5 | Daily brief: scheduled or on activity? | **On first user activity after a configured earliest time** (not before ~7am). | A 6am push while you sleep is noise; "first touch after quiet hours" respects presence. |
+| 6 | Low-confidence extractions → loops? | **Yes, as quiet `needs_review` loops** — surfaced in the queue, never a push until confirmed. | Honest at low confidence; never nags on a hallucinated action. |
+| 7 | Project identity normalization? | **One `resolve_project()` helper** — prefer explicit `project_id` (activity), the `.hs/` project via `repo_root` (agents), the meeting linkage; fall back to repo-root basename / domain. Loops store a `project` string. | Good-enough grouping now; one function to sharpen later. |
+| 8 | Plugin-pack later or first-party? | **First-party, in-tree `holdspeak/cadence/`.** | Cadence is core product surface; the actuator system is already the extension seam for outbound actions. |
+
+**Cross-cutting (corrections to the rough design, from the grounded seam map):**
+
+- **Threading, not asyncio.** `WebRuntime` runs background work as **daemon threads on a shared
+  `runtime_stop_event`** (`web_runtime.py:169,477–482,537,564`), e.g. `PluginQueueMixin`. The
+  cadence loop follows that exact pattern — a `CadenceMixin` daemon thread — **not** the rough
+  design's "periodic async task."
+- **No new infrastructure.** In-process thread + SQLite. No Celery/Redis/Temporal (design §6.3).
+- **Reuse, never rebuild.** Cadence is a *layer* over seams that already ship; §4 maps each.
+
+## 4. The seams we reuse (verified `file:line`)
+
+| Seam | Where | How cadence uses it |
+|------|-------|---------------------|
+| **Runtime hub** | `WebRuntime` `holdspeak/web_runtime.py:138` (8 mixins); daemon-thread pattern `:477–482`, stop `:418/:564` | A `CadenceMixin` (`holdspeak/runtime/cadence.py`) owns `self.cadence_thread`, started in `run()`, joined in cleanup. |
+| **SQLite** | `Database` `holdspeak/db/core.py:810`; `SCHEMA_SQL:142`, `SCHEMA_VERSION=2 :39`; `BaseRepository(connection, container)` `holdspeak/db/base.py` | New `cadence_*` tables in `SCHEMA_SQL`, bump to `3`; `CadenceRepository` in `holdspeak/db/cadence.py`, registered in `Database.__init__:816`. |
+| **Aftercare** | `holdspeak/meeting_aftercare.py` (read-only digest: open_items/decisions/changes); routes in `web/routes/meetings.py` (aftercare read, file-issue, export/slack) | Strongest signal source: open/accepted actions → loops. |
+| **Activity ledger** | `activity_records` `db/core.py:496`; `ActivityRepository` `db/activity.py`; `Nudge`/`compute_nudges()` `holdspeak/activity_nudges.py`; `/api/activity/briefing` | "Is this loop still alive?" — recent-activity suppression/boost. |
+| **Action items** | `action_items` `db/core.py:200` (status pending/completed/dismissed, `review_state`, `owner`); in `MeetingRepository` | Source loops; owner/assign moves. |
+| **Agent hooks** | `AgentSession` `holdspeak/agent_context/models.py` (`awaiting_response`, `last_assistant_text`, `tmux_pane`, `cwd`, `repo_root`); file `~/.config/holdspeak/agent_sessions.json` | Awaiting-response → blocker loop; reply via tmux or `/api/dictation/remote`. |
+| **Actuators** | `ActuatorRepository.record_proposal(...)` → `transition_proposal(...)` `holdspeak/db/actuators.py:42`; audit table; idempotency key; gates `allow_actuators=False`/`allowed_actuators`/`webhook_allowed_hosts` `config.py` | The ONLY path to an external side effect. |
+| **Routes** | `build_*_router(ctx)->APIRouter`; registered `web_server.py:556–567`; `WebContext` `web/context.py` | `build_cadence_router` → `/api/cadence/*`. |
+| **Web UI** | Astro `web/src/pages/*.astro` + `web/src/scripts/*.js`; build to `_built/`; `egress-badge.js` (scope local/mixed/cloud) | A `/cadence` coach page. |
+| **CLI** | `main.py` subparsers + `holdspeak/commands/*.py` (`run_*_command`) | `holdspeak cadence …`. |
+| **Presence** | `desktop_presence.py` `_STATE_META`, `_set_runtime_activity()` | A cadence nudge rides the desktop presence overlay. |
+| **Dogfood** | `dogfood/PROTOCOL.md` (Tier-1 plumbing / Tier-2 real-metal); `tests/e2e/test_dogfood_plumbing_e2e.py`; `HOLDSPEAK_DOGFOOD=1` | A cadence protocol section + fixtures. |
+| **Egress / Intel** | `egress-badge.js`; `intel_egress_posture()` `holdspeak/intel/providers.py:225`; providers local/cloud/auto + structured-JSON validation | Badge every nudge; LLM next-actions are fail-closed JSON. |
+| **Config gate** | `config.py` dataclasses, off-by-default booleans (`meeting.allow_actuators=False`) | `CadenceConfig(enabled=False, pressure="normal", …)`. |
+
+## 5. The core concepts (data model)
+
+`OpenLoop` (id, source_type, source_id, project, title, summary, status [open/snoozed/closed/
+killed/delegated], priority, due_at, snoozed_until, owner, stale_score, last_nudged_at,
+nudge_count) · `EvidenceRef` (kind, id, label, timestamp, deep_link) · `NextBestAction` (loop_id,
+kind, title, body_markdown, confidence, reversible, proposal_id) · `Nudge` (loop_id, action_id,
+surface, severity, message, actions, status) · `CadencePolicy` (source_types, quiet_hours,
+delays, escalation, max/day, surfaces). Full SQL in `phase-1-cadence-core/story-01`.
+
+## 6. The phases (build in dependency order)
+
+Phase 1 leads and is fully storied. Each later phase is storied when it becomes the lead.
+
+| Phase | Title | The crux | Depends on |
+|-------|-------|----------|------------|
+| **1** | **Cadence core** | The loop/nudge/policy substrate: models, migrations, collector (meeting actions + pending proposals), stale-scoring v1, policies + quiet hours, CLI, unit tests. No external side effects, off by default. | — |
+| **2** | Web coach surface | `/api/cadence/*` + a `/cadence` page: loops, evidence deep-links, snooze/kill/close, generate-next-action, egress badges. | 1 |
+| **3** | Agent-blocker push | Awaiting-response agent sessions → loops + a prepared reply; tmux/`/api/dictation/remote` delivery as a nudge action. | 1 |
+| **4** | Telegram remote presence | Pairing + a Telegram surface; `/brief` `/loops` `/agents`; inline-button decisions wired to the cadence API; unpaired-chat rejection; second-confirm for irreversible actions. | 2, 3 |
+| **5** | Daily push brief | A deterministic morning brief (first-activity trigger) with prepared moves; LLM wording behind a capability gate (policy never model-driven). | 2 |
+| **6** | Stale-loop + EOD closure | Escalation policy + an end-of-day closure ritual + batch closure UI; accepted-action → issue proposals; kill/delegate/snooze semantics. | 2, 5 |
+| **7** | LLM next-best-action | Structured-JSON next-action generator (issue/Slack drafts, dedupe clustering), fail-closed validation, preview/approval-gated. | 6 |
+| **8** | Hardening + dogfood | A cadence dogfood protocol + fixtures + e2e, telemetry-free local audit export, docs, and the master off-switch proven. | all |
+
+**Anti-goals** (design §14): not a chatbot, not an autonomous shell executor, not a second runtime,
+not a cloud-first memory, not an MCP free-for-all, not a surveillance daemon, not a vague-reminder
+nag machine, not a separate product.
+
+## 7. Operating cadence (per the repo)
+
+Every shipping commit: branch off `main`, write `.tmp/CONTRACT.md` (8 honest `[x]`), run the
+relevant tests (`uv run pytest -q …`), open a PR, **merge on green** ([[feedback_merge_phases_via_pr]]).
+Each phase updates its `current-phase-status.md` story-status row + "Where we are", this chart's
+"Last updated", and any canon doc the story names. A **dedicated docs story** closes each
+user-facing phase ([[feedback_dedicated_docs_story]]). Prove LLM-shaped features on real metal,
+control-vs-treatment, not just a no-LLM plumbing pass ([[feedback_prefer_real_metal_proof]]).
+
+## 8. Pointers
+
+- **Owner's rough design:** the source brief (this chart refines it into implementation-ready work).
+- **Phase 1 (lead):** `phase-1-cadence-core/current-phase-status.md` + `story-01..06`.
+- **The first agent prompt** the owner supplied (design §16) is satisfied by this chart + Phase 1.
+- **Memories:** [[feedback_no_privacy_novels]], [[feedback_merge_phases_via_pr]],
+  [[feedback_dedicated_docs_story]], [[feedback_prefer_real_metal_proof]],
+  [[feedback_author_pmo_directly]], [[project_phase37_actuators]], [[reference_lan_llm_endpoint]].

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/current-phase-status.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/current-phase-status.md
@@ -1,0 +1,58 @@
+# Cadence Phase 1 — Cadence core
+
+**Status:** planned (lead phase, fully storied). **Start here:** `../README.md` (the program chart —
+the trust boundary, the resolved architecture decisions, and the verified seam map).
+
+**Last updated:** 2026-06-28 (authored).
+
+## Objective
+
+Stand up the loop/nudge/policy **substrate** with **zero external side effects and zero LLM
+dependency**, entirely off by default. After Phase 1 the runtime can, when enabled, project Open
+Loops from meeting action items + pending actuator proposals, score their staleness, decide which
+are due under a quiet-hours-respecting policy, and expose them on the CLI — all deterministic and
+local. Surfaces (web, agent push, Telegram, briefs) build on this in later phases.
+
+## Why it leads
+
+Everything else asks this substrate: the web coach reads loops, the agent-blocker push is a loop
+source, Telegram delivers nudges, the brief ranks loops. Get the models, the source-projection
+idempotency, the scoring, and the off-switch right here and the rest is surfaces.
+
+## The load-bearing decisions (from the chart, applied)
+
+- **Off by default.** `CadenceConfig.enabled = False`; the `CadenceMixin` thread never starts when
+  off → the runtime is byte-identical to today. Proven by a test.
+- **Source-projected loops.** The collector idempotently upserts by `source_type:source_id`; user
+  lifecycle state (snoozed/killed/nudge_count) is preserved across re-collection. A killed loop is
+  never resurrected unless the source materially changes.
+- **Daemon thread on `runtime_stop_event`**, mirroring `PluginQueueMixin` (`web_runtime.py:477`).
+- **No actuators touched in Phase 1.** Pending proposals are a *read* source; cadence proposes
+  nothing yet (that starts in Phase 6/7, always via the existing actuator path).
+
+## Stories
+
+| ID | Title | Status |
+|----|-------|--------|
+| CAD-1-01 | Cadence models + SQLite migrations (`cadence_*` tables, `CadenceRepository`) — **leads** | todo |
+| CAD-1-02 | The collector (meeting action items + pending proposals → source-projected loops) | todo |
+| CAD-1-03 | Stale-scoring v1 (deterministic, explainable) | todo |
+| CAD-1-04 | Cadence policies + quiet hours + the `CadenceMixin` tick (off by default) | todo |
+| CAD-1-05 | CLI: `holdspeak cadence status \| loops \| run-now` | todo |
+| CAD-1-06 | Unit tests for scoring, policy, quiet hours, snooze/kill idempotency | todo |
+
+## Where we are
+
+Not started; fully storied. **CAD-1-01 leads** (the models + tables everything else reads/writes).
+1-02/1-03 then build on it; 1-04 wires the tick + config gate; 1-05 exposes it; 1-06 locks the
+behavior. The whole phase is local + deterministic + off-by-default — a green `uv run pytest -q`
+and a `holdspeak cadence run-now` that prints projected loops is the bar.
+
+## Exit criteria
+
+- `holdspeak cadence status` / `loops` / `run-now` work locally.
+- `run-now` projects loops from imported meeting actions + pending proposals, scored and ordered.
+- **No external side effects exist** in the cadence package (grep proves no connector calls).
+- With `CadenceConfig.enabled = False` (default), the runtime starts no cadence thread and behaves
+  identically to `main` (test-proven).
+- `uv run pytest -q tests/unit/test_cadence_*.py tests/integration/test_cadence_*.py` green.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-01-models-migrations.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-01-models-migrations.md
@@ -1,0 +1,53 @@
+# CAD-1-01 — Cadence models + SQLite migrations
+
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo — **leads the phase.**
+- **Depends on:** nothing. **Unblocks:** every other Phase-1 story.
+
+## Problem
+
+There is no persistence for loops/next-actions/nudges/policies. They need first-class tables
+(chart decision §3.1: source-projected entities, not views) following the repo's storage pattern.
+
+## The design
+
+Reuse the storage pattern verified in the seam map:
+
+1. **Schema.** Append `CREATE TABLE IF NOT EXISTS` blocks to `SCHEMA_SQL`
+   (`holdspeak/db/core.py:142–806`) for `cadence_loops`, `cadence_evidence_refs`,
+   `cadence_next_actions`, `cadence_nudges`, `cadence_policies` (full DDL in the rough design §10,
+   with `status`/`priority`/`severity` as TEXT, timestamps as TEXT ISO-8601, `stale_score REAL`,
+   FKs `ON DELETE CASCADE` to `cadence_loops`). Add indexes: `cadence_loops(status, snoozed_until)`,
+   `cadence_loops(source_type, source_id)` **UNIQUE** (the idempotency key for projection).
+2. **Bump `SCHEMA_VERSION = 2 → 3`** (`core.py:39`). The existing version bump path backs up +
+   re-applies (`core.py:850–891`); the schema-snapshot test must be regenerated
+   ([[reference_schema_snapshot_regen]] — use the identical regex, don't hand-edit).
+3. **Repository.** New `holdspeak/db/cadence.py` → `class CadenceRepository(BaseRepository)`
+   (`db/base.py`: `__init__(self, connection, container)`, JSON helpers provided). Methods:
+   `upsert_loop(...)` (INSERT…ON CONFLICT(source_type,source_id) DO UPDATE — preserving
+   status/snoozed_until/nudge_count when already user-decided), `get_loop`, `list_loops(status=…)`,
+   `set_status(id, status)`, `snooze(id, until)`, `bump_nudge(id, at)`, plus `add_evidence`,
+   `add_next_action`, `record_nudge`, `get_policy`/`upsert_policy`. Register in
+   `Database.__init__` (`core.py:816`) as `self.cadence = CadenceRepository(self._connection, self)`
+   and re-export in `holdspeak/db/__init__.py`.
+4. **Models.** `holdspeak/cadence/models.py` — `@dataclass` (frozen where natural) for `OpenLoop`,
+   `EvidenceRef`, `NextBestAction`, `Nudge`, `CadencePolicy`, with `Literal` enums per the design
+   §4. Pure data; no I/O. The repository converts rows↔dataclasses.
+
+## Scope
+
+- **In:** the 5 tables + indexes, the version bump + snapshot regen, `CadenceRepository`, the
+  dataclasses, registration/export.
+- **Out:** the collector (1-02), scoring (1-03), the tick (1-04), any reads of meetings/proposals.
+
+## Proof / acceptance
+
+- `Database` opens on a fresh DB and on an existing v2 DB (backup-then-migrate path) without error.
+- `CadenceRepository.upsert_loop` is idempotent: two upserts of the same `source_type:source_id`
+  yield one row; the second preserves a prior `status="killed"` / `snoozed_until`.
+- The schema-snapshot test passes after regeneration.
+
+## Test plan
+
+`tests/unit/test_cadence_models.py` (dataclass round-trips), `tests/integration/test_cadence_store.py`
+(real DB: create tables, upsert idempotency, killed-survives-recollection, evidence/next-action FKs
+cascade on loop delete). `uv run pytest -q tests/integration/test_cadence_store.py`.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-02-collector.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-02-collector.md
@@ -1,0 +1,50 @@
+# CAD-1-02 — The collector (sources → source-projected loops)
+
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Depends on:** CAD-1-01. **Unblocks:** 1-03 (scoring reads loops), 1-05 (CLI shows them).
+
+## Problem
+
+Loops must be *projected* from real HoldSpeak state, idempotently, so re-running never duplicates
+or resurrects user-decided loops.
+
+## The design
+
+`holdspeak/cadence/collector.py` → `class LoopCollector`. Phase 1 collects **two** of the design's
+source types (the rest land in later phases — agent sessions in Phase 3, etc.):
+
+1. **Meeting action items.** Read open/accepted items via the meeting repo (`action_items`,
+   `db/core.py:200`; `MeetingRepository` houses them). For each `status="pending"` item, build an
+   `OpenLoop(source_type="meeting_action", source_id=item.id, title=item.task, owner=item.owner,
+   project=resolve_project(...), …)` and one `EvidenceRef(kind="action_item", id=item.id,
+   deep_link="/meetings/<mid>#ai-<id>")`. Low-confidence / unreviewed items (`review_state="pending"`
+   below a threshold) project as **`needs_review` quiet loops** (chart §3.6).
+2. **Pending actuator proposals.** Read `status="proposed"` rows via `ActuatorRepository`
+   (`db/actuators.py`); each → `OpenLoop(source_type="proposal", source_id=proposal.id,
+   title=proposal.preview, …)` + `EvidenceRef(kind="proposal", …)`. **Read only** — Phase 1 proposes
+   nothing.
+3. **Projection = idempotent upsert** via `CadenceRepository.upsert_loop` keyed
+   `source_type:source_id`. A source that disappears (action completed/dismissed) closes its loop
+   (`status="closed"`) rather than deleting it (audit trail). A `killed` loop is never reopened by
+   re-collection.
+4. **`resolve_project()`** (`holdspeak/cadence/projects.py`) — the one normalizer (chart §3.7):
+   explicit `project_id` → meeting linkage → repo-root basename / domain.
+
+## Scope
+
+- **In:** `LoopCollector.collect()` over meeting actions + pending proposals; `resolve_project`;
+  close-on-source-gone; `needs_review` projection.
+- **Out:** agent sessions (Phase 3), activity/dictation/manual sources (later), scoring (1-03),
+  any proposing/executing.
+
+## Proof / acceptance
+
+- Against a seeded DB (imported meeting with 3 actions + 1 pending proposal), `collect()` yields 4
+  loops with correct evidence + deep links; a second `collect()` yields the same 4 (no dupes).
+- Completing an action then re-collecting flips its loop to `closed`, not a new row.
+- A loop manually set `killed` stays killed after `collect()`.
+
+## Test plan
+
+`tests/integration/test_cadence_collector.py` — seed meetings/actions/proposals, assert projection
+counts, idempotency, close-on-gone, killed-survives. `uv run pytest -q tests/integration/test_cadence_collector.py`.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-03-scoring.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-03-scoring.md
@@ -1,0 +1,55 @@
+# CAD-1-03 — Stale-scoring v1 (deterministic, explainable)
+
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Depends on:** CAD-1-01, CAD-1-02. **Unblocks:** 1-04 (the tick orders by score), 1-05.
+
+## Problem
+
+Loops need a deterministic priority so the engine pushes the right one and the user can see *why*.
+No LLM (chart: baseline is deterministic).
+
+## The design
+
+`holdspeak/cadence/scoring.py` → `score_loop(loop, *, now, signals) -> ScoreBreakdown`. Pure
+function, no I/O — takes the loop + a small `signals` struct the collector assembles (recent
+activity for the project, source weight, recurrence count). Implements the design §7.1 additive
+heuristic:
+
+```
+stale_score = age_weight + priority_weight + source_weight + recurrence_weight
+            + accepted_action_weight  − recent_activity_weight − snooze_weight − dismissal_weight
+```
+
+Suggested initial weights (design §7.1, tunable constants in one place):
+
+| Signal | Effect |
+|--------|--------|
+| accepted action not executed | high boost |
+| unowned action | medium boost |
+| appears across related meetings | high boost |
+| related activity touched today | boost (the loop is "alive") |
+| recently dismissed same loop | suppress |
+| snoozed | suppress until due |
+| `needs_review` (low confidence) | suppress (never a push) |
+
+Returns a **`ScoreBreakdown`** (the total **and** the per-signal contributions) so every nudge is
+explainable — the breakdown is what the future debug payload + the "why" line render. Persist the
+total onto `cadence_loops.stale_score` via the repo; keep the breakdown ephemeral (recomputed).
+
+## Scope
+
+- **In:** the pure scorer + `ScoreBreakdown`; the weight constants; persisting the total.
+- **Out:** policy/quiet-hours scheduling (1-04), agent-blocker weight (Phase 3 adds the huge boost),
+  any LLM classification (Phase 7).
+
+## Proof / acceptance
+
+- Deterministic: same inputs → same score (no clock/random leakage; `now` is injected).
+- An accepted-but-unexecuted action outranks an unowned action outranks a fresh low-priority loop.
+- A snoozed or `needs_review` loop scores below any active loop.
+- The breakdown sums to the total.
+
+## Test plan
+
+`tests/unit/test_cadence_scoring.py` — table-driven cases for each weight + ordering invariants +
+breakdown-sums-to-total + determinism (inject `now`). `uv run pytest -q tests/unit/test_cadence_scoring.py`.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-04-policies-tick.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-04-policies-tick.md
@@ -1,0 +1,52 @@
+# CAD-1-04 — Policies + quiet hours + the `CadenceMixin` tick (off by default)
+
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Depends on:** CAD-1-01..03. **Unblocks:** 1-05 (CLI drives the same service), all surfaces.
+
+## Problem
+
+The substrate needs a scheduler that decides *which loops are due now* under quiet hours and a
+per-source cadence — and an in-runtime tick that runs it, **off by default and byte-identical when
+off**.
+
+## The design
+
+1. **Policies.** `holdspeak/cadence/policies.py` — `CadencePolicy` defaults (design §4.5/§7.2):
+   per-source `initial_delay`, `repeat_after`, `escalation_after_count`, `max_nudges_per_day`,
+   `quiet_hours`, `surfaces`. Seed defaults into `cadence_policies` on first run; user-editable
+   later (Phase 2). `pressure` (gentle/normal/aggressive, chart §3.4) is a **timing multiplier**
+   applied here — never changes *what* is nudged or any gate.
+2. **Scheduler.** `holdspeak/cadence/scheduler.py` — `due_loops(loops, policies, *, now) ->
+   list[DueDecision]`: respects `snoozed_until`, quiet hours (default-on; the only exception is an
+   urgent agent-blocker, which Phase 1 has none of yet), `last_nudged_at + repeat_after`, and the
+   daily cap. Pure given `now`.
+3. **Config gate.** Add `CadenceConfig(enabled=False, pressure="normal", quiet_hours=…,
+   max_nudges_per_day=…)` to `holdspeak/config.py` (dataclass, off-by-default, mirroring
+   `meeting.allow_actuators=False`).
+4. **The tick.** `holdspeak/cadence/service.py` → `CadenceService(db, …).tick(now)` = collect →
+   score → persist → compute due decisions (Phase 1 *logs/returns* them; it does **not** render or
+   deliver — surfaces come in Phase 2+). `holdspeak/runtime/cadence.py` → `CadenceMixin` owns
+   `self.cadence_thread`, a daemon thread started in `WebRuntime.run()` **only when
+   `config.cadence.enabled`**, looping `while not self.runtime_stop_event.wait(interval):
+   self.cadence.tick(...)`, and joined in cleanup — mirroring `PluginQueueMixin`
+   (`web_runtime.py:477–482,564`). Add `CadenceMixin` to the `WebRuntime` base list (`:138`).
+
+## Scope
+
+- **In:** default policies + seeding, the pure scheduler, the config gate, `CadenceService.tick`,
+  the `CadenceMixin` daemon thread wired off-by-default.
+- **Out:** nudge rendering/delivery (Phase 2+), escalation/EOD policies (Phase 6), Telegram (Phase 4).
+
+## Proof / acceptance
+
+- With `enabled=False` (default) the cadence thread **never starts**; `WebRuntime` start/stop is
+  byte-identical to `main` (test asserts no thread + no DB writes from cadence).
+- With `enabled=True`, `tick()` returns due decisions for active loops outside quiet hours, honors
+  snooze + the daily cap, and never returns a `needs_review`/snoozed loop as a push.
+- `pressure="aggressive"` shortens delays vs `gentle`; neither changes the loop set.
+
+## Test plan
+
+`tests/unit/test_cadence_scheduler.py` (quiet hours, snooze, repeat window, daily cap, pressure
+multiplier — inject `now`); `tests/integration/test_cadence_runtime_gate.py` (enabled=False ⇒ no
+thread/no writes; enabled=True ⇒ tick runs once). `uv run pytest -q tests/unit/test_cadence_scheduler.py tests/integration/test_cadence_runtime_gate.py`.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-05-cli.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-05-cli.md
@@ -1,0 +1,45 @@
+# CAD-1-05 — CLI: `holdspeak cadence status | loops | run-now`
+
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Depends on:** CAD-1-01..04. **Unblocks:** the phase exit criteria (the first usable surface).
+
+## Problem
+
+The substrate needs a human surface to prove it works before any web/Telegram UI — and the design
+calls for a CLI either way.
+
+## The design
+
+Follow the verified CLI pattern: a subcommand in `holdspeak/main.py` (subparsers) dispatching to
+`holdspeak/commands/cadence.py` → `run_cadence_command(args, *, stream=None) -> int`.
+
+- **`holdspeak cadence status`** — is cadence enabled? policy summary (quiet hours, max/day,
+  pressure), loop counts by status, last tick time.
+- **`holdspeak cadence loops`** — list open loops, ordered by `stale_score` desc: id, title,
+  project, source_type, score, owner, status. `--json` for the structured form; `--all` to include
+  closed/killed.
+- **`holdspeak cadence run-now`** — run one `CadenceService.tick(now)` synchronously (no thread,
+  works even when `enabled=False` so it's testable/dogfoodable) and print the projected + scored
+  loops + which would be due. This is the phase's headline deliverable.
+
+Register: a `cadence` subparser in `main.py` with a `cadence_action` sub-subparser, and an
+`elif args.command == "cadence": return run_cadence_command(args)` handler. Reuse `get_database()`.
+
+## Scope
+
+- **In:** the three subcommands + `--json`/`--all`; argparse registration; the handler.
+- **Out:** snooze/kill from the CLI (Phase 2 adds lifecycle verbs once the web surface exists — or a
+  fast-follow if trivial), brief/closeout (Phases 5/6).
+
+## Proof / acceptance
+
+- `holdspeak cadence run-now` on a seeded DB prints the projected loops with scores and due flags,
+  and is idempotent across runs.
+- `holdspeak cadence loops --json` emits valid JSON the future web/Telegram surfaces can reuse.
+- `holdspeak cadence status` reflects `enabled` honestly.
+
+## Test plan
+
+`tests/unit/test_cadence_cli.py` — invoke `run_cadence_command` with a fake/seeded DB + a captured
+stream; assert ordering, `--json` shape, and that `run-now` works with `enabled=False`.
+`uv run pytest -q tests/unit/test_cadence_cli.py`.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-06-tests.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-06-tests.md
@@ -1,0 +1,46 @@
+# CAD-1-06 — Unit/integration tests + the no-side-effects guard
+
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo — locks the phase's behavior.
+- **Depends on:** CAD-1-01..05.
+
+## Problem
+
+The substrate's invariants (idempotent projection, killed-stays-killed, off-by-default byte-identity,
+no external side effects) must be mechanically enforced, not just hand-checked, before any surface
+builds on it.
+
+## The design
+
+Most behavior is covered by the per-story tests (1-01..05). This story adds the **cross-cutting
+guards** and fills gaps:
+
+1. **No-side-effects guard** — a test that imports the whole `holdspeak.cadence` package and asserts
+   it makes **no** network/connector/actuator-execute calls: grep/AST the package for forbidden
+   symbols (`record_proposal` is allowed only from Phase 6+; in Phase 1 assert it's absent), and a
+   runtime test that a full `tick()` writes only `cadence_*` tables (no `actuator_proposals`
+   insert, no socket). This is the structural proof of the chart's trust boundary.
+2. **Off-by-default byte-identity** — `enabled=False` ⇒ `WebRuntime` starts no cadence thread and
+   the cadence tables stay empty after a start/stop cycle.
+3. **Determinism** — scoring + scheduling with an injected `now` are reproducible (no `datetime.now()`
+   leakage inside the pure functions).
+4. **Idempotency + killed-survives** — re-collection invariants (also in 1-02; assert here as the
+   canonical regression).
+5. **Fixtures** — a small seeded-DB fixture (meeting + actions + a pending proposal) in
+   `tests/integration/conftest` reused by collector/scheduler/CLI tests.
+
+## Scope
+
+- **In:** the no-side-effects guard, the off-by-default test, determinism + idempotency regressions,
+  shared fixtures.
+- **Out:** dogfood protocol/e2e (Phase 8), any LLM-path tests (Phase 7).
+
+## Proof / acceptance
+
+- `uv run pytest -q tests/unit/test_cadence_*.py tests/integration/test_cadence_*.py` green.
+- The no-side-effects guard fails if any cadence module gains a connector/execute call.
+- The off-by-default test fails if the thread starts when disabled.
+
+## Test plan
+
+The aggregate above is the test plan; CI runs it via the standard `uv run pytest -q` (these live in
+`tests/unit` + `tests/integration`, no opt-in flag — they're hermetic, no network, no model).


### PR DESCRIPTION
**Phase 0 (architecture hardening) output** for the **HoldSpeak Cadence Engine** — a local-first
technical chief-of-staff that turns meetings / activity / dictation / coding-agent state into
evidence-backed nudges and nearly-complete next actions:
`Open Loop → Next Best Action → Nudge → Decision`. *Push with receipts, never a nag machine.*

Authored from the owner's rough design + a grounded `file:line` seam map of the real runtime.

## What's here

- **`cadence-engine/README.md`** — the program chart:
  - the **trust boundary** (off by default; every external action is an existing actuator proposal;
    all source text is data, never instructions; one egress badge);
  - the **§15 open questions all resolved** in a decisions table (loops as source-projected DB
    entities, agent-sessions mirrored not migrated, Telegram second-confirm tied to the actuator
    `reversible` flag, a `pressure` personality that scales only timings, first-activity daily
    brief, low-confidence → quiet `needs_review` loops, one `resolve_project()`, first-party);
  - a **verified seam map** (the `WebRuntime` daemon-thread pattern, `db/core.py` `SCHEMA_SQL` +
    `BaseRepository`, aftercare, activity ledger, action items, agent hooks, actuators, routes,
    Astro UI, CLI, presence, dogfood, egress);
  - the **8-phase dependency-ordered plan**.
- **`phase-1-cadence-core/`** — the lead phase, fully storied (CAD-1-01..06): models + `cadence_*`
  migrations (`SCHEMA_VERSION 2→3`) + `CadenceRepository`; the idempotent source-projected collector
  (killed-stays-killed); deterministic explainable stale-scoring; policies + quiet hours + the
  off-by-default `CadenceMixin` daemon-thread tick; the CLI (`status`/`loops`/`run-now`); and a
  no-external-side-effects test guard.

**Grounded correction:** `WebRuntime` uses daemon threads on `runtime_stop_event`
(`web_runtime.py:477`), **not** asyncio — the cadence loop follows that pattern. No new infra.

Docs-only (markdown roadmap). Phases 2–8 are charted and storied as each becomes the lead. Building
Phase 1 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)