### PR TITLE
HSM-20-05: fix a device-only build break the simulator hid (DictateDemo)

### DIFF
--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -30,7 +30,14 @@ struct MeetingCaptureApp: App {
                     NavigationStack { CaptureView(model: CaptureModel(), done: {}) }
                 } else if ProcessInfo.processInfo.environment["HS_DEMO_DICTATE"] != nil {
                     // HSM-20-04 — the dictation surface straight (the iPhone hold-bar teleprompter).
-                    DictateDemo()
+                    // Inlined (not `DictateDemo()`, which is simulator-only) so this root entry
+                    // compiles on device too — the device build caught the cross-platform gap.
+                    NavigationStack { DictateView() }
+                        .onAppear {
+                            let peer = DictatePeerStore.shared
+                            if peer.host.isEmpty { peer.host = "192.168.1.13"; peer.portText = "8081" }
+                            if peer.name.isEmpty { peer.name = "Karol's Mac" }
+                        }
                 } else if ProcessInfo.processInfo.environment["HS_CLASSIC_HOME"] != nil {
                     MeetingListView()
                         .onOpenURL { url in

--- a/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-05-on-device-proof.md
+++ b/pm/roadmap/holdspeak-mobile/phase-20-one-app-every-size/story-05-on-device-proof.md
@@ -2,8 +2,13 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 20
-- **Status:** todo — **the gate.** The ONLY story that promotes an iPhone cell from
-  forward-constraint to proven.
+- **Status:** in progress — **the gate.** The ONLY story that promotes an iPhone cell from
+  forward-constraint to proven. **Build + install + launch on a real iPhone 17 Pro Max
+  (00008150-…) succeeded** (2026-06-27). The device build immediately caught a real 20-04
+  bug the simulator hid: `MeetingCaptureApp`'s `HS_DEMO_DICTATE` root entry referenced the
+  **simulator-only** `DictateDemo` unconditionally (`cannot find 'DictateDemo' in scope` on
+  device); fixed by inlining the device-safe `NavigationStack { DictateView() }`. The app is
+  on the device; the owner's hand-walk of the compact surfaces is the remaining gate.
 - **Depends on:** 20-01, 20-02, 20-03, 20-04 (everything reflows before it is walked).
 - **Unblocks:** the phase closeout + every `🟡` iPhone cell in the parity matrix.
 - **Owner:** **the owner** (only he can walk the cabled iPhone).


### PR DESCRIPTION
Building the Phase 20 app onto a **real iPhone 17 Pro Max** for the HSM-20-05 device walk immediately
caught a bug the simulator could not:

`MeetingCaptureApp`'s `HS_DEMO_DICTATE` root entry (added in 20-04) referenced `DictateDemo()`
**unconditionally**, but `DictateDemo` is `#if targetEnvironment(simulator)` (a sim-only screenshot
helper). The simulator build compiled; the **device build failed** with `cannot find 'DictateDemo'
in scope`.

**Fix:** inline the device-safe equivalent (`NavigationStack { DictateView() }` + the same peer
seeding) so the root entry compiles on device and simulator alike. `DictateDemo` stays for the
classic-home simulator screenshot path.

**Result:** device `xcodebuild` **BUILD SUCCEEDED** (arm64-apple-ios); the app **installed and
launched** on the iPhone. The owner's hand-walk of the compact surfaces is the remaining HSM-20-05
gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)