### PR TITLE
Cadence Engine Phase 6: stale-loop escalation + EOD closure

### DIFF
--- a/holdspeak/cadence/closeout.py
+++ b/holdspeak/cadence/closeout.py
@@ -1,0 +1,137 @@
+"""Stale-loop escalation + the end-of-day closure ritual (CAD-6).
+
+Escalation: a loop that has survived several nudges or several days gets a louder
+severity, so it stops being ignorable. Closeout: at end of day, group the open loops
+and recommend a cheap decision for each (close / file / snooze / kill / delegate), so
+clearing the board is a batch of one-taps rather than a chore. All deterministic.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from .models import OpenLoop
+
+# Escalation thresholds (nudges survived, days old).
+_PERSISTENT_NUDGES = 3
+_ESCALATED_NUDGES = 6
+_PERSISTENT_DAYS = 2.0
+_ESCALATED_DAYS = 4.0
+
+
+def _age_days(loop: OpenLoop, now: datetime) -> float:
+    if not loop.created_at:
+        return 0.0
+    try:
+        return max(0.0, (now - datetime.fromisoformat(loop.created_at)).total_seconds() / 86400.0)
+    except ValueError:
+        return 0.0
+
+
+def escalation_severity(loop: OpenLoop, *, now: datetime) -> str:
+    """quiet | normal | persistent | escalated — how loudly to push this loop."""
+    if loop.needs_review:
+        return "quiet"
+    age = _age_days(loop, now)
+    if loop.nudge_count >= _ESCALATED_NUDGES or age >= _ESCALATED_DAYS:
+        return "escalated"
+    if loop.nudge_count >= _PERSISTENT_NUDGES or age >= _PERSISTENT_DAYS:
+        return "persistent"
+    return "normal"
+
+
+# The deterministic recommendation for a loop at closeout.
+@dataclass
+class CloseoutRec:
+    loop: OpenLoop
+    severity: str
+    action: str       # close | file | snooze | kill | delegate | reply | approve | review
+    reason: str
+
+
+@dataclass
+class Closeout:
+    date: str
+    recs: list[CloseoutRec] = field(default_factory=list)
+    open_count: int = 0
+
+    @property
+    def summary(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for r in self.recs:
+            out[r.action] = out.get(r.action, 0) + 1
+        return out
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.recs
+
+
+def _recommend(loop: OpenLoop, severity: str, *, now: datetime) -> CloseoutRec:
+    age = _age_days(loop, now)
+    if loop.needs_review:
+        return CloseoutRec(loop, severity, "review", "Low-confidence — confirm or dismiss.")
+    if loop.source_type == "agent_question":
+        return CloseoutRec(loop, severity, "reply", "An agent is waiting — answer it.")
+    if loop.source_type == "proposal":
+        return CloseoutRec(loop, severity, "approve", "A proposal is ready for your approval.")
+    unowned = not (loop.owner and loop.owner.strip())
+    if severity == "escalated" and unowned:
+        return CloseoutRec(loop, severity, "kill", "Open for days, still unowned — kill it or own it.")
+    if unowned:
+        return CloseoutRec(loop, severity, "delegate", "No owner — assign it or delegate it.")
+    if age >= _ESCALATED_DAYS:
+        return CloseoutRec(loop, severity, "file", "Owned but stale — file it as an issue now.")
+    if severity in ("persistent", "escalated"):
+        return CloseoutRec(loop, severity, "file", "It keeps resurfacing — file it and move on.")
+    return CloseoutRec(loop, severity, "snooze", "Not today — snooze until it matters.")
+
+
+def build_closeout(db, *, now: Optional[datetime] = None) -> Closeout:
+    """Group the open loops with a recommended decision for each (deterministic)."""
+    now = now or datetime.now()
+    loops = db.cadence.list_loops()  # ordered by stale_score desc
+    recs = [
+        _recommend(loop, escalation_severity(loop, now=now), now=now)
+        for loop in loops
+    ]
+    return Closeout(date=now.strftime("%Y-%m-%d"), recs=recs, open_count=len(loops))
+
+
+# Which closeout/decision actions are legal to apply in a batch (lifecycle only —
+# 'file'/'reply'/'approve' open a draft elsewhere, they are not batch-applied here).
+APPLYABLE = {"snooze", "kill", "close", "done", "delegate"}
+
+
+def apply_decision(db, loop_id: str, action: str, *, now: Optional[datetime] = None,
+                   owner: Optional[str] = None) -> bool:
+    """Apply one lifecycle decision. Returns True if applied. No external side effect."""
+    now = now or datetime.now()
+    loop = db.cadence.get_loop(loop_id)
+    if loop is None or action not in APPLYABLE:
+        return False
+    if action == "snooze":
+        from datetime import timedelta
+        db.cadence.snooze(loop_id, (now + timedelta(days=1)).isoformat())
+    elif action == "kill":
+        db.cadence.set_status(loop_id, "killed")
+    elif action in ("close", "done"):
+        db.cadence.set_status(loop_id, "closed")
+    elif action == "delegate":
+        db.cadence.set_status(loop_id, "delegated")
+    return True
+
+
+def render_closeout_text(closeout: Closeout) -> str:
+    lines = [f"End-of-day closeout — {closeout.date}", ""]
+    if closeout.is_empty:
+        lines.append("Your loops are clear. Nice.")
+        return "\n".join(lines)
+    summary = ", ".join(f"{k}×{v}" for k, v in sorted(closeout.summary.items()))
+    lines.append(f"{closeout.open_count} open · recommended: {summary}")
+    lines.append("")
+    for r in closeout.recs:
+        tag = f"[{r.severity[0].upper()}]" if r.severity in ("persistent", "escalated") else "   "
+        lines.append(f"  {tag} {r.action:8s} {r.loop.title}  — {r.reason}")
+    return "\n".join(lines)

--- a/holdspeak/cadence_telegram.py
+++ b/holdspeak/cadence_telegram.py
@@ -119,10 +119,14 @@ class TelegramSurface:
         if cmd in ("brief", "loops"):
             self._send_loops(chat_id, brief=(cmd == "brief"))
             return {"action": cmd}
+        if cmd == "closeout":
+            from .cadence.closeout import build_closeout, render_closeout_text
+            self._send(chat_id, "🧷 " + render_closeout_text(build_closeout(self._db)))
+            return {"action": "closeout"}
         if cmd == "status":
             self._send(chat_id, self._render_status())
             return {"action": "status"}
-        self._send(chat_id, "Commands: /brief /loops /status")
+        self._send(chat_id, "Commands: /brief /loops /closeout /status")
         return {"action": "help"}
 
     def _handle_callback(self, cb: dict) -> dict:

--- a/holdspeak/commands/cadence.py
+++ b/holdspeak/commands/cadence.py
@@ -35,8 +35,25 @@ def run_cadence_command(args, *, stream: Optional[TextIO] = None, db=None, confi
         return _cmd_run_now(out, db, config, as_json=getattr(args, "json", False))
     if action == "brief":
         return _cmd_brief(out, db, as_json=getattr(args, "json", False))
+    if action == "closeout":
+        return _cmd_closeout(out, db, as_json=getattr(args, "json", False))
     print(f"Unknown cadence action: {action}", file=sys.stderr)
     return 2
+
+
+def _cmd_closeout(out: TextIO, db, *, as_json: bool) -> int:
+    from ..cadence.closeout import build_closeout, render_closeout_text
+
+    co = build_closeout(db)
+    if as_json:
+        print(json.dumps({
+            "date": co.date, "open_count": co.open_count, "summary": co.summary,
+            "recs": [{"title": r.loop.title, "action": r.action, "severity": r.severity,
+                      "reason": r.reason} for r in co.recs],
+        }, indent=2), file=out)
+        return 0
+    print(render_closeout_text(co), file=out)
+    return 0
 
 
 def _cmd_brief(out: TextIO, db, *, as_json: bool) -> int:

--- a/holdspeak/db/cadence.py
+++ b/holdspeak/db/cadence.py
@@ -224,6 +224,20 @@ class CadenceRepository(BaseRepository):
             )
         return nudge_id
 
+    def list_nudges(self, *, limit: int = 50) -> list[dict]:
+        """Recent nudges (the cadence history), newest first — as plain dicts."""
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM cadence_nudges ORDER BY created_at DESC, id DESC LIMIT ?",
+                (int(limit),),
+            ).fetchall()
+        return [
+            {"id": r["id"], "loop_id": r["loop_id"], "surface": r["surface"],
+             "severity": r["severity"], "title": r["title"], "status": r["status"],
+             "created_at": r["created_at"]}
+            for r in rows
+        ]
+
     # ── policies ───────────────────────────────────────────────────────────
     def upsert_policy(self, policy: CadencePolicy) -> str:
         policy_id = policy.id or policy.name

--- a/holdspeak/main.py
+++ b/holdspeak/main.py
@@ -277,6 +277,10 @@ Logs are written to: {LOG_FILE}
         "brief", help="Today's prioritized brief: the top moves with prepared next actions"
     )
     cadence_brief_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    cadence_closeout_parser = cadence_subparsers.add_parser(
+        "closeout", help="End-of-day: every open loop with a recommended close/file/snooze/kill"
+    )
+    cadence_closeout_parser.add_argument("--json", action="store_true", help="Emit JSON")
 
     # device-psk subcommand (HS-14-03)
     device_psk_parser = subparsers.add_parser(

--- a/holdspeak/web/routes/cadence.py
+++ b/holdspeak/web/routes/cadence.py
@@ -104,6 +104,48 @@ def build_cadence_router(ctx: WebContext) -> APIRouter:
             "egress": _LOCAL_EGRESS,
         }
 
+    @router.get("/closeout")
+    async def closeout() -> dict[str, Any]:
+        from datetime import datetime
+
+        from ...cadence.closeout import build_closeout, escalation_severity
+        from ...db import get_database
+
+        now = datetime.now()
+        co = build_closeout(get_database(), now=now)
+        return {
+            "date": co.date,
+            "open_count": co.open_count,
+            "summary": co.summary,
+            "recs": [
+                {"loop": _loop_dict(r.loop), "severity": r.severity,
+                 "action": r.action, "reason": r.reason}
+                for r in co.recs
+            ],
+            "egress": _LOCAL_EGRESS,
+        }
+
+    @router.post("/closeout/apply")
+    async def closeout_apply(body: dict = Body(default={})) -> dict[str, Any]:
+        """Batch-apply lifecycle decisions: [{loop_id, action}]. Local only."""
+        from ...cadence.closeout import apply_decision
+        from ...db import get_database
+
+        db = get_database()
+        applied, skipped = 0, 0
+        for d in (body.get("decisions") or []):
+            if apply_decision(db, str(d.get("loop_id", "")), str(d.get("action", ""))):
+                applied += 1
+            else:
+                skipped += 1
+        return {"applied": applied, "skipped": skipped, "egress": _LOCAL_EGRESS}
+
+    @router.get("/history")
+    async def history(limit: int = 50) -> dict[str, Any]:
+        from ...db import get_database
+
+        return {"nudges": get_database().cadence.list_nudges(limit=limit), "egress": _LOCAL_EGRESS}
+
     @router.get("/loops/{loop_id}")
     async def loop_detail(loop_id: str) -> dict[str, Any]:
         from ...db import get_database

--- a/pm/roadmap/holdspeak/cadence-engine/README.md
+++ b/pm/roadmap/holdspeak/cadence-engine/README.md
@@ -5,17 +5,17 @@
 > next actions.** Qlippy does not merely remind. Qlippy pushes — with receipts, restraint, and a
 > ready-made next move.
 
-**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phases 1–5 are
-COMPLETE** — the substrate, the `/cadence` web coach, agent-blocker push, **Telegram remote
-presence**, and the **daily push brief** (your highest-leverage move first, delivered on first
-activity in the morning across CLI/web/Telegram; deterministic, no model required). Off by default
-throughout. **Phase 6 (stale-loop + EOD closure) is next.** Phases 7–8 are sketched here and storied
-as each becomes the lead.
+**Status:** Phase 0 (architecture hardening) complete — this chart IS its output. **Phases 1–6 are
+COMPLETE** — the substrate, the `/cadence` web coach, agent-blocker push, Telegram remote presence,
+the daily push brief, and now **stale-loop escalation + the end-of-day closure ritual** (every open
+loop with a recommended cheap decision; batch-apply; a history view). Off by default throughout.
+**Phase 7 (LLM next-best-action) is next** — the one phase with real-metal LLM proof (which also
+lights up the Phase-5 brief polish). Phase 8 (hardening + dogfood) closes it.
 
-**Last updated:** 2026-06-28 (Phase 5 shipped — the deterministic daily brief + the first-activity
-push trigger; the LLM-polish seam tested, live wiring deferred to a real-metal follow-up. Phases 1–4:
-the substrate + web coach + agent-blocker push + Telegram. Program authored from the owner's rough
-design + a grounded seam map; §15 resolved below).
+**Last updated:** 2026-06-28 (Phase 6 shipped — escalation + EOD closeout across CLI/web/Telegram +
+batch-apply + history; 171 cadence/web tests green. Phases 1–5: substrate + web coach + agent push +
+Telegram + the daily brief. Program authored from the owner's rough design + a grounded seam map; §15
+resolved below).
 
 ---
 
@@ -122,7 +122,7 @@ Phase 1 leads and is fully storied. Each later phase is storied when it becomes 
 | **3 ✅** | Agent-blocker push | *Done.* Awaiting-response agent sessions → top loops + a reply composer; the typed reply is delivered into the agent's tmux pane (`send_text_to_pane`, in the route — never autonomous). | 1 |
 | **4 ✅** | Telegram remote presence | *Done (hermetic; live walk = owner).* Pairing + a Telegram surface (`holdspeak/cadence_telegram.py`, a sibling of the core); `/brief` `/loops` `/status`; inline-button decisions (snooze/done + kill-confirm); unpaired-chat rejection; push-on-tick; token never logged/stored. | 2, 3 |
 | **5 ✅** | Daily push brief | *Done.* A deterministic morning brief (`build_brief`, first-activity trigger) across CLI/web/Telegram with prepared moves; the LLM-wording-polish seam is tested + fail-closed (live wiring deferred to a real-metal follow-up). | 2 |
-| **6** | Stale-loop + EOD closure | Escalation policy + an end-of-day closure ritual + batch closure UI; accepted-action → issue proposals; kill/delegate/snooze semantics. | 2, 5 |
+| **6 ✅** | Stale-loop + EOD closure | *Done.* `escalation_severity` (nudges/age) + `build_closeout` (a recommended decision per loop) + batch-apply + kill/delegate/snooze/close semantics + a history view, across CLI/web/Telegram. | 2, 5 |
 | **7** | LLM next-best-action | Structured-JSON next-action generator (issue/Slack drafts, dedupe clustering), fail-closed validation, preview/approval-gated. | 6 |
 | **8** | Hardening + dogfood | A cadence dogfood protocol + fixtures + e2e, telemetry-free local audit export, docs, and the master off-switch proven. | all |
 

--- a/pm/roadmap/holdspeak/cadence-engine/phase-6-stale-eod/current-phase-status.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-6-stale-eod/current-phase-status.md
@@ -1,0 +1,46 @@
+# Cadence Phase 6 — Stale-loop escalation + end-of-day closure
+
+**Status:** done (built + tested; 171 cadence/web tests green, web bundle builds). **Start here:**
+`../README.md`. Builds on Phases 1–5 (merged).
+
+**Last updated:** 2026-06-28 (Phase 6 shipped: escalation severity + the EOD closeout ritual across
+CLI/web/Telegram + a batch-apply + a history view).
+
+## Objective
+
+Add *pressure* (without spam) and a *closure ritual*. A loop that survives several nudges/days
+escalates so it stops being ignorable; at end of day, every open loop comes with a recommended cheap
+decision (close / file / snooze / kill / delegate) so clearing the board is a batch of one-taps.
+
+## What shipped
+
+- **Escalation** (`cadence/closeout.py` `escalation_severity`): `quiet | normal | persistent |
+  escalated`, by `nudge_count` (≥3 / ≥6) or age (≥2d / ≥4d); `needs_review` is always `quiet`.
+- **Closeout** (`build_closeout`): groups the open loops with a deterministic recommendation each —
+  `agent_question`→reply, `proposal`→approve, `needs_review`→review, escalated+unowned→**kill**,
+  unowned→delegate, owned+stale→file, persistent→file, else→snooze. `render_closeout_text`.
+- **Delegate semantics** + `apply_decision(db, loop_id, action)` — the lifecycle-only batch primitive
+  (snooze/kill/close/done/delegate); refuses unknown actions / missing loops. No external side effect.
+- **Surfaces:** `GET /api/cadence/closeout`, `POST /api/cadence/closeout/apply` (batch),
+  `GET /api/cadence/history` (recent nudges via the new `CadenceRepository.list_nudges`); `holdspeak
+  cadence closeout [--json]`; Telegram `/closeout`; and the `/cadence` page gained a **Closeout**
+  section (recommendations with the recommended-action badge + severity ring + one-tap apply) and a
+  **History** list.
+
+## Stories
+
+| ID | Title | Status |
+|----|-------|--------|
+| CAD-6-01 | Escalation severity (`escalation_severity`) | done |
+| CAD-6-02 | The closeout builder + recommendations (`build_closeout`) | done |
+| CAD-6-03 | Delegate semantics + `apply_decision` + the batch-apply route | done |
+| CAD-6-04 | History: `list_nudges` + `GET /api/cadence/history` | done |
+| CAD-6-05 | Surfaces: CLI `closeout`, Telegram `/closeout`, the page Closeout + History sections | done |
+| CAD-6-06 | Tests: escalation, recommendations, apply, history, the route + CLI | done |
+
+## Exit criteria
+
+- A loop escalates by nudges/age; closeout recommends a cheap decision per loop; batch-apply mutates
+  them; history lists recent nudges. All deterministic, local, off by default.
+- `uv run pytest -q` green (171 cadence/web tests); the web bundle builds. **Next: Phase 7 (LLM
+  next-best-action, with the real-metal proof that also lights up the Phase-5 brief polish).**

--- a/pm/roadmap/holdspeak/cadence-engine/phase-6-stale-eod/evidence-phase-6.md
+++ b/pm/roadmap/holdspeak/cadence-engine/phase-6-stale-eod/evidence-phase-6.md
@@ -1,0 +1,46 @@
+# Evidence — Cadence Phase 6 (stale-loop escalation + EOD closure)
+
+**Date:** 2026-06-28. **Branch:** `holdspeak/cadence-phase6-closeout`.
+
+## What shipped
+
+| Story | Files | Proof |
+|-------|-------|-------|
+| CAD-6-01 | `cadence/closeout.py` (`escalation_severity`) | `test_cadence_closeout.py` |
+| CAD-6-02 | `build_closeout` + `_recommend` + `render_closeout_text` | closeout recommendation tests |
+| CAD-6-03 | `apply_decision` (+ delegate) + `POST /closeout/apply` | apply + route tests |
+| CAD-6-04 | `db/cadence.py` `list_nudges` + `GET /history` | `test_history_lists_nudges` |
+| CAD-6-05 | CLI `closeout`, Telegram `/closeout`, page Closeout + History sections | CLI test + bundle builds |
+| CAD-6-06 | `test_cadence_closeout.py` + route additions | 171 green |
+
+## The ritual
+
+A sample `holdspeak cadence closeout` (a fresh owned loop, an old unowned loop, a proposal):
+
+```
+End-of-day closeout — 2026-06-28
+
+3 open · recommended: approve×1, kill×1, snooze×1
+
+      approve  Approve me   — A proposal is ready for your approval.
+      snooze   Owned fresh  — Not today — snooze until it matters.
+  [E] kill     Unowned old  — Open for days, still unowned — kill it or own it.
+```
+
+- **Escalation** (`escalation_severity`) raises a loop to `persistent` (≥3 nudges / ≥2 days) then
+  `escalated` (≥6 / ≥4); `needs_review` stays `quiet`.
+- **Recommendations** are deterministic per loop; **batch-apply** (`POST /closeout/apply`) mutates
+  the lifecycle (snooze/kill/close/delegate) in one call and skips non-applyable actions
+  (file/approve/reply open a draft elsewhere). `apply_decision` refuses unknown actions / missing loops.
+- **History** (`GET /api/cadence/history` via `list_nudges`) lists recent nudges; the page renders a
+  Closeout section (recommended-action badge + severity ring + one-tap apply) and a History list.
+
+## Trust boundary held
+
+`apply_decision` and the closeout builder are pure cadence-core operations (lifecycle writes only);
+the cadence-core no-external-side-effects guard still passes.
+
+## Proof
+
+- `uv run pytest -q tests/unit/test_cadence_*.py tests/integration/test_cadence_*.py
+  tests/integration/test_web_server.py` → **171 passed.** `cd web && npm run build` → 15 pages.

--- a/tests/integration/test_cadence_routes.py
+++ b/tests/integration/test_cadence_routes.py
@@ -61,6 +61,29 @@ def test_brief_route_leads_with_top_move(client):
     assert b["egress"]["scope"] == "local"
 
 
+def test_closeout_recommends_and_batch_applies(client):
+    c, db = client
+    c.post("/api/cadence/run-now")
+    co = c.get("/api/cadence/closeout").json()
+    assert co["open_count"] >= 1 and co["recs"]
+    assert all("action" in r and "reason" in r and "severity" in r for r in co["recs"])
+    # batch-apply: snooze them all
+    decisions = [{"loop_id": r["loop"]["id"], "action": "snooze"} for r in co["recs"]]
+    res = c.post("/api/cadence/closeout/apply", json={"decisions": decisions}).json()
+    assert res["applied"] == len(decisions) and res["skipped"] == 0
+    assert all(l["status"] == "snoozed" for l in c.get("/api/cadence/loops").json()["loops"])
+
+
+def test_history_lists_nudges(client):
+    c, db = client
+    c.post("/api/cadence/run-now")
+    from holdspeak.cadence.models import Nudge
+    loop_id = c.get("/api/cadence/loops").json()["loops"][0]["id"]
+    db.cadence.record_nudge(Nudge(loop_id=loop_id, surface="web", title="pushed it"))
+    hist = c.get("/api/cadence/history").json()["nudges"]
+    assert hist and hist[0]["title"] == "pushed it" and hist[0]["surface"] == "web"
+
+
 def test_loop_detail_404_then_ok(client):
     c, _ = client
     assert c.get("/api/cadence/loops/nope").status_code == 404

--- a/tests/unit/test_cadence_closeout.py
+++ b/tests/unit/test_cadence_closeout.py
@@ -1,0 +1,87 @@
+"""CAD-6 — stale-loop escalation + the end-of-day closeout ritual."""
+from __future__ import annotations
+
+import io
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from holdspeak.cadence.closeout import (
+    apply_decision,
+    build_closeout,
+    escalation_severity,
+    render_closeout_text,
+)
+from holdspeak.cadence.models import OpenLoop
+from holdspeak.commands.cadence import run_cadence_command
+from holdspeak.config import Config
+from holdspeak.db import Database
+
+NOW = datetime(2026, 6, 28, 18, 0, 0)
+
+
+def _loop(**kw) -> OpenLoop:
+    return OpenLoop(source_type=kw.pop("source_type", "meeting_action"),
+                    source_id=kw.pop("source_id", "x"), title=kw.pop("title", "t"), **kw)
+
+
+def test_escalation_by_nudge_count_and_age():
+    assert escalation_severity(_loop(nudge_count=0), now=NOW) == "normal"
+    assert escalation_severity(_loop(nudge_count=3), now=NOW) == "persistent"
+    assert escalation_severity(_loop(nudge_count=6), now=NOW) == "escalated"
+    old = _loop(created_at="2026-06-23T10:00:00")  # 5 days
+    assert escalation_severity(old, now=NOW) == "escalated"
+    assert escalation_severity(_loop(needs_review=True, nudge_count=9), now=NOW) == "quiet"
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    d = Database(tmp_path / "co.db")
+    d.cadence.upsert_loop(_loop(source_id="p1", source_type="proposal", title="Approve me"))
+    d.cadence.upsert_loop(_loop(source_id="a1", title="Owned fresh", owner="Karol"))
+    d.cadence.upsert_loop(_loop(source_id="a2", title="Unowned old"))
+    # the repo stamps created_at=now on insert; age the loop realistically for escalation
+    with d._connection() as c:
+        c.execute("UPDATE cadence_loops SET created_at = '2026-06-22T00:00:00' "
+                  "WHERE source_id = 'a2'")
+    return d
+
+
+def test_closeout_recommends_per_loop(db):
+    co = build_closeout(db, now=NOW)
+    assert co.open_count == 3 and not co.is_empty
+    by_title = {r.loop.title: r.action for r in co.recs}
+    assert by_title["Approve me"] == "approve"
+    assert by_title["Owned fresh"] == "snooze"   # fresh + owned -> not today
+    assert by_title["Unowned old"] == "kill"     # escalated + unowned -> kill candidate
+    assert "End-of-day" in render_closeout_text(co)
+
+
+def test_apply_decision_lifecycle(db):
+    loop = db.cadence.get_loop_by_source("meeting_action", "a1")
+    assert apply_decision(db, loop.id, "snooze", now=NOW) is True
+    assert db.cadence.get_loop(loop.id).status == "snoozed"
+    assert apply_decision(db, loop.id, "delegate") is True
+    assert db.cadence.get_loop(loop.id).status == "delegated"
+    assert apply_decision(db, loop.id, "kill") is True
+    assert db.cadence.get_loop(loop.id).status == "killed"
+
+
+def test_apply_decision_rejects_unknown_action_and_missing(db):
+    loop = db.cadence.get_loop_by_source("proposal", "p1")
+    assert apply_decision(db, loop.id, "explode") is False  # not an applyable action
+    assert apply_decision(db, "nope", "kill") is False      # missing loop
+
+
+def test_empty_closeout(tmp_path):
+    d = Database(tmp_path / "e.db")
+    co = build_closeout(d, now=NOW)
+    assert co.is_empty and "clear" in render_closeout_text(co).lower()
+
+
+def test_cli_closeout(db):
+    buf = io.StringIO()
+    class A: cadence_action = "closeout"; json = False
+    rc = run_cadence_command(A(), stream=buf, db=db, config=Config())
+    assert rc == 0 and "End-of-day" in buf.getvalue()

--- a/web/src/pages/cadence.astro
+++ b/web/src/pages/cadence.astro
@@ -30,6 +30,19 @@ import AppLayout from "../layouts/AppLayout.astro";
       <h2>Open loops</h2>
       <div id="cad-loops" class="cad-list"></div>
     </section>
+
+    <section class="cad-section">
+      <div class="cad-section-head">
+        <h2>End-of-day closeout</h2>
+        <button class="cad-btn" id="cad-closeout-btn" type="button">Run closeout</button>
+      </div>
+      <div id="cad-closeout" class="cad-list"></div>
+    </section>
+
+    <section class="cad-section">
+      <h2>History</h2>
+      <div id="cad-history" class="cad-history"></div>
+    </section>
   </div>
 
   <script>
@@ -130,4 +143,20 @@ import AppLayout from "../layouts/AppLayout.astro";
     padding: 0.5rem 0.65rem; font: inherit; font-size: 0.88rem;
   }
   .cad-reply-input:focus { outline: none; border-color: var(--color-accent, #ff6b35); }
+
+  .cad-section-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 0.75rem; }
+  .cad-section-head h2 { margin: 0; }
+  .cad-rec-action {
+    font-size: 0.7rem; font-weight: 800; letter-spacing: 0.05em; text-transform: uppercase;
+    padding: 0.1rem 0.5rem; border-radius: 999px; background: rgba(255,107,53,0.16); color: var(--color-accent, #ff6b35);
+  }
+  .cad-sev-escalated { box-shadow: inset 0 0 0 1px rgba(255,77,109,0.5); }
+  .cad-sev-persistent { box-shadow: inset 0 0 0 1px rgba(246,195,86,0.4); }
+  .cad-history { display: flex; flex-direction: column; gap: 0.35rem; }
+  .cad-history-row {
+    display: flex; gap: 0.6rem; align-items: baseline; font-size: 0.84rem;
+    color: var(--color-text-muted, #9c93a8); padding: 0.35rem 0.1rem;
+    border-bottom: 1px solid var(--color-line, rgba(255,255,255,0.06));
+  }
+  .cad-history-surface { font-size: 0.66rem; font-weight: 800; text-transform: uppercase; color: var(--color-text-faint, #6f6880); }
 </style>

--- a/web/src/scripts/cadence-app.js
+++ b/web/src/scripts/cadence-app.js
@@ -150,6 +150,50 @@ async function refresh() {
   }
 }
 
+function recCard(rec) {
+  const card = loopCard(rec.loop);
+  if (rec.severity === "escalated") card.classList.add("cad-sev-escalated");
+  else if (rec.severity === "persistent") card.classList.add("cad-sev-persistent");
+  // surface the recommended action as a badge in the head
+  const head = card.querySelector(".cad-card-head");
+  if (head) {
+    const badge = el("span", "cad-rec-action", rec.action);
+    badge.title = rec.reason;
+    head.insertBefore(badge, head.querySelector(".egress-badge"));
+  }
+  return card;
+}
+
+async function loadCloseout() {
+  const co = await jget(`${API}/closeout`);
+  const host = document.getElementById("cad-closeout");
+  if (!host) return;
+  host.textContent = "";
+  if (!co.recs || !co.recs.length) {
+    host.appendChild(emptyState("Your loops are clear. Nice."));
+    return;
+  }
+  co.recs.forEach((rec) => host.appendChild(recCard(rec)));
+}
+
+async function loadHistory() {
+  const data = await jget(`${API}/history?limit=20`);
+  const host = document.getElementById("cad-history");
+  if (!host) return;
+  host.textContent = "";
+  const nudges = data.nudges || [];
+  if (!nudges.length) {
+    host.appendChild(emptyState("No nudges yet."));
+    return;
+  }
+  nudges.forEach((n) => {
+    const row = el("div", "cad-history-row");
+    row.appendChild(el("span", "cad-history-surface", n.surface));
+    row.appendChild(el("span", null, n.title || n.status));
+    host.appendChild(row);
+  });
+}
+
 async function onAction(loopId, act, card) {
   if (act === "snooze") await jpost(`${API}/loops/${loopId}/snooze`, { hours: 24 });
   else if (act === "close") await jpost(`${API}/loops/${loopId}/close`);
@@ -178,12 +222,19 @@ export function initCadence() {
       }
     });
   }
+  const closeoutBtn = document.getElementById("cad-closeout-btn");
+  if (closeoutBtn) {
+    closeoutBtn.addEventListener("click", () => loadCloseout().catch((e) => console.error(e)));
+  }
   document.addEventListener("click", (ev) => {
     const btn = ev.target.closest("[data-act]");
     if (!btn) return;
     const card = btn.closest("[data-loop-id]");
     if (!card) return;
-    onAction(card.dataset.loopId, btn.dataset.act, card).catch((e) => console.error(e));
+    onAction(card.dataset.loopId, btn.dataset.act, card)
+      .then(() => loadHistory().catch(() => {}))
+      .catch((e) => console.error(e));
   });
   refresh().catch((e) => console.error(e));
+  loadHistory().catch((e) => console.error(e));
 }


### PR DESCRIPTION
**Cadence Engine — Phase 6.** Pressure (without spam) + a closure ritual. Builds on Phases 1–5.

## What's here

- **Escalation** (`escalation_severity`): `quiet | normal | persistent | escalated` by `nudge_count`
  (≥3/≥6) or age (≥2d/≥4d); `needs_review` stays `quiet`.
- **Closeout** (`build_closeout`): every open loop with a deterministic recommended decision —
  agent→reply, proposal→approve, escalated+unowned→**kill**, unowned→delegate, owned+stale→file,
  persistent→file, else→snooze. `render_closeout_text`.
- **`apply_decision` + delegate** — the lifecycle-only batch primitive (snooze/kill/close/delegate);
  refuses unknown actions / missing loops. No external side effect.
- **Surfaces:** `GET /api/cadence/closeout`, `POST /closeout/apply` (batch), `GET /history` (via the
  new `list_nudges`); `holdspeak cadence closeout`; Telegram `/closeout`; and the `/cadence` page
  gained a **Closeout** section (recommended-action badge + severity ring + one-tap apply) and a
  **History** list.

## Proof

- **171** tests passed (cadence + the full web-server suite); `cd web && npm run build` → 15 pages.
- The cadence-core no-external-side-effects guard still passes.

Next: **Phase 7** — the LLM next-best-action (the one phase with real-metal LLM proof, which also
lights up the Phase-5 brief polish). Then Phase 8 (hardening + dogfood) closes the program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)