### PR TITLE
Cadence Engine Phase 3: agent-blocker push

### DIFF
--- a/holdspeak/cadence/collector.py
+++ b/holdspeak/cadence/collector.py
@@ -11,9 +11,20 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
+import os
+
 from .models import EvidenceRef, OpenLoop
 from .projects import resolve_project
 from .scoring import LoopSignals, score_loop
+
+
+def _first_line(text: str, *, limit: int = 120) -> str:
+    line = (text or "").strip().splitlines()[0].strip() if (text or "").strip() else ""
+    return line[:limit]
+
+
+def _basename(path) -> str:
+    return os.path.basename(str(path).rstrip("/")) if path else ""
 
 # Below this review confidence an extracted action becomes a quiet `needs_review`
 # loop (surfaced, never pushed) rather than a normal loop (chart §3.6). Phase 1
@@ -32,7 +43,49 @@ class LoopCollector:
         loops: list[OpenLoop] = []
         loops += self._collect_meeting_actions(now)
         loops += self._collect_pending_proposals(now)
+        loops += self._collect_agent_questions(now)
         return loops
+
+    # ── awaiting coding-agent sessions (CAD-3-01) ───────────────────────────
+    def _collect_agent_questions(self, now: datetime) -> list[OpenLoop]:
+        """Mirror awaiting Claude/Codex sessions into top-scored agent_question loops.
+
+        READ ONLY — reads the agent-session capture file; the reply DELIVERY is a
+        route concern (`send_text_to_pane`), never this package.
+        """
+        try:
+            from ..agent_context import list_recent_awaiting_agent_sessions
+            sessions = list_recent_awaiting_agent_sessions()
+        except Exception:
+            return []
+        present_ids: list[str] = []
+        out = []
+        for s in sessions:
+            present_ids.append(s.session_id)
+            question = (s.last_assistant_text or "").strip()
+            loop = OpenLoop(
+                source_type="agent_question",
+                source_id=s.session_id,
+                title=_first_line(question) or f"{s.agent} is waiting on you",
+                summary=f"{s.agent} · {s.project_name or _basename(s.repo_root) or s.cwd}",
+                project=resolve_project(explicit=s.project_name, repo_root=s.repo_root or s.cwd),
+                priority="urgent",  # a blocked agent is the top signal
+                owner="you",
+                evidence=[
+                    EvidenceRef(
+                        kind="agent_session",
+                        ref_id=s.session_id,
+                        label=f"{s.agent} session",
+                        timestamp=s.updated_at,
+                        deep_link="/cadence",  # the reply composer lives on the coach page
+                    )
+                ],
+            )
+            saved = self._db.cadence.upsert_loop(loop)
+            self._score(saved, now, LoopSignals())
+            out.append(saved)
+        self._db.cadence.close_missing("agent_question", present_ids)
+        return out
 
     # ── meeting action items ────────────────────────────────────────────────
     def _collect_meeting_actions(self, now: datetime) -> list[OpenLoop]:

--- a/holdspeak/cadence/next_action.py
+++ b/holdspeak/cadence/next_action.py
@@ -45,11 +45,13 @@ def _decide(loop: OpenLoop):
             False,
         )
     if src == "agent_question":
+        where = loop.summary or loop.project or "your terminal"
         return (
             "reply_to_agent",
             f"Reply to the waiting agent: {loop.title}",
-            "A coding agent is blocked on your answer. Review the suggested reply, edit if needed, "
-            "and send.",
+            f"A coding agent ({where}) is blocked on your answer:\n\n> {loop.title}\n\n"
+            "Type your reply on the cadence page — it is sent into the agent's terminal pane. "
+            "Never autonomous: nothing is sent until you press Send.",
             False,
         )
     if src in ("meeting_action", "manual"):

--- a/holdspeak/web/routes/cadence.py
+++ b/holdspeak/web/routes/cadence.py
@@ -124,6 +124,43 @@ def build_cadence_router(ctx: WebContext) -> APIRouter:
         db.cadence.set_status(loop_id, "closed")
         return _loop_dict(db.cadence.get_loop(loop_id))
 
+    @router.post("/loops/{loop_id}/reply")
+    async def reply_to_agent(loop_id: str, body: dict = Body(default={})) -> dict[str, Any]:
+        """Deliver a USER-TYPED reply into a waiting agent's terminal (CAD-3-03).
+
+        Never autonomous: requires an explicit non-empty `text`. Only valid for an
+        `agent_question` loop whose session still has a tmux pane. The delivery uses
+        the existing `send_text_to_pane` transport — the side effect lives HERE, not in
+        the cadence package (which the no-side-effects guard keeps clean).
+        """
+        db, loop = _require(loop_id)
+        if loop.source_type != "agent_question":
+            raise HTTPException(status_code=400, detail="not an agent loop")
+        text = str(body.get("text", "")).strip()
+        if not text:
+            raise HTTPException(status_code=400, detail="reply text is required")
+
+        from ...agent_context import list_recent_awaiting_agent_sessions
+        from ...tmux_transport import TmuxTransportError, send_text_to_pane
+
+        session = next(
+            (s for s in list_recent_awaiting_agent_sessions() if s.session_id == loop.source_id),
+            None,
+        )
+        pane = getattr(session, "tmux_pane", None) if session else None
+        if not pane:
+            raise HTTPException(status_code=409, detail="no terminal pane for this agent session")
+        try:
+            delivery = send_text_to_pane(pane=pane, text=text, submit=True)
+        except TmuxTransportError as exc:
+            raise HTTPException(status_code=502, detail=f"delivery failed: {exc}") from exc
+
+        # The reply answers the agent — close the loop (its question is handled).
+        db.cadence.set_status(loop_id, "closed")
+        db.cadence.bump_nudge(loop_id)
+        return {"delivered": True, "pane": delivery.pane, "submitted": delivery.submitted,
+                "egress": _LOCAL_EGRESS}
+
     @router.post("/run-now")
     async def run_now() -> dict[str, Any]:
         from ...cadence.service import CadenceService

--- a/pm/roadmap/holdspeak/cadence-engine/README.md
+++ b/pm/roadmap/holdspeak/cadence-engine/README.md
@@ -6,13 +6,14 @@
 > ready-made next move.
 
 **Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phases 1
-(cadence core) + 2 (the web coach surface) are COMPLETE** (`holdspeak cadence run-now` projects
-scored loops; the `/cadence` page shows them with prepared next moves + one-tap decisions, off by
-default). **Phase 3 (agent-blocker push) is next.** Phases 4–8 are sketched here and storied as each
-becomes the lead.
+(cadence core), 2 (web coach surface), and 3 (agent-blocker push) are COMPLETE** — `holdspeak cadence
+run-now` projects scored loops; the `/cadence` page shows them with prepared next moves + one-tap
+decisions; and an awaiting Claude/Codex session becomes a top loop you can answer (the reply lands in
+its terminal). Off by default throughout. **Phase 4 (Telegram remote presence) is next.** Phases 5–8
+are sketched here and storied as each becomes the lead.
 
-**Last updated:** 2026-06-28 (Phase 2 shipped — `/api/cadence/*` + the `/cadence` coach page;
-137 cadence/web tests green. Phase 1: the loop/scoring/policy/CLI substrate. Program authored from
+**Last updated:** 2026-06-28 (Phase 3 shipped — awaiting agent sessions → loops + a terminal-delivered
+reply; 141 cadence/web tests green. Phases 1–2: the substrate + the web coach. Program authored from
 the owner's rough design + a grounded seam map; §15 resolved below).
 
 ---
@@ -117,7 +118,7 @@ Phase 1 leads and is fully storied. Each later phase is storied when it becomes 
 |-------|-------|----------|------------|
 | **1 ✅** | **Cadence core** | *Done.* The loop/nudge/policy substrate: models, migrations, collector (meeting actions + pending proposals), stale-scoring v1, policies + quiet hours, CLI, unit tests. No external side effects, off by default. | — |
 | **2 ✅** | Web coach surface | *Done.* `/api/cadence/*` + a `/cadence` page: loops, evidence deep-links, snooze/kill/close, deterministic next-action, egress badges. | 1 |
-| **3** | Agent-blocker push | Awaiting-response agent sessions → loops + a prepared reply; tmux/`/api/dictation/remote` delivery as a nudge action. | 1 |
+| **3 ✅** | Agent-blocker push | *Done.* Awaiting-response agent sessions → top loops + a reply composer; the typed reply is delivered into the agent's tmux pane (`send_text_to_pane`, in the route — never autonomous). | 1 |
 | **4** | Telegram remote presence | Pairing + a Telegram surface; `/brief` `/loops` `/agents`; inline-button decisions wired to the cadence API; unpaired-chat rejection; second-confirm for irreversible actions. | 2, 3 |
 | **5** | Daily push brief | A deterministic morning brief (first-activity trigger) with prepared moves; LLM wording behind a capability gate (policy never model-driven). | 2 |
 | **6** | Stale-loop + EOD closure | Escalation policy + an end-of-day closure ritual + batch closure UI; accepted-action → issue proposals; kill/delegate/snooze semantics. | 2, 5 |

--- a/pm/roadmap/holdspeak/cadence-engine/phase-3-agent-blocker/current-phase-status.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-3-agent-blocker/current-phase-status.md
@@ -1,0 +1,66 @@
+# Cadence Phase 3 — Agent-blocker push
+
+**Status:** done (built + tested; 141 cadence/web tests green, web bundle builds). **Start here:**
+`../README.md`. Builds on Phases 1–2 (merged).
+
+**Last updated:** 2026-06-28 (Phase 3 shipped: awaiting agent sessions → top loops + a reply
+delivered into the agent's terminal from the cadence page, never autonomous).
+
+## Objective
+
+The highest-leverage cadence signal: when a coding agent (Claude/Codex) is **awaiting your
+response**, surface it as a loop with the question + its context, and let you **reply from the
+cadence surface** — the reply delivered into the agent's tmux pane via the existing transport. This
+is the one place cadence performs a (user-initiated, never autonomous) delivery, and it does so
+through the existing seam **outside** the cadence package (so the no-side-effects guard stays green).
+
+## Design decisions
+
+- **Read, don't capture.** The collector reads awaiting sessions via
+  `agent_context.list_recent_awaiting_agent_sessions()` and mirrors them into `agent_question`
+  loops (chart §3.2: mirror, don't migrate). `source_id = session_id`. Scoring already gives
+  `agent_question` the top boost.
+- **Delivery lives in the route, not the package.** `POST /api/cadence/loops/{id}/reply` resolves the
+  session and calls `tmux_transport.send_text_to_pane(...)` — the existing mechanism. The
+  `holdspeak/cadence/` package never imports tmux/subprocess (the Phase-1 guard forbids it). The
+  reply is **user-typed and explicit** — never autonomous, never auto-drafted (the LLM draft is
+  Phase 7).
+- **Honest egress + safety.** A reply leaves the cadence surface for your *local* terminal (tmux on
+  this machine) — egress stays `local`. Reply requires a non-empty body and a resolvable pane;
+  missing tmux is a clear error, never a silent drop.
+
+## Stories
+
+| ID | Title | Status |
+|----|-------|--------|
+| CAD-3-01 | Collector: awaiting agent sessions → `agent_question` loops (with context evidence) | done |
+| CAD-3-02 | Enrich the `reply_to_agent` next-action with the question + cwd/repo context | done |
+| CAD-3-03 | `POST /api/cadence/loops/{id}/reply` — deliver a typed reply via `send_text_to_pane` | done |
+| CAD-3-04 | The `/cadence` agent card: a reply composer (textarea + Send) | done |
+| CAD-3-05 | Tests: collector over a fake session state; reply route (mocked transport); guard green | done |
+
+## Where we are
+
+**Phase 3 is complete.** The collector's `_collect_agent_questions` mirrors
+`list_recent_awaiting_agent_sessions()` into **urgent** `agent_question` loops (the scorer already
+ranks them top), each with the question as the title + an `agent_session` evidence ref. The
+`reply_to_agent` next-action surfaces the question + where the agent is. `POST
+/api/cadence/loops/{id}/reply` delivers a **user-typed** reply into the session's tmux pane via the
+existing `send_text_to_pane` transport (the side effect lives in the route, not the package) and
+closes the loop; it refuses an empty body / a non-agent loop / a missing pane — never autonomous.
+The `/cadence` agent card shows a reply composer. **Proof:** 141 tests green
+(`test_cadence_agent` + the full cadence/web-server suites); the Phase-1 no-side-effects guard still
+passes; the web bundle builds.
+
+**Next: Phase 4 (Telegram remote presence)** — pairing + a Telegram surface delivering nudges and
+receiving decisions, with unpaired-chat rejection and a second-confirm for irreversible actions.
+
+## Exit criteria
+
+- An awaiting Claude/Codex session appears as a top-scored `agent_question` loop with the question
+  text + a `agent_session` evidence ref.
+- `POST /api/cadence/loops/{id}/reply {text}` delivers into the pane (mocked in tests) and is a no-op
+  error for a non-agent loop / empty text / missing pane.
+- The `/cadence` agent card shows the question + context + a reply box that drives the route.
+- The Phase-1 no-external-side-effects guard still passes (the package stays clean); `uv run pytest
+  -q` green; the web bundle builds.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-3-agent-blocker/evidence-phase-3.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-3-agent-blocker/evidence-phase-3.md
@@ -1,0 +1,40 @@
+# Evidence — Cadence Phase 3 (agent-blocker push)
+
+**Date:** 2026-06-28. **Branch:** `holdspeak/cadence-phase3-agent`.
+
+## What shipped
+
+| Story | Files | Proof |
+|-------|-------|-------|
+| CAD-3-01 | `cadence/collector.py` (`_collect_agent_questions`) | `test_cadence_agent.py` (2) |
+| CAD-3-02 | `cadence/next_action.py` (enriched `reply_to_agent`) | covered by routes/page |
+| CAD-3-03 | `web/routes/cadence.py` (`POST /loops/{id}/reply`) | `test_cadence_agent.py` (2) |
+| CAD-3-04 | `web/src/scripts/cadence-app.js` + `cadence.astro` (reply composer) | bundle builds |
+| CAD-3-05 | the tests above + the guard | 8 green incl. guard |
+
+## The capability
+
+- **Collector** mirrors `agent_context.list_recent_awaiting_agent_sessions()` into **urgent**
+  `agent_question` loops keyed by `session_id`, with the question as the title and an `agent_session`
+  evidence ref. The scorer's top `agent_question` weight makes a blocked agent the #1 loop
+  (`test_collector_projects_awaiting_agent_as_top_loop`). When the agent stops awaiting, its loop
+  closes on the next collect (`test_answered_agent_closes_its_loop_on_recollect`).
+- **Reply route** `POST /api/cadence/loops/{id}/reply {text}` resolves the session, delivers the
+  **user-typed** reply into its tmux pane via the existing `send_text_to_pane`, then closes the loop.
+  It refuses an empty body (400), a non-agent loop (400), and a missing pane/session (409) — and
+  delivers nothing in those cases (`test_reply_rejects_empty_and_non_agent_and_missing_pane`). Never
+  autonomous: the reply is only ever the explicit text the user submitted.
+- **Page** — agent cards render a reply textarea + Send that drives the route.
+
+## Trust boundary held
+
+The delivery side effect lives in the **route** (`send_text_to_pane`); the `holdspeak/cadence/`
+package only *reads* sessions. The Phase-1 `test_cadence_package_has_no_external_side_effects` guard
+still passes (no tmux/subprocess/network in the package). Egress stays `local` (the reply goes to a
+terminal on this machine).
+
+## Proof
+
+- `uv run pytest -q tests/unit/test_cadence_*.py tests/integration/test_cadence_*.py
+  tests/integration/test_web_server.py` → **141 passed.**
+- `cd web && npm run build` → 15 pages (the `/cadence` page + the reply composer compile).

--- a/tests/integration/test_cadence_agent.py
+++ b/tests/integration/test_cadence_agent.py
@@ -1,0 +1,107 @@
+"""CAD-3 — agent-blocker push: collecting awaiting sessions + the reply route."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import holdspeak.agent_context as agent_context
+import holdspeak.tmux_transport as tmux_transport
+from holdspeak.cadence.collector import LoopCollector
+from holdspeak.cadence.models import EvidenceRef, OpenLoop
+from holdspeak.db import get_database, reset_database
+from holdspeak.web.context import WebContext
+from holdspeak.web.routes.cadence import build_cadence_router
+
+
+def _write_agent_state(path: Path, *, pane="editor:0.1", awaiting=True):
+    path.write_text(json.dumps({"sessions": {"sess-1": {
+        "agent": "codex", "session_id": "sess-1", "cwd": "/home/k/dev/holdspeak",
+        "updated_at": "2026-06-28T10:00:00+00:00", "hook_event_name": "Stop",
+        "repo_root": "/home/k/dev/holdspeak", "project_name": "holdspeak",
+        "awaiting_response": awaiting,
+        "last_assistant_text": "Should I store pairing state in SQLite or config?",
+        "tmux_pane": pane, "pinned": True,  # pinned = age-exempt, deterministic
+    }}}))
+
+
+@pytest.fixture
+def db(tmp_path: Path, monkeypatch):
+    reset_database()
+    monkeypatch.setattr(agent_context, "AGENT_CONTEXT_FILE", tmp_path / "agent_sessions.json")
+    yield get_database(tmp_path / "agent.db")
+    reset_database()
+
+
+def test_collector_projects_awaiting_agent_as_top_loop(db, tmp_path, monkeypatch):
+    _write_agent_state(tmp_path / "agent_sessions.json")
+    loops = LoopCollector(db).collect()
+    agent_loops = [l for l in loops if l.source_type == "agent_question"]
+    assert len(agent_loops) == 1
+    loop = agent_loops[0]
+    assert "SQLite or config" in loop.title
+    assert loop.priority == "urgent"
+    assert loop.evidence[0].kind == "agent_session"
+    # it should outrank a plain meeting action (the agent boost dominates)
+    assert db.cadence.list_loops()[0].source_type == "agent_question"
+
+
+def test_answered_agent_closes_its_loop_on_recollect(db, tmp_path):
+    _write_agent_state(tmp_path / "agent_sessions.json")
+    LoopCollector(db).collect()
+    loop = db.cadence.get_loop_by_source("agent_question", "sess-1")
+    # the agent is no longer awaiting (answered elsewhere) -> source vanishes -> closed
+    _write_agent_state(tmp_path / "agent_sessions.json", awaiting=False)
+    LoopCollector(db).collect()
+    assert db.cadence.get_loop_by_source("agent_question", "sess-1").status == "closed"
+    assert loop is not None
+
+
+@pytest.fixture
+def client(db, tmp_path, monkeypatch):
+    # seed an agent_question loop directly + a meeting_action loop (the non-agent case)
+    db.cadence.upsert_loop(OpenLoop(
+        source_type="agent_question", source_id="sess-1", title="SQLite or config?",
+        owner="you", priority="urgent",
+        evidence=[EvidenceRef(kind="agent_session", ref_id="sess-1", label="codex session")],
+    ))
+    db.cadence.upsert_loop(OpenLoop(source_type="meeting_action", source_id="a1", title="File it"))
+    app = FastAPI()
+    app.include_router(build_cadence_router(WebContext(get_state=lambda: {})))
+    return TestClient(app), db
+
+
+class _Sess:
+    session_id = "sess-1"
+    tmux_pane = "editor:0.1"
+
+
+def test_reply_delivers_into_pane_and_closes(client, monkeypatch):
+    c, db = client
+    sent = {}
+    monkeypatch.setattr(agent_context, "list_recent_awaiting_agent_sessions", lambda **k: [_Sess()])
+    monkeypatch.setattr(tmux_transport, "send_text_to_pane",
+                        lambda **kw: (sent.update(kw) or tmux_transport.TmuxDelivery(pane=kw["pane"], submitted=True)))
+    loop_id = db.cadence.get_loop_by_source("agent_question", "sess-1").id
+    r = c.post(f"/api/cadence/loops/{loop_id}/reply", json={"text": "Use SQLite; add a migration."})
+    assert r.status_code == 200 and r.json()["delivered"] is True
+    assert sent["pane"] == "editor:0.1" and "SQLite" in sent["text"]
+    assert db.cadence.get_loop(loop_id).status == "closed"  # question handled
+
+
+def test_reply_rejects_empty_and_non_agent_and_missing_pane(client, monkeypatch):
+    c, db = client
+    agent_id = db.cadence.get_loop_by_source("agent_question", "sess-1").id
+    action_id = db.cadence.get_loop_by_source("meeting_action", "a1").id
+    # empty text
+    assert c.post(f"/api/cadence/loops/{agent_id}/reply", json={"text": "  "}).status_code == 400
+    # non-agent loop
+    assert c.post(f"/api/cadence/loops/{action_id}/reply", json={"text": "hi"}).status_code == 400
+    # no resolvable pane / session
+    monkeypatch.setattr(agent_context, "list_recent_awaiting_agent_sessions", lambda **k: [])
+    assert c.post(f"/api/cadence/loops/{agent_id}/reply", json={"text": "hi"}).status_code == 409
+    # never autonomous: nothing delivered, loop stays open
+    assert db.cadence.get_loop(agent_id).status != "closed"

--- a/web/src/pages/cadence.astro
+++ b/web/src/pages/cadence.astro
@@ -120,4 +120,14 @@ import AppLayout from "../layouts/AppLayout.astro";
   }
   .cad-btn:hover { background: rgba(255,255,255,0.1); }
   .cad-btn-danger { color: #ff8a8a; border-color: rgba(255,77,109,0.3); }
+  .cad-btn-send { color: #0b0d12; background: var(--color-accent, #ff6b35); border-color: transparent; font-weight: 700; }
+
+  .cad-reply { margin-top: 0.85rem; display: flex; gap: 0.5rem; align-items: flex-start; }
+  .cad-reply-input {
+    flex: 1 1 auto; resize: vertical; min-height: 2.4rem;
+    color: var(--color-text, #f4ece0); background: rgba(0,0,0,0.25);
+    border: 1px solid var(--color-line, rgba(255,255,255,0.12)); border-radius: 0.5rem;
+    padding: 0.5rem 0.65rem; font: inherit; font-size: 0.88rem;
+  }
+  .cad-reply-input:focus { outline: none; border-color: var(--color-accent, #ff6b35); }
 </style>

--- a/web/src/scripts/cadence-app.js
+++ b/web/src/scripts/cadence-app.js
@@ -81,6 +81,19 @@ function loopCard(loop) {
     card.appendChild(ev);
   }
 
+  // An awaiting coding agent gets a reply composer — type and Send delivers the reply
+  // into its terminal pane (CAD-3-04). Never autonomous: nothing is sent until you click.
+  if (loop.source_type === "agent_question") {
+    const composer = el("div", "cad-reply");
+    const ta = el("textarea", "cad-reply-input");
+    ta.placeholder = "Type your reply to the agent…";
+    ta.rows = 2;
+    const send = el("button", "cad-btn cad-btn-send", "Send reply");
+    send.dataset.act = "reply";
+    composer.append(ta, send);
+    card.appendChild(composer);
+  }
+
   // One-tap decisions.
   const actions = el("div", "cad-actions");
   const snooze = el("button", "cad-btn", "Snooze 1d");
@@ -137,10 +150,16 @@ async function refresh() {
   }
 }
 
-async function onAction(loopId, act) {
+async function onAction(loopId, act, card) {
   if (act === "snooze") await jpost(`${API}/loops/${loopId}/snooze`, { hours: 24 });
   else if (act === "close") await jpost(`${API}/loops/${loopId}/close`);
   else if (act === "kill") await jpost(`${API}/loops/${loopId}/kill`);
+  else if (act === "reply") {
+    const ta = card && card.querySelector(".cad-reply-input");
+    const text = ta ? ta.value.trim() : "";
+    if (!text) return;
+    await jpost(`${API}/loops/${loopId}/reply`, { text });
+  }
   await refresh();
 }
 
@@ -164,7 +183,7 @@ export function initCadence() {
     if (!btn) return;
     const card = btn.closest("[data-loop-id]");
     if (!card) return;
-    onAction(card.dataset.loopId, btn.dataset.act).catch((e) => console.error(e));
+    onAction(card.dataset.loopId, btn.dataset.act, card).catch((e) => console.error(e));
   });
   refresh().catch((e) => console.error(e));
 }


### PR DESCRIPTION
**Cadence Engine — Phase 3 (agent-blocker push).** The highest-leverage signal: when a coding agent
(Claude/Codex) is **awaiting your response**, it becomes the **#1 loop**, and you can answer it from
the `/cadence` page — the reply delivered into its terminal. Still **off by default**, **never
autonomous**. Builds on Phases 1–2 (#170, #171).

## What's here

- **CAD-3-01 — collector:** `_collect_agent_questions` mirrors
  `agent_context.list_recent_awaiting_agent_sessions()` into **urgent** `agent_question` loops
  (`source_id = session_id`), the question as the title + an `agent_session` evidence ref. **Read
  only** — the package never touches tmux. A no-longer-awaiting session closes its loop on recollect.
- **CAD-3-02 — next-action:** `reply_to_agent` surfaces the question + where the agent is.
- **CAD-3-03 — `POST /api/cadence/loops/{id}/reply`:** delivers a **user-typed** reply into the
  session's tmux pane via the existing `send_text_to_pane` (the side effect lives in the **route**,
  not the cadence package), then closes the loop. Refuses empty text (400), a non-agent loop (400), a
  missing pane (409) — delivering nothing in those cases.
- **CAD-3-04 — the page:** agent cards get a reply composer (textarea + Send).
- **CAD-3-05 — tests:** collector over a fake `agent_sessions.json`; the reply route (mocked
  transport) incl. all refusal paths.

## Trust boundary held

The Phase-1 `test_cadence_package_has_no_external_side_effects` guard on `holdspeak/cadence/` still
passes — the delivery is a route concern. Egress stays `local`.

## Proof

- **141** tests passed (cadence + the full web-server suite). `cd web && npm run build` → 15 pages.

Next: **Phase 4** — Telegram remote presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)