### PR TITLE
Cadence Engine Phase 2: the web coach surface

### DIFF
--- a/holdspeak/cadence/next_action.py
+++ b/holdspeak/cadence/next_action.py
@@ -1,0 +1,95 @@
+"""Deterministic Next-Best-Action generator (CAD-2-01).
+
+Maps an Open Loop to the prepared move Qlippy wants the user to decide on — WITHOUT
+an LLM (the LLM-drafted version is Phase 7). The point of the cadence engine is that
+the next decision is cheap: a proposal awaiting approval becomes an `approve_proposal`,
+an owned action becomes a `create_issue` DRAFT (a draft, not an execution — executing
+goes through the actuator path), an unowned action becomes `assign_owner`, and a
+low-confidence extraction becomes `review_draft`.
+"""
+from __future__ import annotations
+
+from .models import NextBestAction, OpenLoop
+
+
+def generate_next_action(loop: OpenLoop) -> NextBestAction:
+    """The single best prepared move for this loop (deterministic)."""
+    kind, title, body, reversible = _decide(loop)
+    return NextBestAction(
+        loop_id=loop.id or "",
+        kind=kind,
+        title=title,
+        body_markdown=body,
+        confidence=0.6,  # deterministic baseline; the LLM path (Phase 7) scores higher/lower
+        reversible=reversible,
+        generated_by="deterministic",
+    )
+
+
+def _decide(loop: OpenLoop):
+    src = loop.source_type
+    if loop.needs_review:
+        return (
+            "review_draft",
+            f"Review: {loop.title}",
+            "This was extracted with low confidence. Confirm it is a real, actionable "
+            "item (then it can be filed), or dismiss it.",
+            True,
+        )
+    if src == "proposal":
+        return (
+            "approve_proposal",
+            f"Approve: {loop.title}",
+            f"{loop.summary or 'A proposed action'} is ready for your approval. Approving runs it "
+            "through the existing approve → execute path; nothing leaves your machine until you do.",
+            False,
+        )
+    if src == "agent_question":
+        return (
+            "reply_to_agent",
+            f"Reply to the waiting agent: {loop.title}",
+            "A coding agent is blocked on your answer. Review the suggested reply, edit if needed, "
+            "and send.",
+            False,
+        )
+    if src in ("meeting_action", "manual"):
+        if not (loop.owner and loop.owner.strip()):
+            return (
+                "assign_owner",
+                f"Assign an owner: {loop.title}",
+                "This action has no owner. Assign it (to you or someone else) so it can move, "
+                "or kill the loop if it is not worth doing.",
+                True,
+            )
+        return (
+            "create_issue",
+            f"File an issue: {loop.title}",
+            _issue_body(loop),
+            False,
+        )
+    if src == "meeting_decision":
+        return (
+            "schedule_followup",
+            f"Schedule a follow-up: {loop.title}",
+            "A decision was made that needs a follow-up. Schedule it or convert it to a tracked item.",
+            True,
+        )
+    return ("review_draft", f"Review: {loop.title}", loop.summary or "", True)
+
+
+def _issue_body(loop: OpenLoop) -> str:
+    lines = [loop.title, ""]
+    meta = []
+    if loop.owner:
+        meta.append(f"Owner: {loop.owner}")
+    if loop.due_at:
+        meta.append(f"Due: {loop.due_at}")
+    if loop.project:
+        meta.append(f"Project: {loop.project}")
+    if meta:
+        lines.append(" · ".join(meta))
+    if loop.evidence:
+        ev = loop.evidence[0]
+        lines.append("")
+        lines.append(f"Source: {ev.label or ev.kind}" + (f" ({ev.deep_link})" if ev.deep_link else ""))
+    return "\n".join(lines)

--- a/holdspeak/web/routes/__init__.py
+++ b/holdspeak/web/routes/__init__.py
@@ -11,6 +11,7 @@ module.
 """
 
 from .activity import build_activity_router
+from .cadence import build_cadence_router
 from .core import build_core_router
 from .dictation import build_dictation_router
 from .meeting_import import build_meeting_import_router
@@ -25,6 +26,7 @@ from .system import build_system_router
 
 __all__ = [
     "build_activity_router",
+    "build_cadence_router",
     "build_core_router",
     "build_dictation_router",
     "build_meeting_import_router",

--- a/holdspeak/web/routes/cadence.py
+++ b/holdspeak/web/routes/cadence.py
@@ -1,0 +1,142 @@
+"""Cadence Engine HTTP routes (CAD-2-02/03).
+
+A read API over the Phase-1 substrate + local lifecycle actions (snooze/kill/close)
++ a synchronous run-now. Every loop carries its evidence, a deterministic prepared
+next action, and an honest egress badge. NO autonomous external side effect: lifecycle
+actions are local cadence_* writes; a `next_action` that maps to a connector is a DRAFT
+(executing it is the actuator approve→execute path, Phase 6/7).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Body, HTTPException
+
+from ..context import WebContext
+
+# Phase 2 reads/writes are local-only; the badge is honest about that.
+_LOCAL_EGRESS = {"scope": "local", "label": "Local only"}
+
+
+def _loop_dict(loop, *, with_next_action: bool = True) -> dict[str, Any]:
+    from ...cadence.next_action import generate_next_action
+
+    out: dict[str, Any] = {
+        "id": loop.id,
+        "title": loop.title,
+        "summary": loop.summary,
+        "project": loop.project,
+        "source_type": loop.source_type,
+        "status": loop.status,
+        "priority": loop.priority,
+        "needs_review": loop.needs_review,
+        "owner": loop.owner,
+        "due_at": loop.due_at,
+        "snoozed_until": loop.snoozed_until,
+        "stale_score": loop.stale_score,
+        "nudge_count": loop.nudge_count,
+        "evidence": [
+            {"kind": e.kind, "ref_id": e.ref_id, "label": e.label,
+             "timestamp": e.timestamp, "deep_link": e.deep_link}
+            for e in loop.evidence
+        ],
+        "egress": _LOCAL_EGRESS,
+    }
+    if with_next_action:
+        na = generate_next_action(loop)
+        out["next_action"] = {
+            "kind": na.kind, "title": na.title, "body_markdown": na.body_markdown,
+            "reversible": na.reversible, "confidence": na.confidence,
+        }
+    return out
+
+
+def build_cadence_router(ctx: WebContext) -> APIRouter:
+    router = APIRouter(prefix="/api/cadence", tags=["cadence"])
+
+    @router.get("/status")
+    async def status() -> dict[str, Any]:
+        from ...config import Config
+        from ...db import get_database
+
+        db = get_database()
+        c = Config.load().cadence
+        counts: dict[str, int] = {}
+        for loop in db.cadence.list_loops(include_terminal=True):
+            counts[loop.status] = counts.get(loop.status, 0) + 1
+        return {
+            "enabled": c.enabled,
+            "pressure": c.pressure,
+            "tick_interval_seconds": c.tick_interval_seconds,
+            "quiet_hours": {"start": c.quiet_hours_start, "end": c.quiet_hours_end},
+            "max_nudges_per_day": c.max_nudges_per_day,
+            "policies": len(db.cadence.list_policies()),
+            "counts": counts,
+            "egress": _LOCAL_EGRESS,
+        }
+
+    @router.get("/loops")
+    async def loops(all: bool = False) -> dict[str, Any]:
+        from ...db import get_database
+
+        db = get_database()
+        items = db.cadence.list_loops(include_terminal=all)
+        return {"loops": [_loop_dict(loop) for loop in items], "egress": _LOCAL_EGRESS}
+
+    @router.get("/loops/{loop_id}")
+    async def loop_detail(loop_id: str) -> dict[str, Any]:
+        from ...db import get_database
+
+        loop = get_database().cadence.get_loop(loop_id)
+        if loop is None:
+            raise HTTPException(status_code=404, detail="loop not found")
+        return _loop_dict(loop)
+
+    def _require(loop_id: str):
+        from ...db import get_database
+
+        db = get_database()
+        loop = db.cadence.get_loop(loop_id)
+        if loop is None:
+            raise HTTPException(status_code=404, detail="loop not found")
+        return db, loop
+
+    @router.post("/loops/{loop_id}/snooze")
+    async def snooze(loop_id: str, body: dict = Body(default={})) -> dict[str, Any]:
+        db, _ = _require(loop_id)
+        until = body.get("until")
+        if not until:
+            hours = float(body.get("hours", 24))
+            until = (datetime.now() + timedelta(hours=hours)).isoformat()
+        db.cadence.snooze(loop_id, until)
+        return _loop_dict(db.cadence.get_loop(loop_id))
+
+    @router.post("/loops/{loop_id}/kill")
+    async def kill(loop_id: str) -> dict[str, Any]:
+        db, _ = _require(loop_id)
+        db.cadence.set_status(loop_id, "killed")  # stays killed across re-collection
+        return _loop_dict(db.cadence.get_loop(loop_id))
+
+    @router.post("/loops/{loop_id}/close")
+    async def close(loop_id: str) -> dict[str, Any]:
+        db, _ = _require(loop_id)
+        db.cadence.set_status(loop_id, "closed")
+        return _loop_dict(db.cadence.get_loop(loop_id))
+
+    @router.post("/run-now")
+    async def run_now() -> dict[str, Any]:
+        from ...cadence.service import CadenceService
+        from ...config import Config
+        from ...db import get_database
+
+        result = CadenceService(get_database(), Config.load().cadence).tick(datetime.now())
+        return {
+            "at": result.at,
+            "projected": result.projected,
+            "open_loops": result.open_loops,
+            "due": [_loop_dict(loop) for loop in result.due],
+            "egress": _LOCAL_EGRESS,
+        }
+
+    return router

--- a/holdspeak/web/routes/pages.py
+++ b/holdspeak/web/routes/pages.py
@@ -161,6 +161,28 @@ def build_pages_router(ctx: WebContext) -> APIRouter:
             )
         return HTMLResponse(html)
 
+    @router.get("/cadence")
+    async def cadence_dashboard() -> Any:
+        """Serve the Cadence coach surface (CAD-2-04: the Astro-built
+        _built/cadence/index.html, driven by /api/cadence/*)."""
+        page = (
+            _HOLDSPEAK_DIR
+            / "static"
+            / "_built"
+            / "cadence"
+            / "index.html"
+        )
+        try:
+            html = page.read_text(encoding="utf-8")
+        except Exception as e:
+            log.error(f"Failed to read cadence.html: {e}")
+            html = (
+                "<!doctype html><html><head><meta charset='utf-8'/>"
+                "<title>HoldSpeak Cadence</title></head>"
+                "<body><h1>Cadence</h1><p>Page unavailable.</p></body></html>"
+            )
+        return HTMLResponse(html)
+
     @router.get("/dictation")
     async def dictation_dashboard() -> Any:
         """Serve the dictation block-config UI (HS-10-09: now read

--- a/holdspeak/web_server.py
+++ b/holdspeak/web_server.py
@@ -502,6 +502,7 @@ class MeetingWebServer:
         from .web.context import WebContext
         from .web.routes import (
             build_activity_router,
+            build_cadence_router,
             build_core_router,
             build_dictation_router,
             build_meeting_import_router,
@@ -554,6 +555,7 @@ class MeetingWebServer:
             mesh_requires_token=not web_auth.is_loopback_host(self.host),
         )
         app.include_router(build_core_router(web_ctx))
+        app.include_router(build_cadence_router(web_ctx))
         app.include_router(build_meetings_router(web_ctx))
         app.include_router(build_meeting_import_router(web_ctx))
         app.include_router(build_mesh_router(web_ctx))

--- a/pm/roadmap/holdspeak/cadence-engine/README.md
+++ b/pm/roadmap/holdspeak/cadence-engine/README.md
@@ -5,13 +5,15 @@
 > next actions.** Qlippy does not merely remind. Qlippy pushes — with receipts, restraint, and a
 > ready-made next move.
 
-**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phase 1
-(cadence core) is COMPLETE** (built + tested, off by default; `holdspeak cadence run-now` projects
-scored loops from your meetings). **Phase 2 (the web coach surface) is next.** Phases 3–8 are
-sketched here and storied as each becomes the lead.
+**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phases 1
+(cadence core) + 2 (the web coach surface) are COMPLETE** (`holdspeak cadence run-now` projects
+scored loops; the `/cadence` page shows them with prepared next moves + one-tap decisions, off by
+default). **Phase 3 (agent-blocker push) is next.** Phases 4–8 are sketched here and storied as each
+becomes the lead.
 
-**Last updated:** 2026-06-28 (Phase 1 shipped — the loop/scoring/policy/CLI substrate; 37 cadence
-tests green. Program authored from the owner's rough design + a grounded seam map; §15 resolved below).
+**Last updated:** 2026-06-28 (Phase 2 shipped — `/api/cadence/*` + the `/cadence` coach page;
+137 cadence/web tests green. Phase 1: the loop/scoring/policy/CLI substrate. Program authored from
+the owner's rough design + a grounded seam map; §15 resolved below).
 
 ---
 
@@ -114,7 +116,7 @@ Phase 1 leads and is fully storied. Each later phase is storied when it becomes 
 | Phase | Title | The crux | Depends on |
 |-------|-------|----------|------------|
 | **1 ✅** | **Cadence core** | *Done.* The loop/nudge/policy substrate: models, migrations, collector (meeting actions + pending proposals), stale-scoring v1, policies + quiet hours, CLI, unit tests. No external side effects, off by default. | — |
-| **2** | Web coach surface | `/api/cadence/*` + a `/cadence` page: loops, evidence deep-links, snooze/kill/close, generate-next-action, egress badges. | 1 |
+| **2 ✅** | Web coach surface | *Done.* `/api/cadence/*` + a `/cadence` page: loops, evidence deep-links, snooze/kill/close, deterministic next-action, egress badges. | 1 |
 | **3** | Agent-blocker push | Awaiting-response agent sessions → loops + a prepared reply; tmux/`/api/dictation/remote` delivery as a nudge action. | 1 |
 | **4** | Telegram remote presence | Pairing + a Telegram surface; `/brief` `/loops` `/agents`; inline-button decisions wired to the cadence API; unpaired-chat rejection; second-confirm for irreversible actions. | 2, 3 |
 | **5** | Daily push brief | A deterministic morning brief (first-activity trigger) with prepared moves; LLM wording behind a capability gate (policy never model-driven). | 2 |

--- a/pm/roadmap/holdspeak/cadence-engine/phase-2-web-coach/current-phase-status.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-2-web-coach/current-phase-status.md
@@ -1,0 +1,64 @@
+# Cadence Phase 2 — The web coach surface
+
+**Status:** done (built + tested; the web bundle builds, 137 cadence/web-server tests green).
+**Start here:** `../README.md` (the program chart). Builds on Phase 1 (merged).
+
+**Last updated:** 2026-06-28 (Phase 2 shipped: the `/api/cadence/*` API + the `/cadence` coach page
+with prepared next moves, evidence deep-links, lifecycle actions, and egress badges).
+
+## Objective
+
+Make the Phase-1 substrate visible and actionable in the local web runtime: a read API over loops +
+their evidence + a prepared next action, lifecycle actions (snooze/kill/close), and a `/cadence`
+coach page that shows *Now* (what's due, with the prepared move) and *Open loops* (with evidence
+deep-links + an egress badge). Still **no autonomous external side effect** — lifecycle actions are
+local; a "next action" that maps to an external connector remains a *draft* (executing it is the
+actuator path, Phase 6/7).
+
+## Design decisions
+
+- **Deterministic next-action (no LLM yet).** A pure `next_action.py` maps a loop to its best
+  prepared move (proposal → `approve_proposal`; owned action → `create_issue` draft; unowned →
+  `assign_owner`; `needs_review` → `review_draft`). The LLM-drafted version is Phase 7.
+- **Routes follow the repo seam:** `build_cadence_router(ctx) -> APIRouter`, handlers call
+  `get_database()` directly (like the meetings/activity routers), registered in `web_server.py`.
+- **Egress honesty:** every loop/response carries `egress: {scope, label}` (Phase 2 reads are
+  `local`); the page renders it via `web/src/scripts/egress-badge.js`. **Card CSS is `<style
+  is:global>`** (the Astro-scoped-CSS gotcha — scoped CSS never reaches JS-injected DOM,
+  [[reference_astro_scoped_css_js_dom]]).
+
+## Stories
+
+| ID | Title | Status |
+|----|-------|--------|
+| CAD-2-01 | Deterministic next-action generator (`cadence/next_action.py`) | done |
+| CAD-2-02 | `/api/cadence/*` routes (status, loops, loop detail, run-now) | done |
+| CAD-2-03 | Lifecycle actions (snooze / kill / close) + audit-honest responses | done |
+| CAD-2-04 | The `/cadence` coach page (Now + Open loops + Policy) with egress badges | done |
+| CAD-2-05 | Tests: next-action unit, route integration, page preflight | done |
+
+## Where we are
+
+**Phase 2 is complete.** `cadence/next_action.py` maps each loop to its prepared move
+(proposal→approve, owned action→issue draft, unowned→assign, needs_review→review). The
+`build_cadence_router` (`web/routes/cadence.py`, registered in `web_server.py`) exposes
+`status`/`loops`/`loops/{id}`/`run-now` + lifecycle `snooze`/`kill`/`close`, each loop carrying its
+evidence, the next action, and a `local` egress badge. The `/cadence` page (`cadence.astro` +
+`cadence-app.js`, served from `pages.py`) renders *Now* + *Open loops* with deep-link evidence,
+egress chips, and one-tap snooze/done/kill — all loop text via `textContent` (source is data, never
+markup). **Proof:** 137 tests green (`test_cadence_next_action`, `test_cadence_routes`,
+`TestCadenceUiSmoke`, + the full web-server suite); the web bundle builds (15 pages); the Phase-1
+no-side-effects guard still passes.
+
+**Next: Phase 3 (agent-blocker push)** — awaiting-response coding-agent sessions → loops + a prepared
+reply, delivered via the tmux/`/api/dictation/remote` path.
+
+## Exit criteria
+
+- `GET /api/cadence/loops` returns scored loops with evidence + a prepared next action; lifecycle
+  POSTs mutate and reflect honestly; `POST /api/cadence/run-now` projects.
+- `/cadence` loads, lists due + open loops with working evidence deep-links + egress badges, and the
+  snooze/kill/close buttons drive the API.
+- No autonomous external side effect (the Phase-1 guard still passes; the page never executes a
+  connector — a next-action is a draft until the actuator path).
+- `uv run pytest -q` green; the web bundle builds.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-2-web-coach/evidence-phase-2.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-2-web-coach/evidence-phase-2.md
@@ -1,0 +1,43 @@
+# Evidence — Cadence Phase 2 (the web coach surface)
+
+**Date:** 2026-06-28. **Branch:** `holdspeak/cadence-phase2-web`.
+
+## What shipped
+
+| Story | Files | Proof |
+|-------|-------|-------|
+| CAD-2-01 | `cadence/next_action.py` | `tests/unit/test_cadence_next_action.py` (6) |
+| CAD-2-02/03 | `web/routes/cadence.py` + `web_server.py` + `web/routes/__init__.py` | `tests/integration/test_cadence_routes.py` (5) |
+| CAD-2-04 | `web/src/pages/cadence.astro` + `web/src/scripts/cadence-app.js` + `web/routes/pages.py` (`/cadence`) | `TestCadenceUiSmoke` (2) |
+| CAD-2-05 | the tests above | all green |
+
+## The surface
+
+- **`/api/cadence/*`** — `GET status`, `GET loops?all=`, `GET loops/{id}`, `POST run-now`, and the
+  lifecycle `POST loops/{id}/{snooze,kill,close}`. Every loop response carries its `evidence` (with
+  deep links), a deterministic `next_action`, and an honest `egress: {scope:"local"}` badge. A
+  **killed** loop survives re-projection through the route (`test_kill_survives_reprojection_via_route`).
+- **`next_action.py`** (deterministic, no LLM) — proposal→`approve_proposal`, owned action→
+  `create_issue` draft (body cites owner/due/source), unowned→`assign_owner`, `needs_review`→
+  `review_draft`, agent_question→`reply_to_agent`. The "next decision is cheap" promise, the LLM
+  draft deferred to Phase 7.
+- **`/cadence` page** — *Now* (top pushable loops) + *Open loops*, each card showing the score, the
+  source/owner/review chips, the **prepared next move** in an accent callout, evidence deep-links,
+  the egress chip, and one-tap **Snooze / Mark done / Kill loop**. A *Run now* button re-projects.
+  All loop text is rendered with **`textContent`** (titles come from transcripts — source is data,
+  never markup; the prompt-injection rule). Card CSS is `<style is:global>` (the Astro-scoped-CSS
+  gotcha — scoped CSS never reaches JS-injected DOM).
+
+## Trust boundary held
+
+No autonomous external side effect: lifecycle actions are local `cadence_*` writes; a `next_action`
+that maps to a connector is a **draft** (executing it remains the actuator approve→execute path,
+Phase 6/7). The Phase-1 `test_cadence_package_has_no_external_side_effects` guard still passes
+(`next_action.py` added no forbidden call).
+
+## Proof
+
+- `uv run pytest -q tests/unit/test_cadence_*.py tests/integration/test_cadence_*.py
+  tests/integration/test_web_server.py` → **137 passed.**
+- `cd web && npm run build` → **15 pages** built (the `/cadence` page compiles; `cadence-app.js`
+  bundles with its `egress-badge.js` import).

--- a/tests/integration/test_cadence_routes.py
+++ b/tests/integration/test_cadence_routes.py
@@ -1,0 +1,85 @@
+"""CAD-2-02/03 — the /api/cadence/* routes over the Phase-1 substrate."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from holdspeak.db import get_database, reset_database
+from holdspeak.web.context import WebContext
+from holdspeak.web.routes.cadence import build_cadence_router
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    reset_database()
+    db = get_database(tmp_path / "routes.db")
+    with db._connection() as c:
+        c.execute("INSERT INTO meetings (id, title, started_at, created_at) "
+                  "VALUES ('m1','Platform sync','2026-06-27T14:00:00','2026-06-27T14:00:00')")
+        c.execute("INSERT INTO action_items (id, meeting_id, task, owner, due, status, review_state, created_at) "
+                  "VALUES ('a1','m1','File the watchdog issue','Karol','2026-06-30','pending','reviewed','2026-06-26T10:00:00')")
+    db.actuators.record_proposal(
+        meeting_id="m1", window_id="m1:aftercare", plugin_id="github_issue_actuator",
+        plugin_version="1.0", idempotency_key="k1", target="github", action="create_issue",
+        preview="Create issue: watchdog around intel queue", reversible=False,
+    )
+    app = FastAPI()
+    app.include_router(build_cadence_router(WebContext(get_state=lambda: {})))
+    yield TestClient(app), db
+    reset_database()
+
+
+def test_status_is_off_by_default(client):
+    c, _ = client
+    r = c.get("/api/cadence/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["enabled"] is False
+    assert body["egress"] == {"scope": "local", "label": "Local only"}
+
+
+def test_run_now_then_loops_carry_evidence_and_next_action(client):
+    c, _ = client
+    assert c.post("/api/cadence/run-now").json()["projected"] == 2
+    loops = c.get("/api/cadence/loops").json()["loops"]
+    assert len(loops) == 2
+    top = loops[0]
+    assert top["evidence"] and top["evidence"][0]["deep_link"]
+    assert top["next_action"]["kind"] in ("approve_proposal", "create_issue")
+    assert top["egress"]["scope"] == "local"
+
+
+def test_loop_detail_404_then_ok(client):
+    c, _ = client
+    assert c.get("/api/cadence/loops/nope").status_code == 404
+    c.post("/api/cadence/run-now")
+    loop_id = c.get("/api/cadence/loops").json()["loops"][0]["id"]
+    assert c.get(f"/api/cadence/loops/{loop_id}").json()["id"] == loop_id
+
+
+def test_snooze_kill_close_mutate(client):
+    c, db = client
+    c.post("/api/cadence/run-now")
+    loop_id = c.get("/api/cadence/loops").json()["loops"][0]["id"]
+
+    snoozed = c.post(f"/api/cadence/loops/{loop_id}/snooze", json={"hours": 2}).json()
+    assert snoozed["status"] == "snoozed" and snoozed["snoozed_until"]
+
+    killed = c.post(f"/api/cadence/loops/{loop_id}/kill").json()
+    assert killed["status"] == "killed"
+    # killed loop drops out of the default (non-terminal) listing
+    open_ids = [l["id"] for l in c.get("/api/cadence/loops").json()["loops"]]
+    assert loop_id not in open_ids
+    assert loop_id in [l["id"] for l in c.get("/api/cadence/loops?all=true").json()["loops"]]
+
+
+def test_kill_survives_reprojection_via_route(client):
+    c, _ = client
+    c.post("/api/cadence/run-now")
+    loop_id = c.get("/api/cadence/loops").json()["loops"][0]["id"]
+    c.post(f"/api/cadence/loops/{loop_id}/kill")
+    c.post("/api/cadence/run-now")  # re-project
+    assert c.get(f"/api/cadence/loops/{loop_id}").json()["status"] == "killed"

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -1866,6 +1866,32 @@ class TestCompanionUiSmoke:
 
 
 @pytest.mark.integration
+class TestCadenceUiSmoke:
+    """CAD-2-04 — the /cadence coach page serves and drives /api/cadence/*."""
+
+    def test_cadence_page_serves_with_sections(self, test_client):
+        response = test_client.get("/cadence")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        html = response.text
+        for marker in ("Cadence", "Open loops", "off by default"):
+            assert marker in html, f"missing cadence page marker: {marker}"
+
+    def test_cadence_page_js_calls_the_api(self, test_client):
+        import re
+
+        html = test_client.get("/cadence").text
+        chunks = re.findall(r'src="(/_built/_astro/[^"]+\.js)"', html)
+        assert chunks, "expected a bundled JS chunk reference on /cadence"
+        js = "".join(test_client.get(src).text for src in set(chunks))
+        # The bundler splits `${API}/status` into the base + the suffix, so assert the
+        # base path and each action segment (not the concatenated whole).
+        assert "/api/cadence" in js, "cadence page JS missing the API base path"
+        for segment in ("/status", "/loops", "/run-now", "/snooze"):
+            assert segment in js, f"cadence page JS missing API segment: {segment}"
+
+
+@pytest.mark.integration
 class TestSettingsApiEndpoints:
     """Tests for web settings API."""
 

--- a/tests/unit/test_cadence_next_action.py
+++ b/tests/unit/test_cadence_next_action.py
@@ -1,0 +1,45 @@
+"""CAD-2-01 — the deterministic next-action generator."""
+from __future__ import annotations
+
+from holdspeak.cadence.models import EvidenceRef, OpenLoop
+from holdspeak.cadence.next_action import generate_next_action
+
+
+def _loop(**kw) -> OpenLoop:
+    return OpenLoop(source_type=kw.pop("source_type", "meeting_action"),
+                    source_id=kw.pop("source_id", "x"), title=kw.pop("title", "Ship the thing"),
+                    id=kw.pop("id", "L1"), **kw)
+
+
+def test_owned_action_drafts_an_issue_with_source():
+    loop = _loop(owner="Karol", due_at="2026-06-30", project="holdspeak",
+                 evidence=[EvidenceRef(kind="action_item", ref_id="a1", label="Standup",
+                                       deep_link="/meetings/m1#ai-a1")])
+    na = generate_next_action(loop)
+    assert na.kind == "create_issue" and na.reversible is False
+    assert "Owner: Karol" in na.body_markdown and "/meetings/m1#ai-a1" in na.body_markdown
+
+
+def test_unowned_action_asks_to_assign_owner():
+    na = generate_next_action(_loop(owner=None))
+    assert na.kind == "assign_owner" and na.reversible is True
+
+
+def test_proposal_maps_to_approve():
+    na = generate_next_action(_loop(source_type="proposal", title="Create issue: watchdog"))
+    assert na.kind == "approve_proposal" and na.reversible is False
+
+
+def test_needs_review_maps_to_review_regardless_of_source():
+    na = generate_next_action(_loop(source_type="meeting_action", owner="Karol", needs_review=True))
+    assert na.kind == "review_draft" and na.reversible is True
+
+
+def test_agent_question_maps_to_reply():
+    na = generate_next_action(_loop(source_type="agent_question", title="SQLite or config?"))
+    assert na.kind == "reply_to_agent"
+
+
+def test_generator_is_deterministic():
+    loop = _loop(owner="Karol")
+    assert generate_next_action(loop).kind == generate_next_action(loop).kind

--- a/web/src/pages/cadence.astro
+++ b/web/src/pages/cadence.astro
@@ -1,0 +1,123 @@
+---
+// The Cadence coach (CAD-2-04). A read-only-by-default surface over the cadence
+// substrate: what's pressing now (with the prepared next move), the open loops, and
+// the policy. All loop text is rendered by cadence-app.js with textContent (source
+// text is data, never markup). Card CSS is `is:global` so it reaches the JS-injected
+// DOM — the standing Astro-scoped-CSS gotcha.
+import AppLayout from "../layouts/AppLayout.astro";
+---
+
+<AppLayout title="HoldSpeak Cadence">
+  <div class="cadence">
+    <header class="page-head">
+      <div>
+        <h1>Cadence</h1>
+        <p class="sub">
+          Open loops from your meetings and proposals, each with a prepared next move.
+          Local-only and off by default — nothing is pushed or sent without you.
+        </p>
+        <p class="cad-policy" id="cad-policy"></p>
+      </div>
+      <button class="cad-run" id="cad-run-now" type="button">Run now</button>
+    </header>
+
+    <section class="cad-section">
+      <h2>Now</h2>
+      <div id="cad-now" class="cad-list"></div>
+    </section>
+
+    <section class="cad-section">
+      <h2>Open loops</h2>
+      <div id="cad-loops" class="cad-list"></div>
+    </section>
+  </div>
+
+  <script>
+    import { initCadence } from "../scripts/cadence-app.js";
+    initCadence();
+  </script>
+</AppLayout>
+
+<style is:global>
+  /* `is:global` so these reach the cards cadence-app.js injects at runtime. */
+  .cadence { max-width: 80rem; margin: 0 auto; padding: 1.5rem 1.25rem 4rem; }
+  .cadence .page-head {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    gap: 1rem; margin-bottom: 1.5rem;
+  }
+  .cadence .page-head h1 { margin: 0 0 0.35rem; }
+  .cadence .sub { margin: 0; color: var(--color-text-muted, #9c93a8); max-width: 46rem; }
+  .cad-policy { margin: 0.5rem 0 0; font-size: 0.82rem; color: var(--color-text-faint, #6f6880); }
+  .cad-run {
+    flex: none; cursor: pointer; font-weight: 700; color: #0b0d12;
+    background: var(--color-accent, #ff6b35); border: 0; border-radius: 0.6rem;
+    padding: 0.6rem 1.1rem;
+  }
+  .cad-run:disabled { opacity: 0.6; cursor: default; }
+
+  .cad-section { margin-bottom: 2rem; }
+  .cad-section h2 {
+    font-size: 0.78rem; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--color-text-faint, #6f6880); margin: 0 0 0.75rem;
+  }
+  .cad-list { display: flex; flex-direction: column; gap: 0.85rem; }
+  .cad-empty { color: var(--color-text-faint, #6f6880); font-size: 0.9rem; margin: 0; }
+
+  .cad-card {
+    background: var(--color-surface-1, rgba(255,255,255,0.04));
+    border: 1px solid var(--color-line, rgba(255,255,255,0.09));
+    border-radius: 0.85rem; padding: 1rem 1.1rem;
+  }
+  .cad-card.is-review { opacity: 0.82; }
+  .cad-card-head { display: flex; align-items: flex-start; gap: 0.8rem; }
+  .cad-score {
+    flex: none; font-weight: 800; font-variant-numeric: tabular-nums;
+    color: var(--color-accent, #ff6b35); min-width: 2.2rem; font-size: 1.1rem;
+  }
+  .cad-title-wrap { flex: 1 1 auto; min-width: 0; }
+  .cad-title { margin: 0 0 0.3rem; font-size: 1.02rem; }
+  .cad-meta { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
+  .cad-badge, .cad-owner, .cad-review {
+    font-size: 0.7rem; font-weight: 700; letter-spacing: 0.04em;
+    padding: 0.1rem 0.45rem; border-radius: 999px;
+  }
+  .cad-badge { background: rgba(91,141,239,0.16); color: #8fb4ff; text-transform: uppercase; }
+  .cad-owner { background: rgba(62,207,142,0.14); color: #5fd6a0; }
+  .cad-review { background: rgba(246,195,86,0.16); color: #f6c356; }
+
+  .cad-next {
+    margin-top: 0.8rem; padding: 0.7rem 0.85rem;
+    background: rgba(255,107,53,0.07); border: 1px solid rgba(255,107,53,0.22);
+    border-radius: 0.6rem;
+  }
+  .cad-next-label {
+    font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--color-accent, #ff6b35); margin-bottom: 0.25rem;
+  }
+  .cad-next-title { font-weight: 700; }
+  .cad-next-body {
+    margin: 0.4rem 0 0; white-space: pre-wrap; font-family: inherit;
+    font-size: 0.85rem; color: var(--color-text-muted, #9c93a8);
+  }
+
+  .cad-evidence { margin-top: 0.7rem; display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; }
+  .cad-evidence-label {
+    font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--color-text-faint, #6f6880);
+  }
+  .cad-evidence-link {
+    font-size: 0.82rem; color: #8fb4ff; text-decoration: none;
+    border-bottom: 1px dashed rgba(143,180,255,0.45);
+  }
+  .cad-evidence-link:hover { border-bottom-style: solid; }
+
+  .cad-actions { margin-top: 0.85rem; display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .cad-btn {
+    cursor: pointer; font-size: 0.82rem; font-weight: 600;
+    color: var(--color-text, #f4ece0);
+    background: rgba(255,255,255,0.06); border: 1px solid var(--color-line, rgba(255,255,255,0.1));
+    border-radius: 0.5rem; padding: 0.4rem 0.75rem;
+  }
+  .cad-btn:hover { background: rgba(255,255,255,0.1); }
+  .cad-btn-danger { color: #ff8a8a; border-color: rgba(255,77,109,0.3); }
+</style>

--- a/web/src/scripts/cadence-app.js
+++ b/web/src/scripts/cadence-app.js
@@ -1,0 +1,170 @@
+// The Cadence coach (CAD-2-04). Reads /api/cadence/* and renders the open loops
+// with their prepared next action, evidence deep-links, and an egress badge.
+//
+// SECURITY: loop titles/bodies derive from meeting transcripts (untrusted), so every
+// piece of source text is written with textContent — never innerHTML. Source text is
+// data, never markup (the cadence prompt-injection rule).
+import { renderEgressBadge } from "./egress-badge.js";
+
+const API = "/api/cadence";
+
+async function jget(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`${url} → ${r.status}`);
+  return r.json();
+}
+async function jpost(url, body) {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : "{}",
+  });
+  if (!r.ok) throw new Error(`${url} → ${r.status}`);
+  return r.json();
+}
+
+function el(tag, cls, text) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text != null) e.textContent = text;
+  return e;
+}
+
+function egressChip(badge) {
+  const chip = el("span", "egress-badge");
+  renderEgressBadge(chip, badge || { scope: "local", label: "Local only" });
+  return chip;
+}
+
+function loopCard(loop) {
+  const card = el("article", "cad-card");
+  card.dataset.loopId = loop.id;
+  if (loop.needs_review) card.classList.add("is-review");
+
+  const head = el("div", "cad-card-head");
+  head.appendChild(el("span", "cad-score", loop.stale_score.toFixed(0)));
+  const titleWrap = el("div", "cad-title-wrap");
+  titleWrap.appendChild(el("h3", "cad-title", loop.title));
+  const meta = el("div", "cad-meta");
+  meta.appendChild(el("span", "cad-badge", loop.source_type.replace("_", " ")));
+  if (loop.owner) meta.appendChild(el("span", "cad-owner", loop.owner));
+  if (loop.needs_review) meta.appendChild(el("span", "cad-review", "needs review"));
+  titleWrap.appendChild(meta);
+  head.appendChild(titleWrap);
+  head.appendChild(egressChip(loop.egress));
+  card.appendChild(head);
+
+  // The prepared next move — the whole point: the next decision is cheap.
+  if (loop.next_action) {
+    const na = el("div", "cad-next");
+    na.appendChild(el("div", "cad-next-label", "Prepared next move"));
+    na.appendChild(el("div", "cad-next-title", loop.next_action.title));
+    if (loop.next_action.body_markdown) {
+      na.appendChild(el("pre", "cad-next-body", loop.next_action.body_markdown));
+    }
+    card.appendChild(na);
+  }
+
+  // Evidence — why this loop exists, with deep links.
+  if (loop.evidence && loop.evidence.length) {
+    const ev = el("div", "cad-evidence");
+    ev.appendChild(el("span", "cad-evidence-label", "Evidence"));
+    loop.evidence.forEach((e) => {
+      if (e.deep_link) {
+        const a = el("a", "cad-evidence-link", e.label || e.kind);
+        a.href = e.deep_link;
+        ev.appendChild(a);
+      } else {
+        ev.appendChild(el("span", "cad-evidence-link", e.label || e.kind));
+      }
+    });
+    card.appendChild(ev);
+  }
+
+  // One-tap decisions.
+  const actions = el("div", "cad-actions");
+  const snooze = el("button", "cad-btn", "Snooze 1d");
+  snooze.dataset.act = "snooze";
+  const close = el("button", "cad-btn", "Mark done");
+  close.dataset.act = "close";
+  const kill = el("button", "cad-btn cad-btn-danger", "Kill loop");
+  kill.dataset.act = "kill";
+  actions.append(snooze, close, kill);
+  card.appendChild(actions);
+
+  return card;
+}
+
+function emptyState(msg) {
+  return el("p", "cad-empty", msg);
+}
+
+async function refresh() {
+  const [status, loopsResp] = await Promise.all([
+    jget(`${API}/status`),
+    jget(`${API}/loops`),
+  ]);
+  const loops = loopsResp.loops || [];
+
+  // Policy summary.
+  const pol = document.getElementById("cad-policy");
+  if (pol) {
+    pol.textContent = "";
+    const q = status.quiet_hours;
+    const line = `${status.enabled ? "On" : "Off"} · ${status.pressure} · ` +
+      `quiet ${String(q.start).padStart(2, "0")}:00–${String(q.end).padStart(2, "0")}:00 · ` +
+      `max ${status.max_nudges_per_day}/day`;
+    pol.appendChild(el("span", null, line));
+  }
+
+  // "Now": the highest-staleness pushable loops (not needs_review).
+  const now = document.getElementById("cad-now");
+  const later = document.getElementById("cad-loops");
+  if (now) now.textContent = "";
+  if (later) later.textContent = "";
+
+  const pushable = loops.filter((l) => !l.needs_review);
+  const top = pushable.slice(0, 3);
+  const rest = loops.filter((l) => !top.includes(l));
+
+  if (now) {
+    if (top.length) top.forEach((l) => now.appendChild(loopCard(l)));
+    else now.appendChild(emptyState("Nothing pressing. Run a tick to refresh from your meetings."));
+  }
+  if (later) {
+    if (rest.length) rest.forEach((l) => later.appendChild(loopCard(l)));
+    else later.appendChild(emptyState("No other open loops."));
+  }
+}
+
+async function onAction(loopId, act) {
+  if (act === "snooze") await jpost(`${API}/loops/${loopId}/snooze`, { hours: 24 });
+  else if (act === "close") await jpost(`${API}/loops/${loopId}/close`);
+  else if (act === "kill") await jpost(`${API}/loops/${loopId}/kill`);
+  await refresh();
+}
+
+export function initCadence() {
+  const runBtn = document.getElementById("cad-run-now");
+  if (runBtn) {
+    runBtn.addEventListener("click", async () => {
+      runBtn.disabled = true;
+      runBtn.textContent = "Running…";
+      try {
+        await jpost(`${API}/run-now`);
+        await refresh();
+      } finally {
+        runBtn.disabled = false;
+        runBtn.textContent = "Run now";
+      }
+    });
+  }
+  document.addEventListener("click", (ev) => {
+    const btn = ev.target.closest("[data-act]");
+    if (!btn) return;
+    const card = btn.closest("[data-loop-id]");
+    if (!card) return;
+    onAction(card.dataset.loopId, btn.dataset.act).catch((e) => console.error(e));
+  });
+  refresh().catch((e) => console.error(e));
+}


### PR DESCRIPTION
**Cadence Engine — Phase 2 (the web coach surface).** Makes the Phase-1 substrate visible and
actionable in the local web runtime — still **off by default**, still **no autonomous external side
effect**. Builds on Phase 1 (#170).

## What's here

- **CAD-2-01 — `cadence/next_action.py`** (deterministic, no LLM): proposal→`approve_proposal`,
  owned action→`create_issue` draft (cites owner/due/source), unowned→`assign_owner`,
  `needs_review`→`review_draft`, agent→`reply_to_agent`. *The next decision is cheap.*
- **CAD-2-02/03 — `/api/cadence/*`**: `GET status|loops|loops/{id}`, `POST run-now`, and lifecycle
  `POST loops/{id}/snooze|kill|close`. Every loop carries its **evidence (deep links)**, a
  **next_action**, and an honest **egress badge**. Killed survives re-projection through the route.
- **CAD-2-04 — the `/cadence` page** (`cadence.astro` + `cadence-app.js`): *Now* + *Open loops*, each
  card with the score, source/owner/review chips, the **prepared next move** in an accent callout,
  evidence deep-links, the egress chip, and one-tap **Snooze / Mark done / Kill loop** + *Run now*.
  All loop text via `textContent` (source is data, never markup); card CSS is `<style is:global>`.
- **CAD-2-05** — next-action unit + route integration (incl. kill-survives-via-route) + a `/cadence`
  page smoke (serves + the bundled JS calls `/api/cadence/*`).

## Trust boundary held

Lifecycle actions are local `cadence_*` writes; a next-action that maps to a connector is a **draft**
(executing it stays the actuator approve→execute path, Phase 6/7). The Phase-1
no-external-side-effects guard still passes.

## Proof

- **137** tests passed (cadence + the full web-server suite).
- `cd web && npm run build` → **15 pages** (the `/cadence` page compiles; `cadence-app.js` bundles).

Next: **Phase 3** — agent-blocker push (awaiting coding-agent → loop + prepared reply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)