### PR TITLE
Cadence Engine Phase 1: the cadence core (off by default)

### DIFF
--- a/holdspeak/cadence/__init__.py
+++ b/holdspeak/cadence/__init__.py
@@ -1,0 +1,31 @@
+"""The Cadence Engine (CAD-1) — a local-first technical chief-of-staff.
+
+Turns existing HoldSpeak knowledge (meetings, activity, dictation, coding-agent
+state) into evidence-backed nudges and nearly-complete next actions:
+
+    Open Loop -> Next Best Action -> Nudge -> Decision
+
+Hard invariants (see pm/roadmap/holdspeak/cadence-engine/README.md):
+- Off by default (CadenceConfig.enabled is False); byte-identical when off.
+- No external side effect except via the existing actuator propose/approve/execute
+  path. This package performs NONE; it only reads sources and writes cadence_* rows.
+- Every nudge carries evidence; killed loops stay killed; quiet hours default-on.
+"""
+
+from .models import (
+    CadencePolicy,
+    EvidenceRef,
+    Nudge,
+    NextBestAction,
+    OpenLoop,
+    ScoreBreakdown,
+)
+
+__all__ = [
+    "OpenLoop",
+    "EvidenceRef",
+    "NextBestAction",
+    "Nudge",
+    "CadencePolicy",
+    "ScoreBreakdown",
+]

--- a/holdspeak/cadence/collector.py
+++ b/holdspeak/cadence/collector.py
@@ -1,0 +1,104 @@
+"""The LoopCollector (CAD-1-02) — projects Open Loops from real HoldSpeak state.
+
+Phase 1 collects two source types: meeting action items and pending actuator
+proposals. Projection is an idempotent upsert keyed (source_type, source_id), so
+re-running never duplicates and never resurrects a user-decided loop; a source that
+disappears is CLOSED (audit), not deleted. READ ONLY — the collector proposes and
+executes nothing (that is Phase 6/7, always via the actuator path).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from .models import EvidenceRef, OpenLoop
+from .projects import resolve_project
+from .scoring import LoopSignals, score_loop
+
+# Below this review confidence an extracted action becomes a quiet `needs_review`
+# loop (surfaced, never pushed) rather than a normal loop (chart §3.6). Phase 1
+# proxy: an item still in review_state="pending" is treated as needs_review.
+_REVIEW_PENDING = "pending"
+
+
+class LoopCollector:
+    def __init__(self, db, *, meeting_scan_limit: int = 50):
+        self._db = db
+        self._meeting_scan_limit = meeting_scan_limit
+
+    def collect(self, *, now: Optional[datetime] = None) -> list[OpenLoop]:
+        """Project + score loops from the current sources; return the live set."""
+        now = now or datetime.now()
+        loops: list[OpenLoop] = []
+        loops += self._collect_meeting_actions(now)
+        loops += self._collect_pending_proposals(now)
+        return loops
+
+    # ── meeting action items ────────────────────────────────────────────────
+    def _collect_meeting_actions(self, now: datetime) -> list[OpenLoop]:
+        items = self._db.meetings.list_action_items(include_completed=False)
+        present_ids = [it.id for it in items]
+        out = []
+        for it in items:
+            needs_review = (it.review_state or _REVIEW_PENDING) == _REVIEW_PENDING
+            unowned = not (it.owner and it.owner.strip())
+            loop = OpenLoop(
+                source_type="meeting_action",
+                source_id=it.id,
+                title=it.task,
+                summary=f"From {it.meeting_title or 'a meeting'}",
+                project=resolve_project(meeting_label=it.meeting_title),
+                priority="high" if (it.due and not unowned) else "normal",
+                needs_review=needs_review,
+                owner=it.owner,
+                due_at=it.due,
+                evidence=[
+                    EvidenceRef(
+                        kind="action_item",
+                        ref_id=it.id,
+                        label=it.task[:80],
+                        timestamp=str(it.source_timestamp) if it.source_timestamp else None,
+                        deep_link=f"/meetings/{it.meeting_id}#ai-{it.id}",
+                    )
+                ],
+            )
+            saved = self._db.cadence.upsert_loop(loop)
+            self._score(saved, now, LoopSignals(unowned=unowned))
+            out.append(saved)
+        self._db.cadence.close_missing("meeting_action", present_ids)
+        return out
+
+    # ── pending actuator proposals (read only) ──────────────────────────────
+    def _collect_pending_proposals(self, now: datetime) -> list[OpenLoop]:
+        present_ids: list[str] = []
+        out = []
+        meetings = self._db.meetings.list_meetings(limit=self._meeting_scan_limit)
+        for m in meetings:
+            for p in self._db.actuators.list_proposals(m.id, status="proposed"):
+                present_ids.append(p.id)
+                loop = OpenLoop(
+                    source_type="proposal",
+                    source_id=p.id,
+                    title=p.preview,
+                    summary=f"{p.action} → {p.target}",
+                    project=resolve_project(meeting_label=getattr(m, "title", None)),
+                    priority="high",  # a proposal awaiting your approval is leverage
+                    evidence=[
+                        EvidenceRef(
+                            kind="proposal",
+                            ref_id=p.id,
+                            label=p.preview[:80],
+                            deep_link=f"/meetings/{p.meeting_id}#proposal-{p.id}",
+                        )
+                    ],
+                )
+                saved = self._db.cadence.upsert_loop(loop)
+                self._score(saved, now, LoopSignals())
+                out.append(saved)
+        self._db.cadence.close_missing("proposal", present_ids)
+        return out
+
+    def _score(self, loop: OpenLoop, now: datetime, signals: LoopSignals) -> None:
+        breakdown = score_loop(loop, now=now, signals=signals)
+        loop.stale_score = breakdown.total
+        self._db.cadence.set_stale_score(loop.id, breakdown.total)

--- a/holdspeak/cadence/models.py
+++ b/holdspeak/cadence/models.py
@@ -1,0 +1,149 @@
+"""Cadence Engine data models (CAD-1-01).
+
+Pure dataclasses — no I/O. The repository (`holdspeak/db/cadence.py`) converts
+rows to/from these; the rest of the engine (collector, scoring, scheduler)
+operates on them.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+LoopStatus = Literal["open", "snoozed", "closed", "killed", "delegated"]
+Priority = Literal["low", "normal", "high", "urgent"]
+SourceType = Literal[
+    "meeting_action",
+    "meeting_decision",
+    "agent_question",
+    "activity_record",
+    "proposal",
+    "manual",
+    "system",
+]
+EvidenceKind = Literal[
+    "meeting_segment",
+    "artifact",
+    "action_item",
+    "activity_record",
+    "agent_session",
+    "proposal",
+    "dictation_journal",
+]
+NextActionKind = Literal[
+    "review_draft",
+    "approve_proposal",
+    "reply_to_agent",
+    "create_issue",
+    "draft_slack_update",
+    "mark_done",
+    "assign_owner",
+    "schedule_followup",
+    "kill_loop",
+    "snooze",
+]
+Surface = Literal["desktop", "telegram", "web", "cli", "ipad"]
+Severity = Literal["quiet", "normal", "persistent", "escalated"]
+NudgeStatus = Literal["pending", "shown", "acted", "dismissed", "expired"]
+
+
+@dataclass
+class EvidenceRef:
+    """Why a loop exists — a citation the user can follow."""
+
+    kind: EvidenceKind
+    ref_id: str
+    label: str = ""
+    timestamp: Optional[str] = None
+    deep_link: Optional[str] = None
+    id: Optional[str] = None  # assigned by the store
+
+
+@dataclass
+class OpenLoop:
+    """An unresolved item that may deserve future attention.
+
+    Projected from a source by the collector; keyed by (source_type, source_id).
+    The lifecycle fields (status/snoozed_until/nudge_count) are the user's, and
+    survive re-collection.
+    """
+
+    source_type: SourceType
+    source_id: str
+    title: str
+    summary: str = ""
+    project: Optional[str] = None
+    status: LoopStatus = "open"
+    priority: Priority = "normal"
+    needs_review: bool = False
+    owner: Optional[str] = None
+    due_at: Optional[str] = None
+    snoozed_until: Optional[str] = None
+    stale_score: float = 0.0
+    last_nudged_at: Optional[str] = None
+    nudge_count: int = 0
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    id: Optional[str] = None  # assigned by the store
+    evidence: list[EvidenceRef] = field(default_factory=list)
+
+
+@dataclass
+class NextBestAction:
+    """The prepared thing Qlippy wants the user to decide on."""
+
+    loop_id: str
+    kind: NextActionKind
+    title: str
+    body_markdown: str = ""
+    confidence: float = 0.0
+    reversible: bool = True
+    proposal_id: Optional[str] = None
+    generated_by: str = "deterministic"
+    generated_at: Optional[str] = None
+    id: Optional[str] = None
+
+
+@dataclass
+class Nudge:
+    """A surfaced recommendation at a specific time on a specific surface."""
+
+    loop_id: str
+    surface: Surface
+    severity: Severity = "normal"
+    next_action_id: Optional[str] = None
+    title: str = ""
+    message_markdown: str = ""
+    status: NudgeStatus = "pending"
+    created_at: Optional[str] = None
+    shown_at: Optional[str] = None
+    acted_at: Optional[str] = None
+    expires_at: Optional[str] = None
+    id: Optional[str] = None
+
+
+@dataclass
+class CadencePolicy:
+    """How often Qlippy pushes for a given class of loop.
+
+    `config` holds the tunable knobs (quiet hours, delays, escalation, caps,
+    surfaces); persisted as JSON so policies are editable without a migration.
+    """
+
+    name: str
+    enabled: bool = True
+    config: dict = field(default_factory=dict)
+    updated_at: Optional[str] = None
+    id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ScoreBreakdown:
+    """The staleness total AND its per-signal contributions, so every nudge is
+    explainable. Ephemeral (recomputed); only the total persists on the loop."""
+
+    total: float
+    contributions: dict  # signal name -> signed contribution
+
+    def explain(self) -> str:
+        parts = [f"{k}={v:+.1f}" for k, v in sorted(self.contributions.items())]
+        return f"score={self.total:.1f} (" + ", ".join(parts) + ")"

--- a/holdspeak/cadence/policies.py
+++ b/holdspeak/cadence/policies.py
@@ -1,0 +1,48 @@
+"""Default cadence policies (CAD-1-04).
+
+The per-source push rhythms from the design (§4.5/§7.2), seeded on first run and
+user-editable later (Phase 2). Phase 1's scheduler reads config-level quiet hours +
+the daily cap; these policies are the durable home the richer scheduling (Phase 6)
+will consume. Timing values are in minutes.
+"""
+from __future__ import annotations
+
+from .models import CadencePolicy
+
+_DEFAULTS: list[dict] = [
+    {
+        "name": "agent_blocker",
+        "config": {"source_types": ["agent_question"], "initial_delay_minutes": 5,
+                   "repeat_after_minutes": 15, "escalation_after_count": 3, "max_nudges_per_day": 20},
+    },
+    {
+        "name": "meeting_aftercare",
+        "config": {"source_types": ["meeting_action", "meeting_decision"], "initial_delay_minutes": 20,
+                   "repeat_after_minutes": 240, "escalation_after_count": 2, "max_nudges_per_day": 6},
+    },
+    {
+        "name": "proposal_pending",
+        "config": {"source_types": ["proposal"], "initial_delay_minutes": 30,
+                   "repeat_after_minutes": 240, "escalation_after_count": 4, "max_nudges_per_day": 8},
+    },
+    {
+        "name": "stale_loop",
+        "config": {"source_types": ["meeting_action", "manual"], "initial_delay_minutes": 1440,
+                   "repeat_after_minutes": 1440, "escalation_after_count": 2, "max_nudges_per_day": 4},
+    },
+]
+
+
+def default_policies() -> list[CadencePolicy]:
+    return [CadencePolicy(name=d["name"], config=d["config"]) for d in _DEFAULTS]
+
+
+def seed_policies(db) -> int:
+    """Upsert any default policy that is not already present. Returns # seeded."""
+    existing = {p.id for p in db.cadence.list_policies()}
+    seeded = 0
+    for policy in default_policies():
+        if policy.name not in existing:
+            db.cadence.upsert_policy(policy)
+            seeded += 1
+    return seeded

--- a/holdspeak/cadence/projects.py
+++ b/holdspeak/cadence/projects.py
@@ -1,0 +1,27 @@
+"""resolve_project (CAD-1-02) — the ONE project-identity normalizer (chart §3.7).
+
+Phase 1 is deliberately simple: prefer an explicit project, else a meeting label,
+else a repo-root basename, else a domain. One function so later sources (activity,
+agents) sharpen grouping in one place rather than scattering heuristics.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+def resolve_project(
+    *,
+    explicit: Optional[str] = None,
+    meeting_label: Optional[str] = None,
+    repo_root: Optional[str] = None,
+    domain: Optional[str] = None,
+) -> Optional[str]:
+    for candidate in (explicit, meeting_label):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    if repo_root and repo_root.strip():
+        return os.path.basename(repo_root.rstrip("/")) or None
+    if domain and domain.strip():
+        return domain.strip()
+    return None

--- a/holdspeak/cadence/scheduler.py
+++ b/holdspeak/cadence/scheduler.py
@@ -1,0 +1,88 @@
+"""The scheduler (CAD-1-04) — decides which loops are DUE to nudge now.
+
+Pure given `now`. Respects: terminal/needs_review suppression, snooze, quiet hours
+(default-on), a per-loop repeat window scaled by the `pressure` setting, and the
+daily nudge cap. Phase 1 returns the due set; rendering/delivery is Phase 2+.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from .models import OpenLoop
+
+# Base repeat window (hours) before the same loop is eligible to nudge again.
+_BASE_REPEAT_HOURS = 4.0
+_PRESSURE_MULT = {"gentle": 2.0, "normal": 1.0, "aggressive": 0.5}
+
+
+@dataclass
+class SchedulerConfig:
+    """The subset of CadenceConfig the scheduler needs (kept pure/injectable)."""
+
+    pressure: str = "normal"
+    quiet_hours_start: int = 22
+    quiet_hours_end: int = 8
+    max_nudges_per_day: int = 12
+
+
+def in_quiet_hours(now: datetime, start: int, end: int) -> bool:
+    """Is `now` inside the quiet window [start, end) on a 24h clock (wraps midnight)?"""
+    h = now.hour
+    if start == end:
+        return False
+    if start < end:
+        return start <= h < end
+    return h >= start or h < end  # wraps midnight (e.g. 22 → 8)
+
+
+def _repeat_hours(pressure: str) -> float:
+    return _BASE_REPEAT_HOURS * _PRESSURE_MULT.get(pressure, 1.0)
+
+
+def _parse(ts: Optional[str]) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+
+
+def due_loops(
+    loops: list[OpenLoop],
+    *,
+    now: datetime,
+    config: SchedulerConfig,
+    nudged_today: int = 0,
+) -> list[OpenLoop]:
+    """Return the loops that should be nudged now, highest staleness first.
+
+    `loops` is expected to already exclude closed/killed (the repo's default list).
+    """
+    if config.max_nudges_per_day and nudged_today >= config.max_nudges_per_day:
+        return []
+    if in_quiet_hours(now, config.quiet_hours_start, config.quiet_hours_end):
+        return []  # Phase 1 has no urgent agent-blocker exception yet (Phase 3)
+
+    repeat = _repeat_hours(config.pressure)
+    eligible: list[OpenLoop] = []
+    for loop in loops:
+        if loop.status in ("closed", "killed", "delegated"):
+            continue
+        if loop.needs_review:
+            continue  # low-confidence: surfaced in the queue, never a push
+        snoozed = _parse(loop.snoozed_until)
+        if loop.status == "snoozed" and snoozed and snoozed > now:
+            continue
+        last = _parse(loop.last_nudged_at)
+        if last is not None and (now - last).total_seconds() < repeat * 3600.0:
+            continue
+        eligible.append(loop)
+
+    eligible.sort(key=lambda l: l.stale_score, reverse=True)
+    if config.max_nudges_per_day:
+        room = max(0, config.max_nudges_per_day - nudged_today)
+        return eligible[:room]
+    return eligible

--- a/holdspeak/cadence/scoring.py
+++ b/holdspeak/cadence/scoring.py
@@ -1,0 +1,84 @@
+"""Stale-scoring v1 (CAD-1-03) — deterministic and explainable.
+
+A pure function: given a loop, the current time, and a small `signals` struct the
+collector assembles, return a `ScoreBreakdown` (the total AND the per-signal
+contributions, so every nudge can say *why*). No clock or randomness inside — `now`
+is injected. No LLM. The weights are the single tuning surface.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from .models import OpenLoop, ScoreBreakdown
+
+# The single tuning surface (design §7.1). Positive = more urgent.
+W_PRIORITY = {"low": 0.0, "normal": 4.0, "high": 9.0, "urgent": 16.0}
+W_AGE_PER_DAY = 1.5          # per day since created, capped
+W_AGE_CAP = 12.0
+W_ACCEPTED_UNEXECUTED = 10.0  # an accepted action not yet filed/executed
+W_UNOWNED = 5.0               # nobody owns it
+W_RECURRENCE_PER = 4.0        # appears across N related meetings
+W_SOURCE = {                  # which source it came from
+    "agent_question": 20.0,   # a coding agent is blocked on you (Phase 3 populates)
+    "proposal": 7.0,
+    "meeting_action": 3.0,
+    "meeting_decision": 3.0,
+    "activity_record": 1.0,
+    "manual": 2.0,
+    "system": 0.0,
+}
+W_RECENT_ACTIVITY = 6.0       # touched today ⇒ alive ⇒ surface it (boost, not suppress)
+W_NEEDS_REVIEW = 14.0         # low-confidence ⇒ strongly suppress (never a push)
+W_DISMISS_PER = 5.0           # user dismissed it before ⇒ suppress
+
+
+@dataclass
+class LoopSignals:
+    """The collector-assembled context the scorer needs (no DB access in scoring)."""
+
+    accepted_unexecuted: bool = False
+    unowned: bool = False
+    recurrence_count: int = 0       # # of related meetings it appears across (beyond the first)
+    recent_activity: bool = False   # related project touched today
+    dismissals: int = 0             # prior dismissals of this loop
+    age_days: float = 0.0
+
+
+def _age_days(loop: OpenLoop, now: datetime) -> float:
+    if not loop.created_at:
+        return 0.0
+    try:
+        created = datetime.fromisoformat(loop.created_at)
+    except ValueError:
+        return 0.0
+    return max(0.0, (now - created).total_seconds() / 86400.0)
+
+
+def score_loop(
+    loop: OpenLoop, *, now: datetime, signals: Optional[LoopSignals] = None
+) -> ScoreBreakdown:
+    """Deterministic staleness score + the per-signal breakdown."""
+    s = signals or LoopSignals()
+    age_days = s.age_days or _age_days(loop, now)
+    c: dict[str, float] = {}
+
+    c["priority"] = W_PRIORITY.get(loop.priority, 0.0)
+    c["age"] = min(W_AGE_CAP, W_AGE_PER_DAY * age_days)
+    c["source"] = W_SOURCE.get(loop.source_type, 0.0)
+    if s.accepted_unexecuted:
+        c["accepted_unexecuted"] = W_ACCEPTED_UNEXECUTED
+    if s.unowned:
+        c["unowned"] = W_UNOWNED
+    if s.recurrence_count > 0:
+        c["recurrence"] = W_RECURRENCE_PER * s.recurrence_count
+    if s.recent_activity:
+        c["recent_activity"] = W_RECENT_ACTIVITY
+    if loop.needs_review:
+        c["needs_review"] = -W_NEEDS_REVIEW
+    if s.dismissals > 0:
+        c["dismissals"] = -W_DISMISS_PER * s.dismissals
+
+    total = round(sum(c.values()), 2)
+    return ScoreBreakdown(total=total, contributions=dict(c))

--- a/holdspeak/cadence/service.py
+++ b/holdspeak/cadence/service.py
@@ -1,0 +1,79 @@
+"""CadenceService (CAD-1-04) — the orchestrated tick.
+
+One tick = collect (project + score loops from sources) -> reload open loops ->
+decide which are due under the policy. Phase 1 RETURNS the due set; it does not
+render or deliver nudges (surfaces are Phase 2+) and performs no external side
+effect. The service is driven by the in-runtime `CadenceMixin` thread (only when
+enabled) and by `holdspeak cadence run-now` (synchronously, even when disabled).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from .collector import LoopCollector
+from .models import OpenLoop
+from .policies import seed_policies
+from .scheduler import SchedulerConfig, due_loops
+
+
+@dataclass
+class TickResult:
+    at: str
+    projected: int = 0
+    open_loops: int = 0
+    due: list[OpenLoop] = field(default_factory=list)
+
+    @property
+    def due_count(self) -> int:
+        return len(self.due)
+
+
+class CadenceService:
+    def __init__(self, db, config):
+        self._db = db
+        self._config = config  # a CadenceConfig
+        self._collector = LoopCollector(db)
+        self._seeded = False
+
+    def _ensure_seeded(self) -> None:
+        if not self._seeded:
+            seed_policies(self._db)
+            self._seeded = True
+
+    def _scheduler_config(self) -> SchedulerConfig:
+        c = self._config
+        return SchedulerConfig(
+            pressure=getattr(c, "pressure", "normal"),
+            quiet_hours_start=getattr(c, "quiet_hours_start", 22),
+            quiet_hours_end=getattr(c, "quiet_hours_end", 8),
+            max_nudges_per_day=getattr(c, "max_nudges_per_day", 12),
+        )
+
+    def _nudged_today(self, now: datetime) -> int:
+        """Count nudges created today (Phase 1 creates none, so this is 0)."""
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+        with self._db._connection() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM cadence_nudges WHERE created_at >= ?", (start,)
+            ).fetchone()
+        return int(row["n"]) if row else 0
+
+    def tick(self, now: Optional[datetime] = None) -> TickResult:
+        now = now or datetime.now()
+        self._ensure_seeded()
+        projected = self._collector.collect(now=now)
+        open_loops = self._db.cadence.list_loops()  # excludes terminal, ordered by score
+        due = due_loops(
+            open_loops,
+            now=now,
+            config=self._scheduler_config(),
+            nudged_today=self._nudged_today(now),
+        )
+        return TickResult(
+            at=now.isoformat(),
+            projected=len(projected),
+            open_loops=len(open_loops),
+            due=due,
+        )

--- a/holdspeak/commands/cadence.py
+++ b/holdspeak/commands/cadence.py
@@ -1,0 +1,108 @@
+"""`holdspeak cadence …` (CAD-1-05).
+
+The first human surface for the Cadence Engine: inspect what it would push, before
+any web/Telegram UI exists. `run-now` runs one synchronous tick (works even when
+cadence is disabled, so it's testable/dogfoodable) and prints the projected, scored,
+and due loops. No external side effects.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from typing import Optional, TextIO
+
+from ..config import Config
+from ..db import get_database
+
+
+def _out(stream: Optional[TextIO]) -> TextIO:
+    return stream or sys.stdout
+
+
+def run_cadence_command(args, *, stream: Optional[TextIO] = None, db=None, config=None) -> int:
+    out = _out(stream)
+    db = db if db is not None else get_database()
+    config = config if config is not None else Config.load()
+    action = getattr(args, "cadence_action", None) or "status"
+
+    if action == "status":
+        return _cmd_status(out, db, config)
+    if action == "loops":
+        return _cmd_loops(out, db, as_json=getattr(args, "json", False),
+                          include_all=getattr(args, "all", False))
+    if action == "run-now":
+        return _cmd_run_now(out, db, config, as_json=getattr(args, "json", False))
+    print(f"Unknown cadence action: {action}", file=sys.stderr)
+    return 2
+
+
+def _cmd_status(out: TextIO, db, config) -> int:
+    c = config.cadence
+    loops = db.cadence.list_loops(include_terminal=True)
+    by_status: dict[str, int] = {}
+    for loop in loops:
+        by_status[loop.status] = by_status.get(loop.status, 0) + 1
+    print("Cadence Engine", file=out)
+    print(f"  enabled:        {c.enabled}", file=out)
+    print(f"  pressure:       {c.pressure}", file=out)
+    print(f"  tick interval:  {c.tick_interval_seconds}s", file=out)
+    print(f"  quiet hours:    {c.quiet_hours_start:02d}:00–{c.quiet_hours_end:02d}:00", file=out)
+    print(f"  max nudges/day: {c.max_nudges_per_day}", file=out)
+    print(f"  policies:       {len(db.cadence.list_policies())}", file=out)
+    if by_status:
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(by_status.items()))
+        print(f"  loops:          {summary}", file=out)
+    else:
+        print("  loops:          none yet (run `holdspeak cadence run-now`)", file=out)
+    return 0
+
+
+def _loop_dict(loop) -> dict:
+    return {
+        "id": loop.id,
+        "title": loop.title,
+        "project": loop.project,
+        "source_type": loop.source_type,
+        "status": loop.status,
+        "priority": loop.priority,
+        "needs_review": loop.needs_review,
+        "owner": loop.owner,
+        "stale_score": loop.stale_score,
+    }
+
+
+def _cmd_loops(out: TextIO, db, *, as_json: bool, include_all: bool) -> int:
+    loops = db.cadence.list_loops(include_terminal=include_all)
+    if as_json:
+        print(json.dumps([_loop_dict(loop) for loop in loops], indent=2), file=out)
+        return 0
+    if not loops:
+        print("No open loops. Run `holdspeak cadence run-now` to project from your meetings.", file=out)
+        return 0
+    for loop in loops:
+        review = " [review]" if loop.needs_review else ""
+        owner = loop.owner or "unowned"
+        print(f"  {loop.stale_score:6.1f}  {loop.source_type:14s}  {owner:12s}  {loop.title}{review}", file=out)
+    return 0
+
+
+def _cmd_run_now(out: TextIO, db, config, *, as_json: bool) -> int:
+    from ..cadence.service import CadenceService
+
+    result = CadenceService(db, config.cadence).tick(datetime.now())
+    if as_json:
+        print(json.dumps({
+            "at": result.at,
+            "projected": result.projected,
+            "open_loops": result.open_loops,
+            "due": [_loop_dict(loop) for loop in result.due],
+        }, indent=2), file=out)
+        return 0
+    print(f"Tick @ {result.at}", file=out)
+    print(f"  projected: {result.projected}   open: {result.open_loops}   due now: {result.due_count}", file=out)
+    if result.due:
+        print("  Due to nudge (highest staleness first):", file=out)
+        for loop in result.due:
+            print(f"    {loop.stale_score:6.1f}  {loop.title}  ({loop.source_type})", file=out)
+    return 0

--- a/holdspeak/config.py
+++ b/holdspeak/config.py
@@ -685,6 +685,32 @@ class WakeWordConfig:
 
 
 @dataclass
+class CadenceConfig:
+    """The Cadence Engine (CAD-1) — OFF BY DEFAULT.
+
+    When `enabled` is False the runtime starts no cadence thread and behaves
+    identically to a build without cadence. `pressure` scales policy *timings*
+    only (never what is nudged or any safety gate). `tick_interval_seconds` is how
+    often the in-runtime loop projects + scores. Quiet hours are default-on.
+    """
+
+    enabled: bool = False
+    pressure: str = "normal"  # gentle | normal | aggressive (timing multiplier only)
+    tick_interval_seconds: int = 300
+    quiet_hours_start: int = 22  # local hour [0..23]
+    quiet_hours_end: int = 8
+    max_nudges_per_day: int = 12
+
+    def __post_init__(self) -> None:
+        if self.pressure not in ("gentle", "normal", "aggressive"):
+            self.pressure = "normal"
+        self.tick_interval_seconds = max(30, int(self.tick_interval_seconds))
+        self.quiet_hours_start = int(self.quiet_hours_start) % 24
+        self.quiet_hours_end = int(self.quiet_hours_end) % 24
+        self.max_nudges_per_day = max(0, int(self.max_nudges_per_day))
+
+
+@dataclass
 class Config:
     """Main configuration container."""
     config_version: int = CONFIG_VERSION
@@ -697,6 +723,7 @@ class Config:
     presence: PresenceConfig = field(default_factory=PresenceConfig)
     wake_word: WakeWordConfig = field(default_factory=WakeWordConfig)
     mesh: MeshConfig = field(default_factory=MeshConfig)
+    cadence: CadenceConfig = field(default_factory=CadenceConfig)
 
     @classmethod
     def load(cls, path: Optional[Path] = None) -> "Config":
@@ -740,6 +767,7 @@ class Config:
                 presence=_coerce(PresenceConfig, data.get("presence", {}) or {}, section="presence"),
                 wake_word=_coerce(WakeWordConfig, data.get("wake_word", {}) or {}, section="wake_word"),
                 mesh=_coerce(MeshConfig, data.get("mesh", {}) or {}, section="mesh"),
+                cadence=_coerce(CadenceConfig, data.get("cadence", {}) or {}, section="cadence"),
             )
         except Exception as exc:
             # Last-resort fallback for a genuinely broken config (bad JSON, wrong

--- a/holdspeak/db/__init__.py
+++ b/holdspeak/db/__init__.py
@@ -12,6 +12,7 @@ from .actuators import ActuatorRepository  # noqa: F401
 from .corrections import DictationCorrectionRepository  # noqa: F401
 from .journal import DictationJournalRepository  # noqa: F401
 from .milestones import MilestoneRepository, FIRST_DICTATION_SUCCESS  # noqa: F401
+from .cadence import CadenceRepository  # noqa: F401
 from .primitives import (  # noqa: F401
     NoteRepository,
     KBRepository,

--- a/holdspeak/db/cadence.py
+++ b/holdspeak/db/cadence.py
@@ -1,0 +1,293 @@
+"""CadenceRepository — persistence for the Cadence Engine (CAD-1-01).
+
+Stores Open Loops and their evidence / next-actions / nudges / policies. Loops
+are source-PROJECTED: `upsert_loop` is idempotent on (source_type, source_id) and
+PRESERVES the user's lifecycle decisions (status/snoozed_until/nudge_count/score)
+across re-collection — so a killed loop stays killed and a snoozed loop stays
+snoozed. This repo only reads + writes cadence_* rows; it performs no external
+side effect (those go through the actuator path in later phases).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from ..cadence.models import (
+    CadencePolicy,
+    EvidenceRef,
+    NextBestAction,
+    Nudge,
+    OpenLoop,
+)
+from .base import BaseRepository
+
+# Statuses the user has explicitly decided — never overwritten by re-projection.
+_USER_DECIDED = {"killed", "snoozed", "delegated"}
+
+
+def _now() -> str:
+    return datetime.now().isoformat()
+
+
+class CadenceRepository(BaseRepository):
+    """Durable home for cadence loops/evidence/next-actions/nudges/policies."""
+
+    # ── loops ──────────────────────────────────────────────────────────────
+    def upsert_loop(self, loop: OpenLoop) -> OpenLoop:
+        """Idempotently project a loop from its source.
+
+        Insert when new (status defaults to the loop's, usually 'open'); on an
+        existing (source_type, source_id) update only the SOURCE-derived fields
+        (title/summary/project/owner/priority/needs_review/due_at) and leave the
+        user's lifecycle state untouched. Evidence is replaced to mirror the source.
+        """
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM cadence_loops WHERE source_type = ? AND source_id = ?",
+                (loop.source_type, loop.source_id),
+            ).fetchone()
+            now = _now()
+            if row is None:
+                loop_id = loop.id or uuid.uuid4().hex
+                conn.execute(
+                    """
+                    INSERT INTO cadence_loops
+                        (id, source_type, source_id, project, title, summary, status,
+                         priority, needs_review, owner, created_at, updated_at, due_at,
+                         snoozed_until, stale_score, last_nudged_at, nudge_count)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        loop_id, loop.source_type, loop.source_id, loop.project,
+                        loop.title, loop.summary, loop.status, loop.priority,
+                        1 if loop.needs_review else 0, loop.owner, now, now,
+                        loop.due_at, loop.snoozed_until, loop.stale_score,
+                        loop.last_nudged_at, loop.nudge_count,
+                    ),
+                )
+            else:
+                loop_id = row["id"]
+                conn.execute(
+                    """
+                    UPDATE cadence_loops
+                       SET project = ?, title = ?, summary = ?, priority = ?,
+                           needs_review = ?, owner = ?, due_at = ?, updated_at = ?
+                     WHERE id = ?
+                    """,
+                    (
+                        loop.project, loop.title, loop.summary, loop.priority,
+                        1 if loop.needs_review else 0, loop.owner, loop.due_at,
+                        now, loop_id,
+                    ),
+                )
+            # mirror evidence (cheap; source-derived)
+            conn.execute("DELETE FROM cadence_evidence_refs WHERE loop_id = ?", (loop_id,))
+            for ev in loop.evidence:
+                conn.execute(
+                    """
+                    INSERT INTO cadence_evidence_refs
+                        (id, loop_id, kind, ref_id, label, timestamp, deep_link)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (uuid.uuid4().hex, loop_id, ev.kind, ev.ref_id, ev.label,
+                     ev.timestamp, ev.deep_link),
+                )
+        return self.get_loop(loop_id)  # type: ignore[return-value]
+
+    def get_loop(self, loop_id: str) -> Optional[OpenLoop]:
+        with self._connection() as conn:
+            row = conn.execute("SELECT * FROM cadence_loops WHERE id = ?", (loop_id,)).fetchone()
+            if row is None:
+                return None
+            ev = conn.execute(
+                "SELECT * FROM cadence_evidence_refs WHERE loop_id = ? ORDER BY id", (loop_id,)
+            ).fetchall()
+        return _row_to_loop(row, ev)
+
+    def get_loop_by_source(self, source_type: str, source_id: str) -> Optional[OpenLoop]:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT id FROM cadence_loops WHERE source_type = ? AND source_id = ?",
+                (source_type, source_id),
+            ).fetchone()
+        return self.get_loop(row["id"]) if row else None
+
+    def list_loops(
+        self, *, status: Optional[str] = None, include_terminal: bool = False
+    ) -> list[OpenLoop]:
+        """Open loops ordered by staleness desc. By default excludes closed/killed."""
+        clauses, params = [], []
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        elif not include_terminal:
+            clauses.append("status NOT IN ('closed', 'killed')")
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        with self._connection() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM cadence_loops{where} ORDER BY stale_score DESC, updated_at DESC",
+                params,
+            ).fetchall()
+            out = []
+            for row in rows:
+                ev = conn.execute(
+                    "SELECT * FROM cadence_evidence_refs WHERE loop_id = ? ORDER BY id",
+                    (row["id"],),
+                ).fetchall()
+                out.append(_row_to_loop(row, ev))
+        return out
+
+    def set_status(self, loop_id: str, status: str) -> None:
+        with self._connection() as conn:
+            conn.execute(
+                "UPDATE cadence_loops SET status = ?, updated_at = ? WHERE id = ?",
+                (status, _now(), loop_id),
+            )
+
+    def snooze(self, loop_id: str, until: str) -> None:
+        with self._connection() as conn:
+            conn.execute(
+                "UPDATE cadence_loops SET status = 'snoozed', snoozed_until = ?, updated_at = ? WHERE id = ?",
+                (until, _now(), loop_id),
+            )
+
+    def set_stale_score(self, loop_id: str, score: float) -> None:
+        with self._connection() as conn:
+            conn.execute(
+                "UPDATE cadence_loops SET stale_score = ? WHERE id = ?", (score, loop_id)
+            )
+
+    def bump_nudge(self, loop_id: str, at: Optional[str] = None) -> None:
+        with self._connection() as conn:
+            conn.execute(
+                "UPDATE cadence_loops SET nudge_count = nudge_count + 1, last_nudged_at = ? WHERE id = ?",
+                (at or _now(), loop_id),
+            )
+
+    def close_missing(self, source_type: str, present_source_ids: list[str]) -> int:
+        """Close loops of `source_type` whose source vanished (audit, not delete).
+
+        Never touches user-decided (killed/snoozed/delegated) loops. Returns count.
+        """
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT id, source_id, status FROM cadence_loops WHERE source_type = ?",
+                (source_type,),
+            ).fetchall()
+            present = set(present_source_ids)
+            closed = 0
+            for row in rows:
+                if (
+                    row["source_id"] not in present
+                    and row["status"] not in _USER_DECIDED
+                    and row["status"] != "closed"
+                ):
+                    conn.execute(
+                        "UPDATE cadence_loops SET status = 'closed', updated_at = ? WHERE id = ?",
+                        (_now(), row["id"]),
+                    )
+                    closed += 1
+        return closed
+
+    # ── next actions ───────────────────────────────────────────────────────
+    def add_next_action(self, action: NextBestAction) -> str:
+        action_id = action.id or uuid.uuid4().hex
+        with self._connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO cadence_next_actions
+                    (id, loop_id, kind, title, body_markdown, confidence, reversible,
+                     proposal_id, generated_by, generated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (action_id, action.loop_id, action.kind, action.title, action.body_markdown,
+                 action.confidence, 1 if action.reversible else 0, action.proposal_id,
+                 action.generated_by, action.generated_at or _now()),
+            )
+        return action_id
+
+    # ── nudges ─────────────────────────────────────────────────────────────
+    def record_nudge(self, nudge: Nudge) -> str:
+        nudge_id = nudge.id or uuid.uuid4().hex
+        with self._connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO cadence_nudges
+                    (id, loop_id, next_action_id, surface, severity, title,
+                     message_markdown, status, created_at, shown_at, acted_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (nudge_id, nudge.loop_id, nudge.next_action_id, nudge.surface, nudge.severity,
+                 nudge.title, nudge.message_markdown, nudge.status, nudge.created_at or _now(),
+                 nudge.shown_at, nudge.acted_at, nudge.expires_at),
+            )
+        return nudge_id
+
+    # ── policies ───────────────────────────────────────────────────────────
+    def upsert_policy(self, policy: CadencePolicy) -> str:
+        policy_id = policy.id or policy.name
+        with self._connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO cadence_policies (id, name, enabled, config_json, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name = excluded.name, enabled = excluded.enabled,
+                    config_json = excluded.config_json, updated_at = excluded.updated_at
+                """,
+                (policy_id, policy.name, 1 if policy.enabled else 0,
+                 self._json_dumps(policy.config, fallback="{}"), _now()),
+            )
+        return policy_id
+
+    def get_policy(self, policy_id: str) -> Optional[CadencePolicy]:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM cadence_policies WHERE id = ?", (policy_id,)
+            ).fetchone()
+        return _row_to_policy(row, self) if row else None
+
+    def list_policies(self) -> list[CadencePolicy]:
+        with self._connection() as conn:
+            rows = conn.execute("SELECT * FROM cadence_policies ORDER BY id").fetchall()
+        return [_row_to_policy(row, self) for row in rows]
+
+
+def _row_to_loop(row, evidence_rows) -> OpenLoop:
+    return OpenLoop(
+        id=row["id"],
+        source_type=row["source_type"],
+        source_id=row["source_id"],
+        project=row["project"],
+        title=row["title"],
+        summary=row["summary"],
+        status=row["status"],
+        priority=row["priority"],
+        needs_review=bool(row["needs_review"]),
+        owner=row["owner"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        due_at=row["due_at"],
+        snoozed_until=row["snoozed_until"],
+        stale_score=row["stale_score"],
+        last_nudged_at=row["last_nudged_at"],
+        nudge_count=row["nudge_count"],
+        evidence=[
+            EvidenceRef(
+                id=e["id"], kind=e["kind"], ref_id=e["ref_id"], label=e["label"],
+                timestamp=e["timestamp"], deep_link=e["deep_link"],
+            )
+            for e in evidence_rows
+        ],
+    )
+
+
+def _row_to_policy(row, repo: BaseRepository) -> CadencePolicy:
+    return CadencePolicy(
+        id=row["id"],
+        name=row["name"],
+        enabled=bool(row["enabled"]),
+        config=repo._json_loads_dict(row["config_json"]),
+        updated_at=row["updated_at"],
+    )

--- a/holdspeak/db/core.py
+++ b/holdspeak/db/core.py
@@ -19,6 +19,7 @@ from .actuators import ActuatorRepository
 from .corrections import DictationCorrectionRepository
 from .journal import DictationJournalRepository
 from .milestones import MilestoneRepository
+from .cadence import CadenceRepository
 from .primitives import (
     AgentRepository,
     ChainRepository,
@@ -36,7 +37,7 @@ log = get_logger("db")
 
 # Default database location
 DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "holdspeak" / "holdspeak.db"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 class SchemaVersionError(RuntimeError):
@@ -803,6 +804,85 @@ CREATE INDEX IF NOT EXISTS idx_chains_modified ON chains(last_modified DESC);
 CREATE INDEX IF NOT EXISTS idx_workflows_modified ON workflows(last_modified DESC);
 CREATE INDEX IF NOT EXISTS idx_directories_modified ON directories(last_modified DESC);
 CREATE INDEX IF NOT EXISTS idx_directory_memberships_dir ON directory_memberships(directory_id);
+
+-- ── Cadence Engine (CAD-1-01) ──────────────────────────────────────────────
+-- Open Loops are source-PROJECTED entities: the collector idempotently upserts
+-- one row per (source_type, source_id); the user's lifecycle decisions
+-- (snoozed/killed/nudge_count) live only here and survive re-collection (a
+-- killed loop stays killed). The engine is off by default and writes ONLY these
+-- cadence_* tables — it never performs an external side effect (that goes through
+-- the existing actuator propose->approve->execute path in later phases).
+CREATE TABLE IF NOT EXISTS cadence_loops (
+    id TEXT PRIMARY KEY,
+    source_type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    project TEXT,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'open',     -- open, snoozed, closed, killed, delegated
+    priority TEXT NOT NULL DEFAULT 'normal',  -- low, normal, high, urgent
+    needs_review INTEGER NOT NULL DEFAULT 0,  -- low-confidence: quiet, never a push
+    owner TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    due_at TEXT,
+    snoozed_until TEXT,
+    stale_score REAL NOT NULL DEFAULT 0,
+    last_nudged_at TEXT,
+    nudge_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cadence_loops_source ON cadence_loops(source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_cadence_loops_status ON cadence_loops(status, snoozed_until);
+
+CREATE TABLE IF NOT EXISTS cadence_evidence_refs (
+    id TEXT PRIMARY KEY,
+    loop_id TEXT NOT NULL REFERENCES cadence_loops(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    ref_id TEXT NOT NULL,
+    label TEXT NOT NULL DEFAULT '',
+    timestamp TEXT,
+    deep_link TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_cadence_evidence_loop ON cadence_evidence_refs(loop_id);
+
+CREATE TABLE IF NOT EXISTS cadence_next_actions (
+    id TEXT PRIMARY KEY,
+    loop_id TEXT NOT NULL REFERENCES cadence_loops(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body_markdown TEXT NOT NULL DEFAULT '',
+    confidence REAL NOT NULL DEFAULT 0,
+    reversible INTEGER NOT NULL DEFAULT 1,
+    proposal_id TEXT,
+    generated_by TEXT NOT NULL DEFAULT 'deterministic',
+    generated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_cadence_next_actions_loop ON cadence_next_actions(loop_id);
+
+CREATE TABLE IF NOT EXISTS cadence_nudges (
+    id TEXT PRIMARY KEY,
+    loop_id TEXT NOT NULL REFERENCES cadence_loops(id) ON DELETE CASCADE,
+    next_action_id TEXT,
+    surface TEXT NOT NULL,
+    severity TEXT NOT NULL DEFAULT 'normal',  -- quiet, normal, persistent, escalated
+    title TEXT NOT NULL DEFAULT '',
+    message_markdown TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'pending',   -- pending, shown, acted, dismissed, expired
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    shown_at TEXT,
+    acted_at TEXT,
+    expires_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_cadence_nudges_loop ON cadence_nudges(loop_id);
+CREATE INDEX IF NOT EXISTS idx_cadence_nudges_status ON cadence_nudges(status);
+
+CREATE TABLE IF NOT EXISTS cadence_policies (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    config_json TEXT NOT NULL DEFAULT '{}',
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 """
 
 
@@ -822,6 +902,7 @@ class Database:
         self.dictation_corrections = DictationCorrectionRepository(self._connection, self)
         self.dictation_journal = DictationJournalRepository(self._connection, self)
         self.milestones = MilestoneRepository(self._connection, self)
+        self.cadence = CadenceRepository(self._connection, self)  # CAD-1-01
         # Primitive Framework: the desk's synced first-class primitives.
         self.notes = NoteRepository(self._connection, self)
         self.kbs = KBRepository(self._connection, self)

--- a/holdspeak/main.py
+++ b/holdspeak/main.py
@@ -13,6 +13,7 @@ os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 from .config import Config
 from .transcribe import Transcriber
 from .commands.actions import run_actions_command
+from .commands.cadence import run_cadence_command
 from .commands.agent_hook import (
     build_argparse_subparsers as _build_agent_hook_subparsers,
     run_agent_hook_command,
@@ -258,6 +259,21 @@ Logs are written to: {LOG_FILE}
     )
     _build_agent_hook_subparsers(agent_hook_parser)
 
+    # cadence subcommand (CAD-1-05) — inspect the Cadence Engine
+    cadence_parser = subparsers.add_parser(
+        "cadence",
+        help="The Cadence Engine: see open loops + what would be nudged (off by default)",
+    )
+    cadence_subparsers = cadence_parser.add_subparsers(dest="cadence_action")
+    cadence_subparsers.add_parser("status", help="Show cadence config + loop counts")
+    cadence_loops_parser = cadence_subparsers.add_parser("loops", help="List open loops by staleness")
+    cadence_loops_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    cadence_loops_parser.add_argument("--all", action="store_true", help="Include closed/killed")
+    cadence_run_parser = cadence_subparsers.add_parser(
+        "run-now", help="Run one tick now (projects + scores loops from your meetings)"
+    )
+    cadence_run_parser.add_argument("--json", action="store_true", help="Emit JSON")
+
     # device-psk subcommand (HS-14-03)
     device_psk_parser = subparsers.add_parser(
         "device-psk",
@@ -360,6 +376,9 @@ Logs are written to: {LOG_FILE}
     # Handle agent-hook subcommand
     if args.command == "agent-hook":
         raise SystemExit(run_agent_hook_command(args))
+
+    if args.command == "cadence":
+        raise SystemExit(run_cadence_command(args))
 
     # Handle device-psk subcommand (HS-14-03)
     if args.command == "device-psk":

--- a/holdspeak/runtime/cadence.py
+++ b/holdspeak/runtime/cadence.py
@@ -1,0 +1,46 @@
+"""CadenceMixin (CAD-1-04) — the in-runtime cadence tick.
+
+Mirrors PluginQueueMixin: a daemon thread on `runtime_stop_event`, started by
+WebRuntime.run() ONLY when `config.cadence.enabled` is True. When disabled the
+thread never starts and the runtime is byte-identical to a build without cadence.
+The loop performs no external side effect — it projects + scores loops and computes
+which are due (delivery is Phase 2+).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..logging_config import get_logger
+
+log = get_logger("runtime.cadence")
+
+
+class CadenceMixin:
+    def _cadence_enabled(self) -> bool:
+        return bool(getattr(getattr(self.config, "cadence", None), "enabled", False))
+
+    def _cadence_service(self):
+        """Lazily build a CadenceService bound to the shared DB + config."""
+        if getattr(self, "_cadence_service_obj", None) is None:
+            from ..cadence.service import CadenceService
+            from ..db import get_database
+
+            self._cadence_service_obj = CadenceService(get_database(), self.config.cadence)
+        return self._cadence_service_obj
+
+    def _cadence_tick_once(self) -> None:
+        try:
+            result = self._cadence_service().tick()
+            if result.due:
+                log.info(
+                    "cadence tick: %d projected, %d open, %d due",
+                    result.projected, result.open_loops, result.due_count,
+                )
+        except Exception as exc:  # never let the tick crash the runtime
+            log.error("cadence tick failed: %s", exc)
+
+    def _cadence_loop(self) -> None:
+        interval = max(30, int(getattr(self.config.cadence, "tick_interval_seconds", 300)))
+        # An initial settle so startup isn't contended; then tick on the interval.
+        while not self.runtime_stop_event.wait(interval):
+            self._cadence_tick_once()

--- a/holdspeak/web_runtime.py
+++ b/holdspeak/web_runtime.py
@@ -126,6 +126,7 @@ def _dictation_journal_repo():
 
 
 from .runtime.activity import RuntimeActivityMixin
+from .runtime.cadence import CadenceMixin
 from .runtime.device_glue import DeviceGlueMixin
 from .runtime.dictation_capture import DictationCaptureMixin
 from .runtime.meeting_glue import MeetingGlueMixin
@@ -144,6 +145,7 @@ class WebRuntime(
     DictationCaptureMixin,
     WakeWordGlueMixin,
     DeviceGlueMixin,
+    CadenceMixin,
 ):
     """Web-first runtime: owns the web server, hotkey/device capture, the
     meeting session, and the MIR plugin pipeline.
@@ -280,6 +282,8 @@ class WebRuntime(
             log.warning(f"plugin pack discovery failed: {_pack_err}")
 
         self.plugin_queue_thread: Optional[threading.Thread] = None
+        self.cadence_thread: Optional[threading.Thread] = None  # CAD-1-04 (off by default)
+        self._cadence_service_obj = None
 
         try:
             self.typer: Optional[TextTyper] = TextTyper()
@@ -480,6 +484,16 @@ class WebRuntime(
             daemon=True,
         )
         self.plugin_queue_thread.start()
+        # The Cadence Engine tick — OFF BY DEFAULT (CAD-1-04). The thread starts only
+        # when the user has opted in; otherwise the runtime is byte-identical to a
+        # build without cadence.
+        if self._cadence_enabled():
+            self.cadence_thread = threading.Thread(
+                target=self._cadence_loop,
+                name="HoldSpeakCadenceEngine",
+                daemon=True,
+            )
+            self.cadence_thread.start()
         self._warm_transcriber_in_background()
 
         try:
@@ -563,6 +577,8 @@ class WebRuntime(
                     log.debug(f"Desktop presence close failed: {exc}")
             if self.plugin_queue_thread is not None:
                 self.plugin_queue_thread.join(timeout=2.0)
+            if self.cadence_thread is not None:
+                self.cadence_thread.join(timeout=2.0)
 
 
 def run_web_runtime(

--- a/pm/roadmap/holdspeak/cadence-engine/README.md
+++ b/pm/roadmap/holdspeak/cadence-engine/README.md
@@ -5,12 +5,13 @@
 > next actions.** Qlippy does not merely remind. Qlippy pushes — with receipts, restraint, and a
 > ready-made next move.
 
-**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. Phase 1
-(cadence core) is the lead and fully storied. Phases 2–8 are sketched here and storied as each
-becomes the lead.
+**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phase 1
+(cadence core) is COMPLETE** (built + tested, off by default; `holdspeak cadence run-now` projects
+scored loops from your meetings). **Phase 2 (the web coach surface) is next.** Phases 3–8 are
+sketched here and storied as each becomes the lead.
 
-**Last updated:** 2026-06-28 (program authored from the owner's rough design + a grounded seam map
-of the real runtime; §15 open questions resolved below).
+**Last updated:** 2026-06-28 (Phase 1 shipped — the loop/scoring/policy/CLI substrate; 37 cadence
+tests green. Program authored from the owner's rough design + a grounded seam map; §15 resolved below).
 
 ---
 
@@ -112,7 +113,7 @@ Phase 1 leads and is fully storied. Each later phase is storied when it becomes 
 
 | Phase | Title | The crux | Depends on |
 |-------|-------|----------|------------|
-| **1** | **Cadence core** | The loop/nudge/policy substrate: models, migrations, collector (meeting actions + pending proposals), stale-scoring v1, policies + quiet hours, CLI, unit tests. No external side effects, off by default. | — |
+| **1 ✅** | **Cadence core** | *Done.* The loop/nudge/policy substrate: models, migrations, collector (meeting actions + pending proposals), stale-scoring v1, policies + quiet hours, CLI, unit tests. No external side effects, off by default. | — |
 | **2** | Web coach surface | `/api/cadence/*` + a `/cadence` page: loops, evidence deep-links, snooze/kill/close, generate-next-action, egress badges. | 1 |
 | **3** | Agent-blocker push | Awaiting-response agent sessions → loops + a prepared reply; tmux/`/api/dictation/remote` delivery as a nudge action. | 1 |
 | **4** | Telegram remote presence | Pairing + a Telegram surface; `/brief` `/loops` `/agents`; inline-button decisions wired to the cadence API; unpaired-chat rejection; second-confirm for irreversible actions. | 2, 3 |

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/current-phase-status.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/current-phase-status.md
@@ -1,9 +1,10 @@
 # Cadence Phase 1 — Cadence core
 
-**Status:** planned (lead phase, fully storied). **Start here:** `../README.md` (the program chart —
+**Status:** done (sim/local-proven; CI green). **Start here:** `../README.md` (the program chart —
 the trust boundary, the resolved architecture decisions, and the verified seam map).
 
-**Last updated:** 2026-06-28 (authored).
+**Last updated:** 2026-06-28 (Phase 1 complete: all six stories built + tested; the substrate
+projects scored loops from meetings + pending proposals, off by default, no external side effects).
 
 ## Objective
 
@@ -35,26 +36,35 @@ idempotency, the scoring, and the off-switch right here and the rest is surfaces
 | ID | Title | Status |
 |----|-------|--------|
 | CAD-1-01 | Cadence models + SQLite migrations (`cadence_*` tables, `CadenceRepository`) — **leads** | done |
-| CAD-1-02 | The collector (meeting action items + pending proposals → source-projected loops) | todo |
-| CAD-1-03 | Stale-scoring v1 (deterministic, explainable) | todo |
-| CAD-1-04 | Cadence policies + quiet hours + the `CadenceMixin` tick (off by default) | todo |
-| CAD-1-05 | CLI: `holdspeak cadence status \| loops \| run-now` | todo |
-| CAD-1-06 | Unit tests for scoring, policy, quiet hours, snooze/kill idempotency | todo |
+| CAD-1-02 | The collector (meeting action items + pending proposals → source-projected loops) | done |
+| CAD-1-03 | Stale-scoring v1 (deterministic, explainable) | done |
+| CAD-1-04 | Cadence policies + quiet hours + the `CadenceMixin` tick (off by default) | done |
+| CAD-1-05 | CLI: `holdspeak cadence status \| loops \| run-now` | done |
+| CAD-1-06 | Unit tests for scoring, policy, quiet hours, snooze/kill idempotency | done |
 
 ## Where we are
 
-**CAD-1-01 landed** (the foundation): `cadence_*` tables in `SCHEMA_SQL` (`SCHEMA_VERSION 2→3`, the
-canonical snapshot regenerated), the `holdspeak/cadence/models.py` dataclasses, and
-`CadenceRepository` (`holdspeak/db/cadence.py`) registered on `Database`. Source-projection
-invariants proven by `tests/integration/test_cadence_store.py` (9 tests: idempotent upsert,
-killed-stays-killed, snooze-survives, `close_missing` spares user-decided loops, evidence cascade,
-policies round-trip) + the schema-policy/doctor suite (77 green). Inert + off by default: the tables
-exist but nothing reads them yet.
+**Phase 1 is complete (all six stories done, CI green).** The substrate works end-to-end:
+`holdspeak cadence run-now` projects scored Open Loops from meeting action items + pending actuator
+proposals, ordered by staleness, with low-confidence extractions suppressed as quiet `needs_review`
+loops — entirely local, deterministic, off by default, no external side effects.
 
-**Next: CAD-1-02..06** — the collector (meeting actions + pending proposals → loops), deterministic
-stale-scoring, policies + quiet hours + the off-by-default `CadenceMixin` tick + `CadenceConfig`, and
-the `holdspeak cadence status|loops|run-now` CLI, closing with the no-side-effects guard. The bar:
-a green `uv run pytest -q` and `holdspeak cadence run-now` printing scored projected loops.
+- **CAD-1-01** — `cadence_*` tables (`SCHEMA_VERSION 2→3`, snapshot regenerated), models,
+  `CadenceRepository` (source-projected; killed-stays-killed).
+- **CAD-1-02** — `LoopCollector` over meeting actions + pending proposals; `resolve_project`;
+  idempotent upsert; `close_missing` on source-gone.
+- **CAD-1-03** — deterministic, explainable `score_loop` (+ `ScoreBreakdown`).
+- **CAD-1-04** — `CadenceConfig` (off by default, `pressure`/quiet-hours), `default_policies`,
+  the pure `due_loops` scheduler, `CadenceService.tick`, and the `CadenceMixin` daemon-thread tick
+  wired into `WebRuntime.run()` **only when enabled** (byte-identical when off; thread joined on stop).
+- **CAD-1-05** — `holdspeak cadence status | loops | run-now` (`--json`, `--all`).
+- **CAD-1-06** — the no-external-side-effects guard + off-by-default gate + determinism tests.
+
+**Proof:** 37 cadence tests green (`tests/unit/test_cadence_*` + `tests/integration/test_cadence_*`);
+230 config/doctor/schema/cadence tests green; the schema migration + config round-trip verified.
+
+**Next: Phase 2 (the web coach surface)** — `/api/cadence/*` + a `/cadence` page that reads this
+substrate (loops, evidence deep-links, snooze/kill/close, egress badges).
 
 ## Exit criteria
 

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/current-phase-status.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/current-phase-status.md
@@ -34,7 +34,7 @@ idempotency, the scoring, and the off-switch right here and the rest is surfaces
 
 | ID | Title | Status |
 |----|-------|--------|
-| CAD-1-01 | Cadence models + SQLite migrations (`cadence_*` tables, `CadenceRepository`) — **leads** | todo |
+| CAD-1-01 | Cadence models + SQLite migrations (`cadence_*` tables, `CadenceRepository`) — **leads** | done |
 | CAD-1-02 | The collector (meeting action items + pending proposals → source-projected loops) | todo |
 | CAD-1-03 | Stale-scoring v1 (deterministic, explainable) | todo |
 | CAD-1-04 | Cadence policies + quiet hours + the `CadenceMixin` tick (off by default) | todo |
@@ -43,10 +43,18 @@ idempotency, the scoring, and the off-switch right here and the rest is surfaces
 
 ## Where we are
 
-Not started; fully storied. **CAD-1-01 leads** (the models + tables everything else reads/writes).
-1-02/1-03 then build on it; 1-04 wires the tick + config gate; 1-05 exposes it; 1-06 locks the
-behavior. The whole phase is local + deterministic + off-by-default — a green `uv run pytest -q`
-and a `holdspeak cadence run-now` that prints projected loops is the bar.
+**CAD-1-01 landed** (the foundation): `cadence_*` tables in `SCHEMA_SQL` (`SCHEMA_VERSION 2→3`, the
+canonical snapshot regenerated), the `holdspeak/cadence/models.py` dataclasses, and
+`CadenceRepository` (`holdspeak/db/cadence.py`) registered on `Database`. Source-projection
+invariants proven by `tests/integration/test_cadence_store.py` (9 tests: idempotent upsert,
+killed-stays-killed, snooze-survives, `close_missing` spares user-decided loops, evidence cascade,
+policies round-trip) + the schema-policy/doctor suite (77 green). Inert + off by default: the tables
+exist but nothing reads them yet.
+
+**Next: CAD-1-02..06** — the collector (meeting actions + pending proposals → loops), deterministic
+stale-scoring, policies + quiet hours + the off-by-default `CadenceMixin` tick + `CadenceConfig`, and
+the `holdspeak cadence status|loops|run-now` CLI, closing with the no-side-effects guard. The bar:
+a green `uv run pytest -q` and `holdspeak cadence run-now` printing scored projected loops.
 
 ## Exit criteria
 

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/evidence-phase-1.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/evidence-phase-1.md
@@ -1,0 +1,49 @@
+# Evidence — Cadence Phase 1 (cadence core)
+
+**Date:** 2026-06-28. **Branch:** `holdspeak/cadence-phase1-core`.
+
+## What shipped (all six stories)
+
+| Story | Files | Proof |
+|-------|-------|-------|
+| CAD-1-01 | `db/core.py` (cadence_* tables, v2→3), `cadence/models.py`, `db/cadence.py`, `db/__init__.py` | `tests/integration/test_cadence_store.py` (9) |
+| CAD-1-02 | `cadence/collector.py`, `cadence/projects.py` | `tests/integration/test_cadence_collector.py` (5) |
+| CAD-1-03 | `cadence/scoring.py` | `tests/unit/test_cadence_scoring.py` (6) |
+| CAD-1-04 | `config.py` (`CadenceConfig`), `cadence/policies.py`, `cadence/scheduler.py`, `cadence/service.py`, `runtime/cadence.py`, `web_runtime.py` | `tests/unit/test_cadence_scheduler.py` (8) |
+| CAD-1-05 | `commands/cadence.py`, `main.py` | `tests/unit/test_cadence_cli.py` (5) |
+| CAD-1-06 | the guard | `tests/unit/test_cadence_guard.py` (4) |
+
+## The substrate, demonstrated
+
+A local end-to-end run (a seeded meeting with two action items + one pending GitHub-issue proposal):
+
+```
+Tick @ 2026-06-28T10:00:00
+  projected: 3   open: 3   due now: 2
+  Due to nudge (highest staleness first):
+     16.8  Create issue: watchdog around intel queue   (proposal)
+     12.8  File the watchdog issue                      (meeting_action)
+   (-1.2  Maybe revisit the retry budget — needs_review, SUPPRESSED, not due)
+```
+
+The proposal (awaiting approval) outranks the owned+due action; the unreviewed/low-confidence
+action becomes a quiet `needs_review` loop that is surfaced but **never pushed**. A second tick
+re-projects to the same 3 loops (idempotent, no dupes). Completing an action closes its loop;
+killing a loop survives re-collection.
+
+## The trust boundary, enforced
+
+- **Off by default:** `Config().cadence.enabled is False`; `WebRuntime.run()` starts the
+  `CadenceMixin` thread only when enabled and joins it on stop — byte-identical when off.
+- **No external side effects:** `test_cadence_package_has_no_external_side_effects` greps the whole
+  `holdspeak/cadence/` package and fails on any `record_proposal`/`transition_proposal`/connector/
+  network/`subprocess`/`tmux` reference. The collector reads proposals via
+  `db.actuators.list_proposals` only.
+- **Deterministic:** scoring + scheduling take an injected `now` (no clock/randomness inside).
+
+## Proof
+
+- `uv run pytest -q tests/unit/test_cadence_*.py tests/integration/test_cadence_*.py` → **37 passed.**
+- `uv run pytest -q tests/unit/ -k "config or doctor or schema or cadence"` → **230 passed** (the
+  `SCHEMA_VERSION 2→3` bump + the new `CadenceConfig` round-trip + snapshot are clean).
+- Config round-trip: `cadence` persists in the saved JSON, `enabled=False` by default.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-01-models-migrations.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-01-models-migrations.md
@@ -1,6 +1,8 @@
 # CAD-1-01 — Cadence models + SQLite migrations
 
-- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo — **leads the phase.**
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** done — **leads the phase.**
+  Built + tested (`tests/integration/test_cadence_store.py`, 9 green; schema snapshot regenerated;
+  77 db/doctor tests green). Off by default / inert.
 - **Depends on:** nothing. **Unblocks:** every other Phase-1 story.
 
 ## Problem

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-02-collector.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-02-collector.md
@@ -1,6 +1,6 @@
 # CAD-1-02 — The collector (sources → source-projected loops)
 
-- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** done (built + tested; CI green)
 - **Depends on:** CAD-1-01. **Unblocks:** 1-03 (scoring reads loops), 1-05 (CLI shows them).
 
 ## Problem

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-03-scoring.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-03-scoring.md
@@ -1,6 +1,6 @@
 # CAD-1-03 — Stale-scoring v1 (deterministic, explainable)
 
-- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** done (built + tested; CI green)
 - **Depends on:** CAD-1-01, CAD-1-02. **Unblocks:** 1-04 (the tick orders by score), 1-05.
 
 ## Problem

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-04-policies-tick.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-04-policies-tick.md
@@ -1,6 +1,6 @@
 # CAD-1-04 — Policies + quiet hours + the `CadenceMixin` tick (off by default)
 
-- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** done (built + tested; CI green)
 - **Depends on:** CAD-1-01..03. **Unblocks:** 1-05 (CLI drives the same service), all surfaces.
 
 ## Problem

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-05-cli.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-05-cli.md
@@ -1,6 +1,6 @@
 # CAD-1-05 — CLI: `holdspeak cadence status | loops | run-now`
 
-- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** done (built + tested; CI green)
 - **Depends on:** CAD-1-01..04. **Unblocks:** the phase exit criteria (the first usable surface).
 
 ## Problem

--- a/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-06-tests.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-1-cadence-core/story-06-tests.md
@@ -1,6 +1,6 @@
 # CAD-1-06 — Unit/integration tests + the no-side-effects guard
 
-- **Program:** cadence-engine · **Phase:** 1 · **Status:** todo — locks the phase's behavior.
+- **Program:** cadence-engine · **Phase:** 1 · **Status:** done (built + tested; CI green) — locks the phase's behavior.
 - **Depends on:** CAD-1-01..05.
 
 ## Problem

--- a/tests/fixtures/db_schema_canonical.txt
+++ b/tests/fixtures/db_schema_canonical.txt
@@ -35,6 +35,12 @@ index idx_artifact_sources_ref: CREATE INDEX idx_artifact_sources_ref ON artifac
 index idx_artifacts_meeting: CREATE INDEX idx_artifacts_meeting ON artifacts(meeting_id, created_at DESC)
 index idx_artifacts_type: CREATE INDEX idx_artifacts_type ON artifacts(artifact_type, created_at DESC)
 index idx_bookmarks_meeting: CREATE INDEX idx_bookmarks_meeting ON bookmarks(meeting_id)
+index idx_cadence_evidence_loop: CREATE INDEX idx_cadence_evidence_loop ON cadence_evidence_refs(loop_id)
+index idx_cadence_loops_source: CREATE UNIQUE INDEX idx_cadence_loops_source ON cadence_loops(source_type, source_id)
+index idx_cadence_loops_status: CREATE INDEX idx_cadence_loops_status ON cadence_loops(status, snoozed_until)
+index idx_cadence_next_actions_loop: CREATE INDEX idx_cadence_next_actions_loop ON cadence_next_actions(loop_id)
+index idx_cadence_nudges_loop: CREATE INDEX idx_cadence_nudges_loop ON cadence_nudges(loop_id)
+index idx_cadence_nudges_status: CREATE INDEX idx_cadence_nudges_status ON cadence_nudges(status)
 index idx_chains_modified: CREATE INDEX idx_chains_modified ON chains(last_modified DESC)
 index idx_connector_runs_connector_started: CREATE INDEX idx_connector_runs_connector_started
 ON connector_runs(connector_id, started_at DESC)
@@ -247,6 +253,67 @@ table bookmarks: CREATE TABLE bookmarks (
     timestamp REAL NOT NULL,
     label TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+table cadence_evidence_refs: CREATE TABLE cadence_evidence_refs (
+    id TEXT PRIMARY KEY,
+    loop_id TEXT NOT NULL REFERENCES cadence_loops(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    ref_id TEXT NOT NULL,
+    label TEXT NOT NULL DEFAULT '',
+    timestamp TEXT,
+    deep_link TEXT
+)
+table cadence_loops: CREATE TABLE cadence_loops (
+    id TEXT PRIMARY KEY,
+    source_type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    project TEXT,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'open',     -- open, snoozed, closed, killed, delegated
+    priority TEXT NOT NULL DEFAULT 'normal',  -- low, normal, high, urgent
+    needs_review INTEGER NOT NULL DEFAULT 0,  -- low-confidence: quiet, never a push
+    owner TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    due_at TEXT,
+    snoozed_until TEXT,
+    stale_score REAL NOT NULL DEFAULT 0,
+    last_nudged_at TEXT,
+    nudge_count INTEGER NOT NULL DEFAULT 0
+)
+table cadence_next_actions: CREATE TABLE cadence_next_actions (
+    id TEXT PRIMARY KEY,
+    loop_id TEXT NOT NULL REFERENCES cadence_loops(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body_markdown TEXT NOT NULL DEFAULT '',
+    confidence REAL NOT NULL DEFAULT 0,
+    reversible INTEGER NOT NULL DEFAULT 1,
+    proposal_id TEXT,
+    generated_by TEXT NOT NULL DEFAULT 'deterministic',
+    generated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+table cadence_nudges: CREATE TABLE cadence_nudges (
+    id TEXT PRIMARY KEY,
+    loop_id TEXT NOT NULL REFERENCES cadence_loops(id) ON DELETE CASCADE,
+    next_action_id TEXT,
+    surface TEXT NOT NULL,
+    severity TEXT NOT NULL DEFAULT 'normal',  -- quiet, normal, persistent, escalated
+    title TEXT NOT NULL DEFAULT '',
+    message_markdown TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'pending',   -- pending, shown, acted, dismissed, expired
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    shown_at TEXT,
+    acted_at TEXT,
+    expires_at TEXT
+)
+table cadence_policies: CREATE TABLE cadence_policies (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    config_json TEXT NOT NULL DEFAULT '{}',
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 )
 table chains: CREATE TABLE chains (
     id TEXT PRIMARY KEY,

--- a/tests/integration/test_cadence_collector.py
+++ b/tests/integration/test_cadence_collector.py
@@ -1,0 +1,77 @@
+"""CAD-1-02 — the collector projects loops from meeting actions + pending proposals."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from holdspeak.cadence.collector import LoopCollector
+from holdspeak.config import Config
+from holdspeak.db import Database
+
+NOW = datetime(2026, 6, 28, 10, 0, 0)
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path) -> Database:
+    db = Database(tmp_path / "c.db")
+    with db._connection() as c:
+        c.execute(
+            "INSERT INTO meetings (id, title, started_at, created_at) "
+            "VALUES ('m1','Platform sync','2026-06-27T14:00:00','2026-06-27T14:00:00')"
+        )
+        c.execute(
+            "INSERT INTO action_items (id, meeting_id, task, owner, due, status, review_state, created_at) "
+            "VALUES ('a1','m1','File the watchdog issue','Karol','2026-06-30','pending','reviewed','2026-06-26T10:00:00')"
+        )
+        c.execute(
+            "INSERT INTO action_items (id, meeting_id, task, owner, status, review_state, created_at) "
+            "VALUES ('a2','m1','Maybe revisit retry budget',NULL,'pending','pending','2026-06-27T10:00:00')"
+        )
+    db.actuators.record_proposal(
+        meeting_id="m1", window_id="m1:aftercare", plugin_id="github_issue_actuator",
+        plugin_version="1.0", idempotency_key="k1", target="github", action="create_issue",
+        preview="Create issue: watchdog around intel queue", reversible=False,
+    )
+    return db
+
+
+def test_collect_projects_actions_and_proposals_with_evidence(seeded_db: Database):
+    loops = LoopCollector(seeded_db).collect(now=NOW)
+    assert len(loops) == 3
+    by_source = {l.source_type for l in loops}
+    assert by_source == {"meeting_action", "proposal"}
+    a1 = seeded_db.cadence.get_loop_by_source("meeting_action", "a1")
+    assert a1.evidence and a1.evidence[0].deep_link == "/meetings/m1#ai-a1"
+    a2 = seeded_db.cadence.get_loop_by_source("meeting_action", "a2")
+    assert a2.needs_review is True  # unreviewed extraction -> quiet review loop
+
+
+def test_collect_is_idempotent(seeded_db: Database):
+    LoopCollector(seeded_db).collect(now=NOW)
+    LoopCollector(seeded_db).collect(now=NOW)
+    assert len(seeded_db.cadence.list_loops()) == 3  # no dupes
+
+
+def test_completing_an_action_closes_its_loop(seeded_db: Database):
+    LoopCollector(seeded_db).collect(now=NOW)
+    with seeded_db._connection() as c:
+        c.execute("UPDATE action_items SET status='completed' WHERE id='a1'")
+    LoopCollector(seeded_db).collect(now=NOW)
+    assert seeded_db.cadence.get_loop_by_source("meeting_action", "a1").status == "closed"
+
+
+def test_killed_loop_not_resurrected_by_collect(seeded_db: Database):
+    LoopCollector(seeded_db).collect(now=NOW)
+    loop = seeded_db.cadence.get_loop_by_source("meeting_action", "a1")
+    seeded_db.cadence.set_status(loop.id, "killed")
+    LoopCollector(seeded_db).collect(now=NOW)
+    assert seeded_db.cadence.get_loop_by_source("meeting_action", "a1").status == "killed"
+
+
+def test_scores_are_persisted_and_ordered(seeded_db: Database):
+    LoopCollector(seeded_db).collect(now=NOW)
+    loops = seeded_db.cadence.list_loops()  # ordered by score desc
+    assert loops[0].stale_score >= loops[-1].stale_score
+    assert all(l.stale_score != 0 or l.needs_review for l in loops)

--- a/tests/integration/test_cadence_store.py
+++ b/tests/integration/test_cadence_store.py
@@ -1,0 +1,122 @@
+"""CAD-1-01 — CadenceRepository persistence + the source-projection invariants.
+
+Real SQLite, no network, no model. Proves: schema v3 applies, upsert is idempotent
+on (source_type, source_id), the user's lifecycle decisions survive re-projection
+(killed stays killed), close_missing closes vanished sources without touching
+user-decided loops, evidence cascades on loop delete, and policies round-trip.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from holdspeak.cadence.models import (
+    CadencePolicy,
+    EvidenceRef,
+    NextBestAction,
+    Nudge,
+    OpenLoop,
+)
+from holdspeak.db import Database
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    return Database(tmp_path / "cadence.db")
+
+
+def _loop(source_id: str = "a1", **kw) -> OpenLoop:
+    return OpenLoop(
+        source_type="meeting_action",
+        source_id=source_id,
+        title=kw.pop("title", "File the issue"),
+        project=kw.pop("project", "holdspeak"),
+        evidence=kw.pop(
+            "evidence",
+            [EvidenceRef(kind="action_item", ref_id=source_id, label="Standup",
+                         deep_link=f"/meetings/m1#ai-{source_id}")],
+        ),
+        **kw,
+    )
+
+
+def test_schema_v3_applies_and_loop_round_trips(db: Database):
+    saved = db.cadence.upsert_loop(_loop())
+    assert saved.id and saved.status == "open"
+    assert len(saved.evidence) == 1 and saved.evidence[0].deep_link == "/meetings/m1#ai-a1"
+    fetched = db.cadence.get_loop(saved.id)
+    assert fetched is not None and fetched.title == "File the issue"
+
+
+def test_upsert_is_idempotent_on_source_key(db: Database):
+    a = db.cadence.upsert_loop(_loop())
+    b = db.cadence.upsert_loop(_loop(title="File the issue (reworded)"))
+    assert a.id == b.id  # one row
+    assert b.title == "File the issue (reworded)"  # source fields update
+    assert len(db.cadence.list_loops()) == 1
+
+
+def test_killed_loop_survives_reprojection(db: Database):
+    loop = db.cadence.upsert_loop(_loop())
+    db.cadence.set_status(loop.id, "killed")
+    again = db.cadence.upsert_loop(_loop(title="resurrected?"))
+    assert again.status == "killed"  # never resurrected by re-collection
+    assert db.cadence.list_loops() == []  # excludes terminal by default
+    assert len(db.cadence.list_loops(include_terminal=True)) == 1
+
+
+def test_snoozed_loop_keeps_snooze_through_reprojection(db: Database):
+    loop = db.cadence.upsert_loop(_loop())
+    db.cadence.snooze(loop.id, "2999-01-01T00:00:00")
+    again = db.cadence.upsert_loop(_loop())
+    assert again.status == "snoozed" and again.snoozed_until == "2999-01-01T00:00:00"
+
+
+def test_close_missing_closes_vanished_but_spares_user_decided(db: Database):
+    db.cadence.upsert_loop(_loop("a1"))
+    killed = db.cadence.upsert_loop(_loop("a2"))
+    db.cadence.set_status(killed.id, "killed")
+    # only a2's source remains present; a1 vanished, a2 is killed
+    closed = db.cadence.close_missing("meeting_action", present_source_ids=["a2"])
+    assert closed == 1  # a1 closed
+    assert db.cadence.get_loop_by_source("meeting_action", "a1").status == "closed"
+    assert db.cadence.get_loop_by_source("meeting_action", "a2").status == "killed"  # spared
+
+
+def test_evidence_cascades_on_loop_delete(db: Database):
+    loop = db.cadence.upsert_loop(_loop())
+    with db._connection() as conn:
+        conn.execute("DELETE FROM cadence_loops WHERE id = ?", (loop.id,))
+        remaining = conn.execute(
+            "SELECT COUNT(*) AS n FROM cadence_evidence_refs WHERE loop_id = ?", (loop.id,)
+        ).fetchone()["n"]
+    assert remaining == 0
+
+
+def test_next_action_and_nudge_persist(db: Database):
+    loop = db.cadence.upsert_loop(_loop())
+    aid = db.cadence.add_next_action(
+        NextBestAction(loop_id=loop.id, kind="create_issue", title="Draft issue", confidence=0.9)
+    )
+    nid = db.cadence.record_nudge(
+        Nudge(loop_id=loop.id, surface="cli", next_action_id=aid, title="File it")
+    )
+    assert aid and nid
+
+
+def test_policies_round_trip(db: Database):
+    db.cadence.upsert_policy(CadencePolicy(name="agent_blocker", config={"initial_delay_minutes": 5}))
+    db.cadence.upsert_policy(CadencePolicy(name="agent_blocker", config={"initial_delay_minutes": 10}))
+    got = db.cadence.get_policy("agent_blocker")
+    assert got is not None and got.config["initial_delay_minutes"] == 10  # upsert updated
+    assert len(db.cadence.list_policies()) == 1
+
+
+def test_stale_score_and_nudge_bump_persist(db: Database):
+    loop = db.cadence.upsert_loop(_loop())
+    db.cadence.set_stale_score(loop.id, 42.5)
+    db.cadence.bump_nudge(loop.id, at="2026-06-28T10:00:00")
+    again = db.cadence.get_loop(loop.id)
+    assert again.stale_score == 42.5 and again.nudge_count == 1
+    assert again.last_nudged_at == "2026-06-28T10:00:00"

--- a/tests/unit/test_cadence_cli.py
+++ b/tests/unit/test_cadence_cli.py
@@ -1,0 +1,67 @@
+"""CAD-1-05 — the `holdspeak cadence` CLI."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from holdspeak.commands.cadence import run_cadence_command
+from holdspeak.config import Config
+from holdspeak.db import Database
+
+
+class _Args:
+    def __init__(self, action, **kw):
+        self.cadence_action = action
+        self.json = kw.get("json", False)
+        self.all = kw.get("all", False)
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    db = Database(tmp_path / "cli.db")
+    with db._connection() as c:
+        c.execute("INSERT INTO meetings (id, title, started_at, created_at) "
+                  "VALUES ('m1','Standup','2026-06-27T14:00:00','2026-06-27T14:00:00')")
+        c.execute("INSERT INTO action_items (id, meeting_id, task, owner, status, review_state, created_at) "
+                  "VALUES ('a1','m1','File the issue','Karol','pending','reviewed','2026-06-26T10:00:00')")
+    return db
+
+
+def _run(action, db, **kw) -> str:
+    buf = io.StringIO()
+    rc = run_cadence_command(_Args(action, **kw), stream=buf, db=db, config=Config())
+    assert rc == 0
+    return buf.getvalue()
+
+
+def test_run_now_works_with_cadence_disabled(db: Database):
+    # Config() has cadence.enabled = False by default; run-now must still work.
+    assert Config().cadence.enabled is False
+    out = _run("run-now", db)
+    assert "projected: 1" in out
+
+
+def test_run_now_json_shape(db: Database):
+    out = _run("run-now", db, json=True)
+    data = json.loads(out)
+    assert data["projected"] == 1 and "due" in data and "open_loops" in data
+
+
+def test_loops_lists_by_staleness(db: Database):
+    _run("run-now", db)  # project first
+    out = _run("loops", db)
+    assert "File the issue" in out
+
+
+def test_loops_json_is_valid(db: Database):
+    _run("run-now", db)
+    data = json.loads(_run("loops", db, json=True))
+    assert isinstance(data, list) and data[0]["title"] == "File the issue"
+
+
+def test_status_reports_enabled_honestly(db: Database):
+    out = _run("status", db)
+    assert "enabled:        False" in out

--- a/tests/unit/test_cadence_guard.py
+++ b/tests/unit/test_cadence_guard.py
@@ -1,0 +1,69 @@
+"""CAD-1-06 — the trust-boundary guards.
+
+Phase 1's hard invariants, mechanically enforced before any surface builds on the
+substrate: the cadence package performs NO external side effect, and it is off by
+default (the runtime starts no cadence thread when disabled).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from holdspeak.config import CadenceConfig, Config
+
+
+CADENCE_DIR = Path(__file__).resolve().parents[2] / "holdspeak" / "cadence"
+
+# Forbidden in Phase 1: any outbound side effect or actuator EXECUTION. (Reading
+# proposals is fine; PROPOSING/executing is Phase 6+.) The collector reaches the
+# actuator repo only through db.actuators.list_proposals — never record_proposal,
+# transition_proposal, or a connector/network call.
+_FORBIDDEN = [
+    r"record_proposal",
+    r"transition_proposal",
+    r"execute_proposal",
+    r"requests\.",
+    r"urllib",
+    r"httpx",
+    r"socket\.",
+    r"subprocess",
+    r"os\.system",
+    r"tmux",
+]
+
+
+def test_cadence_package_has_no_external_side_effects():
+    offenders = []
+    for path in CADENCE_DIR.rglob("*.py"):
+        text = path.read_text()
+        for pat in _FORBIDDEN:
+            if re.search(pat, text):
+                offenders.append(f"{path.name}: {pat}")
+    assert not offenders, (
+        "The cadence package must perform no external side effect in Phase 1 "
+        f"(outbound actions go through the actuator path in later phases): {offenders}"
+    )
+
+
+def test_cadence_is_off_by_default():
+    assert Config().cadence.enabled is False
+
+
+def test_cadence_config_clamps_invalid_values():
+    c = CadenceConfig(pressure="wild", tick_interval_seconds=1, quiet_hours_start=99)
+    assert c.pressure == "normal"          # invalid pressure falls back
+    assert c.tick_interval_seconds >= 30   # floored
+    assert 0 <= c.quiet_hours_start <= 23  # wrapped
+
+
+def test_runtime_gate_reflects_config():
+    # The WebRuntime start guard reads config.cadence.enabled via _cadence_enabled().
+    from holdspeak.runtime.cadence import CadenceMixin
+
+    class _Stub(CadenceMixin):
+        def __init__(self, enabled):
+            self.config = Config()
+            self.config.cadence.enabled = enabled
+
+    assert _Stub(False)._cadence_enabled() is False
+    assert _Stub(True)._cadence_enabled() is True

--- a/tests/unit/test_cadence_scheduler.py
+++ b/tests/unit/test_cadence_scheduler.py
@@ -1,0 +1,67 @@
+"""CAD-1-04 — the scheduler: quiet hours, snooze, repeat window, daily cap, pressure."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from holdspeak.cadence.models import OpenLoop
+from holdspeak.cadence.scheduler import SchedulerConfig, due_loops, in_quiet_hours
+
+
+def _loop(score=10.0, **kw) -> OpenLoop:
+    loop = OpenLoop(source_type="meeting_action", source_id=kw.pop("sid", "x"),
+                    title=kw.pop("title", "t"), stale_score=score, **kw)
+    return loop
+
+
+DAYTIME = datetime(2026, 6, 28, 10, 0, 0)
+NIGHT = datetime(2026, 6, 28, 23, 0, 0)
+CFG = SchedulerConfig(quiet_hours_start=22, quiet_hours_end=8, max_nudges_per_day=12)
+
+
+def test_quiet_hours_wraps_midnight():
+    assert in_quiet_hours(NIGHT, 22, 8)
+    assert in_quiet_hours(datetime(2026, 6, 28, 3, 0), 22, 8)
+    assert not in_quiet_hours(DAYTIME, 22, 8)
+
+
+def test_no_nudges_during_quiet_hours():
+    assert due_loops([_loop()], now=NIGHT, config=CFG) == []
+
+
+def test_daytime_loop_is_due():
+    due = due_loops([_loop()], now=DAYTIME, config=CFG)
+    assert len(due) == 1
+
+
+def test_needs_review_never_due():
+    assert due_loops([_loop(needs_review=True)], now=DAYTIME, config=CFG) == []
+
+
+def test_snoozed_loop_suppressed_until_due():
+    snoozed = _loop(status="snoozed", snoozed_until="2999-01-01T00:00:00")
+    assert due_loops([snoozed], now=DAYTIME, config=CFG) == []
+    past = _loop(status="snoozed", snoozed_until="2000-01-01T00:00:00")
+    assert len(due_loops([past], now=DAYTIME, config=CFG)) == 1
+
+
+def test_repeat_window_suppresses_recently_nudged():
+    recent = _loop(last_nudged_at="2026-06-28T09:00:00")  # 1h ago, < 4h window
+    assert due_loops([recent], now=DAYTIME, config=CFG) == []
+    old = _loop(last_nudged_at="2026-06-28T00:00:00")  # 10h ago
+    assert len(due_loops([old], now=DAYTIME, config=CFG)) == 1
+
+
+def test_daily_cap_limits_and_orders_by_score():
+    loops = [_loop(score=s, sid=f"s{s}") for s in (1, 9, 5, 7)]
+    cfg = SchedulerConfig(max_nudges_per_day=2)
+    due = due_loops(loops, now=DAYTIME, config=cfg, nudged_today=0)
+    assert [l.stale_score for l in due] == [9, 7]  # top 2, highest first
+    assert due_loops(loops, now=DAYTIME, config=cfg, nudged_today=2) == []  # cap reached
+
+
+def test_pressure_changes_repeat_window():
+    nudged = _loop(last_nudged_at="2026-06-28T07:30:00")  # 2.5h ago
+    gentle = SchedulerConfig(pressure="gentle")     # 8h window -> suppressed
+    aggressive = SchedulerConfig(pressure="aggressive")  # 2h window -> eligible
+    assert due_loops([nudged], now=DAYTIME, config=gentle) == []
+    assert len(due_loops([nudged], now=DAYTIME, config=aggressive)) == 1

--- a/tests/unit/test_cadence_scoring.py
+++ b/tests/unit/test_cadence_scoring.py
@@ -1,0 +1,54 @@
+"""CAD-1-03 — deterministic, explainable stale-scoring."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from holdspeak.cadence.models import OpenLoop
+from holdspeak.cadence.scoring import LoopSignals, score_loop
+
+NOW = datetime(2026, 6, 28, 10, 0, 0)
+
+
+def _loop(**kw) -> OpenLoop:
+    return OpenLoop(source_type=kw.pop("source_type", "meeting_action"),
+                    source_id=kw.pop("source_id", "x"), title=kw.pop("title", "t"), **kw)
+
+
+def test_breakdown_sums_to_total():
+    b = score_loop(_loop(priority="high"), now=NOW,
+                   signals=LoopSignals(unowned=True, recurrence_count=2))
+    assert round(sum(b.contributions.values()), 2) == b.total
+
+
+def test_deterministic_with_injected_now():
+    loop = _loop(priority="normal", created_at="2026-06-20T10:00:00")
+    a = score_loop(loop, now=NOW)
+    b = score_loop(loop, now=NOW)
+    assert a.total == b.total
+
+
+def test_accepted_unexecuted_outranks_unowned_outranks_plain():
+    accepted = score_loop(_loop(priority="normal"), now=NOW,
+                          signals=LoopSignals(accepted_unexecuted=True))
+    unowned = score_loop(_loop(priority="normal"), now=NOW, signals=LoopSignals(unowned=True))
+    plain = score_loop(_loop(priority="low"), now=NOW)
+    assert accepted.total > unowned.total > plain.total
+
+
+def test_needs_review_is_strongly_suppressed():
+    normal = score_loop(_loop(priority="normal"), now=NOW)
+    review = score_loop(_loop(priority="normal", needs_review=True), now=NOW)
+    assert review.total < normal.total
+    assert review.contributions["needs_review"] < 0
+
+
+def test_agent_question_source_dominates():
+    agent = score_loop(_loop(source_type="agent_question"), now=NOW)
+    action = score_loop(_loop(source_type="meeting_action"), now=NOW)
+    assert agent.total > action.total  # a blocked coding agent is the top signal
+
+
+def test_dismissals_suppress():
+    base = score_loop(_loop(priority="normal"), now=NOW)
+    dismissed = score_loop(_loop(priority="normal"), now=NOW, signals=LoopSignals(dismissals=2))
+    assert dismissed.total < base.total


### PR DESCRIPTION
**Cadence Engine — Phase 1 (cadence core).** The loop/scoring/policy substrate. All-new, **off by
default**, **zero external side effects** (a test guard proves it). Builds on the roadmap (#169).

`holdspeak cadence run-now` now projects scored **Open Loops** from your meeting action items +
pending actuator proposals, ordered by staleness, with low-confidence extractions suppressed as
quiet `needs_review` loops — entirely local and deterministic.

## What's here

- **CAD-1-01** — `cadence_*` tables (`SCHEMA_VERSION 2→3`, snapshot regenerated), `cadence/models.py`,
  `CadenceRepository` (source-projected; **killed stays killed**).
- **CAD-1-02** — `LoopCollector` over meeting actions + pending proposals (read-only); idempotent
  upsert; `resolve_project`; `close_missing` on source-gone.
- **CAD-1-03** — deterministic, explainable `score_loop` (+ `ScoreBreakdown`): agent-question ≫
  accepted-unexecuted > unowned; `needs_review`/dismissals suppress.
- **CAD-1-04** — `CadenceConfig` (off by default; `pressure` scales timings only; quiet hours
  default-on), default policies, the pure `due_loops` scheduler, `CadenceService.tick`, and the
  `CadenceMixin` daemon thread wired into `WebRuntime.run()` **only when enabled** (byte-identical
  off; joined on stop) — mirroring `PluginQueueMixin`.
- **CAD-1-05** — `holdspeak cadence status | loops | run-now` (`--json`, `--all`).
- **CAD-1-06** — the no-external-side-effects guard + the off-by-default gate test.

## Demonstrated end-to-end

Seeded meeting + 2 actions + 1 GitHub-issue proposal → the proposal awaiting approval (16.8)
outranks the owned+due action (12.8); the unreviewed action becomes a suppressed `needs_review`
loop; re-tick is idempotent.

## Proof

- **37** cadence tests passed (`tests/unit/test_cadence_*` + `tests/integration/test_cadence_*`).
- **230** config/doctor/schema/cadence tests passed (the v2→3 bump + `CadenceConfig` round-trip clean).

Next: **Phase 2** — the `/api/cadence/*` + `/cadence` web coach surface over this substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)