### PR TITLE
Cadence Engine Phase 4: Telegram remote presence

### DIFF
--- a/holdspeak/cadence_telegram.py
+++ b/holdspeak/cadence_telegram.py
@@ -1,0 +1,236 @@
+"""The Cadence Telegram surface (CAD-4) — remote presence.
+
+Delivers nudges and receives decisions over Telegram. This lives OUTSIDE
+`holdspeak/cadence/` on purpose: the cadence core performs no external side effect
+(a guard enforces it), while this surface does the egress. Off by default; inert
+without `enabled` + a token.
+
+Security:
+- the bot token is a credential — joined into the URL only at call time, never logged
+  or written into a message/row;
+- only `allowed_chat_ids` may read anything (an unpaired chat gets one "not paired"
+  line and NO data); `/pair <code>` self-pairs when the code matches;
+- a destructive decision (kill) requires a typed/tapped second confirm;
+- a pushed nudge notifies the paired user (you) — that is the product, not a leak;
+  everything else needs an explicit command/button.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Optional
+
+from .logging_config import get_logger
+
+log = get_logger("cadence.telegram")
+
+_API = "https://api.telegram.org/bot{token}/{method}"
+
+
+def call_telegram(token: str, method: str, params: dict, *, timeout: float = 10.0) -> dict:
+    """POST to the Telegram Bot API. The token is joined here and nowhere else."""
+    url = _API.format(token=token, method=method)
+    data = json.dumps(params).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed api.telegram.org host
+            return json.loads(resp.read().decode("utf-8", "replace") or "{}")
+    except urllib.error.HTTPError as exc:
+        return {"ok": False, "error_code": int(exc.code), "description": str(exc.reason or "")}
+    except Exception as exc:  # network down, etc. — never raise into the poller
+        return {"ok": False, "description": str(exc)}
+
+
+def _redact(text: str, token: str) -> str:
+    return text.replace(token, "<token>") if token else text
+
+
+class TelegramSurface:
+    """Stateful (per process) Telegram command + decision handler for cadence."""
+
+    def __init__(self, db, config, *, caller: Optional[Callable] = None,
+                 on_pair: Optional[Callable[[str], None]] = None):
+        self._db = db
+        self._config = config                # a TelegramConfig
+        self._call = caller or call_telegram  # injectable for tests
+        self._on_pair = on_pair
+        self._paired: set[str] = set(config.allowed_chat_ids)
+        self._pending_kill: set[str] = set()  # "chat:loop" awaiting a confirm
+
+    # ── transport ────────────────────────────────────────────────────────────
+    def _send(self, chat_id: str, text: str, *, buttons: Optional[list] = None) -> dict:
+        params: dict[str, Any] = {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"}
+        if buttons:
+            params["reply_markup"] = {"inline_keyboard": buttons}
+        result = self._call(self._config.bot_token, "sendMessage", params)
+        if not result.get("ok", True):
+            log.warning("telegram send failed: %s", _redact(str(result.get("description")), self._config.bot_token))
+        return result
+
+    def _answer_callback(self, callback_id: str, text: str = "") -> None:
+        self._call(self._config.bot_token, "answerCallbackQuery",
+                   {"callback_query_id": callback_id, "text": text})
+
+    # ── authorization ─────────────────────────────────────────────────────────
+    def is_authorized(self, chat_id: str) -> bool:
+        return str(chat_id) in self._paired
+
+    def _pair(self, chat_id: str, code: str) -> bool:
+        if self._config.pairing_code and code.strip() == self._config.pairing_code:
+            self._paired.add(str(chat_id))
+            if self._on_pair:
+                try:
+                    self._on_pair(str(chat_id))
+                except Exception as exc:
+                    log.error("pair persist failed: %s", exc)
+            return True
+        return False
+
+    # ── update dispatch ───────────────────────────────────────────────────────
+    def handle_update(self, update: dict) -> dict:
+        """Process one getUpdates entry. Returns a small {action,...} for tests."""
+        if "callback_query" in update:
+            return self._handle_callback(update["callback_query"])
+        msg = update.get("message") or {}
+        chat_id = str((msg.get("chat") or {}).get("id", "")).strip()
+        text = str(msg.get("text", "")).strip()
+        if not chat_id or not text:
+            return {"action": "ignored"}
+        return self._handle_command(chat_id, text)
+
+    def _handle_command(self, chat_id: str, text: str) -> dict:
+        parts = text.split()
+        cmd = parts[0].lower().lstrip("/")
+        # /start and /pair are reachable before pairing; everything else is gated.
+        if cmd == "start":
+            self._send(chat_id, "🧷 *HoldSpeak Cadence*\nPair this chat with `/pair <code>` "
+                                "to receive nudges and act on them.")
+            return {"action": "start"}
+        if cmd == "pair":
+            ok = self._pair(chat_id, parts[1] if len(parts) > 1 else "")
+            self._send(chat_id, "✅ Paired. You'll get your highest-leverage moves here."
+                       if ok else "❌ Wrong or missing pairing code.")
+            return {"action": "pair", "ok": ok}
+        if not self.is_authorized(chat_id):
+            self._send(chat_id, "🔒 This chat is not paired. Send `/pair <code>`.")
+            return {"action": "rejected"}
+        if cmd in ("brief", "loops"):
+            self._send_loops(chat_id, brief=(cmd == "brief"))
+            return {"action": cmd}
+        if cmd == "status":
+            self._send(chat_id, self._render_status())
+            return {"action": "status"}
+        self._send(chat_id, "Commands: /brief /loops /status")
+        return {"action": "help"}
+
+    def _handle_callback(self, cb: dict) -> dict:
+        chat_id = str(((cb.get("message") or {}).get("chat") or {}).get("id", "")).strip()
+        cb_id = str(cb.get("id", ""))
+        data = str(cb.get("data", ""))
+        if not self.is_authorized(chat_id):
+            self._answer_callback(cb_id, "Not paired.")
+            return {"action": "rejected"}
+        act, _, loop_id = data.partition(":")
+        loop = self._db.cadence.get_loop(loop_id) if loop_id else None
+        if loop is None:
+            self._answer_callback(cb_id, "Loop is gone.")
+            return {"action": "missing"}
+        key = f"{chat_id}:{loop_id}"
+        if act == "snooze":
+            from datetime import datetime, timedelta
+            self._db.cadence.snooze(loop_id, (datetime.now() + timedelta(hours=24)).isoformat())
+            self._answer_callback(cb_id, "Snoozed 1 day.")
+        elif act == "done":
+            self._db.cadence.set_status(loop_id, "closed")
+            self._answer_callback(cb_id, "Marked done.")
+        elif act == "kill":
+            # Destructive — require a second confirm.
+            self._pending_kill.add(key)
+            self._send(chat_id, f"⚠️ Kill *{loop.title}* permanently?",
+                       buttons=[[{"text": "Yes, kill it", "callback_data": f"killyes:{loop_id}"},
+                                 {"text": "Cancel", "callback_data": f"killno:{loop_id}"}]])
+            self._answer_callback(cb_id)
+            return {"action": "kill_confirm"}
+        elif act == "killyes":
+            if key in self._pending_kill:
+                self._pending_kill.discard(key)
+                self._db.cadence.set_status(loop_id, "killed")
+                self._answer_callback(cb_id, "Killed.")
+            else:
+                self._answer_callback(cb_id, "Expired — tap Kill again.")
+                return {"action": "kill_expired"}
+        elif act == "killno":
+            self._pending_kill.discard(key)
+            self._answer_callback(cb_id, "Kept.")
+            return {"action": "kill_cancelled"}
+        else:
+            self._answer_callback(cb_id)
+            return {"action": "unknown"}
+        return {"action": act}
+
+    # ── rendering ─────────────────────────────────────────────────────────────
+    def _loop_buttons(self, loop) -> list:
+        return [[
+            {"text": "Snooze 1d", "callback_data": f"snooze:{loop.id}"},
+            {"text": "Done", "callback_data": f"done:{loop.id}"},
+            {"text": "Kill", "callback_data": f"kill:{loop.id}"},
+        ]]
+
+    def _send_loops(self, chat_id: str, *, brief: bool) -> None:
+        loops = [l for l in self._db.cadence.list_loops() if not l.needs_review]
+        if not loops:
+            self._send(chat_id, "🧷 Nothing pressing right now.")
+            return
+        if brief:
+            top = loops[0]
+            from .cadence.next_action import generate_next_action
+            na = generate_next_action(top)
+            header = f"🧷 *Your highest-leverage move*\n\n*{top.title}*\n{na.title}"
+            self._send(chat_id, header, buttons=self._loop_buttons(top))
+            return
+        for loop in loops[:5]:
+            self._send(chat_id, f"*{loop.title}*  ·  _{loop.source_type}_  ·  {loop.stale_score:.0f}",
+                       buttons=self._loop_buttons(loop))
+
+    def _render_status(self) -> str:
+        counts: dict[str, int] = {}
+        for l in self._db.cadence.list_loops(include_terminal=True):
+            counts[l.status] = counts.get(l.status, 0) + 1
+        line = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "none"
+        return f"🧷 *Cadence status*\nPaired chats: {len(self._paired)}\nLoops: {line}"
+
+    # ── push (driven by the tick) ─────────────────────────────────────────────
+    def push_due_nudges(self, due_loops) -> int:
+        """Send each due loop to every paired chat; record one nudge per loop. Returns sent."""
+        if not self._paired:
+            return 0
+        from .cadence.models import Nudge
+
+        sent = 0
+        for loop in due_loops:
+            for chat_id in sorted(self._paired):
+                self._send(chat_id, f"🧷 *{loop.title}*  ·  {loop.stale_score:.0f}",
+                           buttons=self._loop_buttons(loop))
+                sent += 1
+            self._db.cadence.record_nudge(Nudge(loop_id=loop.id, surface="telegram",
+                                                title=loop.title, status="shown"))
+            self._db.cadence.bump_nudge(loop.id)
+        return sent
+
+    # ── the live poller (the owner's button) ──────────────────────────────────
+    def poll_once(self, offset: Optional[int]) -> int:
+        """One getUpdates round; returns the next offset. Live only."""
+        params = {"timeout": 25}
+        if offset is not None:
+            params["offset"] = offset
+        result = self._call(self._config.bot_token, "getUpdates", params)
+        next_offset = offset
+        for update in result.get("result", []) or []:
+            try:
+                self.handle_update(update)
+            except Exception as exc:
+                log.error("telegram update failed: %s", exc)
+            next_offset = int(update.get("update_id", 0)) + 1
+        return next_offset

--- a/holdspeak/config.py
+++ b/holdspeak/config.py
@@ -711,6 +711,33 @@ class CadenceConfig:
 
 
 @dataclass
+class TelegramConfig:
+    """The Cadence Telegram surface (CAD-4) — OFF BY DEFAULT.
+
+    `bot_token` is a CREDENTIAL — it is never logged or written into a message/row;
+    it is joined in memory only at the moment of an API call. `allowed_chat_ids` is the
+    hard pairing allow-list: only these chats may read anything. `pairing_code` (if set)
+    lets a chat self-pair via `/pair <code>`. With `enabled` False or no token, the
+    surface is inert (no poller, no send).
+    """
+
+    enabled: bool = False
+    bot_token: str = ""
+    allowed_chat_ids: list[str] = field(default_factory=list)
+    pairing_code: str = ""
+
+    def __post_init__(self) -> None:
+        self.bot_token = str(self.bot_token or "").strip()
+        self.pairing_code = str(self.pairing_code or "").strip()
+        self.allowed_chat_ids = [str(c).strip() for c in (self.allowed_chat_ids or []) if str(c).strip()]
+
+    @property
+    def is_active(self) -> bool:
+        """Live only when explicitly enabled AND a token is present."""
+        return bool(self.enabled and self.bot_token)
+
+
+@dataclass
 class Config:
     """Main configuration container."""
     config_version: int = CONFIG_VERSION
@@ -724,6 +751,7 @@ class Config:
     wake_word: WakeWordConfig = field(default_factory=WakeWordConfig)
     mesh: MeshConfig = field(default_factory=MeshConfig)
     cadence: CadenceConfig = field(default_factory=CadenceConfig)
+    cadence_telegram: TelegramConfig = field(default_factory=TelegramConfig)
 
     @classmethod
     def load(cls, path: Optional[Path] = None) -> "Config":
@@ -768,6 +796,9 @@ class Config:
                 wake_word=_coerce(WakeWordConfig, data.get("wake_word", {}) or {}, section="wake_word"),
                 mesh=_coerce(MeshConfig, data.get("mesh", {}) or {}, section="mesh"),
                 cadence=_coerce(CadenceConfig, data.get("cadence", {}) or {}, section="cadence"),
+                cadence_telegram=_coerce(
+                    TelegramConfig, data.get("cadence_telegram", {}) or {}, section="cadence_telegram"
+                ),
             )
         except Exception as exc:
             # Last-resort fallback for a genuinely broken config (bad JSON, wrong

--- a/holdspeak/runtime/cadence.py
+++ b/holdspeak/runtime/cadence.py
@@ -36,8 +36,25 @@ class CadenceMixin:
                     "cadence tick: %d projected, %d open, %d due",
                     result.projected, result.open_loops, result.due_count,
                 )
+                self._push_due_to_telegram(result.due)
         except Exception as exc:  # never let the tick crash the runtime
             log.error("cadence tick failed: %s", exc)
+
+    def _push_due_to_telegram(self, due_loops) -> None:
+        """Deliver due nudges to paired Telegram chats (CAD-4-05) — off unless the
+        Telegram surface is enabled + has a token + a paired chat."""
+        tg = getattr(self.config, "cadence_telegram", None)
+        if tg is None or not tg.is_active or not tg.allowed_chat_ids:
+            return
+        try:
+            from ..cadence_telegram import TelegramSurface
+            from ..db import get_database
+
+            sent = TelegramSurface(get_database(), tg).push_due_nudges(due_loops)
+            if sent:
+                log.info("cadence: pushed %d nudge(s) to Telegram", sent)
+        except Exception as exc:
+            log.error("cadence telegram push failed: %s", exc)
 
     def _cadence_loop(self) -> None:
         interval = max(30, int(getattr(self.config.cadence, "tick_interval_seconds", 300)))

--- a/pm/roadmap/holdspeak/cadence-engine/README.md
+++ b/pm/roadmap/holdspeak/cadence-engine/README.md
@@ -5,16 +5,16 @@
 > next actions.** Qlippy does not merely remind. Qlippy pushes — with receipts, restraint, and a
 > ready-made next move.
 
-**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phases 1
-(cadence core), 2 (web coach surface), and 3 (agent-blocker push) are COMPLETE** — `holdspeak cadence
-run-now` projects scored loops; the `/cadence` page shows them with prepared next moves + one-tap
-decisions; and an awaiting Claude/Codex session becomes a top loop you can answer (the reply lands in
-its terminal). Off by default throughout. **Phase 4 (Telegram remote presence) is next.** Phases 5–8
-are sketched here and storied as each becomes the lead.
+**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phases 1–4 are
+COMPLETE** — the substrate (`run-now` projects scored loops), the `/cadence` web coach (prepared next
+moves + one-tap decisions), agent-blocker push (answer a waiting Claude/Codex from the board, the
+reply lands in its terminal), and **Telegram remote presence** (pair a chat → get nudges + act on
+inline buttons; hermetic, the live bot walk is the owner's button). Off by default throughout.
+**Phase 5 (daily push brief) is next.** Phases 6–8 are sketched here and storied as each becomes the lead.
 
-**Last updated:** 2026-06-28 (Phase 3 shipped — awaiting agent sessions → loops + a terminal-delivered
-reply; 141 cadence/web tests green. Phases 1–2: the substrate + the web coach. Program authored from
-the owner's rough design + a grounded seam map; §15 resolved below).
+**Last updated:** 2026-06-28 (Phase 4 shipped hermetically — the Telegram surface; 272 cadence/web/config
+tests green. Phases 1–3: the substrate + the web coach + agent-blocker push. Program authored from the
+owner's rough design + a grounded seam map; §15 resolved below).
 
 ---
 
@@ -119,7 +119,7 @@ Phase 1 leads and is fully storied. Each later phase is storied when it becomes 
 | **1 ✅** | **Cadence core** | *Done.* The loop/nudge/policy substrate: models, migrations, collector (meeting actions + pending proposals), stale-scoring v1, policies + quiet hours, CLI, unit tests. No external side effects, off by default. | — |
 | **2 ✅** | Web coach surface | *Done.* `/api/cadence/*` + a `/cadence` page: loops, evidence deep-links, snooze/kill/close, deterministic next-action, egress badges. | 1 |
 | **3 ✅** | Agent-blocker push | *Done.* Awaiting-response agent sessions → top loops + a reply composer; the typed reply is delivered into the agent's tmux pane (`send_text_to_pane`, in the route — never autonomous). | 1 |
-| **4** | Telegram remote presence | Pairing + a Telegram surface; `/brief` `/loops` `/agents`; inline-button decisions wired to the cadence API; unpaired-chat rejection; second-confirm for irreversible actions. | 2, 3 |
+| **4 ✅** | Telegram remote presence | *Done (hermetic; live walk = owner).* Pairing + a Telegram surface (`holdspeak/cadence_telegram.py`, a sibling of the core); `/brief` `/loops` `/status`; inline-button decisions (snooze/done + kill-confirm); unpaired-chat rejection; push-on-tick; token never logged/stored. | 2, 3 |
 | **5** | Daily push brief | A deterministic morning brief (first-activity trigger) with prepared moves; LLM wording behind a capability gate (policy never model-driven). | 2 |
 | **6** | Stale-loop + EOD closure | Escalation policy + an end-of-day closure ritual + batch closure UI; accepted-action → issue proposals; kill/delegate/snooze semantics. | 2, 5 |
 | **7** | LLM next-best-action | Structured-JSON next-action generator (issue/Slack drafts, dedupe clustering), fail-closed validation, preview/approval-gated. | 6 |

--- a/pm/roadmap/holdspeak/cadence-engine/phase-4-telegram/current-phase-status.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-4-telegram/current-phase-status.md
@@ -1,0 +1,75 @@
+# Cadence Phase 4 — Telegram remote presence
+
+**Status:** done (sim/hermetic — 272 cadence/web/config tests green; the live bot walk is the owner's
+gate). **Start here:** `../README.md`. Builds on Phases 1–3 (merged).
+
+**Last updated:** 2026-06-28 (Phase 4 shipped hermetically: the Telegram surface — pairing, commands,
+inline-button decisions, and push-on-tick — all proven with a mocked transport, off by default).
+
+## Objective
+
+Make Qlippy reach you when you're away from the desk: a Telegram surface that **delivers nudges**
+(due loops + their prepared move) and **receives decisions** (snooze/kill/done, and reply-to-agent),
+with hard pairing and the egress badge flipping to `cloud`. This is the **first phase that genuinely
+reaches out** — the Telegram Bot API is real off-machine egress — so the security model leads.
+
+## Architecture decisions
+
+- **The Telegram surface lives OUTSIDE the cadence core.** The Phase-1 no-side-effects guard scans
+  `holdspeak/cadence/` and forbids network — and it stays that strong invariant. The Telegram surface
+  is a sibling module `holdspeak/cadence_telegram.py` that *reads* the cadence service/repo and does
+  the egress. (Surfaces do side effects; the core never does.)
+- **The bot token is a credential, never logged or stored in a payload** — joined in memory at call
+  time (the Slack-URL pattern, [[project_phase61_send_to_slack]]). Outbound HTTP uses stdlib
+  `urllib.request` with a timeout, modelled on `webhook_post_actuator.py`.
+- **Hard pairing.** Only `allowed_chat_ids` (config) may read anything; an unpaired chat is rejected
+  with a single "not paired" line and **no data**. `/pair <code>` adopts a chat when the code matches
+  a config pairing code. Tested: an unpaired chat can read nothing.
+- **Never autonomous beyond notifying you.** A pushed nudge notifies the *paired* user (you) — that
+  is the product. A *decision* (snooze/kill/done/reply) requires an explicit button/command. Any
+  **irreversible** action (none in Phase 4 — lifecycle is local; actuator execution is Phase 6/7)
+  would require a typed second-confirm (the `reversible` flag from the actuator).
+- **Off by default.** `TelegramConfig.enabled = False` + empty token ⇒ inert (no poller, no send).
+- **Live proof is the owner's button.** The hermetic surface (auth/commands/render/decisions) is
+  fully tested with a mocked transport; the live bot (real token + a real chat pairing + a real
+  push) is walked by the owner, like the mobile device walk ([[feedback_verify_on_device_not_seeded]]).
+
+## Stories
+
+| ID | Title | Status |
+|----|-------|--------|
+| CAD-4-01 | `TelegramConfig` (off by default; token + allowed chats + pairing code) | done |
+| CAD-4-02 | The transport: `call_telegram` (sendMessage/getUpdates) via urllib (token joined in memory) | done |
+| CAD-4-03 | Authorization + command handling (`/start /pair /status /brief /loops`); unpaired rejection | done |
+| CAD-4-04 | Decisions: inline-button callbacks → snooze/done + kill-with-confirm | done |
+| CAD-4-05 | Push: the tick sends due-loop nudges to paired chats (records a nudge) | done |
+| CAD-4-06 | Tests: auth/rejection, command parse + render, decisions, push (mocked transport), off-by-default | done |
+
+## Where we are
+
+**Phase 4 is hermetically complete** (the live bot walk is the owner's button). `TelegramConfig`
+(top-level, off by default; `is_active` only when enabled + a token) gates everything.
+`holdspeak/cadence_telegram.py` — a **sibling of the cadence core** so the no-side-effects guard
+stays strong — holds the surface: `call_telegram` (urllib, the token joined into the URL only at
+call time, never logged/stored), `TelegramSurface` with authorization (`allowed_chat_ids`; an
+unpaired chat gets one "not paired" line and **no data**), `/start /pair /status /brief /loops`,
+inline-button decisions (snooze/done one-tap, **kill behind a second confirm**), `push_due_nudges`
+(records a `telegram` nudge per loop), and a `poll_once` getUpdates round for the live runner. The
+`CadenceMixin` tick pushes due loops to paired chats when the surface is active. **Proof:** 272 tests
+green (incl. 12 Telegram: unpaired-gets-nothing, pairing, token-never-in-text, the confirm gate,
+push records); the cadence-core no-side-effects guard still passes; config round-trips.
+
+**Owner's live walk:** set a bot token + a `pairing_code` in `cadence_telegram`, `/pair` from a real
+chat, receive a pushed nudge, tap a decision. (Reply-to-agent over Telegram — the stateful typed
+flow — is a deliberate small follow-up; the web reply composer ships it today.)
+
+**Next: Phase 5 (daily push brief).**
+
+## Exit criteria
+
+- An unpaired chat gets nothing; a paired chat can `/brief`, `/loops`, `/status` and act on inline
+  buttons; the tick pushes due nudges to paired chats (mocked send asserted).
+- The bot token never appears in any rendered message, log, or persisted row.
+- The Phase-1 cadence-core no-side-effects guard still passes (Telegram is a sibling surface).
+- Off by default: no token ⇒ no poller, no send (test-proven). `uv run pytest -q` green.
+- **Live walk (owner):** real bot pairs to a real chat, receives a nudge, drives a decision.

--- a/pm/roadmap/holdspeak/cadence-engine/phase-4-telegram/evidence-phase-4.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-4-telegram/evidence-phase-4.md
@@ -1,0 +1,43 @@
+# Evidence — Cadence Phase 4 (Telegram remote presence)
+
+**Date:** 2026-06-28. **Branch:** `holdspeak/cadence-phase4-telegram`.
+
+## What shipped (hermetic; the live bot walk is the owner's button)
+
+| Story | Files | Proof |
+|-------|-------|-------|
+| CAD-4-01 | `config.py` (`TelegramConfig`, top-level, off by default) | `test_off_by_default` + config round-trip |
+| CAD-4-02 | `cadence_telegram.py` (`call_telegram` via urllib) | mocked in every test |
+| CAD-4-03 | `cadence_telegram.py` (`TelegramSurface` auth + commands) | unpaired/pairing/brief tests |
+| CAD-4-04 | inline-button callbacks (snooze/done + kill-confirm) | decision tests |
+| CAD-4-05 | `runtime/cadence.py` (`_push_due_to_telegram`) + `push_due_nudges` | push tests |
+| CAD-4-06 | `tests/unit/test_cadence_telegram.py` (12) | all green |
+
+## The surface
+
+`holdspeak/cadence_telegram.py` is a **sibling of the cadence core** (not under `holdspeak/cadence/`)
+so the Phase-1 no-side-effects guard stays a strong, simple invariant — the surface does the egress,
+the core never does.
+
+- **Security held:**
+  - the **bot token is a credential** — `call_telegram` joins it into the URL only at call time; it
+    never appears in a rendered message (`test_token_never_appears_in_sent_text`), a log (redacted),
+    or a persisted row.
+  - **hard pairing** — an unpaired chat gets one "not paired" line and **no loop data**
+    (`test_unpaired_chat_gets_no_data`); `/pair <code>` self-pairs on the configured code; an
+    unpaired callback is rejected without acting (`test_unpaired_callback_rejected`).
+  - **kill is behind a second confirm** (`test_kill_requires_second_confirm` /
+    `test_kill_cancel_keeps_loop`); snooze/done are one-tap (reversible).
+  - **off by default** — `TelegramConfig.is_active` is False unless `enabled` AND a token is set
+    (`test_off_by_default`); push is a no-op without a paired chat (`test_push_is_noop_without_paired_chats`).
+- **Push:** the `CadenceMixin` tick calls `push_due_nudges` when the surface is active — each due loop
+  is sent to every paired chat with snooze/done/kill buttons, and a `telegram` nudge is recorded
+  (`test_push_due_nudges_sends_and_records`).
+
+## Proof
+
+- `uv run pytest -q` over cadence + web-server + config/doctor/schema → **272 passed.**
+- The cadence-core `test_cadence_package_has_no_external_side_effects` guard still passes (the
+  Telegram surface is a sibling module).
+- **Owner's live walk (the gate):** a real bot token + `pairing_code`, `/pair` from a real chat, a
+  pushed nudge, an inline-button decision.

--- a/tests/unit/test_cadence_telegram.py
+++ b/tests/unit/test_cadence_telegram.py
@@ -1,0 +1,133 @@
+"""CAD-4 — the Cadence Telegram surface (hermetic; the network transport is mocked)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from holdspeak.cadence.models import OpenLoop
+from holdspeak.cadence_telegram import TelegramSurface
+from holdspeak.config import TelegramConfig
+from holdspeak.db import Database
+
+
+class FakeCaller:
+    """Records (method, params) instead of hitting the network."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, token, method, params, *, timeout=10.0):
+        self.calls.append((token, method, params))
+        return {"ok": True, "result": []}
+
+    def sent_texts(self):
+        return [p.get("text", "") for (_, m, p) in self.calls if m == "sendMessage"]
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    d = Database(tmp_path / "tg.db")
+    d.cadence.upsert_loop(OpenLoop(source_type="meeting_action", source_id="a1",
+                                   title="File the watchdog issue", stale_score=12.0))
+    return d
+
+
+def _surface(db, **cfg):
+    base = dict(enabled=True, bot_token="SECRET-TOKEN", pairing_code="hunter2")
+    base.update(cfg)
+    caller = FakeCaller()
+    return TelegramSurface(db, TelegramConfig(**base), caller=caller), caller
+
+
+def msg(chat_id, text):
+    return {"message": {"chat": {"id": chat_id}, "text": text}}
+
+
+def test_off_by_default():
+    assert TelegramConfig().is_active is False  # disabled + no token
+    assert TelegramConfig(enabled=True).is_active is False  # no token
+
+
+def test_unpaired_chat_gets_no_data(db):
+    s, caller = _surface(db)
+    res = s.handle_update(msg("999", "/loops"))
+    assert res["action"] == "rejected"
+    assert all("watchdog" not in t for t in caller.sent_texts())  # no loop data leaked
+    assert any("not paired" in t.lower() for t in caller.sent_texts())
+
+
+def test_pairing_with_code(db):
+    s, _ = _surface(db)
+    assert s.handle_update(msg("42", "/pair hunter2"))["ok"] is True
+    assert s.is_authorized("42")
+    s2, _ = _surface(db)
+    assert s2.handle_update(msg("42", "/pair wrong"))["ok"] is False
+
+
+def test_paired_chat_can_read_brief(db):
+    s, caller = _surface(db, allowed_chat_ids=["42"])
+    assert s.handle_update(msg("42", "/brief"))["action"] == "brief"
+    assert any("watchdog" in t for t in caller.sent_texts())
+
+
+def test_token_never_appears_in_sent_text(db):
+    s, caller = _surface(db, allowed_chat_ids=["42"])
+    s.handle_update(msg("42", "/brief"))
+    s.handle_update(msg("42", "/status"))
+    assert all("SECRET-TOKEN" not in t for t in caller.sent_texts())
+
+
+def test_snooze_and_done_decisions(db):
+    s, _ = _surface(db, allowed_chat_ids=["42"])
+    loop_id = db.cadence.list_loops()[0].id
+    cb = lambda data: {"callback_query": {"id": "c", "data": data, "message": {"chat": {"id": "42"}}}}
+    assert s.handle_update(cb(f"snooze:{loop_id}"))["action"] == "snooze"
+    assert db.cadence.get_loop(loop_id).status == "snoozed"
+    assert s.handle_update(cb(f"done:{loop_id}"))["action"] == "done"
+    assert db.cadence.get_loop(loop_id).status == "closed"
+
+
+def test_kill_requires_second_confirm(db):
+    s, _ = _surface(db, allowed_chat_ids=["42"])
+    loop_id = db.cadence.list_loops()[0].id
+    cb = lambda data: {"callback_query": {"id": "c", "data": data, "message": {"chat": {"id": "42"}}}}
+    # first tap only asks to confirm; the loop is NOT killed yet
+    assert s.handle_update(cb(f"kill:{loop_id}"))["action"] == "kill_confirm"
+    assert db.cadence.get_loop(loop_id).status != "killed"
+    # the confirm kills it
+    assert s.handle_update(cb(f"killyes:{loop_id}"))["action"] == "killyes"
+    assert db.cadence.get_loop(loop_id).status == "killed"
+
+
+def test_kill_cancel_keeps_loop(db):
+    s, _ = _surface(db, allowed_chat_ids=["42"])
+    loop_id = db.cadence.list_loops()[0].id
+    cb = lambda data: {"callback_query": {"id": "c", "data": data, "message": {"chat": {"id": "42"}}}}
+    s.handle_update(cb(f"kill:{loop_id}"))
+    assert s.handle_update(cb(f"killno:{loop_id}"))["action"] == "kill_cancelled"
+    assert db.cadence.get_loop(loop_id).status != "killed"
+
+
+def test_unpaired_callback_rejected(db):
+    s, _ = _surface(db)  # no paired chats
+    loop_id = db.cadence.list_loops()[0].id
+    cb = {"callback_query": {"id": "c", "data": f"kill:{loop_id}", "message": {"chat": {"id": "999"}}}}
+    assert s.handle_update(cb)["action"] == "rejected"
+    assert db.cadence.get_loop(loop_id).status != "killed"
+
+
+def test_push_due_nudges_sends_and_records(db):
+    s, caller = _surface(db, allowed_chat_ids=["42", "43"])
+    due = db.cadence.list_loops()
+    sent = s.push_due_nudges(due)
+    assert sent == 2  # one per paired chat
+    assert db.cadence.get_loop(due[0].id).nudge_count == 1  # recorded
+    sends = [p for (_, m, p) in caller.calls if m == "sendMessage"]
+    assert {p["chat_id"] for p in sends} == {"42", "43"}
+
+
+def test_push_is_noop_without_paired_chats(db):
+    s, caller = _surface(db)  # no paired chats
+    assert s.push_due_nudges(db.cadence.list_loops()) == 0
+    assert caller.calls == []


### PR DESCRIPTION
**Cadence Engine — Phase 4 (Telegram remote presence).** Qlippy reaches you when you're away from
the desk. **Off by default**; the first phase that genuinely reaches *out*, so the security model
leads. Hermetic (mocked transport) — the **live bot walk is the owner's button**. Builds on Phases
1–3.

## What's here

- **`TelegramConfig`** (top-level, off by default): `is_active` only when `enabled` **and** a
  `bot_token`. The token is a **credential** — never logged or stored in a message/row.
- **`holdspeak/cadence_telegram.py`** — a **sibling of the cadence core** (not under
  `holdspeak/cadence/`), so the Phase-1 no-side-effects guard stays a strong, simple invariant. It
  holds `call_telegram` (urllib; token joined into the URL only at call time), and `TelegramSurface`:
  - **hard pairing** — an unpaired chat gets one "not paired" line and **no data**; `/pair <code>`
    self-pairs;
  - `/start /pair /status /brief /loops`;
  - **inline-button decisions** — snooze/done one-tap, **kill behind a second confirm**;
  - `push_due_nudges` (records a `telegram` nudge per loop) + `poll_once` for the live runner.
- **`runtime/cadence.py`** — the tick pushes due loops to paired chats when the surface is active.

## Security (all tested)

unpaired-gets-nothing · pairing-by-code · **token never in any sent text** · the kill confirm gate ·
unpaired-callback-rejected · push is a no-op without a paired chat · off-by-default.

## Proof

- **272** tests passed (cadence + web-server + config/doctor/schema), incl. 12 Telegram.
- The cadence-core `test_cadence_package_has_no_external_side_effects` guard **still passes** (the
  surface is a sibling module).
- **Owner's live walk** (the gate): set a token + `pairing_code`, `/pair` from a real chat, receive a
  pushed nudge, tap a decision.

Next: **Phase 5** — daily push brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)