### PR TITLE
iPhone usability + in-app model downloads (+ park Core AI)

### DIFF
--- a/apple/App/CompanionShellApp.swift
+++ b/apple/App/CompanionShellApp.swift
@@ -134,7 +134,7 @@ final class ShellModel: ObservableObject {
     func previewDictation() async {
         let utterance = dictateText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !utterance.isEmpty else { return }
-        guard let c = client() else { dictateError = "Pair your Mac first."; return }
+        guard let c = client() else { dictateError = "Pair your desktop first."; return }
         dictating = true; dictateError = ""; dictateSent = false; defer { dictating = false }
         do {
             let result = try await c.dictationDryRun(utterance: utterance)
@@ -144,17 +144,17 @@ final class ShellModel: ObservableObject {
             } else {
                 dictatePreview = result
             }
-        } catch { dictatePreview = nil; dictateError = "Couldn't reach your Mac for a preview." }
+        } catch { dictatePreview = nil; dictateError = "Couldn't reach your desktop for a preview." }
     }
 
-    /// Commit the previewed text: free-type the rewritten result into the focused Mac app.
+    /// Commit the previewed text: free-type the rewritten result into the focused desktop app.
     func sendDictation() async {
         guard let c = client(), let preview = dictatePreview else { return }
         dictating = true; dictateError = ""; defer { dictating = false }
         do {
             _ = try await c.sendRemoteDictation(text: preview.finalText, target: .focused)
             dictateSent = true; dictatePreview = nil; dictateText = ""
-        } catch { dictateError = "Send failed. Is a Mac app focused?" }
+        } catch { dictateError = "Send failed. Is a desktop app focused?" }
     }
 
     // MARK: Aftercare (HSM-19-01) — the close-the-loop digest for a meeting.
@@ -349,7 +349,7 @@ struct ShellView: View {
                 .padding(11).background(Sig.s2, in: RoundedRectangle(cornerRadius: 12))
                 .overlay(RoundedRectangle(cornerRadius: 12).stroke(art.status == "needs_review" ? Sig.warn.opacity(0.4) : Sig.line, lineWidth: 1))
             }
-            rowNote("Confidence is the model's certainty in the synthesis; the sources are where it came from. A needs-review artifact stays unsettled until you accept it.")
+            rowNote("Accept a needs-review artifact to settle it.")
         }
         .cardChrome(border: Sig.accent.opacity(0.3))
     }
@@ -415,7 +415,7 @@ struct ShellView: View {
                 }
             }
 
-            rowNote("An accepted action becomes a GitHub issue proposal you approve separately, never automatically.")
+            rowNote("Accepted actions become issue proposals you approve.")
         }
         .cardChrome(border: Sig.accent.opacity(0.3))
     }
@@ -439,7 +439,7 @@ struct ShellView: View {
             }
             let local = model.state?.local.meetings ?? []
             if local.isEmpty {
-                rowNote("No local recordings yet. Capture, transcription and inference run on-device.")
+                rowNote("No recordings yet.")
             } else {
                 ForEach(local) { m in meetingRow(m, tint: Sig.local) }
             }
@@ -457,7 +457,7 @@ struct ShellView: View {
                 if meetings.isEmpty {
                     rowNote("No meetings on the desktop yet.")
                 } else {
-                    Text("Tap a meeting for its close-the-loop digest + artifacts")
+                    Text("Tap a meeting for its digest")
                         .font(.caption2).foregroundStyle(Sig.faint)
                     ForEach(meetings) { m in
                         Button {
@@ -481,7 +481,7 @@ struct ShellView: View {
                     }
                 }
             } else {
-                rowNote("The desktop isn't reachable right now. Nothing here is blocked — your iPad's own runtime above is fully live. It reconnects on its own when the server returns.")
+                rowNote("Desktop not reachable. Your iPad runtime stays live.")
                 Button { Task { await model.load() } } label: { label("Retry", "arrow.clockwise", filled: false) }
             }
         }
@@ -492,7 +492,7 @@ struct ShellView: View {
 
     private var dictateScreen: some View {
         VStack(alignment: .leading, spacing: 14) {
-            peerHeader("DICTATE", "Watch the rewrite resolve, then send to your Mac", Sig.local, live: true)
+            peerHeader("DICTATE", "Watch the rewrite resolve, then send to your desktop", Sig.local, live: true)
 
                 VStack(alignment: .leading, spacing: 8) {
                     Text("WHAT YOU'D SAY").font(.caption2.weight(.bold)).tracking(1.4).foregroundStyle(Sig.faint)
@@ -518,10 +518,10 @@ struct ShellView: View {
                     VStack(alignment: .leading, spacing: 11) {
                         HStack(spacing: 7) {
                             Image(systemName: "arrow.right.circle.fill").foregroundStyle(Sig.local)
-                            Text(destination.map { "Types into \($0)" } ?? "Types into the focused Mac app")
+                            Text(destination.map { "Types into \($0)" } ?? "Types into the focused desktop app")
                                 .font(.caption.weight(.semibold)).foregroundStyle(Sig.muted)
                             Spacer()
-                            egressChip("Local + \(model.host.isEmpty ? "your Mac" : model.host)")
+                            egressChip("Local + \(model.host.isEmpty ? "your desktop" : model.host)")
                         }
                         Text(preview.finalText).font(.title3.weight(.semibold)).foregroundStyle(Sig.text)
                             .textSelection(.enabled).fixedSize(horizontal: false, vertical: true)
@@ -540,7 +540,7 @@ struct ShellView: View {
                                 HStack(spacing: 7) {
                                     if model.dictating { ProgressView().controlSize(.mini).tint(.black) }
                                     else { Image(systemName: "paperplane.fill") }
-                                    Text("Send to your Mac")
+                                    Text("Send to your desktop")
                                 }
                                 .font(.subheadline.weight(.semibold)).foregroundStyle(.black)
                                 .frame(maxWidth: .infinity).padding(.vertical, 11)
@@ -555,13 +555,12 @@ struct ShellView: View {
                 if model.dictateSent {
                     HStack(spacing: 7) {
                         Image(systemName: "checkmark.circle.fill").foregroundStyle(Sig.ok)
-                        Text("Sent to your Mac").font(.caption.weight(.semibold)).foregroundStyle(Sig.ok)
+                        Text("Sent to your desktop").font(.caption.weight(.semibold)).foregroundStyle(Sig.ok)
                     }
                 }
                 if !model.dictateError.isEmpty {
                     Text(model.dictateError).font(.caption).foregroundStyle(Sig.warn)
                 }
-                rowNote("Preview shows exactly what would type. Send free-types it into the focused Mac app, never autonomously. Speak-to-fill lands next.")
             }
             .cardChrome(border: Sig.local.opacity(0.35))
     }
@@ -594,7 +593,7 @@ struct ShellView: View {
             peerHeader("ANSWER THE CODER", "The agent's question, on your iPad", Sig.accent,
                        live: model.board.awaiting)
             if model.board.targets.isEmpty {
-                rowNote("No coder is waiting right now. When an agent in your session asks a question, it surfaces here — answer it by voice.")
+                rowNote("No coder is waiting.")
             } else {
                 ForEach(model.board.targets) { t in
                     VStack(alignment: .leading, spacing: 6) {
@@ -614,7 +613,6 @@ struct ShellView: View {
                     .overlay(RoundedRectangle(cornerRadius: 11).stroke(Sig.line, lineWidth: 1))
                 }
             }
-            rowNote("Speak your answer; it transcribes on-device and delivers into the coder — never autonomously.")
         }
         .cardChrome(border: Sig.line)
     }
@@ -646,8 +644,6 @@ struct ShellView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("COMPANION").font(.caption.weight(.bold)).tracking(2).foregroundStyle(Sig.accent)
                     Text("Point your iPad at your desktop").font(.largeTitle.bold()).foregroundStyle(Sig.text)
-                    Text("It stays a full on-device runtime — pairing just adds the server you code against.")
-                        .font(.footnote).foregroundStyle(Sig.faint)
                 }
                 VStack(alignment: .leading, spacing: 14) {
                     field("Host", text: $model.host, placeholder: "192.168.1.x", keyboard: .URL)

--- a/apple/App/MeetingCapture/AppSettings.swift
+++ b/apple/App/MeetingCapture/AppSettings.swift
@@ -29,7 +29,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     header
                     label("WHERE INTELLIGENCE RUNS")
-                    targetCard(.local, "This iPad", "Fully on-device · nothing ever leaves", "ipad", Sig.localGradient)
+                    targetCard(.local, "This iPad", "Runs on this iPad", "ipad", Sig.localGradient)
                     if cfg.isLocal { onDeviceModelCard }
                     targetCard(.homelab, "LAN endpoint", "An OpenAI-compatible server on your network", "server.rack", Sig.accentGradient)
                     if !cfg.isLocal { endpointCard }
@@ -71,7 +71,7 @@ struct SettingsView: View {
                         GlyphChip(system: "tray.and.arrow.down.fill", gradient: Sig.accentGradient, size: 42)
                         VStack(alignment: .leading, spacing: 2) {
                             Text("No models on this iPad").font(.system(size: 15.5, weight: .heavy)).foregroundStyle(Sig.text)
-                            Text("Import a .gguf to run intelligence on-device").font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint)
+                            Text("Tap to download one").font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint)
                         }
                         Spacer(); Image(systemName: "chevron.right").font(.system(size: 13, weight: .bold)).foregroundStyle(Sig.faint)
                     }
@@ -286,7 +286,7 @@ struct SettingsView: View {
             GlyphChip(system: "globe", gradient: Sig.localGradient, size: 50)
             VStack(alignment: .leading, spacing: 3) {
                 Text("Spoken language").font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text)
-                Text("Auto detects per utterance; pick one for short or mixed speech").font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint)
+                Text("Auto-detects per utterance.").font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint)
             }
             Spacer()
             Menu {

--- a/apple/App/MeetingCapture/CompanionMesh.swift
+++ b/apple/App/MeetingCapture/CompanionMesh.swift
@@ -130,7 +130,7 @@ struct AgentDeskView: View {
             }
             VStack(spacing: 6) {
                 Text("No agents linked").font(.system(size: 18, weight: .heavy)).foregroundStyle(Sig.text)
-                Text("Run a coding agent on your desktop — it appears here the moment it needs you")
+                Text("Run a coding agent on your desktop")
                     .font(.system(size: 13, weight: .medium)).foregroundStyle(Sig.faint)
                     .multilineTextAlignment(.center)
             }
@@ -281,10 +281,10 @@ private struct AgentDeskCard: View {
     }
 }
 
-// MARK: - Dictate to your Mac (HSM-15-01 — the flagship mesh surface)
+// MARK: - Dictate to your desktop (HSM-15-01 — the flagship mesh surface)
 
 /// The paired desktop peer, persisted across launches. The flagship home reads this to name the
-/// "Dictate to {your Mac}" tile and to know whether to invite pairing. Seedable via the
+/// "Dictate to {your desktop}" tile and to know whether to invite pairing. Seedable via the
 /// `HS_DESKTOP_*` env (a real-metal LAN trace) so a device run points at a live server with no taps.
 @MainActor final class DictatePeerStore: ObservableObject {
     static let shared = DictatePeerStore()
@@ -316,7 +316,7 @@ private struct AgentDeskCard: View {
         let n = name.trimmingCharacters(in: .whitespaces)
         if !n.isEmpty { return n }
         let h = host.trimmingCharacters(in: .whitespaces)
-        return h.isEmpty ? "your Mac" : h
+        return h.isEmpty ? "your desktop" : h
     }
 
     var peer: DesktopPeer? {
@@ -456,8 +456,8 @@ private struct AgentDeskCard: View {
     #endif
 }
 
-/// The flagship "Dictate to your Mac" surface (HSM-15-01): the iPad is the best mic in the house,
-/// your Mac has every app you work in. Pick it up, talk, and the words land in whatever is focused —
+/// The flagship "Dictate to your desktop" surface (HSM-15-01): the iPad is the best mic in the house,
+/// your desktop has every app you work in. Pick it up, talk, and the words land in whatever is focused —
 /// transcribed on-device, typed through the desktop's full dictation pipeline. No prose; chips + symbols.
 struct DictateView: View {
     @StateObject private var model = DictateModel()
@@ -557,7 +557,7 @@ struct DictateView: View {
         let armed = model.isPaired
         return HStack(spacing: 12) {
             Image(systemName: model.listening ? "waveform" : "mic.fill").font(.system(size: 20, weight: .bold))
-            Text(model.listening ? "Release to send" : (armed ? "Hold to talk" : "Pair your Mac to start"))
+            Text(model.listening ? "Release to send" : (armed ? "Hold to talk" : "Pair your desktop to start"))
                 .font(.system(size: 17, weight: .heavy))
             if model.listening { Spacer(minLength: 4); MicWaveform(level: CGFloat(model.level), active: true, bars: 16, height: 22).frame(width: 90, height: 22) }
         }
@@ -637,12 +637,12 @@ struct DictateView: View {
         switch model.reach {
         case .unpaired:
             Button { tactile(.medium); pairing = true } label: {
-                statusChip("link.badge.plus", "Pair your Mac to start", Sig.accent, filled: true)
+                statusChip("link.badge.plus", "Pair your desktop to start", Sig.accent, filled: true)
             }
             .buttonStyle(PressableCard())
         case .asleep:
             Button { tactile(); Task { await model.probe() } } label: {
-                statusChip("moon.zzz.fill", "Mac asleep · not reachable — tap to retry", Sig.warn)
+                statusChip("moon.zzz.fill", "Desktop asleep · not reachable — tap to retry", Sig.warn)
             }
             .buttonStyle(PressableCard())
         case .reachable:
@@ -795,7 +795,7 @@ struct DictateView: View {
     }
 }
 
-// MARK: - The Connect surface ("Your Computer" — discovery-first pairing, HSM-15-10)
+// MARK: - The Connect surface ("Your Desktop" — discovery-first pairing, HSM-15-10)
 
 /// One computer the iPad found on the LAN by Bonjour (`_holdspeak._tcp`). Identified by the
 /// advertised name; host/port arrive on resolve so tap-to-connect needs no IP typing. `requiresToken`
@@ -930,7 +930,7 @@ struct MeshInfo: Decodable, Equatable {
     var requiresToken: Bool?
 }
 
-/// "Your Computer" — the first-class, discovery-first place to find and pair with your desktop
+/// "Your Desktop" — the first-class, discovery-first place to find and pair with your desktop
 /// (HSM-15-10). Browses the LAN by Bonjour, lists computers by name + reach, tap-to-connect (host/port
 /// from discovery — no IP typing), a tight token pairing step when required, and a manual fallback.
 /// The single paired peer it writes (`DictatePeerStore`) is what dictation / Agent Desk / the Queue
@@ -1003,7 +1003,7 @@ struct ConnectView: View {
                 .padding(.horizontal, 10).padding(.vertical, 5)
                 .background(Sig.local.opacity(0.12), in: Capsule())
                 .overlay(Capsule().strokeBorder(Sig.local.opacity(0.25), lineWidth: 1))
-                Text("Your Computer").font(.system(size: 36, weight: .heavy)).foregroundStyle(Sig.text)
+                Text("Your Desktop").font(.system(size: 36, weight: .heavy)).foregroundStyle(Sig.text)
                     .shadow(color: .black.opacity(0.3), radius: 8, y: 3)
             }
             Spacer()
@@ -1135,8 +1135,8 @@ struct ConnectView: View {
                     .foregroundStyle(Sig.local)
             }
             VStack(spacing: 6) {
-                Text("Looking for your computer…").font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text)
-                Text("Run HoldSpeak on your Mac and it shows up here by name. No IP to type.")
+                Text("Looking for your desktop…").font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text)
+                Text("Run HoldSpeak on your desktop.")
                     .font(.system(size: 13, weight: .medium)).foregroundStyle(Sig.faint)
                     .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
             }
@@ -1193,7 +1193,7 @@ struct ConnectView: View {
                         .textInputAutocapitalization(.never).autocorrectionDisabled()
                         .padding(14).background(Sig.s2, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Sig.line, lineWidth: 1))
-                    Text("Your Mac prints it on startup. Copy it here once and this iPad stays paired.")
+                    Text("Printed on your desktop at startup.")
                         .font(.system(size: 12)).foregroundStyle(Sig.faint)
                 }
                 Button { connect(target, token: pairToken.isEmpty ? nil : pairToken) } label: {
@@ -1261,7 +1261,7 @@ struct ConnectView: View {
 
 #if targetEnvironment(simulator)
 /// Simulator-only: the Connect surface with a seeded discovery list (HS_DEMO_CONNECT=1) so the
-/// "Your Computer" screen renders fully without a live LAN service.
+/// "Your Desktop" screen renders fully without a live LAN service.
 struct ConnectDemo: View {
     var body: some View { NavigationStack { ConnectView() } }
 }
@@ -1279,14 +1279,14 @@ struct PairMacSheet: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     HStack {
-                        Text("Pair your Mac").font(.system(size: 28, weight: .heavy)).foregroundStyle(Sig.text)
+                        Text("Pair your desktop").font(.system(size: 28, weight: .heavy)).foregroundStyle(Sig.text)
                         Spacer()
                         Button { dismiss() } label: {
                             Image(systemName: "xmark").font(.system(size: 15, weight: .bold)).foregroundStyle(Sig.muted)
                                 .frame(width: 38, height: 38).background(Sig.s2, in: Circle())
                         }
                     }
-                    Text("Run HoldSpeak on your Mac, then point this iPad at it over your network.")
+                    Text("Run HoldSpeak on your desktop.")
                         .font(.system(size: 14)).foregroundStyle(Sig.faint)
                     field("Name", text: $peers.name, placeholder: "Karol's Mac")
                     field("Host", text: $peers.host, placeholder: "192.168.1.x")

--- a/apple/App/MeetingCapture/DeskAgents.swift
+++ b/apple/App/MeetingCapture/DeskAgents.swift
@@ -484,7 +484,7 @@ struct DioAgentBuilder: View {
             if showAdvanced {
                 Text("WHAT TO ASK").font(.system(size: 10, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.muted)
                 editor($draft.userTemplate, placeholder: "{input}", minH: 52)
-                Text("Use {input} for your question, or the card you route through it.")
+                Text("Use {input} for your question.")
                     .font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
                 Text("CONTEXT IT CARRIES").font(.system(size: 10, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.muted).padding(.top, 4)
                 editor($draft.manualContext, placeholder: "Pinned notes the agent always knows…", minH: 60)
@@ -683,7 +683,7 @@ struct DioAgentChat: View {
                     if !agent.manualContext.isEmpty { tag("Pinned notes", "note.text") }
                 }
             }
-            Text("Tip: long-press a card on the desk and pick \(agent.name) to bring it in.")
+            Text("Long-press a desk card to use \(agent.name).")
                 .font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted.opacity(0.8)).multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity).padding(.top, 28)
@@ -876,7 +876,7 @@ struct DioChainSheet: View {
                         .background(Capsule().fill(LinearGradient(colors: [Color(hex: 0xFF8A5B), DioPal.accent], startPoint: .top, endPoint: .bottom)))
                         .opacity(ready ? 1 : 0.45)
                 }.buttonStyle(.plain)
-                Text("Tip: long-press a desk card and pick this chain to run it on that card.").font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted.opacity(0.8))
+                Text("Long-press a desk card to run this chain.").font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted.opacity(0.8))
             }
             .padding(20).frame(maxWidth: 520)
             .background(RoundedRectangle(cornerRadius: 28, style: .continuous).fill(Color(hex: 0x14121B)).overlay(RoundedRectangle(cornerRadius: 28, style: .continuous).strokeBorder(.white.opacity(0.1), lineWidth: 1)))
@@ -919,7 +919,7 @@ struct DioChainBuilder: View {
                         sec("NAME") { field($draft.name, "e.g. Refine") }
                         sec("THE PIPELINE · runs top to bottom") {
                             if draft.steps.isEmpty {
-                                Text("Add agents below — each one's output flows into the next.").font(.system(size: 12, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
+                                Text("Add agents to the chain.").font(.system(size: 12, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
                             }
                             ForEach(Array(draft.steps.enumerated()), id: \.offset) { i, sid in
                                 if let a = agents.first(where: { $0.id == sid }) {
@@ -939,7 +939,7 @@ struct DioChainBuilder: View {
                         }
                         sec("ADD AN AGENT") {
                             if agents.isEmpty {
-                                Text("Create some agents first, then chain them here.").font(.system(size: 12, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
+                                Text("Create an agent first.").font(.system(size: 12, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
                             } else {
                                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 8)], spacing: 8) {
                                     ForEach(agents) { a in

--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -82,7 +82,7 @@ struct DioSyncStatus: View {
     private var caption: String {
         switch state {
         case .idle:     return "Tap to sync"
-        case .unpaired: return "No Mac paired"
+        case .unpaired: return "No desktop paired"
         case .syncing:  return "Syncing…"
         case .synced:   return lastSyncedAt.map { "Synced · \(dioRelativeAgo($0))" } ?? "Synced"
         case .offline:  return "Offline · queued"
@@ -145,7 +145,7 @@ struct DioSyncStatus: View {
     }
 }
 
-// per-primitive sync cue — what's canonical (synced to your Mac) vs local-only / pending.
+// per-primitive sync cue — what's canonical (synced to your desktop) vs local-only / pending.
 enum PrimSyncCue: Equatable {
     case synced          // confirmed canonical on the hub (this session) — calm mint dot
     case pending         // edited locally, not yet pushed/confirmed — amber ring
@@ -154,7 +154,7 @@ enum PrimSyncCue: Equatable {
 }
 
 // A tiny, hushed corner mark on a card carrying its sync cue. A filled mint check = canonical
-// on your Mac; a hollow amber ring = pending; a quiet slashed cloud = local-only (games).
+// on your desktop; a hollow amber ring = pending; a quiet slashed cloud = local-only (games).
 struct SyncCueBadge: View {
     struct Spec { let glyph: String; let tint: Color; let filled: Bool; let breathes: Bool }
     let spec: Spec
@@ -209,7 +209,7 @@ struct DioZoneEmpty: View {
                 .frame(height: 130)
                 VStack(spacing: 7) {
                     Text("\(name) is empty").font(.system(size: 20, weight: .black, design: .rounded)).foregroundStyle(DioPal.text)
-                    Text("Drag a meeting onto this zone from your desk to file it here.")
+                    Text("Drag a meeting here to file it.")
                         .font(.system(size: 13, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
                         .multilineTextAlignment(.center).frame(maxWidth: 300)
                 }
@@ -259,7 +259,7 @@ struct DioFirstBoot: View {
                 .frame(height: 140)
                 VStack(spacing: 6) {
                     Text("Your desk is ready").font(.system(size: 21, weight: .black, design: .rounded)).foregroundStyle(DioPal.text)
-                    Text("An empty desk, waiting for your first meeting.").font(.system(size: 13, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
+                    Text("Record your first meeting.").font(.system(size: 13, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
                 }
                 .padding(.bottom, 26)
                 // the guided spine
@@ -406,7 +406,7 @@ struct DioHero: View {
                         .offset(y: -s * 0.62).transition(.scale.combined(with: .opacity))
                 }
                 // the SUBTLE per-primitive sync cue: a corner mark for what's canonical (synced to
-                // your Mac) vs local-only / pending. Hushed by design — and yields to the NEW halo.
+                // your desktop) vs local-only / pending. Hushed by design — and yields to the NEW halo.
                 if !arrived && mode != .recede, let badge = SyncCueBadge.spec(syncCue) {
                     SyncCueBadge(spec: badge).offset(x: s * 0.40, y: -s * 0.40)
                         .transition(.scale.combined(with: .opacity))
@@ -1040,7 +1040,7 @@ struct DioInlineKBCard: View {
     }
 }
 
-// THE IN-WORLD CONNECT CARD — pair your Mac FROM THE DESK (host · port · token), never a system
+// THE IN-WORLD CONNECT CARD — pair your desktop FROM THE DESK (host · port · token), never a system
 // alert and never buried behind a flag. Host + token are required for a LAN bind; a Test button
 // proves the Mac answers before you commit. Lifts on the desk like the editor cards (no scrim).
 struct DioConnectCard: View {
@@ -1073,13 +1073,13 @@ struct DioConnectCard: View {
                     Image(systemName: "laptopcomputer").font(.system(size: 18, weight: .bold)).foregroundStyle(.white)
                 }
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(paired ? "YOUR MAC" : "CONNECT YOUR MAC").font(.system(size: 11, weight: .black, design: .rounded)).tracking(1.4).foregroundStyle(tint)
+                    Text(paired ? "YOUR DESKTOP" : "CONNECT YOUR DESKTOP").font(.system(size: 11, weight: .black, design: .rounded)).tracking(1.4).foregroundStyle(tint)
                     Text("Sync + send run through it").font(.system(size: 11.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
                 }
                 Spacer(minLength: 0)
                 Button(action: onCancel) { Image(systemName: "xmark").font(.system(size: 14, weight: .black)).foregroundStyle(DioPal.muted).frame(width: 30, height: 30).background(Circle().fill(.white.opacity(0.06))) }.buttonStyle(.plain)
             }
-            field(label: "NAME", placeholder: "e.g. Studio Mac", text: $name, mic: true, keyboard: .default)
+            field(label: "NAME", placeholder: "e.g. Studio desktop", text: $name, mic: true, keyboard: .default)
             field(label: "HOST", placeholder: "192.168.1.13", text: $host, mic: true, keyboard: .URL, focus: $hostFocused, mono: true)
             HStack(alignment: .bottom, spacing: 12) {
                 field(label: "PORT", placeholder: "8765", text: $port, mic: false, keyboard: .numberPad, mono: true).frame(width: 96)
@@ -1151,7 +1151,7 @@ struct DioConnectCard: View {
                     #endif
                 } label: { Text("Paste").font(.system(size: 10.5, weight: .heavy, design: .rounded)).foregroundStyle(tint) }.buttonStyle(.plain)
             }
-            TextField("from your Mac", text: $token)
+            TextField("from your desktop", text: $token)
                 .font(.system(size: 13, weight: .bold, design: .monospaced)).foregroundStyle(DioPal.text)
                 .textFieldStyle(.plain).autocorrectionDisabled().textInputAutocapitalization(.never)
                 .lineLimit(1).truncationMode(.middle)
@@ -1500,7 +1500,7 @@ struct DioRecordModePicker: View {
             VStack(alignment: .leading, spacing: 11) {
                 Text("WHAT ARE WE CAPTURING?").font(.system(size: 10, weight: .black, design: .rounded)).tracking(1.2).foregroundStyle(DioPal.muted)
                 choice(icon: "waveform.badge.mic", title: "Start a meeting", sub: "record & weave it on-device", tint: DioPal.accent, action: onMeeting)
-                choice(icon: "desktopcomputer", title: "Talk to the desktop", sub: "dictate straight to your Mac", tint: DioPal.cobalt, action: onDesktop)
+                choice(icon: "desktopcomputer", title: "Talk to the desktop", sub: "dictate straight to your desktop", tint: DioPal.cobalt, action: onDesktop)
             }
             .padding(15).frame(width: 296)
             .background(RoundedRectangle(cornerRadius: 24, style: .continuous).fill(Color(hex: 0x15121C))
@@ -1929,7 +1929,7 @@ struct DioAmbientRecorder: View {
                     Text(model.transcribing ? "WEAVING" : (isDesktop ? "DICTATING" : "REC")).font(.system(size: 10, weight: .heavy, design: .rounded)).tracking(2).foregroundStyle(DioPal.text)
                     Text(timeString(model.elapsedSeconds)).font(.system(size: 11, weight: .heavy, design: .rounded).monospacedDigit()).foregroundStyle(DioPal.muted)
                 }
-                HStack(spacing: 4) { Image(systemName: isDesktop ? "desktopcomputer" : "lock.fill").font(.system(size: 8, weight: .bold)); Text(isDesktop ? "to your Mac" : "on device").font(.system(size: 9, weight: .heavy, design: .rounded)) }
+                HStack(spacing: 4) { Image(systemName: isDesktop ? "desktopcomputer" : "lock.fill").font(.system(size: 8, weight: .bold)); Text(isDesktop ? "to your desktop" : "on device").font(.system(size: 9, weight: .heavy, design: .rounded)) }
                     .foregroundStyle(isDesktop ? DioPal.cobalt : DioPal.mint)
             }
         }
@@ -2026,7 +2026,7 @@ struct DioWindowSlider: View {
                         .foregroundStyle(.white).frame(maxWidth: .infinity).frame(height: 50)
                         .background(Capsule().fill(LinearGradient(colors: [tint, tint.opacity(0.6)], startPoint: .top, endPoint: .bottom)))
                 }.buttonStyle(.plain)
-                Text("Runs now — your recording keeps going.").font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).frame(maxWidth: .infinity, alignment: .center)
+                Text("Runs now.").font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).frame(maxWidth: .infinity, alignment: .center)
             }
             .padding(20).frame(width: 322)
             .background(RoundedRectangle(cornerRadius: 26, style: .continuous).fill(Color(hex: 0x15121C)).overlay(RoundedRectangle(cornerRadius: 26, style: .continuous).strokeBorder(.white.opacity(0.12), lineWidth: 1)))
@@ -2176,7 +2176,7 @@ struct DioRecordOrb: View {
 // A pending route through an agent/chain whose "where it runs" the user is choosing —
 // on this iPad (on-device) or on the paired Mac (the hub's big model). Captured so the
 // run target sheet can fire the right path with the card's text intact.
-// The RUNS-ON choice the user can remember (Phase-15 fluid compute) — on this iPad or your Mac.
+// The RUNS-ON choice the user can remember (Phase-15 fluid compute) — on this iPad or your desktop.
 // (Named `DeskRunTarget` to avoid colliding with RuntimeCore's workflow-step `RunTarget`.)
 enum DeskRunTarget: String { case device, mac }
 
@@ -2201,7 +2201,7 @@ struct PendingHubRun: Identifiable, Equatable {
 }
 
 // WHERE IT RUNS — the Mesh RUNS-ON choice for routing a card through an agent/chain:
-// on this iPad (private, on-device) or on your Mac (its big model, LAN egress). When no
+// on this iPad (private, on-device) or on your desktop (its big model, LAN egress). When no
 // Mac is paired, the hub row is disabled with a clear "pair first" cue; on-device stays
 // the default. Premium DioPal sheet — never a flat picker.
 struct DioRunTargetSheet: View {
@@ -2234,9 +2234,9 @@ struct DioRunTargetSheet: View {
                        isDefault: preferred == .device, action: onDevice)
                 // ON YOUR MAC — the hub's big model; LAN egress; disabled when unpaired.
                 runRow(icon: "desktopcomputer", tint: Color(hex: 0xF5A524),
-                       name: "On your Mac",
-                       sub: paired ? "big model · \(peerLabel)" : "pair your Mac to use its big model",
-                       egress: .cloud("your Mac"), enabled: paired,
+                       name: "On your desktop",
+                       sub: paired ? "big model · \(peerLabel)" : "pair your desktop to use its big model",
+                       egress: .cloud("your desktop"), enabled: paired,
                        isDefault: paired && preferred == .mac, action: onHub)
                 Button(action: onCancel) {
                     Text("Cancel").font(.system(size: 14, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.muted)
@@ -2389,9 +2389,9 @@ struct DioRoutingTheater: View {
 struct DioPrintedCard: View {
     let rec: OutputRecord; let egress: EgressBadge.Scope; let onKeep: () -> Void; let onBin: () -> Void
     @State private var shown = false
-    // honest provenance: a hub run reads "fresh from your Mac", anything else "from the AI core".
+    // honest provenance: a hub run reads "fresh from your desktop", anything else "from the AI core".
     private var freshLine: String {
-        if case .cloud(let t) = egress, t == "your Mac" { return "fresh from your Mac" }
+        if case .cloud(let t) = egress, t == "your desktop" { return "fresh from your desktop" }
         return "fresh from the AI core"
     }
     var body: some View {
@@ -2587,14 +2587,14 @@ struct DioActSheet: View {
                 if !configured {
                     HStack(spacing: 6) {
                         Image(systemName: "desktopcomputer").font(.system(size: 10, weight: .bold))
-                        Text("Pair your Mac to send · tap a connector tile on the desk").font(.system(size: 10.5, weight: .heavy, design: .rounded))
+                        Text("Pair your desktop to send").font(.system(size: 10.5, weight: .heavy, design: .rounded))
                     }.foregroundStyle(DioPal.muted).padding(.horizontal, 10).frame(height: 28).background(Capsule().fill(.white.opacity(0.05)))
                 }
                 Text("SEND TO").font(.system(size: 10.5, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.muted).tracking(1.4)
                 VStack(spacing: 8) {
                     ForEach(connectors, id: \.connId) { c in
                         Button { onSend(c.connId, c.name) } label: {
-                            actRow(symbol: c.symbol, tint: c.tint, name: "Send to \(c.name)", sub: configured ? "via your Mac" : "needs your Mac", egress: .cloud(c.name))
+                            actRow(symbol: c.symbol, tint: c.tint, name: "Send to \(c.name)", sub: configured ? "via your desktop" : "needs your desktop", egress: .cloud(c.name))
                         }.buttonStyle(.plain).disabled(!configured).opacity(configured ? 1 : 0.45)
                     }
                 }
@@ -2658,7 +2658,7 @@ struct DeskHostLink {
         var body: [String: Any] = ["text": text]
         if !title.isEmpty { body["title"] = title }
         let (data, resp) = try await post("api/companion/\(target)/propose", body)
-        try Self.check(data, resp, "Your Mac refused the send.")
+        try Self.check(data, resp, "Your desktop refused the send.")
         let p = (try? JSONSerialization.jsonObject(with: data) as? [String: Any])?["proposal"] as? [String: Any]
         return (p?["id"] as? String ?? "", p?["preview"] as? String ?? text)
     }
@@ -2666,12 +2666,12 @@ struct DeskHostLink {
     func decide(target: String, id: String, approved: Bool) async throws -> (status: String, error: String?) {
         let (data, resp) = try await post("api/companion/\(target)/\(id)/decision",
                                           ["decision": approved ? "approved" : "rejected", "decided_by": "ipad-desk"])
-        try Self.check(data, resp, "Your Mac refused the decision.")
+        try Self.check(data, resp, "Your desktop refused the decision.")
         let p = (try? JSONSerialization.jsonObject(with: data) as? [String: Any])?["proposal"] as? [String: Any]
         return (p?["status"] as? String ?? "", p?["error"] as? String)
     }
     private func post(_ path: String, _ body: [String: Any]) async throws -> (Data, URLResponse) {
-        guard let u = base?.appendingPathComponent(path) else { throw HostError.message("No Mac paired.") }
+        guard let u = base?.appendingPathComponent(path) else { throw HostError.message("No desktop paired.") }
         var r = URLRequest(url: u); r.httpMethod = "POST"; r.timeoutInterval = 14
         r.setValue("application/json", forHTTPHeaderField: "Content-Type")
         auth(&r)
@@ -2803,6 +2803,11 @@ struct DioStage: View {
     @State private var openGameId: String? = nil
     @AppStorage("hs.desk.gamewin.posX") private var gameWinX: Double = 0.5
     @AppStorage("hs.desk.gamewin.posY") private var gameWinY: Double = 0.46
+    // The in-world note/KB editor is a MOVABLE window on the lane (drag its grab bar, position
+    // persists) — the same affordance as a game window, so every primitive you open can be moved.
+    @AppStorage("hs.desk.editorwin.posX") private var editorWinX: Double = 0.5
+    @AppStorage("hs.desk.editorwin.posY") private var editorWinY: Double = 0.5
+    @State private var editorDragStart: CGPoint? = nil
     @AppStorage("hs.diorama.games") private var gamesJSON = ""  // games placed on the desk as primitives
     @State private var placedGames: [GameRecord] = []
     @State private var coders: [CoderSession] = []             // HSM-17 live Claude/Codex sessions on the desk
@@ -2843,7 +2848,7 @@ struct DioStage: View {
     @State private var routeTo: CGPoint = .zero
     @State private var printed: OutputRecord? = nil
     // the egress of the CURRENT printed card — on-device routes are .local; a hub run is
-    // .cloud("your Mac"). Drives the printed card's honest egress badge (POSITIONING canon).
+    // .cloud("your desktop"). Drives the printed card's honest egress badge (POSITIONING canon).
     @State private var printedEgress: EgressBadge.Scope = .local
     @State private var routeError: String? = nil
     // connectors (the integrations half: drop an output on Slack → approve → the MAC sends).
@@ -2853,7 +2858,7 @@ struct DioStage: View {
     @AppStorage("hs.peer.token") private var peerToken = ""   // hub web auth token (LAN bind requires it)
     @AppStorage("hs.peer.name") private var peerName = ""     // friendly name for the paired Mac
     // The remembered RUNS-ON choice (Phase-15 fluid compute) — "" = unset (sensible default),
-    // "device" = on this iPad, "mac" = on your Mac. The picker still opens; it just pre-honors
+    // "device" = on this iPad, "mac" = on your desktop. The picker still opens; it just pre-honors
     // the last pick so the user isn't re-choosing every run. Falls back to on-device when unpaired.
     @AppStorage("hs.desk.runtarget") private var runTargetPref = ""
     @State private var sendSourceId: String? = nil
@@ -2901,7 +2906,7 @@ struct DioStage: View {
     @State private var editingChain: ChainRecord? = nil   // chain builder open
     @State private var editingZone: ZoneRec? = nil        // the zone style editor is open
     @State private var runChainSheet: ChainRecord? = nil  // the run/manage sheet
-    // RUN ON THE HUB (the Mesh "RUNS ON: your Mac") — routing a card through an agent/chain
+    // RUN ON THE HUB (the Mesh "RUNS ON: your desktop") — routing a card through an agent/chain
     // offers running it on the desktop hub's big model instead of on-device. The choice
     // sheet captures the pending run; the hub run lands a printed card with a cloud egress.
     @State private var pendingHubRun: PendingHubRun? = nil  // the run/where-it-runs picker is open
@@ -3049,6 +3054,10 @@ struct DioStage: View {
     var body: some View {
         GeometryReader { geo in
             let w = geo.size.width, h = geo.size.height
+            // The desk is full-bleed (.ignoresSafeArea below), so `h` is the SAFE height but every
+            // element is laid out from the PHYSICAL top/bottom. These are the real device insets
+            // (Dynamic Island / home indicator) — top/bottom chrome must clear them by hand.
+            let topInset = geo.safeAreaInsets.top, botInset = geo.safeAreaInsets.bottom
             // The one width authority — size class first, this frame's width second. Every
             // stray `w < 500` / `w >= 500` / `UIScreen.main.bounds` read folds into this.
             let camera = DeskCamera.resolve(sizeClass: hSizeClass, width: w)
@@ -3122,7 +3131,7 @@ struct DioStage: View {
                 // card column on iPhone (.lane). `positions[id]` is untouched either way, so rotating
                 // back to .wide restores the exact hand-arranged desk (HSM-20-02).
                 ForEach([pathKey], id: \.self) { _ in
-                    if camera.isLane { laneColumn(w, h) } else { level(w, h) }
+                    if camera.isLane { laneColumn(w, h, topInset, botInset) } else { level(w, h) }
                 }
                     .transition(diveTransition)
 
@@ -3131,17 +3140,35 @@ struct DioStage: View {
                 if camera.isLane, editingNote != nil || editingKB != nil {
                     Color.clear.contentShape(Rectangle()).ignoresSafeArea()
                         .onTapGesture { commitInlineEdit() }.zIndex(58)
-                    if let n = editingNote {
-                        DioInlineNoteCard(note: editingNoteBinding(n), onDone: { commitNote() }, onDelete: { deleteNote("note:\(n.id)") })
-                            .frame(width: camera.cardWidth(304, in: w))
-                            .position(clampInline(CGPoint(x: w / 2, y: h * 0.4), w, h, cardW: camera.cardWidth(304, in: w), cardH: 320))
-                            .zIndex(60).id(n.id)
-                    } else if let k = editingKB {
-                        DioInlineKBCard(kb: editingKBBinding(k), onDone: { commitKB() }, onDelete: { deleteKB("kb:\(k.id)") })
-                            .frame(width: camera.cardWidth(288, in: w))
-                            .position(clampInline(CGPoint(x: w / 2, y: h * 0.4), w, h, cardW: camera.cardWidth(288, in: w), cardH: 170))
-                            .zIndex(60).id(k.id)
+                    let isNote = editingNote != nil
+                    let cardW = camera.cardWidth(isNote ? 304 : 288, in: w)
+                    let cardH: CGFloat = isNote ? 320 : 170
+                    let pin = editorWinPin(w, h, cardW: cardW, cardH: cardH + 30)
+                    VStack(spacing: 0) {
+                        // grab bar — drag the window anywhere, the spot persists (like a game window)
+                        ZStack {
+                            Capsule().fill(.white.opacity(0.10)).frame(width: 60, height: 22)
+                            Capsule().fill(.white.opacity(0.55)).frame(width: 38, height: 5)
+                        }
+                            .frame(maxWidth: .infinity).frame(height: 30).contentShape(Rectangle())
+                            .gesture(
+                                DragGesture(coordinateSpace: .global)
+                                    .onChanged { v in
+                                        if editorDragStart == nil { editorDragStart = pin }
+                                        editorWinX = Double((editorDragStart!.x + v.translation.width) / w)
+                                        editorWinY = Double((editorDragStart!.y + v.translation.height) / h)
+                                    }
+                                    .onEnded { _ in editorDragStart = nil }
+                            )
+                        if let n = editingNote {
+                            DioInlineNoteCard(note: editingNoteBinding(n), onDone: { commitNote() }, onDelete: { deleteNote("note:\(n.id)") }).id(n.id)
+                        } else if let k = editingKB {
+                            DioInlineKBCard(kb: editingKBBinding(k), onDone: { commitKB() }, onDelete: { deleteKB("kb:\(k.id)") }).id(k.id)
+                        }
                     }
+                    .frame(width: cardW)
+                    .position(pin)
+                    .zIndex(60)
                 }
 
                 // the live lasso rectangle while dragging on empty desk
@@ -3203,7 +3230,7 @@ struct DioStage: View {
                         Image(systemName: "gearshape.fill").font(.system(size: 16, weight: .bold)).foregroundStyle(DioPal.text.opacity(0.85))
                             .frame(width: 42, height: 42).background(Circle().fill(.white.opacity(0.08)).overlay(Circle().strokeBorder(.white.opacity(0.12), lineWidth: 1)))
                     }.buttonStyle(.plain)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading).padding(.top, h * 0.045).padding(.leading, 18).zIndex(70)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading).padding(.top, topInset + 8).padding(.leading, 18).zIndex(70)
                 }
                 // THE SYNC STATUS — port your primitives to/from the paired Mac (hub), FELT.
                 // A premium ambient pill that wears the live state (syncing / synced·"2m ago" /
@@ -3221,12 +3248,12 @@ struct DioStage: View {
                                 }.buttonStyle(.plain)
                             }
                         } else {
-                            // Unpaired: an inviting "Connect your Mac" pill — the front-door pairing entry
+                            // Unpaired: an inviting "Connect your desktop" pill — the front-door pairing entry
                             // (was unreachable on the desk; pairing lived behind the classic home).
                             Button { haptic(.medium); withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) { connecting = true } } label: {
                                 HStack(spacing: 8) {
                                     Image(systemName: "laptopcomputer.and.arrow.down").font(.system(size: 13, weight: .bold))
-                                    Text("Connect your Mac").font(.system(size: 13, weight: .heavy, design: .rounded))
+                                    Text("Connect your desktop").font(.system(size: 13, weight: .heavy, design: .rounded))
                                 }
                                 .foregroundStyle(DioPal.cobalt).padding(.horizontal, 14).frame(height: 38)
                                 .background(Capsule().fill(DioPal.cobalt.opacity(0.12)).overlay(Capsule().strokeBorder(DioPal.cobalt.opacity(0.4), lineWidth: 1.2)))
@@ -3234,15 +3261,17 @@ struct DioStage: View {
                         }
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .padding(.top, h * 0.045).padding(.leading, 18 + 50).zIndex(70)
+                    .padding(.top, topInset + 8).padding(.leading, 18 + 50).zIndex(70)
                     .transition(.scale.combined(with: .opacity))
                 }
                 // THE RAIL — Agents · Chains · Play. On iPad it sits open at the right; on a phone
                 // (compact) it collapses behind a slim edge tab so it never covers the canvas.
-                if landed && selected == nil && summonSource == nil && !capturing && openAgent == nil
+                if landed && selected == nil && summonSource == nil && openAgent == nil
                     && editingAgent == nil && editingChain == nil && runChainSheet == nil && chainRelay == nil
                     && openGameId == nil && !arkadeOpen && connecting == false
                     && !showRouteSheet && !routing && printed == nil && !showSendCard && !showActSheet && !firstRun {
+                    // NB: the rail (Agents · Chains · Play) stays available DURING a meeting — recording
+                    // and playing/answering are not mutually exclusive (owner: the phone can do both).
                     let compact = camera.railCollapses
                     if compact && !railOpen {
                         // the collapsed handle — tap to slide the rail in
@@ -3331,7 +3360,7 @@ struct DioStage: View {
                         VStack(spacing: 6) {
                             Image(systemName: "tray").font(.system(size: 26)).foregroundStyle(DioPal.muted)
                             Text("No tool can take this yet").font(.system(size: 14, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
-                            Text("Add a model in Settings, or pair your Mac for connectors.").font(.system(size: 11.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).multilineTextAlignment(.center)
+                            Text("Add a model in Settings.").font(.system(size: 11.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).multilineTextAlignment(.center)
                         }.padding(18).background(RoundedRectangle(cornerRadius: 18).fill(.black.opacity(0.8)))
                         .frame(maxWidth: 280).position(x: w / 2, y: max(140, summonAt.y - 150)).zIndex(121)
                     } else {
@@ -3374,7 +3403,7 @@ struct DioStage: View {
                         .overlay(alignment: .top) {
                             if lane { Capsule().fill(.white.opacity(0.32)).frame(width: 46, height: 5).padding(.top, 9) }
                         }
-                        .padding(.vertical, lane ? 0 : 22).padding(.trailing, lane ? 0 : 16)
+                        .padding(.top, lane ? 0 : 22).padding(.bottom, lane ? botInset : 22).padding(.trailing, lane ? 0 : 16)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: lane ? .bottom : .trailing)
                         .transition(.move(edge: lane ? .bottom : .trailing).combined(with: .opacity))
                         .animation(dockSpring, value: lane).zIndex(60)
@@ -3383,7 +3412,7 @@ struct DioStage: View {
                 if !path.isEmpty && selected == nil && !showRouteSheet && !routing && printed == nil && !showSendCard {
                     DioBackBar(crumbs: crumbs(), onBack: { climbOut() }, onJump: { jump(to: $0) })
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                        .padding(.top, h * 0.045).zIndex(100)
+                        .padding(.top, topInset + 8).zIndex(100)
                 }
 
                 // the keystone routing flow: sheet → theater → printed card (keep/bin)
@@ -3401,10 +3430,10 @@ struct DioStage: View {
                 if let rec = printed {
                     DioPrintedCard(rec: rec, egress: printedEgress, onKeep: { keepPrinted() }, onBin: { binPrinted() }).zIndex(130)
                 }
-                // WHERE IT RUNS — the run-target picker for an agent/chain route (on-device vs your Mac).
+                // WHERE IT RUNS — the run-target picker for an agent/chain route (on-device vs your desktop).
                 if let run = pendingHubRun {
                     DioRunTargetSheet(run: run, paired: hostLink != nil,
-                                      peerLabel: peerHost.isEmpty ? "your Mac" : peerHost,
+                                      peerLabel: peerHost.isEmpty ? "your desktop" : peerHost,
                                       preferred: preferredRunTarget,
                                       remembered: DeskRunTarget(rawValue: runTargetPref) != nil,
                                       onDevice: { runOnDevice(run) },
@@ -3516,7 +3545,7 @@ struct DioStage: View {
                 if let t = sentToast {
                     HStack(spacing: 7) { Image(systemName: "checkmark.circle.fill"); Text(t).font(.system(size: 13, weight: .heavy, design: .rounded)) }
                         .foregroundStyle(.white).padding(.horizontal, 16).frame(height: 40).background(Capsule().fill(DioPal.mint.opacity(0.92)))
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top).padding(.top, h * 0.04)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top).padding(.top, topInset + 8)
                         .transition(.move(edge: .top).combined(with: .opacity)).zIndex(200)
                 }
             }
@@ -3608,7 +3637,7 @@ struct DioStage: View {
                     switch sv {
                     case "syncing": syncing = true
                     case "offline": syncState = .offline
-                    case "error":   syncState = .error("Couldn’t reach your Mac")
+                    case "error":   syncState = .error("Couldn’t reach your desktop")
                     case "pull":
                         // a remote-authored note arrives on the next pull → NEW-arrival treatment
                         syncState = .synced
@@ -3688,7 +3717,7 @@ struct DioStage: View {
                     if ag == "builder" { DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { withAnimation { editingAgent = AgentRecord.blank() } } }
                     if ag == "chainbuild" { DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { withAnimation { editingChain = ChainRecord(id: "newc", name: "Refine", steps: ["seed1", "seed3"]) } } }
                     if ag == "chainrun" { DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { withAnimation { runChainSheet = chains.first } } }
-                    // the WHERE-IT-RUNS picker (on-device vs your Mac) — seeded paired so the hub row is live.
+                    // the WHERE-IT-RUNS picker (on-device vs your desktop) — seeded paired so the hub row is live.
                     if ag == "runtarget" || ag == "runtarget-unpaired" {
                         if ag == "runtarget" { peerHost = "192.168.1.43"; peerPort = "8080" }
                         else { peerHost = ""; peerPort = "8000" }   // unpaired → hub row disabled with a cue
@@ -3698,14 +3727,14 @@ struct DioStage: View {
                                                                           inputId: "mtg.q3", inputTitle: "Q3 kickoff") }
                         }
                     }
-                    // a hub run's RESULT — the printed card with the cloud · your Mac egress badge.
+                    // a hub run's RESULT — the printed card with the cloud · your desktop egress badge.
                     if ag == "hubresult" {
                         peerHost = "192.168.1.43"; peerPort = "8080"
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                            printedEgress = .cloud("your Mac")
+                            printedEgress = .cloud("your desktop")
                             withAnimation { printed = OutputRecord(id: "hubdemo", title: "Scout",
                                 body: "Three concrete facts: the mesh-sync approval contract is the riskiest piece, the air-gapped proof is due Friday, and the egress badge copy still has no owner.",
-                                source: "Q3 kickoff", lens: "Agent · your Mac", path: "",
+                                source: "Q3 kickoff", lens: "Agent · your desktop", path: "",
                                 provenance: RunProvenance(sourceCardId: "mtg.q3", sourceCardTitle: "Q3 kickoff",
                                                           viaId: "seed1", viaName: "Scout", viaKind: "agent")) }
                         }
@@ -3747,7 +3776,7 @@ struct DioStage: View {
                 TextField("Tool name (e.g. Risks, Brief)", text: $toolName)
                 Button("Cancel", role: .cancel) { routeSourceId = nil }
                 Button("Save") { saveTool(); routeSourceId = nil }
-            } message: { Text("It becomes a tile on your desk. Drop a meeting or output on it to run this Ask again — no retyping.") }
+            } message: { Text("Becomes a reusable tile on your desk.") }
             .alert("New zone", isPresented: $namingZone) {
                 TextField("Name", text: $newZoneName)
                 Button("Cancel", role: .cancel) { newZoneName = "" }
@@ -3757,7 +3786,7 @@ struct DioStage: View {
                 TextField("Name", text: $newKBName)
                 Button("Cancel", role: .cancel) { newKBName = "" }
                 Button("Create") { createKB(newKBName); newKBName = "" }
-            } message: { Text("A typed container you drop notes and outputs into, then ask grounded questions.") }
+            } message: { Text("A container for notes you can ask over.") }
             .sheet(isPresented: Binding(get: { openMeeting != nil }, set: { if !$0 { openMeeting = nil } })) {
                 if let m = openMeeting { NavigationStack { MeetingDetailView(meeting: m) }.preferredColorScheme(.dark) }
             }
@@ -3805,7 +3834,7 @@ struct DioStage: View {
     /// desk shows has a row here; zones are divable rows; the chip rail filters by kind. Tapping a
     /// row is identical to tapping its canvas primitive (notes/KBs edit in-world; everything else
     /// opens the pull-out, which rises from the bottom edge on the lane).
-    @ViewBuilder private func laneColumn(_ w: CGFloat, _ h: CGFloat) -> some View {
+    @ViewBuilder private func laneColumn(_ w: CGFloat, _ h: CGFloat, _ topInset: CGFloat, _ botInset: CGFloat) -> some View {
         let zs = childZones()
         let prims = members()
         let buckets = laneBuckets(prims)
@@ -3838,10 +3867,10 @@ struct DioStage: View {
                         DioLaneRow(glyph: p.glyph, tint: p.color, symbol: p.isSymbol, title: p.title,
                                    badge: p.kind.badge, subtitle: p.subtitle, arrived: arrivedIds.contains(p.id)) { tapPrimitive(p) }
                     }
-                }.padding(.horizontal, 16).padding(.top, 2).padding(.bottom, 132)
+                }.padding(.horizontal, 16).padding(.top, 2).padding(.bottom, 132 + botInset)
             }
         }
-        .padding(.top, h * 0.115)   // clear the top-left gear + connect/sync chrome
+        .padding(.top, topInset + 54)   // clear the Dynamic Island + the top-left gear/connect/sync chrome
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
@@ -3931,6 +3960,11 @@ struct DioStage: View {
         let x = min(max(p.x, cardW / 2 + pad), w - cardW / 2 - pad)
         let y = min(max(p.y, cardH / 2 + pad), max(cardH / 2 + pad, h * 0.46))
         return CGPoint(x: x, y: y)
+    }
+    /// The persisted, clamped centre for the movable in-world editor window (note/KB) on the lane.
+    private func editorWinPin(_ w: CGFloat, _ h: CGFloat, cardW: CGFloat, cardH: CGFloat) -> CGPoint {
+        CGPoint(x: min(max(CGFloat(editorWinX) * w, cardW / 2 + 8), w - cardW / 2 - 8),
+                y: min(max(CGFloat(editorWinY) * h, cardH / 2 + 30), h - cardH / 2 - 8))
     }
     /// Tap a desk card: notes + KBs flip to IN-WORLD edit in place; a live coder opens its feed;
     /// everything else opens its pullout (select).
@@ -4373,7 +4407,7 @@ struct DioStage: View {
         case .agent:                                            // a tailored agent → answer grounded in the card
             guard let ap = target as? AgentPrimitive,
                   let src = members().first(where: { $0.id == sourceId }) else { break }
-            // offer WHERE it runs (on-device vs your Mac's big model) — on-device stays default.
+            // offer WHERE it runs (on-device vs your desktop's big model) — on-device stays default.
             offerRunTarget(.init(kind: .agent(ap.rec), input: src.routableText, inputId: src.id, inputTitle: src.title))
         case .chain:                                            // a crew → run the card through each agent in order
             guard let cp = target as? ChainPrimitive,
@@ -4425,14 +4459,14 @@ struct DioStage: View {
     }
     private func sendNow(title: String, text: String) {
         guard let link = hostLink else {
-            withAnimation { showSendCard = false }; sendOverride = nil; routeError = "Pair your Mac first — tap the \(sendTargetName) tile."; return
+            withAnimation { showSendCard = false }; sendOverride = nil; routeError = "Pair your desktop first — tap the \(sendTargetName) tile."; return
         }
         sending = true
         let target = sendTargetName
         Task { @MainActor in
             if await link.reachable() == false {
                 sending = false; withAnimation { showSendCard = false }; sendOverride = nil
-                routeError = "Your Mac isn’t reachable. Wake it and make sure it’s on the same network."
+                routeError = "Your desktop isn’t reachable. Wake it and make sure it’s on the same network."
                 return
             }
             do {
@@ -4444,14 +4478,14 @@ struct DioStage: View {
                     #if canImport(UIKit)
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
                     #endif
-                    toast("Sent to \(target) via your Mac")
+                    toast("Sent to \(target) via your desktop")
                 } else {
                     routeError = decision.error ?? "\(target) send didn’t complete (status: \(decision.status))."
                 }
             } catch let DeskHostLink.HostError.message(m) {
                 sending = false; withAnimation { showSendCard = false }; sendOverride = nil; routeError = m
             } catch {
-                sending = false; withAnimation { showSendCard = false }; sendOverride = nil; routeError = "Couldn’t reach your Mac."
+                sending = false; withAnimation { showSendCard = false }; sendOverride = nil; routeError = "Couldn’t reach your desktop."
             }
         }
     }
@@ -4594,7 +4628,7 @@ struct DioStage: View {
             }
         }
     }
-    // MARK: - Run on the hub (the Mesh "RUNS ON: your Mac")
+    // MARK: - Run on the hub (the Mesh "RUNS ON: your desktop")
 
     /// A built `HTTPDesktopClient` for the paired peer, or nil when unpaired/malformed.
     /// Reuses the same host/port the desk already pairs against (`hs.peer.*`); the hub
@@ -4608,7 +4642,7 @@ struct DioStage: View {
     }
 
     /// The remembered RUN-ON choice, sanity-clamped to what's actually possible right now:
-    /// honors the last pick when valid; otherwise on-device. "On your Mac" is only sensible
+    /// honors the last pick when valid; otherwise on-device. "On your desktop" is only sensible
     /// when paired — an unpaired desk always defaults to on-device regardless of the stored pref.
     private var preferredRunTarget: DeskRunTarget {
         if hostLink != nil, DeskRunTarget(rawValue: runTargetPref) == .mac { return .mac }
@@ -4620,7 +4654,7 @@ struct DioStage: View {
     private func rememberRunTarget(_ t: DeskRunTarget) { runTargetPref = t.rawValue }
 
     /// Open the where-it-runs picker for a routed agent/chain. The picker pre-highlights the
-    /// remembered choice (on-device by default / when unpaired); "your Mac" is offered when
+    /// remembered choice (on-device by default / when unpaired); "your desktop" is offered when
     /// paired, disabled (with a cue) when not.
     private func offerRunTarget(_ run: PendingHubRun) {
         haptic(.medium)
@@ -4637,14 +4671,14 @@ struct DioStage: View {
         }
     }
 
-    /// The user picked "your Mac" — run the agent/chain on the desktop hub's big model
+    /// The user picked "your desktop" — run the agent/chain on the desktop hub's big model
     /// via `HTTPDesktopClient`, land the result as a printed card with a CLOUD egress
     /// badge (it ran on the Mac, not on-device). Errors surface honestly — never silent.
     private func runOnHub(_ run: PendingHubRun) {
         rememberRunTarget(.mac)
         withAnimation { pendingHubRun = nil }
         guard let client = desktopClient else {
-            routeError = "Pair your Mac first to run on its big model."
+            routeError = "Pair your desktop first to run on its big model."
             return
         }
         let input = String(run.input.prefix(8000))
@@ -4669,12 +4703,12 @@ struct DioStage: View {
                 withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
                     printed = OutputRecord(id: UUID().uuidString,
                                            title: title,
-                                           body: clean.isEmpty ? "(your Mac returned nothing)" : clean,
+                                           body: clean.isEmpty ? "(your desktop returned nothing)" : clean,
                                            source: source,
-                                           lens: run.isChain ? "Chain · your Mac" : "Agent · your Mac",
+                                           lens: run.isChain ? "Chain · your desktop" : "Agent · your desktop",
                                            path: zpath,
                                            provenance: run.provenance)
-                    printedEgress = .cloud("your Mac")
+                    printedEgress = .cloud("your desktop")
                 }
                 selectedSet = []
             } catch {
@@ -4689,14 +4723,14 @@ struct DioStage: View {
     private func hubRunError(_ error: Error) -> String {
         if let e = error as? HTTPDesktopClient.DesktopClientError {
             switch e {
-            case .http(502), .http(503): return "Your Mac has no model loaded — start the desktop runtime and try again."
-            case .http(404): return "That agent or crew isn’t on your Mac yet — sync first, then run on the hub."
-            case .http(let code): return "Your Mac refused the run (status \(code))."
-            case .malformed: return "Your Mac sent back something the desk couldn’t read."
+            case .http(502), .http(503): return "Your desktop has no model loaded — start the desktop runtime and try again."
+            case .http(404): return "That agent or crew isn’t on your desktop yet — sync first, then run on the hub."
+            case .http(let code): return "Your desktop refused the run (status \(code))."
+            case .malformed: return "Your desktop sent back something the desk couldn’t read."
             }
         }
-        if error is URLError { return "Your Mac isn’t reachable. Wake it and make sure it’s on the same network." }
-        return "Couldn’t run on your Mac."
+        if error is URLError { return "Your desktop isn’t reachable. Wake it and make sure it’s on the same network." }
+        return "Couldn’t run on your desktop."
     }
 
     private func saveChain(_ rec: ChainRecord) {
@@ -4822,9 +4856,9 @@ struct DioStage: View {
                 }
             } else if outcome.pendingAfter > 0 {
                 syncState = .offline
-                lastSyncSummary = "Offline · queued for your Mac"
+                lastSyncSummary = "Offline · queued for your desktop"
             } else {
-                syncState = .error("Couldn’t reach your Mac")
+                syncState = .error("Couldn’t reach your desktop")
                 lastSyncSummary = nil
             }
             if let s = lastSyncSummary { toast(s) }

--- a/apple/App/MeetingCapture/DeskPrimitive.swift
+++ b/apple/App/MeetingCapture/DeskPrimitive.swift
@@ -151,7 +151,7 @@ struct ModelPrimitive: DeskPrimitive {
     var title: String { name }
     var preview: String? { "on device · ready" }
     var sections: [PrimitiveSection] {
-        [.init(label: "MODEL", tint: DioPal.cobalt, body: .text("\(name) — loaded and ready. Every meeting is summarised on this iPad; nothing leaves the device."))]
+        [.init(label: "MODEL", tint: DioPal.cobalt, body: .text("\(name) — loaded and ready."))]
     }
     var accepts: [PrimitiveKind] { [.meeting, .summary, .actions, .transcript, .topics, .note, .artifact] } // the AI core eats anything
 }
@@ -188,7 +188,7 @@ struct KBPrimitive: DeskPrimitive {
     var title: String { rec.name }
     var preview: String? { "\(rec.items) item\(rec.items == 1 ? "" : "s")" }
     var sections: [PrimitiveSection] {
-        [.init(label: "KNOWLEDGE", tint: DioPal.violet, body: .text("\(rec.items) item\(rec.items == 1 ? "" : "s") filed here. Drop a note or output on this KB to add it, then ask a grounded question cited from your own knowledge."))]
+        [.init(label: "KNOWLEDGE", tint: DioPal.violet, body: .text("\(rec.items) item\(rec.items == 1 ? "" : "s") filed here."))]
     }
     var actions: [PrimitiveAction] {
         [PrimitiveAction(label: "Rename", icon: "pencil", role: .openEditor),
@@ -214,9 +214,7 @@ struct GamePrimitive: DeskPrimitive {
     var subtitle: String { best > 0 ? "best \(best) · tap to play" : "tap to play" }
     var preview: String? { best > 0 ? "Best: \(best)" : "Tap to play" }
     var sections: [PrimitiveSection] {
-        [.init(label: "GAME", tint: DioPal.cobalt, body: .text(best > 0
-            ? "Your best is \(best). Play to beat it, then harvest the score onto your desk as a card."
-            : "A quick desk game. Play it, then harvest your score as a card you can route or file."))]
+        [.init(label: "GAME", tint: DioPal.cobalt, body: .text(best > 0 ? "Your best: \(best)." : "A quick desk game."))]
     }
     var actions: [PrimitiveAction] {
         [PrimitiveAction(label: "Play", icon: "play.fill", role: .custom("play")),
@@ -387,15 +385,15 @@ struct ConnectorPrimitive: DeskPrimitive {
     var color: Color { tint }
     var base: CGFloat { 116 }
     var title: String { name }
-    var subtitle: String { configured ? "via your Mac · \(detail)" : "tap to pair your Mac" }
-    var preview: String? { configured ? "via your Mac" : "pair your Mac" }
+    var subtitle: String { configured ? "via your desktop · \(detail)" : "tap to pair your desktop" }
+    var preview: String? { configured ? "via your desktop" : "pair your desktop" }
     var sections: [PrimitiveSection] {
         [.init(label: "CONNECTOR", tint: tint, body: .text(configured
-            ? "Sends go through your Mac (\(detail)). Drop a card here, approve it, and your Mac posts to \(name) — the credential stays on the Mac, never on this iPad."
-            : "Pair your Mac to send. Your iPad proposes; your Mac approves and posts to \(name). The iPad never holds the \(name) credential."))]
+            ? "Sends to \(name) via your desktop (\(detail))."
+            : "Pair your desktop to send to \(name)."))]
     }
     var actions: [PrimitiveAction] {
-        [PrimitiveAction(label: configured ? "Your Mac · \(detail)" : "Pair your Mac", icon: "desktopcomputer", role: .custom("connect"))]
+        [PrimitiveAction(label: configured ? "Your desktop ·\(detail)" : "Pair your desktop", icon: "desktopcomputer", role: .custom("connect"))]
     }
     var accepts: [PrimitiveKind] { configured ? [.artifact, .summary, .actions, .topics, .meeting] : [] }
 }
@@ -436,7 +434,7 @@ struct WorkflowPrimitive: DeskPrimitive {
     var subtitle: String { "a saved Ask · drop to run" }
     var preview: String? { "drop to run" }
     var sections: [PrimitiveSection] {
-        [.init(label: "WORKFLOW", tint: DioPal.violet, body: .text("A saved Ask. Drop a meeting or an output here and it runs through the AI core — no prompt to retype.")),
+        [.init(label: "WORKFLOW", tint: DioPal.violet, body: .text("A saved Ask.")),
          .init(label: "PROMPT", tint: DioPal.muted, body: .text(rec.prompt))]
     }
     var accepts: [PrimitiveKind] { [.meeting, .summary, .actions, .topics, .artifact] }

--- a/apple/App/MeetingCapture/ModelDownloads.swift
+++ b/apple/App/MeetingCapture/ModelDownloads.swift
@@ -1,0 +1,319 @@
+import SwiftUI
+import Foundation
+
+// In-app model downloads: a curated suggested list + a Hugging Face search, both pulling
+// GGUF weights straight into the app's Documents (where the on-device runtime loads from).
+// Reuses the canonical HF resolve URL the engine's ModelDownloader uses; adds a cancellable
+// URLSession so a multi-GB download has a progress bar + a Cancel.
+
+// MARK: - Curated suggestions
+
+/// One hand-picked model the app knows runs on this device's bundled llama.cpp.
+struct SuggestedModel: Identifiable {
+    var id: String { fileName }            // the on-disk name is the stable id
+    let name: String
+    let detail: String                     // approx size + device fit
+    let repo: String                       // Hugging Face "owner/name"
+    let fileName: String                   // exact .gguf in the repo
+}
+
+enum SuggestedModels {
+    // Ordered small → large. Each fileName was verified against the repo's file list.
+    static let all: [SuggestedModel] = [
+        SuggestedModel(name: "Llama 3.2 3B Instruct",
+                       detail: "~2.0 GB · fast, great on iPhone",
+                       repo: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+                       fileName: "Llama-3.2-3B-Instruct-Q4_K_M.gguf"),
+        SuggestedModel(name: "Qwen3 4B Instruct 2507",
+                       detail: "~2.5 GB · recommended",
+                       repo: "unsloth/Qwen3-4B-Instruct-2507-GGUF",
+                       fileName: "Qwen3-4B-Instruct-2507-Q4_K_M.gguf"),
+        SuggestedModel(name: "Gemma 3n E4B",
+                       detail: "~4.2 GB · Google, built for on-device",
+                       repo: "unsloth/gemma-3n-E4B-it-GGUF",
+                       fileName: "gemma-3n-E4B-it-Q4_K_M.gguf"),
+        SuggestedModel(name: "Llama 3.1 8B Instruct",
+                       detail: "~4.9 GB · best on iPad",
+                       repo: "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+                       fileName: "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"),
+    ]
+}
+
+// MARK: - Download manager
+
+/// One download at a time, with live 0…1 progress and a Cancel. Writes into `ModelFiles.root`
+/// (Documents) under the file's own name, so `localGGUF()` finds it immediately.
+@MainActor final class ModelDownloadManager: ObservableObject {
+    static let shared = ModelDownloadManager()
+
+    @Published var progress: [String: Double] = [:]   // fileName → 0…1 (present only while active/just-done)
+    @Published var activeFile: String? = nil           // the fileName currently downloading
+    @Published var errorMsg: String? = nil
+
+    private var session: URLSession?
+
+    func isInstalled(_ fileName: String) -> Bool {
+        FileManager.default.fileExists(atPath: ModelFiles.root.appendingPathComponent(fileName).path)
+    }
+
+    func start(repo: String, fileName: String) {
+        guard activeFile == nil else { return }                 // serialize downloads
+        if isInstalled(fileName) { return }
+        guard let url = URL(string: "https://huggingface.co/\(repo)/resolve/main/\(fileName)?download=true") else {
+            errorMsg = "Couldn't build that download URL."; return
+        }
+        let dest = ModelFiles.root.appendingPathComponent(fileName)
+        errorMsg = nil; activeFile = fileName; progress[fileName] = 0.0001
+        let delegate = DownloadProxy(
+            destination: dest,
+            onProgress: { [weak self] p in Task { @MainActor in self?.progress[fileName] = p } },
+            onDone: { [weak self] result in Task { @MainActor in self?.finish(fileName, result) } })
+        let s = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        delegate.session = s
+        session = s
+        s.downloadTask(with: url).resume()
+    }
+
+    func cancel() {
+        session?.invalidateAndCancel(); session = nil
+        if let f = activeFile { progress[f] = nil }
+        activeFile = nil
+    }
+
+    private func finish(_ fileName: String, _ result: Result<Void, Error>) {
+        session = nil; activeFile = nil
+        switch result {
+        case .success:
+            progress[fileName] = 1
+            // Make a freshly-downloaded model the active one if nothing was chosen yet.
+            if InferenceConfigStore.shared.localModelId.isEmpty {
+                InferenceConfigStore.shared.localModelId = fileName
+            }
+        case .failure(let e):
+            progress[fileName] = nil
+            let ns = e as NSError
+            if ns.code == NSURLErrorCancelled { errorMsg = nil }      // user-cancelled: quiet
+            else { errorMsg = friendly(ns) }
+        }
+    }
+
+    private func friendly(_ e: NSError) -> String {
+        if let status = (e.userInfo["status"] as? Int) {
+            switch status {
+            case 401, 403: return "That model is gated — it needs a Hugging Face token to download."
+            case 404:      return "Not found — the file may have moved or the name is wrong."
+            default:       return "Download failed (HTTP \(status))."
+            }
+        }
+        return "Download failed. Check your connection and try again."
+    }
+}
+
+/// URLSession delegate that streams to a temp file and atomically moves it into place.
+/// Separate object (not the @MainActor manager) so the delegate callbacks stay off the main actor;
+/// it forwards to the manager via main-actor closures.
+private final class DownloadProxy: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    let destination: URL
+    let onProgress: @Sendable (Double) -> Void
+    let onDone: @Sendable (Result<Void, Error>) -> Void
+    var session: URLSession?
+
+    init(destination: URL,
+         onProgress: @escaping @Sendable (Double) -> Void,
+         onDone: @escaping @Sendable (Result<Void, Error>) -> Void) {
+        self.destination = destination; self.onProgress = onProgress; self.onDone = onDone
+    }
+
+    func urlSession(_ s: URLSession, downloadTask: URLSessionDownloadTask,
+                    didWriteData _: Int64, totalBytesWritten written: Int64,
+                    totalBytesExpectedToWrite total: Int64) {
+        if total > 0 { onProgress(Double(written) / Double(total)) }
+    }
+
+    func urlSession(_ s: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        defer { s.finishTasksAndInvalidate() }
+        if let http = downloadTask.response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            onDone(.failure(NSError(domain: "hf", code: http.statusCode, userInfo: ["status": http.statusCode])))
+            return
+        }
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: location, to: destination)
+            onProgress(1); onDone(.success(()))
+        } catch { onDone(.failure(error as NSError)) }
+    }
+
+    func urlSession(_ s: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error { s.finishTasksAndInvalidate(); onDone(.failure(error as NSError)) }
+    }
+}
+
+// MARK: - Hugging Face search
+
+/// Searches the public HF model index for GGUF repos, then lists a repo's .gguf files to pick from.
+@MainActor final class HFSearch: ObservableObject {
+    @Published var query = ""
+    @Published var repos: [String] = []
+    @Published var files: [String] = []        // .gguf files of the expanded repo
+    @Published var expanded: String? = nil      // the repo whose files are shown
+    @Published var state: State = .idle
+    enum State: Equatable { case idle, searching, loadingFiles, empty, failed }
+
+    private struct Hit: Decodable { let id: String }
+    private struct Repo: Decodable { let siblings: [Sib]?; struct Sib: Decodable { let rfilename: String } }
+
+    func search() async {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard q.count >= 2 else { return }
+        state = .searching; repos = []; files = []; expanded = nil
+        let enc = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? q
+        guard let url = URL(string: "https://huggingface.co/api/models?search=\(enc)&filter=gguf&limit=25&sort=downloads&direction=-1") else { state = .failed; return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let hits = try JSONDecoder().decode([Hit].self, from: data)
+            repos = hits.map(\.id)
+            state = repos.isEmpty ? .empty : .idle
+        } catch { state = .failed }
+    }
+
+    func loadFiles(_ repo: String) async {
+        if expanded == repo { expanded = nil; files = []; return }   // collapse
+        expanded = repo; files = []; state = .loadingFiles
+        guard let url = URL(string: "https://huggingface.co/api/models/\(repo)") else { state = .failed; return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let r = try JSONDecoder().decode(Repo.self, from: data)
+            files = (r.siblings ?? []).map(\.rfilename)
+                .filter { $0.lowercased().hasSuffix(".gguf") }
+                .sorted()
+            state = .idle
+        } catch { state = .failed }
+    }
+}
+
+// MARK: - UI sections (rendered inside ModelsView)
+
+/// The curated "Suggested" section: one row per model with Download → progress → Installed.
+struct SuggestedModelsSection: View {
+    @ObservedObject var dl = ModelDownloadManager.shared
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("SUGGESTED").font(.system(size: 11, weight: .heavy)).tracking(1.2).foregroundStyle(Sig.faint)
+            ForEach(SuggestedModels.all) { m in
+                ModelDownloadRow(name: m.name, detail: m.detail, repo: m.repo, fileName: m.fileName)
+            }
+        }
+    }
+}
+
+/// A download row used by both the suggested list and the search file list.
+struct ModelDownloadRow: View {
+    let name: String
+    let detail: String
+    let repo: String
+    let fileName: String
+    @ObservedObject private var dl = ModelDownloadManager.shared
+
+    var body: some View {
+        let installed = dl.isInstalled(fileName)
+        let prog = dl.progress[fileName]
+        let active = dl.activeFile == fileName
+        return HStack(spacing: 13) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous).fill(Sig.accent.opacity(0.16))
+                Image(systemName: installed ? "checkmark" : "arrow.down.circle.fill")
+                    .font(.system(size: 18, weight: .bold)).foregroundStyle(installed ? Sig.ok : Sig.accent)
+            }.frame(width: 44, height: 44)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(name).font(.system(size: 15.5, weight: .bold)).foregroundStyle(Sig.text).lineLimit(1)
+                if active, let p = prog {
+                    ProgressView(value: p).tint(Sig.accent)
+                    Text("Downloading… \(Int(p * 100))%").font(.system(size: 11.5, weight: .semibold)).foregroundStyle(Sig.muted)
+                } else {
+                    Text(installed ? "Installed · on this iPad" : detail)
+                        .font(.system(size: 12, weight: .semibold)).foregroundStyle(installed ? Sig.ok : Sig.faint).lineLimit(1)
+                }
+            }
+            Spacer(minLength: 4)
+            trailing(installed: installed, active: active)
+        }
+        .padding(13)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(active ? Sig.accent.opacity(0.5) : Sig.line, lineWidth: 1))
+    }
+
+    @ViewBuilder private func trailing(installed: Bool, active: Bool) -> some View {
+        if active {
+            Button { tactile(); dl.cancel() } label: {
+                Image(systemName: "xmark").font(.system(size: 14, weight: .bold)).foregroundStyle(Sig.faint)
+                    .frame(width: 38, height: 38).background(Sig.s3, in: Circle())
+            }
+        } else if installed {
+            Image(systemName: "checkmark.seal.fill").font(.system(size: 18, weight: .bold)).foregroundStyle(Sig.ok).frame(width: 38, height: 38)
+        } else {
+            Button { tactile(); dl.start(repo: repo, fileName: fileName) } label: {
+                Text("Get").font(.system(size: 14, weight: .heavy)).foregroundStyle(.black)
+                    .padding(.horizontal, 16).frame(height: 36)
+                    .background(Sig.accent, in: Capsule())
+            }.disabled(dl.activeFile != nil)   // one at a time
+            .opacity(dl.activeFile != nil ? 0.4 : 1)
+        }
+    }
+}
+
+/// The "Search Hugging Face" section: query → repos → tap a repo → pick a .gguf to download.
+struct HFSearchSection: View {
+    @StateObject private var hf = HFSearch()
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("SEARCH HUGGING FACE").font(.system(size: 11, weight: .heavy)).tracking(1.2).foregroundStyle(Sig.faint)
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass").font(.system(size: 14, weight: .bold)).foregroundStyle(Sig.faint)
+                TextField("e.g. gemma 4, qwen, phi…", text: $hf.query)
+                    .font(.system(size: 15, weight: .semibold)).foregroundStyle(Sig.text)
+                    .textInputAutocapitalization(.never).autocorrectionDisabled()
+                    .submitLabel(.search).onSubmit { Task { await hf.search() } }
+                if hf.state == .searching || hf.state == .loadingFiles { ProgressView().controlSize(.small).tint(Sig.accent) }
+            }
+            .padding(.horizontal, 13).padding(.vertical, 12)
+            .background(Sig.s2, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Color.white.opacity(0.08), lineWidth: 1))
+
+            switch hf.state {
+            case .empty:  Text("No GGUF repositories found.").font(.system(size: 12)).foregroundStyle(Sig.faint)
+            case .failed: Text("Search failed. Check your connection.").font(.system(size: 12)).foregroundStyle(Sig.warn)
+            default: EmptyView()
+            }
+
+            ForEach(hf.repos, id: \.self) { repo in
+                VStack(alignment: .leading, spacing: 8) {
+                    Button { tactile(); Task { await hf.loadFiles(repo) } } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: hf.expanded == repo ? "chevron.down" : "chevron.right")
+                                .font(.system(size: 11, weight: .bold)).foregroundStyle(Sig.faint)
+                            Text(repo).font(.system(size: 13.5, weight: .bold)).foregroundStyle(Sig.text).lineLimit(1)
+                            Spacer(minLength: 0)
+                        }
+                    }.buttonStyle(.plain)
+                    if hf.expanded == repo {
+                        if hf.files.isEmpty && hf.state != .loadingFiles {
+                            Text("No .gguf files in this repo.").font(.system(size: 11.5)).foregroundStyle(Sig.faint).padding(.leading, 19)
+                        }
+                        ForEach(hf.files, id: \.self) { file in
+                            ModelDownloadRow(name: file, detail: "from \(repo)", repo: repo, fileName: file)
+                        }
+                        if !hf.files.isEmpty {
+                            Text("New architectures may not load on this build.")
+                                .font(.system(size: 10.5, weight: .medium)).foregroundStyle(Sig.faint).padding(.leading, 2)
+                        }
+                    }
+                }
+                .padding(12)
+                .background(Sig.s1, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).stroke(Sig.line, lineWidth: 1))
+            }
+        }
+    }
+}

--- a/apple/App/MeetingCapture/ModelManager.swift
+++ b/apple/App/MeetingCapture/ModelManager.swift
@@ -55,6 +55,7 @@ struct ModelsView: View {
     @State private var importing = false
     @State private var note = ""
     @State private var busy = false
+    @ObservedObject private var dl = ModelDownloadManager.shared
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -69,9 +70,15 @@ struct ModelsView: View {
                     }
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Models").font(.system(size: 32, weight: .heavy)).foregroundStyle(Sig.text)
-                        Text("Everything runs on this iPad. Import a .gguf from Files or AirDrop — no Mac, no account.")
+                        Text("Download one, or import a .gguf.")
                             .font(.system(size: 14)).foregroundStyle(Sig.faint)
                     }
+                    SuggestedModelsSection()
+                    if let err = dl.errorMsg {
+                        Text(err).font(.system(size: 12, weight: .semibold)).foregroundStyle(Sig.warn)
+                    }
+                    HFSearchSection()
+                    Text("OR IMPORT YOUR OWN").font(.system(size: 11, weight: .heavy)).tracking(1.2).foregroundStyle(Sig.faint).padding(.top, 4)
                     Button { importing = true } label: { importCta }.disabled(busy)
                     if !note.isEmpty {
                         HStack(spacing: 7) {
@@ -79,10 +86,8 @@ struct ModelsView: View {
                             Text(note).font(.system(size: 13, weight: .semibold)).foregroundStyle(Sig.muted)
                         }
                     }
-                    if models.isEmpty && !busy {
-                        Text("No models yet. Import one to power on-device intelligence.")
-                            .font(.callout).foregroundStyle(Sig.faint).padding(.top, 6)
-                    } else {
+                    if !models.isEmpty {
+                        Text("ON THIS IPAD").font(.system(size: 11, weight: .heavy)).tracking(1.2).foregroundStyle(Sig.faint).padding(.top, 4)
                         ForEach(models) { modelCard($0) }
                     }
                 }
@@ -102,6 +107,7 @@ struct ModelsView: View {
             }
         }
         .onAppear(perform: refresh)
+        .onChange(of: dl.activeFile) { _, now in if now == nil { refresh() } }   // a download just finished → relist
     }
 
     private func refresh() { withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) { models = ModelFiles.installed() } }
@@ -111,7 +117,7 @@ struct ModelsView: View {
             Image(systemName: "square.and.arrow.down.fill").font(.system(size: 20, weight: .bold)).foregroundStyle(Sig.accent)
             VStack(alignment: .leading, spacing: 2) {
                 Text("Import a model").font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text)
-                Text("Pick a .gguf from Files (AirDrop a model, then import it here)").font(.system(size: 12)).foregroundStyle(Sig.faint)
+                Text("Pick a .gguf from Files").font(.system(size: 12)).foregroundStyle(Sig.faint)
             }
             Spacer()
             Image(systemName: "chevron.right").font(.system(size: 13, weight: .bold)).foregroundStyle(Sig.faint)

--- a/apple/App/MeetingCapture/QueuePresence.swift
+++ b/apple/App/MeetingCapture/QueuePresence.swift
@@ -169,7 +169,7 @@ struct QueueHUD: View {
             if store.blocked > 0 {
                 HStack(spacing: 7) {
                     Image(systemName: "clock.arrow.circlepath").font(.system(size: 11, weight: .bold))
-                    Text("Blocked runs auto-resume when their model is reachable.").font(.system(size: 11, weight: .medium))
+                    Text("Resumes when the model is reachable.").font(.system(size: 11, weight: .medium))
                 }
                 .foregroundStyle(Sig.faint).padding(.horizontal, 16).padding(.bottom, 14)
             }

--- a/apple/App/MeetingCapture/ReviewUI.swift
+++ b/apple/App/MeetingCapture/ReviewUI.swift
@@ -209,7 +209,7 @@ final class MeetingReviewState: ObservableObject {
             availableBytes: Self.availableMemoryBytes(), modelBytes: modelBytes,
             marginBytes: 768 * 1_048_576, ceiling: Self.contextCeiling)
         do {
-            let provider = try LlamaProvider(modelPath: modelPath, maxTokenCount: Int32(context))
+            let provider = try LlamaProvider.make(modelPath: modelPath, maxTokenCount: Int32(context))
             let transcript = Transcript(meetingId: meeting.id, segments: meeting.segments,
                                         transcriptHash: "ondevice-\(meeting.segments.count)")
             let fixed = try await ArtifactCorrection.corrected(
@@ -312,9 +312,14 @@ final class MeetingReviewState: ObservableObject {
 
     static func localGGUF() -> String? {
         guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return nil }
-        return ((try? FileManager.default.contentsOfDirectory(at: docs, includingPropertiesForKeys: nil)) ?? [])
+        let ggufs = ((try? FileManager.default.contentsOfDirectory(at: docs, includingPropertiesForKeys: nil)) ?? [])
             .filter { $0.pathExtension.lowercased() == "gguf" }
-            .sorted { $0.lastPathComponent < $1.lastPathComponent }.first?.path
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        // Honour the model picked in Settings (persisted by InferenceConfigStore under this key);
+        // fall back to the first installed model when nothing is selected.
+        let selected = UserDefaults.standard.string(forKey: "hs.inf.localmodel") ?? ""
+        if !selected.isEmpty, let m = ggufs.first(where: { $0.lastPathComponent == selected }) { return m.path }
+        return ggufs.first?.path
     }
 }
 
@@ -645,7 +650,7 @@ struct ArtifactDetailView: View {
                         Button { showVoice = true } label: {
                             HStack(spacing: 9) {
                                 Image(systemName: "mic.badge.plus").font(.system(size: 16, weight: .bold))
-                                Text("Not right? Fix it by voice").font(.system(size: 15.5, weight: .heavy))
+                                Text("Fix it by voice").font(.system(size: 15.5, weight: .heavy))
                             }
                             .foregroundStyle(tint)
                             .frame(maxWidth: .infinity).frame(height: 54)
@@ -964,7 +969,7 @@ struct GenerationTheater: View {
             if !types.isEmpty { constellation }
             HStack(spacing: 6) {
                 Image(systemName: "lock.shield.fill").font(.system(size: 11, weight: .bold))
-                Text("Running on this iPad · no network").font(.system(size: 11, weight: .semibold))
+                Text("On-device").font(.system(size: 11, weight: .semibold))
             }
             .foregroundStyle(Sig.local)
             .padding(.horizontal, 11).padding(.vertical, 6)

--- a/apple/App/MeetingCapture/SketchDiagram.swift
+++ b/apple/App/MeetingCapture/SketchDiagram.swift
@@ -344,7 +344,7 @@ struct DiagramPreview: View {
             if graph.nodes.isEmpty {
                 VStack(spacing: 8) {
                     Image(systemName: "scribble.variable").font(.system(size: 26)).foregroundStyle(Sig.faint)
-                    Text("Draw boxes, diamonds and arrows — the diagram builds itself.")
+                    Text("Draw boxes, diamonds, and arrows.")
                         .font(.system(size: 13)).foregroundStyle(Sig.faint).multilineTextAlignment(.center)
                 }.frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -476,7 +476,7 @@ struct SketchToDiagramView: View {
                         if model.mermaid.isEmpty {
                             VStack(spacing: 8) {
                                 Image(systemName: "scribble.variable").font(.system(size: 26)).foregroundStyle(Sig.faint)
-                                Text("Draw boxes, diamonds and arrows — or tap Recognize with AI.")
+                                Text("Draw boxes, diamonds, and arrows.")
                                     .font(.system(size: 13)).foregroundStyle(Sig.faint).multilineTextAlignment(.center)
                             }.frame(maxWidth: .infinity, maxHeight: .infinity)
                         } else {
@@ -570,7 +570,7 @@ struct SketchToDiagramView: View {
         switch mode {
         case .local:
             guard let p = localModelPath else { throw InferenceSettingsError.localEngineUnavailable }
-            return try LlamaProvider(modelPath: p, maxTokenCount: Int32(context))
+            return try LlamaProvider.make(modelPath: p, maxTokenCount: Int32(context))   // template auto-picked per model family
         case .homelab, .endpoint:
             guard let cfg = endpointConfig else { throw InferenceSettingsError.endpointNotConfigured }
             return OpenAIEndpointProvider(config: cfg)

--- a/apple/App/MeetingCapture/WorkbenchUI.swift
+++ b/apple/App/MeetingCapture/WorkbenchUI.swift
@@ -986,7 +986,7 @@ private struct NodeInspectorSheet: View {
             section("PROMPT") {
                 ZStack(alignment: .topLeading) {
                     if prompt.isEmpty {
-                        Text("Write what the model should do. Use {input} for the wired input.")
+                        Text("What should the model do? Use {input}.")
                             .font(.system(size: 14)).foregroundStyle(Sig.faint).padding(.horizontal, 9).padding(.vertical, 12)
                     }
                     TextEditor(text: $prompt).font(.system(size: 14)).foregroundStyle(Sig.text)

--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -23,7 +23,9 @@ struct MeetingCaptureApp: App {
             ZStack(alignment: .top) {
                 // HS_DEMO_NOTEBOOK opens straight onto the notebook surface for a
                 // screenshot run (no mic/taps needed); the real entry is the meeting list.
-                if ProcessInfo.processInfo.environment["HS_DEMO_NOTEBOOK"] != nil {
+                if ProcessInfo.processInfo.environment["HS_DEMO_MODELS"] != nil {
+                    NavigationStack { ModelsView() }
+                } else if ProcessInfo.processInfo.environment["HS_DEMO_NOTEBOOK"] != nil {
                     DemoNotebookView()
                 } else if ProcessInfo.processInfo.environment["HS_DEMO_CAPTURE"] != nil {
                     // HSM-20-03 — the live capture canvas straight, for a compact-width screenshot run.
@@ -578,10 +580,10 @@ struct MeetingListView: View {
                             .accessibilityLabel("New recording — capture a meeting on-device")
                         Button { tactile(.medium); showDictate = true } label: { dictateCta }
                             .buttonStyle(PressableCard())
-                            .accessibilityLabel("Dictate to your Mac — talk on this iPad, the words land on your Mac")
+                            .accessibilityLabel("Dictate to your desktop — talk on this iPad, the words land on your desktop")
                         Button { tactile(.medium); showConnect = true } label: { connectCta }
                             .buttonStyle(PressableCard())
-                            .accessibilityLabel("Your Computer — find and pair with your desktop on your network")
+                            .accessibilityLabel("Your Desktop — find and pair with your desktop on your network")
                         NavigationLink { WorkbenchView() } label: { workbenchCta }.buttonStyle(PressableCard())
                         NavigationLink { AgentDeskView(state: CompanionBoardState()) } label: { agentDeskCta }.buttonStyle(PressableCard())
                         HStack(spacing: 12) {
@@ -701,7 +703,7 @@ struct MeetingListView: View {
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text("New recording").font(.system(size: 21, weight: .heavy)).foregroundStyle(.black)
-                Text("Tap to capture — transcribed live on this iPad")
+                Text("Tap to capture")
                     .font(.system(size: 13, weight: .semibold)).foregroundStyle(.black.opacity(0.68))
             }
             Spacer()
@@ -734,7 +736,7 @@ struct MeetingListView: View {
             GlyphChip(system: "cpu.fill", gradient: Sig.localGradient, size: 50)
             VStack(alignment: .leading, spacing: 3) {
                 Text("Agent Desk").font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text)
-                Text("Your live agents — answer the one that's waiting").font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint)
+                Text("Your live agents").font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint)
             }
             Spacer()
             Image(systemName: "chevron.right").font(.system(size: 13, weight: .bold)).foregroundStyle(Sig.faint)
@@ -742,14 +744,14 @@ struct MeetingListView: View {
         .padding(15).frame(maxWidth: .infinity, alignment: .leading).signalCard(radius: 20)
     }
 
-    // The flagship mesh tile — talk on this iPad, the words land in whatever's focused on your Mac.
+    // The flagship mesh tile — talk on this iPad, the words land in whatever's focused on your desktop.
     // Peer-named when paired; invites pairing when not. Wears the ON-DEVICE / local-mesh badge.
     private var dictateCta: some View {
         let paired = peers.isPaired
         return HStack(spacing: 14) {
             GlyphChip(system: "mic.fill", gradient: Sig.accentGradient, size: 50)
             VStack(alignment: .leading, spacing: 5) {
-                Text(paired ? "Dictate to \(peers.displayName)" : "Dictate to your Mac")
+                Text(paired ? "Dictate to \(peers.displayName)" : "Dictate to your desktop")
                     .font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text).lineLimit(1)
                 if paired {
                     HStack(spacing: 6) {
@@ -761,7 +763,7 @@ struct MeetingListView: View {
                     .background(Sig.local.opacity(0.12), in: Capsule())
                     .overlay(Capsule().strokeBorder(Sig.local.opacity(0.25), lineWidth: 1))
                 } else {
-                    Text("Tap to pair — your iPad is the best mic in the house")
+                    Text("Tap to pair")
                         .font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint).lineLimit(1)
                 }
             }
@@ -779,7 +781,7 @@ struct MeetingListView: View {
         return HStack(spacing: 14) {
             GlyphChip(system: "laptopcomputer", gradient: Sig.localGradient, size: 50)
             VStack(alignment: .leading, spacing: 5) {
-                Text(paired ? peers.displayName : "Your Computer")
+                Text(paired ? peers.displayName : "Your Desktop")
                     .font(.system(size: 17, weight: .heavy)).foregroundStyle(Sig.text).lineLimit(1)
                 if paired {
                     HStack(spacing: 6) {
@@ -791,7 +793,7 @@ struct MeetingListView: View {
                     .background(Sig.local.opacity(0.12), in: Capsule())
                     .overlay(Capsule().strokeBorder(Sig.local.opacity(0.25), lineWidth: 1))
                 } else {
-                    Text("Find and pair your desktop — no IP to type")
+                    Text("Find and pair your desktop")
                         .font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint).lineLimit(1)
                 }
             }
@@ -859,7 +861,7 @@ struct MeetingListView: View {
             }
             VStack(spacing: 6) {
                 Text("No meetings yet").font(.system(size: 18, weight: .heavy)).foregroundStyle(Sig.text)
-                Text("Press New recording to capture your first meeting. It transcribes live and stays on this iPad — nothing leaves.")
+                Text("Tap New recording to start.")
                     .font(.system(size: 13, weight: .medium)).foregroundStyle(Sig.faint)
                     .multilineTextAlignment(.center).frame(maxWidth: 320).lineSpacing(2)
             }
@@ -986,7 +988,7 @@ struct CaptureView: View {
         } else {
             VStack(spacing: 8) {
                 Image(systemName: "pencil.and.scribble").font(.largeTitle).foregroundStyle(Sig.local)
-                Text("Press Record to start a meeting, then take handwritten notes here — they save with it.")
+                Text("Record a meeting to take notes.")
                     .font(.callout).foregroundStyle(Sig.faint).multilineTextAlignment(.center)
             }
             .frame(maxWidth: .infinity, minHeight: 360)
@@ -1692,7 +1694,7 @@ struct MeetingDetailView: View {
             // Whatever's been produced so far — generated artifacts and/or handwritten
             // notes — streams in here.
             if review.artifacts.isEmpty && !review.generating {
-                Text("Generate decisions, action items, risks and more from this meeting — or add your handwritten notes. All on-device.")
+                Text("Generate decisions, actions, and risks.")
                     .font(.caption).foregroundStyle(Sig.faint)
             } else {
                 ForEach(review.groups, id: \.type) { group in

--- a/apple/Sources/InferenceLlama/LlamaProvider.swift
+++ b/apple/Sources/InferenceLlama/LlamaProvider.swift
@@ -37,6 +37,47 @@ public final class LlamaProvider: ILLMProvider, @unchecked Sendable {
         self.llm = llm
     }
 
+    /// Build a provider that picks the model's chat template from its filename — so a
+    /// downloaded/imported Gemma, Llama-3, Mistral or Qwen is prompted in its OWN format
+    /// instead of a one-size-fits-all ChatML (wrong markers = degraded output). Prefer this
+    /// over the raw init at every call site that loads a user-chosen model.
+    public static func make(modelPath: String, maxTokenCount: Int32 = 2048) throws -> LlamaProvider {
+        try LlamaProvider(modelPath: modelPath,
+                          template: autoTemplate(for: modelPath),
+                          maxTokenCount: maxTokenCount)
+    }
+
+    /// Map a GGUF filename to its chat template. Families are detected by the conventional
+    /// tokens model authors keep in their filenames; unknown ⇒ ChatML (the safe, common default).
+    public static func autoTemplate(for modelPath: String) -> Template {
+        let n = (modelPath as NSString).lastPathComponent.lowercased()
+        if n.contains("gemma")                                           { return .gemma }
+        if n.contains("qwen")                                            { return .chatML() }   // Qwen = ChatML
+        if n.contains("mistral") || n.contains("mixtral") || n.contains("nemo") { return .mistral }
+        if n.contains("phi-3") || n.contains("phi3") || n.contains("phi-4") || n.contains("phi4") { return phi }
+        if n.contains("llama-3") || n.contains("llama3") || n.contains("meta-llama-3") { return llama3 }
+        return .chatML()
+    }
+
+    /// Llama-3/3.1/3.2 header format (the bundled `.llama()` preset is Llama-**2** `[INST]`,
+    /// which is wrong for the Llama-3 line). BOS is added by the tokenizer, so no prefix here.
+    static let llama3 = Template(
+        system: ("<|start_header_id|>system<|end_header_id|>\n\n", "<|eot_id|>"),
+        user:   ("<|start_header_id|>user<|end_header_id|>\n\n", "<|eot_id|>"),
+        bot:    ("<|start_header_id|>assistant<|end_header_id|>\n\n", "<|eot_id|>"),
+        stopSequence: "<|eot_id|>",
+        systemPrompt: nil
+    )
+
+    /// Phi-3/Phi-4 turn format.
+    static let phi = Template(
+        system: ("<|system|>\n", "<|end|>\n"),
+        user:   ("<|user|>\n", "<|end|>\n"),
+        bot:    ("<|assistant|>\n", "<|end|>\n"),
+        stopSequence: "<|end|>",
+        systemPrompt: nil
+    )
+
     public func complete(prompt: String) async throws -> String {
         // One-shot completion. NOTE: LLM.swift accumulates KV context across
         // `getCompletion` calls (it's built for chat) and never clears it, so a single

--- a/pm/roadmap/holdspeak/BACKLOG.md
+++ b/pm/roadmap/holdspeak/BACKLOG.md
@@ -221,3 +221,31 @@ user-facing guide re-framed with why-ledes + canonical feature names + the
 humanizer voice (and the em-dash cleanup the pre-P55 corpus never had), and
 a voice drift guard. The pitch stays as honest as the product.
 *Lands on:* the Phase-51 docs hygiene lineage + the per-phase docs-story culture.
+
+---
+### R. Core AI provider (mobile / Apple on-device, iOS 27) — PARKED (toolchain-blocked)
+Apple shipped **Core AI** (the iOS/macOS 27 on-device inference runtime) + the open
+`apple/coreai-models` repo (HF→`.aimodel` export recipes + a Swift runtime) + the
+**Foundation Models** `LanguageModel`/`LanguageModelExecutor` protocol that lets a custom
+model plug into `LanguageModelSession` exactly like Apple's system model. This is the durable
+answer to the llama.cpp-xcframework treadmill: Apple owns the runtime + a maintained catalog
+(Gemma 3, Qwen2.5/3, Qwen3-MoE, Mistral, Mixtral, GPT-OSS), with ANE acceleration.
+
+**The play (NOT a rewrite):** add `CoreAIProvider: ILLMProvider` as a new Mode behind the
+existing seam, gated `@available(iOS 27)` + `#if canImport(CoreAI)`, wrapping
+`CoreAILanguageModel`/`LanguageModelSession`. llama.cpp/GGUF stays the path for iOS 17–26;
+Core AI is additive for 27+. Optionally route the app boundary through `LanguageModelSession`
+so Apple-system / PCC / cloud / Core AI all sit behind one protocol.
+
+**Why parked (do not start until cleared):**
+- **Toolchain:** needs Xcode 27 + iOS 27 SDK. We're on Xcode 26.5 / iOS 26.5 — `CoreAI.framework`
+  is not in our SDK (only `FoundationModels.framework`). Cannot compile/verify until installed.
+- **Different artifact pipeline:** Core AI runs Mac-exported `.aimodel` bundles, NOT GGUF — so the
+  in-app HF GGUF downloader feeds llama.cpp, not Core AI. Core AI needs its own `.aimodel`
+  distribution story (bundle or host exported assets).
+- **Beta risk:** `CoreAI.framework` is device-SDK-only (needs `canImport` guards), `AIModelCache`
+  cache-honoring bugs, and a reported Gemma-4-12B MPSGraph scratch-heap overflow on macOS 27 beta.
+  Not accepting PRs.
+
+*Lands on:* the existing `ILLMProvider` seam (Contracts/RuntimeCore depend on the protocol, not the
+engine) + the per-device model policy. Owner action gates the start: install Xcode 27 / iOS 27.


### PR DESCRIPTION
Owner-driven iteration on the iPad/iPhone app (one bundled PR, per request).

## What's in here
- **Wording:** `Mac` → **"your desktop"** everywhere (Mac *and* Linux are supported); the egress sentinel stayed matched; "CONNECT YOUR MAC" → "CONNECT YOUR DESKTOP".
- **iPhone safe area:** the desk was full-bleed with chrome hand-placed by %-of-height, so the gear/Sync header bled under the Dynamic Island. Now reads the real insets — top chrome + lane column clear the Island, the rising pull-out clears the home indicator.
- **Movable note:** the in-world note/KB editor opens as a **draggable window** (grab handle + persisted position) — the same affordance as a game window.
- **Games during a meeting:** dropped the single `!capturing` flag that hid the whole rail (Agents · Chains · **Play**) while recording.
- **Prose cull:** removed the multi-sentence manuals / reassurance novels / how-to tails app-wide; kept action microcopy + dynamic status.
- **In-app model downloads:** new `ModelDownloads.swift` — curated suggested list (Llama 3.2 3B / Qwen3-4B / **Gemma 3n E4B** / Llama 3.1 8B) with live progress + cancel, plus a **Hugging Face search**, writing GGUF into Documents where the runtime loads. Fixed `localGGUF()` ignoring the Settings pick.
- **Per-model chat templates:** `LlamaProvider.make` auto-selects the template by model family (custom **Llama-3** header, **Gemma** turns, **Mistral** `[INST]`, **ChatML** for Qwen, **Phi** turns) instead of ChatML-for-everything.
- **Parked Core AI** (Apple iOS 27 on-device runtime) on `BACKLOG.md` (R) — the durable answer to the llama.cpp-xcframework treadmill, blocked on Xcode 27 / iOS 27.

## Validation
- `cd apple && swift test` → **381 tests, 0 failures** (8 skipped).
- `xcodebuild` iphonesimulator build **SUCCEEDED**; device-SDK compile (`-sdk iphoneos`) **SUCCEEDED**.
- Simulator screenshots for each visible change; prior build installed + launched on a real iPhone 17 Pro Max.

## Not verified here (owner device walk)
- Interaction behaviors: dragging the note, games mid-meeting, an actual model download/load, and per-template generation quality — these are the on-device gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)