### PR TITLE
Streamlined agent builder + grounding context + context gauge; author Phase 24 (runtime profiles)

### DIFF
--- a/apple/App/MeetingCapture/AppSettings.swift
+++ b/apple/App/MeetingCapture/AppSettings.swift
@@ -29,7 +29,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     header
                     label("WHERE INTELLIGENCE RUNS")
-                    targetCard(.local, "This iPad", "Runs on this iPad", "ipad", Sig.localGradient)
+                    targetCard(.local, "This \(DeviceLabel.current)", "Runs on this \(DeviceLabel.current)", DeviceLabel.current == "iPhone" ? "iphone" : "ipad", Sig.localGradient)
                     if cfg.isLocal { onDeviceModelCard }
                     targetCard(.homelab, "LAN endpoint", "An OpenAI-compatible server on your network", "server.rack", Sig.accentGradient)
                     if !cfg.isLocal { endpointCard }
@@ -70,7 +70,7 @@ struct SettingsView: View {
                     HStack(spacing: 10) {
                         GlyphChip(system: "tray.and.arrow.down.fill", gradient: Sig.accentGradient, size: 42)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("No models on this iPad").font(.system(size: 15.5, weight: .heavy)).foregroundStyle(Sig.text)
+                            Text("No models on this \(DeviceLabel.current)").font(.system(size: 15.5, weight: .heavy)).foregroundStyle(Sig.text)
                             Text("Tap to download one").font(.system(size: 12, weight: .medium)).foregroundStyle(Sig.faint)
                         }
                         Spacer(); Image(systemName: "chevron.right").font(.system(size: 13, weight: .bold)).foregroundStyle(Sig.faint)

--- a/apple/App/MeetingCapture/DeskAgents.swift
+++ b/apple/App/MeetingCapture/DeskAgents.swift
@@ -327,9 +327,22 @@ struct DioAgentBuilder: View {
     let onSave: (AgentRecord) -> Void
     let onCancel: () -> Void
     var isNew: Bool
+    var contextLimit: Int = 16_384         // the chosen runtime's usable context (on-device budget)
+    var zoneTokens: Int = 0                // est. tokens the current zone's meetings would add
+
+    /// Tokens the grounding context costs at rest — exactly what `agentRoleAndContext` assembles:
+    /// the role (system prompt) + the notes + the zone's meetings (the KB injects only a hint today).
+    private var groundingTokens: Int {
+        OnDeviceBudget.estimateTokens(draft.systemPrompt)
+        + OnDeviceBudget.estimateTokens(draft.manualContext)
+        + (draft.useZoneContext ? zoneTokens : 0)
+        + (draft.kb.isEmpty ? 0 : 12)
+    }
     @State private var avatarGroup = 0
     @State private var showAdvanced = false
     @State private var showRawPrompt = false
+    @State private var showFaces = false
+    @State private var step = 0          // 0 = what it does · 1 = name & face
     @State private var pop = false
 
     private let cols = Array(repeating: GridItem(.flexible(), spacing: 12), count: 6)
@@ -343,14 +356,12 @@ struct DioAgentBuilder: View {
                 header
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 22) {
-                        pickAFace
-                        whoAreThey
-                        personality
-                        advanced
+                        if step == 0 { step1Behavior } else { step2Identity }
                     }
                     .padding(.horizontal, 22).padding(.top, 4).padding(.bottom, 18)
+                    .transition(.opacity)
                 }
-                saveBar
+                bottomBar
             }
             .frame(maxWidth: 600)
             .background(RoundedRectangle(cornerRadius: 30, style: .continuous).fill(Color(hex: 0x14121B))
@@ -361,76 +372,162 @@ struct DioAgentBuilder: View {
         .onChange(of: draft.avatar) { _ in pop = true; DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { pop = false } }
     }
 
-    // the playful hero — a big bobbing avatar that pops when you change it, the name inline, a dice to reroll
+    private func advance() { withAnimation(.spring(response: 0.4, dampingFraction: 0.86)) { step = 1 } }
+
+    // A light step-aware header — the title tells you where you are; close lives here.
     private var header: some View {
-        HStack(spacing: 14) {
-            TimelineView(.animation) { tl in
-                let bob = CGFloat(sin(tl.date.timeIntervalSinceReferenceDate * 1.4) * 3)
-                AgentAvatarView(avatarId: draft.avatar, size: 68).offset(y: -bob)
-                    .scaleEffect(pop ? 1.18 : 1).animation(.spring(response: 0.3, dampingFraction: 0.5), value: pop)
-            }
-            .frame(width: 72, height: 72)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(isNew ? "Meet your new agent" : "Edit agent").font(.system(size: 11.5, weight: .heavy, design: .rounded)).foregroundStyle(tint).tracking(0.4)
-                Text(draft.name.isEmpty ? "Unnamed" : draft.name).font(.system(size: 22, weight: .black, design: .rounded)).foregroundStyle(DioPal.text).lineLimit(1)
-                Text(draft.role.isEmpty ? "give them a vibe below" : draft.role).font(.system(size: 12.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).lineLimit(1)
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("STEP \(step + 1) OF 2").font(.system(size: 11, weight: .black, design: .rounded)).tracking(1).foregroundStyle(tint)
+                Text(step == 0 ? "What should it do?" : "Name & face").font(.system(size: 22, weight: .black, design: .rounded)).foregroundStyle(DioPal.text)
             }
             Spacer(minLength: 0)
-            Button { surprise() } label: {
-                Image(systemName: "dice.fill").font(.system(size: 17, weight: .bold)).foregroundStyle(.white)
-                    .frame(width: 40, height: 40).background(Circle().fill(tint.opacity(0.85)))
-            }.buttonStyle(.plain)
             Button { onCancel() } label: { Image(systemName: "xmark.circle.fill").font(.system(size: 26)).foregroundStyle(DioPal.muted) }.buttonStyle(.plain)
         }
-        .padding(.horizontal, 22).padding(.top, 18).padding(.bottom, 14)
+        .padding(.horizontal, 22).padding(.top, 18).padding(.bottom, 12)
     }
 
-    // FACE FIRST — the fun part: group tabs + the gallery
-    private var pickAFace: some View {
-        section("PICK A FACE · \(AgentAvatars.all.count)") {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(Array(AgentAvatars.groups.enumerated()), id: \.element.id) { i, g in
-                        Button { withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) { avatarGroup = i }; haptic() } label: {
-                            Text("\(g.title) · \(g.avatars.count)")
-                                .font(.system(size: 12.5, weight: .heavy, design: .rounded))
-                                .foregroundStyle(avatarGroup == i ? .white : DioPal.muted)
-                                .padding(.horizontal, 14).frame(height: 34)
-                                .background(Capsule().fill(avatarGroup == i ? tint.opacity(0.85) : .white.opacity(0.06)))
-                        }.buttonStyle(.plain)
-                    }
-                }.padding(.horizontal, 2)
+    // STEP 1 — what it does: describe it, or tap a recipe (which jumps straight to naming).
+    private var step1Behavior: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            section("DESCRIBE IT, IN YOUR WORDS") {
+                editor($draft.systemPrompt, placeholder: "e.g. a sharp researcher who pulls out the facts, names and open questions…", minH: 92)
             }
-            LazyVGrid(columns: cols, spacing: 12) {
-                ForEach(AgentAvatars.groups[avatarGroup].avatars) { av in
-                    Button { draft.avatar = av.id; haptic() } label: {
-                        AgentAvatarView(avatarId: av.id, size: 44, selected: draft.avatar == av.id)
-                    }.buttonStyle(.plain)
+            section("OR START FROM A RECIPE") {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
+                    ForEach(AgentPresets.all, id: \.name) { p in
+                        Button { applyPreset(p); advance() } label: { recipeCard(p) }.buttonStyle(.plain)
+                    }
                 }
             }
         }
     }
 
-    private var whoAreThey: some View {
-        section("WHO ARE THEY?") {
-            field("Name", text: $draft.name, placeholder: "e.g. Scout")
-            field("Vibe (one line)", text: $draft.role, placeholder: "e.g. digs for the facts")
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 9) {
-                    ForEach(AgentPresets.all, id: \.name) { p in
-                        Button { applyPreset(p) } label: {
-                            HStack(spacing: 7) {
-                                AgentAvatarView(avatarId: p.avatar, size: 24)
-                                VStack(alignment: .leading, spacing: 0) {
-                                    Text(p.name).font(.system(size: 12, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
-                                    Text(p.role).font(.system(size: 9, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
-                                }
-                            }
-                            .padding(.horizontal, 10).padding(.vertical, 7)
-                            .background(Capsule().fill(.white.opacity(0.06)).overlay(Capsule().strokeBorder(.white.opacity(0.1), lineWidth: 1)))
+    private func recipeCard(_ p: AgentPreset) -> some View {
+        HStack(spacing: 10) {
+            AgentAvatarView(avatarId: p.avatar, size: 38)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(p.name).font(.system(size: 14.5, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
+                Text(p.role).font(.system(size: 11, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).lineLimit(2).multilineTextAlignment(.leading)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(11).frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 16, style: .continuous).fill(.white.opacity(0.05))
+            .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).strokeBorder(.white.opacity(0.1), lineWidth: 1)))
+    }
+
+    // STEP 2 — make it yours: the hero, name + vibe, personality, a collapsed face picker, advanced.
+    private var step2Identity: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            heroRow
+            section("NAME") { field("Name", text: $draft.name, placeholder: "e.g. Scout") }
+            section("VIBE · ONE LINE") { field("Vibe", text: $draft.role, placeholder: "e.g. digs for the facts") }
+            knowsSection
+            personality
+            faceCollapsible
+            advanced
+        }
+    }
+
+    // GROUNDING CONTEXT — first-class, not buried: point it at a knowledge base, pin facts it
+    // always carries, and optionally feed it the zone's meetings.
+    private var knowsSection: some View {
+        section("GROUNDING CONTEXT") {
+            Text("Stuff your agent always knows.").font(.system(size: 12, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
+            ContextGauge(used: groundingTokens, limit: contextLimit)
+                .padding(11)
+                .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(.white.opacity(0.04)).overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(.white.opacity(0.07), lineWidth: 1)))
+            Text("KNOWLEDGE BASE").font(.system(size: 9.5, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.muted.opacity(0.8)).padding(.top, 2)
+            if knowledgeBases.isEmpty {
+                Text("Make a knowledge base on the desk, then point this agent at it.")
+                    .font(.system(size: 11.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted.opacity(0.8))
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        kbChip("None", icon: "nosign", on: draft.kb.isEmpty) { draft.kb = "" }
+                        ForEach(knowledgeBases, id: \.self) { k in
+                            kbChip(k, icon: "diamond.fill", on: draft.kb == k) { draft.kb = k }
+                        }
+                    }.padding(.horizontal, 2)
+                }
+            }
+            Text("NOTES").font(.system(size: 9.5, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.muted.opacity(0.8)).padding(.top, 6)
+            editor($draft.manualContext, placeholder: "Facts it should always have on hand — names, preferences, project context…", minH: 64)
+            Toggle(isOn: $draft.useZoneContext) {
+                Text("Read this zone's meetings").font(.system(size: 13.5, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
+            }.tint(tint).padding(.top, 2)
+        }
+    }
+
+    private func kbChip(_ label: String, icon: String, on: Bool, _ tap: @escaping () -> Void) -> some View {
+        Button { haptic(); tap() } label: {
+            HStack(spacing: 6) {
+                Image(systemName: icon).font(.system(size: 10, weight: .bold))
+                Text(label).font(.system(size: 12.5, weight: .heavy, design: .rounded)).lineLimit(1)
+                if on { Image(systemName: "checkmark").font(.system(size: 9, weight: .black)) }
+            }
+            .foregroundStyle(on ? .white : DioPal.text.opacity(0.85))
+            .padding(.horizontal, 12).frame(height: 34)
+            .background(Capsule().fill(on ? tint.opacity(0.85) : .white.opacity(0.06)).overlay(Capsule().strokeBorder(.white.opacity(on ? 0 : 0.1), lineWidth: 1)))
+        }.buttonStyle(.plain)
+    }
+
+    // the playful hero — a big bobbing avatar that pops when you change it, with a dice to reroll
+    private var heroRow: some View {
+        HStack(spacing: 14) {
+            TimelineView(.animation) { tl in
+                let bob = CGFloat(sin(tl.date.timeIntervalSinceReferenceDate * 1.4) * 3)
+                AgentAvatarView(avatarId: draft.avatar, size: 64).offset(y: -bob)
+                    .scaleEffect(pop ? 1.18 : 1).animation(.spring(response: 0.3, dampingFraction: 0.5), value: pop)
+            }
+            .frame(width: 70, height: 70)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(draft.name.isEmpty ? "Unnamed" : draft.name).font(.system(size: 20, weight: .black, design: .rounded)).foregroundStyle(DioPal.text).lineLimit(1)
+                Text(draft.role.isEmpty ? "give it a vibe" : draft.role).font(.system(size: 12, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).lineLimit(1)
+            }
+            Spacer(minLength: 0)
+            Button { surprise() } label: {
+                Image(systemName: "dice.fill").font(.system(size: 16, weight: .bold)).foregroundStyle(.white)
+                    .frame(width: 38, height: 38).background(Circle().fill(tint.opacity(0.85)))
+            }.buttonStyle(.plain)
+        }
+    }
+
+    // the face picker, collapsed by default (100 faces shouldn't dominate the screen)
+    private var faceCollapsible: some View {
+        section("FACE") {
+            Button { withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { showFaces.toggle() } } label: {
+                HStack(spacing: 11) {
+                    AgentAvatarView(avatarId: draft.avatar, size: 40)
+                    Text(showFaces ? "Hide faces" : "Change face").font(.system(size: 13.5, weight: .heavy, design: .rounded)).foregroundStyle(tint)
+                    Spacer(minLength: 0)
+                    Image(systemName: showFaces ? "chevron.up" : "chevron.down").font(.system(size: 12, weight: .black)).foregroundStyle(DioPal.muted)
+                }
+                .padding(.horizontal, 13).frame(height: 56)
+                .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(.white.opacity(0.05)).overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(.white.opacity(0.08), lineWidth: 1)))
+            }.buttonStyle(.plain)
+            if showFaces {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(Array(AgentAvatars.groups.enumerated()), id: \.element.id) { i, g in
+                            Button { withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) { avatarGroup = i }; haptic() } label: {
+                                Text("\(g.title) · \(g.avatars.count)")
+                                    .font(.system(size: 12.5, weight: .heavy, design: .rounded))
+                                    .foregroundStyle(avatarGroup == i ? .white : DioPal.muted)
+                                    .padding(.horizontal, 14).frame(height: 34)
+                                    .background(Capsule().fill(avatarGroup == i ? tint.opacity(0.85) : .white.opacity(0.06)))
+                            }.buttonStyle(.plain)
+                        }
+                    }.padding(.horizontal, 2)
+                }
+                LazyVGrid(columns: cols, spacing: 12) {
+                    ForEach(AgentAvatars.groups[avatarGroup].avatars) { av in
+                        Button { draft.avatar = av.id; haptic() } label: {
+                            AgentAvatarView(avatarId: av.id, size: 44, selected: draft.avatar == av.id)
                         }.buttonStyle(.plain)
                     }
-                }.padding(.horizontal, 2)
+                }
             }
         }
     }
@@ -477,7 +574,7 @@ struct DioAgentBuilder: View {
                 HStack(spacing: 7) {
                     Image(systemName: showAdvanced ? "chevron.down" : "chevron.right").font(.system(size: 11, weight: .black))
                     Text("ADVANCED").font(.system(size: 10.5, weight: .black, design: .rounded)).tracking(1.2)
-                    Text("context · what to ask").font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted.opacity(0.7))
+                    Text("prompt template").font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted.opacity(0.7))
                     Spacer(minLength: 0)
                 }.foregroundStyle(DioPal.muted)
             }.buttonStyle(.plain)
@@ -486,45 +583,41 @@ struct DioAgentBuilder: View {
                 editor($draft.userTemplate, placeholder: "{input}", minH: 52)
                 Text("Use {input} for your question.")
                     .font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
-                Text("CONTEXT IT CARRIES").font(.system(size: 10, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.muted).padding(.top, 4)
-                editor($draft.manualContext, placeholder: "Pinned notes the agent always knows…", minH: 60)
-                Toggle(isOn: $draft.useZoneContext) {
-                    Text("Include this zone's meetings").font(.system(size: 13, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
-                }.tint(tint)
-                if !knowledgeBases.isEmpty {
-                    HStack {
-                        Text("Knowledge base").font(.system(size: 13, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
-                        Spacer()
-                        Menu {
-                            Button("None") { draft.kb = "" }
-                            ForEach(knowledgeBases, id: \.self) { k in Button(k) { draft.kb = k } }
-                        } label: {
-                            HStack(spacing: 5) { Text(draft.kb.isEmpty ? "None" : draft.kb).font(.system(size: 12.5, weight: .heavy, design: .rounded)); Image(systemName: "chevron.up.chevron.down").font(.system(size: 10, weight: .bold)) }
-                                .foregroundStyle(tint).padding(.horizontal, 12).frame(height: 34).background(Capsule().fill(.white.opacity(0.07)))
-                        }
-                    }
-                }
             }
         }
     }
 
-    private var saveBar: some View {
+    private var bottomBar: some View {
         HStack(spacing: 12) {
-            Button { onCancel() } label: {
-                Text("Cancel").font(.system(size: 15, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.muted)
-                    .frame(maxWidth: .infinity).frame(height: 50).background(Capsule().fill(.white.opacity(0.06)))
-            }.buttonStyle(.plain)
-            Button { save() } label: {
-                HStack(spacing: 7) {
-                    Image(systemName: isNew ? "sparkles" : "checkmark")
-                    Text(isNew ? "Bring to life" : "Save").font(.system(size: 15.5, weight: .heavy, design: .rounded))
-                }
-                .foregroundStyle(.white).frame(maxWidth: .infinity).frame(height: 50)
-                .background(Capsule().fill(LinearGradient(colors: [tint, AgentAvatars.deep(draft.avatar)], startPoint: .top, endPoint: .bottom)))
-                .opacity(canSave ? 1 : 0.45)
-            }.buttonStyle(.plain).disabled(!canSave)
+            if step == 0 {
+                Button { onCancel() } label: { mutedCap("Cancel") }.buttonStyle(.plain)
+                Button { advance() } label: {
+                    HStack(spacing: 7) { Text("Next").font(.system(size: 15.5, weight: .heavy, design: .rounded)); Image(systemName: "arrow.right") }
+                        .foregroundStyle(.white).frame(maxWidth: .infinity).frame(height: 50)
+                        .background(Capsule().fill(LinearGradient(colors: [tint, AgentAvatars.deep(draft.avatar)], startPoint: .top, endPoint: .bottom)))
+                }.buttonStyle(.plain)
+            } else {
+                Button { withAnimation(.spring(response: 0.4, dampingFraction: 0.86)) { step = 0 } } label: {
+                    HStack(spacing: 6) { Image(systemName: "arrow.left"); Text("Back").font(.system(size: 15, weight: .heavy, design: .rounded)) }
+                        .foregroundStyle(DioPal.muted).frame(maxWidth: .infinity).frame(height: 50).background(Capsule().fill(.white.opacity(0.06)))
+                }.buttonStyle(.plain)
+                Button { save() } label: {
+                    HStack(spacing: 7) {
+                        Image(systemName: isNew ? "sparkles" : "checkmark")
+                        Text(isNew ? "Bring to life" : "Save").font(.system(size: 15.5, weight: .heavy, design: .rounded))
+                    }
+                    .foregroundStyle(.white).frame(maxWidth: .infinity).frame(height: 50)
+                    .background(Capsule().fill(LinearGradient(colors: [tint, AgentAvatars.deep(draft.avatar)], startPoint: .top, endPoint: .bottom)))
+                    .opacity(canSave ? 1 : 0.45)
+                }.buttonStyle(.plain).disabled(!canSave)
+            }
         }
         .padding(.horizontal, 22).padding(.vertical, 16)
+    }
+
+    private func mutedCap(_ t: String) -> some View {
+        Text(t).font(.system(size: 15, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.muted)
+            .frame(maxWidth: .infinity).frame(height: 50).background(Capsule().fill(.white.opacity(0.06)))
     }
 
     private var canSave: Bool { !draft.name.trimmingCharacters(in: .whitespaces).isEmpty }
@@ -593,6 +686,32 @@ struct DioAgentBuilder: View {
         #if canImport(UIKit)
         UIImpactFeedbackGenerator(style: s).impactOccurred()
         #endif
+    }
+}
+
+// A ring gauge: how much of the agent's context its grounding eats before you even ask. Green under
+// 60%, amber to 85%, red past it — a live "this knowledge base alone fills it" signal.
+struct ContextGauge: View {
+    let used: Int
+    let limit: Int
+    private var frac: Double { limit <= 0 ? 0 : min(1, Double(used) / Double(limit)) }
+    private var color: Color { frac < 0.6 ? DioPal.mint : (frac < 0.85 ? Color(hex: 0xF5A623) : Color(hex: 0xFF6B6B)) }
+    private func fmt(_ n: Int) -> String { n >= 1000 ? String(format: "%.1fk", Double(n) / 1000) : "\(n)" }
+    var body: some View {
+        HStack(spacing: 13) {
+            ZStack {
+                Circle().stroke(.white.opacity(0.08), lineWidth: 6)
+                Circle().trim(from: 0, to: frac).stroke(color, style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                    .rotationEffect(.degrees(-90)).animation(.easeOut(duration: 0.3), value: frac)
+                Text("\(Int(frac * 100))%").font(.system(size: 12.5, weight: .black, design: .rounded)).foregroundStyle(DioPal.text)
+            }
+            .frame(width: 48, height: 48)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(fmt(used)) / \(fmt(limit)) tokens").font(.system(size: 13, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
+                Text("filled before you ask a thing").font(.system(size: 10.5, weight: .semibold, design: .rounded)).foregroundStyle(color)
+            }
+            Spacer(minLength: 0)
+        }
     }
 }
 

--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -2229,7 +2229,7 @@ struct DioRunTargetSheet: View {
                     Spacer(minLength: 0)
                 }
                 // ON DEVICE — the default, private, no network.
-                runRow(icon: "ipad", tint: DioPal.mint, name: "On this iPad",
+                runRow(icon: DeviceLabel.current == "iPhone" ? "iphone" : "ipad", tint: DioPal.mint, name: "On this \(DeviceLabel.current)",
                        sub: "private · no network", egress: .local, enabled: true,
                        isDefault: preferred == .device, action: onDevice)
                 // ON YOUR MAC — the hub's big model; LAN egress; disabled when unpaired.
@@ -2376,7 +2376,7 @@ struct DioRoutingTheater: View {
             }
             VStack(spacing: 3) {
                 Text("Routing \(sourceTitle)").font(.system(size: 14, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.text)
-                Text("\(lens) · \(local ? "on this iPad · no network" : "endpoint")").font(.system(size: 11.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
+                Text("\(lens) · \(local ? "on this \(DeviceLabel.current) · no network" : "endpoint")").font(.system(size: 11.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
             }
             .padding(.horizontal, 16).padding(.vertical, 9).background(Capsule().fill(.black.opacity(0.55)))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom).padding(.bottom, 130)
@@ -3198,7 +3198,9 @@ struct DioStage: View {
                 // the bottom-right thumb corner); the diorama keeps it bottom-right.
                 DioCompanion(landed: landed, excited: selected != nil)
                     .position(x: w * 0.9, y: camera.isLane ? h * 0.66 : h * 0.86)
-                if landed && selected == nil && summonSource == nil && !capturing {
+                if landed && selected == nil && summonSource == nil && !capturing
+                    && editingNote == nil && editingKB == nil && !connecting
+                    && !showRouteSheet && !routing && printed == nil && !showSendCard && !showActSheet {
                     VStack(spacing: 4) {
                         DioRecordOrb { haptic(.medium); withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) { showRecordPicker = true } }
                         Text("Record").font(.system(size: 10, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.muted).tracking(0.5)
@@ -3211,18 +3213,21 @@ struct DioStage: View {
                 if camera.isLane && landed && selected == nil && summonSource == nil && !capturing
                     && editingNote == nil && editingKB == nil && !connecting && !showRouteSheet && !routing
                     && printed == nil && !showSendCard && !showActSheet && !firstRun {
-                    Menu {
-                        Button { createNote() } label: { Label("New Note", systemImage: "square.and.pencil") }
-                        Button { createKBInline() } label: { Label("New KB", systemImage: "diamond.fill") }
-                        Button { haptic(.light); namingZone = true } label: { Label("New Zone", systemImage: "plus.circle.fill") }
-                    } label: {
-                        Image(systemName: "plus").font(.system(size: 24, weight: .black)).foregroundStyle(.white)
-                            .frame(width: 58, height: 58)
-                            .background(Circle().fill(LinearGradient(colors: [Color(hex: 0xFF8A5B), DioPal.accent], startPoint: .top, endPoint: .bottom))
-                                .shadow(color: DioPal.accent.opacity(0.5), radius: 12, y: 4))
-                    }.simultaneousGesture(TapGesture().onEnded { haptic(.medium) })
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-                    .padding(.trailing, 20).padding(.bottom, h * 0.15).zIndex(73)
+                    VStack(spacing: 4) {
+                        Menu {
+                            Button { createNote() } label: { Label("New Note", systemImage: "square.and.pencil") }
+                            Button { createKBInline() } label: { Label("New KB", systemImage: "diamond.fill") }
+                            Button { haptic(.light); namingZone = true } label: { Label("New Zone", systemImage: "plus.circle.fill") }
+                        } label: {
+                            Image(systemName: "plus").font(.system(size: 24, weight: .black)).foregroundStyle(.white)
+                                .frame(width: 64, height: 64)
+                                .background(Circle().fill(LinearGradient(colors: [Color(hex: 0xFF8A5B), DioPal.accent], startPoint: .top, endPoint: .bottom))
+                                    .shadow(color: DioPal.accent.opacity(0.5), radius: 12, y: 4))
+                        }.simultaneousGesture(TapGesture().onEnded { haptic(.medium) })
+                        Text("New").font(.system(size: 10, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.muted).tracking(0.5)
+                    }
+                    // mirror the Record orb (bottom-left) on the bottom-right, same baseline
+                    .position(x: w - 58, y: orbPos(w, h).y).zIndex(73)
                 }
                 // a desk-native settings entry (no bouncing to an old screen)
                 if landed && selected == nil && summonSource == nil && !capturing && path.isEmpty {
@@ -3475,7 +3480,8 @@ struct DioStage: View {
                     DioAgentBuilder(draft: draft, knowledgeBases: knowledgeBases,
                                     onSave: { saveAgent($0) },
                                     onCancel: { withAnimation { editingAgent = nil } },
-                                    isNew: !agents.contains { $0.id == draft.id })
+                                    isNew: !agents.contains { $0.id == draft.id },
+                                    contextLimit: agentContextLimit(), zoneTokens: zoneGroundingTokens())
                         .id(draft.id)
                         .zIndex(145).transition(.opacity)
                 }
@@ -4570,6 +4576,24 @@ struct DioStage: View {
         if !a.kb.isEmpty { ctx.append("Lean on the knowledge base \"\(a.kb)\" when relevant.") }
         if !ctx.isEmpty { blocks.append("[CONTEXT]\n" + ctx.joined(separator: "\n\n")) }
         return blocks
+    }
+
+    // For the builder's context gauge: the est. tokens this zone's meetings would add as grounding
+    // (mirrors the assembly above — title + first 2000 chars per meeting).
+    private func zoneGroundingTokens() -> Int {
+        let z = contentMembers().filter { $0.kind == .meeting }
+            .map { "## \($0.title)\n\(String($0.routableText.prefix(2000)))" }.joined(separator: "\n\n")
+        return z.isEmpty ? 0 : OnDeviceBudget.estimateTokens("Meetings filed here:\n" + z)
+    }
+
+    // The chosen runtime's usable context: the on-device budget when local (clamped by RAM), else the
+    // ceiling as a reference for an endpoint (whose true window we don't control).
+    private func agentContextLimit() -> Int {
+        guard InferenceConfigStore.shared.isLocal, let p = MeetingReviewState.localGGUF() else { return 16_384 }
+        let modelBytes = ((try? FileManager.default.attributesOfItem(atPath: p))?[.size] as? Int) ?? 0
+        let availRaw = Int(os_proc_available_memory())
+        let avail = availRaw > 0 ? availRaw : Int(ProcessInfo.processInfo.physicalMemory / 2)
+        return OnDeviceBudget.contextTokens(availableBytes: avail, modelBytes: modelBytes, marginBytes: 768 * 1_048_576, ceiling: 16_384)
     }
 
     // route a card THROUGH an agent (radial): assemble role + context + the card, infer → printed card.

--- a/apple/App/MeetingCapture/ModelDownloads.swift
+++ b/apple/App/MeetingCapture/ModelDownloads.swift
@@ -1,5 +1,24 @@
 import SwiftUI
 import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// "iPhone" / "iPad" (or "device") — so chrome says the right thing on each device instead of
+/// hardcoding "iPad". Use `this \(DeviceLabel.current)` for "this device" phrasings.
+enum DeviceLabel {
+    static var current: String {
+        #if canImport(UIKit)
+        switch UIDevice.current.userInterfaceIdiom {
+        case .phone: return "iPhone"
+        case .pad:   return "iPad"
+        default:     return "device"
+        }
+        #else
+        return "device"
+        #endif
+    }
+}
 
 // In-app model downloads: a curated suggested list + a Hugging Face search, both pulling
 // GGUF weights straight into the app's Documents (where the on-device runtime loads from).
@@ -41,19 +60,45 @@ enum SuggestedModels {
 
 // MARK: - Download manager
 
-/// One download at a time, with live 0…1 progress and a Cancel. Writes into `ModelFiles.root`
-/// (Documents) under the file's own name, so `localGGUF()` finds it immediately.
-@MainActor final class ModelDownloadManager: ObservableObject {
+/// One download at a time, on a BACKGROUND URLSession so a multi-GB pull survives the screen
+/// locking / the app being suspended or even terminated (iOS keeps transferring and relaunches
+/// the app to finish — see `HoldSpeakAppDelegate`). Live 0…1 progress + Cancel; writes into
+/// `ModelFiles.root` (Documents) under the file's own name so `localGGUF()` finds it immediately.
+@MainActor final class ModelDownloadManager: NSObject, ObservableObject {
     static let shared = ModelDownloadManager()
 
     @Published var progress: [String: Double] = [:]   // fileName → 0…1 (present only while active/just-done)
     @Published var activeFile: String? = nil           // the fileName currently downloading
     @Published var errorMsg: String? = nil
 
-    private var session: URLSession?
+    /// Set by the app delegate when iOS relaunches us to finish background transfers; called once
+    /// the session reports all events delivered.
+    var backgroundCompletion: (() -> Void)?
+
+    static let sessionId = "dev.holdspeak.modeldownload"
+    private let proxy = BackgroundDownloadProxy()
+    private lazy var session: URLSession = {
+        let cfg = URLSessionConfiguration.background(withIdentifier: Self.sessionId)
+        cfg.sessionSendsLaunchEvents = true     // relaunch the app to deliver completion
+        cfg.isDiscretionary = false             // start now, don't wait for "ideal" conditions
+        cfg.allowsCellularAccess = true
+        return URLSession(configuration: cfg, delegate: proxy, delegateQueue: nil)
+    }()
 
     func isInstalled(_ fileName: String) -> Bool {
         FileManager.default.fileExists(atPath: ModelFiles.root.appendingPathComponent(fileName).path)
+    }
+
+    /// Touch the background session early (app launch / relaunch) so in-flight transfers reattach,
+    /// then restore the UI to whatever is still downloading.
+    func ensureSession() {
+        session.getAllTasks { tasks in
+            guard let t = tasks.compactMap({ $0 as? URLSessionDownloadTask }).first,
+                  let f = t.originalRequest?.url?.lastPathComponent else { return }
+            let p = t.countOfBytesExpectedToReceive > 0
+                ? Double(t.countOfBytesReceived) / Double(t.countOfBytesExpectedToReceive) : 0.0001
+            Task { @MainActor in self.activeFile = f; self.progress[f] = p }
+        }
     }
 
     func start(repo: String, fileName: String) {
@@ -62,91 +107,103 @@ enum SuggestedModels {
         guard let url = URL(string: "https://huggingface.co/\(repo)/resolve/main/\(fileName)?download=true") else {
             errorMsg = "Couldn't build that download URL."; return
         }
-        let dest = ModelFiles.root.appendingPathComponent(fileName)
         errorMsg = nil; activeFile = fileName; progress[fileName] = 0.0001
-        let delegate = DownloadProxy(
-            destination: dest,
-            onProgress: { [weak self] p in Task { @MainActor in self?.progress[fileName] = p } },
-            onDone: { [weak self] result in Task { @MainActor in self?.finish(fileName, result) } })
-        let s = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        delegate.session = s
-        session = s
-        s.downloadTask(with: url).resume()
+        setKeepAwake(true)
+        session.downloadTask(with: url).resume()
     }
 
     func cancel() {
-        session?.invalidateAndCancel(); session = nil
+        session.getAllTasks { tasks in tasks.forEach { $0.cancel() } }
         if let f = activeFile { progress[f] = nil }
-        activeFile = nil
+        activeFile = nil; setKeepAwake(false)
     }
 
-    private func finish(_ fileName: String, _ result: Result<Void, Error>) {
-        session = nil; activeFile = nil
-        switch result {
-        case .success:
-            progress[fileName] = 1
-            // Make a freshly-downloaded model the active one if nothing was chosen yet.
-            if InferenceConfigStore.shared.localModelId.isEmpty {
-                InferenceConfigStore.shared.localModelId = fileName
-            }
-        case .failure(let e):
-            progress[fileName] = nil
-            let ns = e as NSError
-            if ns.code == NSURLErrorCancelled { errorMsg = nil }      // user-cancelled: quiet
-            else { errorMsg = friendly(ns) }
+    // Called by the proxy (on main) as a transfer reports progress / finishes.
+    func report(_ fileName: String, progress p: Double) { activeFile = fileName; progress[fileName] = p }
+
+    func succeeded(_ fileName: String) {
+        progress[fileName] = 1; activeFile = nil; setKeepAwake(false)
+        if InferenceConfigStore.shared.localModelId.isEmpty {   // auto-select the first model
+            InferenceConfigStore.shared.localModelId = fileName
         }
     }
 
-    private func friendly(_ e: NSError) -> String {
-        if let status = (e.userInfo["status"] as? Int) {
-            switch status {
-            case 401, 403: return "That model is gated — it needs a Hugging Face token to download."
-            case 404:      return "Not found — the file may have moved or the name is wrong."
-            default:       return "Download failed (HTTP \(status))."
-            }
+    func failed(_ fileName: String, code: Int, cancelled: Bool) {
+        progress[fileName] = nil; activeFile = nil; setKeepAwake(false)
+        if cancelled { errorMsg = nil; return }
+        switch code {
+        case 401, 403: errorMsg = "That model is gated — it needs a Hugging Face token to download."
+        case 404:      errorMsg = "Not found — the file may have moved or the name is wrong."
+        case 0:        errorMsg = "Download failed. Check your connection and try again."
+        default:       errorMsg = "Download failed (HTTP \(code))."
         }
-        return "Download failed. Check your connection and try again."
+    }
+
+    private func setKeepAwake(_ on: Bool) {
+        #if canImport(UIKit)
+        UIApplication.shared.isIdleTimerDisabled = on   // don't auto-lock mid-download (foreground)
+        #endif
     }
 }
 
-/// URLSession delegate that streams to a temp file and atomically moves it into place.
-/// Separate object (not the @MainActor manager) so the delegate callbacks stay off the main actor;
-/// it forwards to the manager via main-actor closures.
-private final class DownloadProxy: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
-    let destination: URL
-    let onProgress: @Sendable (Double) -> Void
-    let onDone: @Sendable (Result<Void, Error>) -> Void
-    var session: URLSession?
-
-    init(destination: URL,
-         onProgress: @escaping @Sendable (Double) -> Void,
-         onDone: @escaping @Sendable (Result<Void, Error>) -> Void) {
-        self.destination = destination; self.onProgress = onProgress; self.onDone = onDone
-    }
-
+/// Background-session delegate (off the main actor). Derives the destination from the task's own
+/// URL — so it's stateless across an app relaunch — moves the finished file into place, and forwards
+/// to the manager on the main actor.
+private final class BackgroundDownloadProxy: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
     func urlSession(_ s: URLSession, downloadTask: URLSessionDownloadTask,
                     didWriteData _: Int64, totalBytesWritten written: Int64,
                     totalBytesExpectedToWrite total: Int64) {
-        if total > 0 { onProgress(Double(written) / Double(total)) }
+        guard total > 0, let f = downloadTask.originalRequest?.url?.lastPathComponent else { return }
+        let p = Double(written) / Double(total)
+        Task { @MainActor in ModelDownloadManager.shared.report(f, progress: p) }
     }
 
     func urlSession(_ s: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-        defer { s.finishTasksAndInvalidate() }
+        guard let f = downloadTask.originalRequest?.url?.lastPathComponent else { return }
         if let http = downloadTask.response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-            onDone(.failure(NSError(domain: "hf", code: http.statusCode, userInfo: ["status": http.statusCode])))
+            let code = http.statusCode
+            Task { @MainActor in ModelDownloadManager.shared.failed(f, code: code, cancelled: false) }
             return
         }
+        // Move synchronously — the temp file is gone once this returns.
+        let dest = ModelFiles.root.appendingPathComponent(f)
         do {
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
-            try FileManager.default.moveItem(at: location, to: destination)
-            onProgress(1); onDone(.success(()))
-        } catch { onDone(.failure(error as NSError)) }
+            try? FileManager.default.createDirectory(at: ModelFiles.root, withIntermediateDirectories: true)
+            if FileManager.default.fileExists(atPath: dest.path) { try FileManager.default.removeItem(at: dest) }
+            try FileManager.default.moveItem(at: location, to: dest)
+            Task { @MainActor in ModelDownloadManager.shared.succeeded(f) }
+        } catch {
+            Task { @MainActor in ModelDownloadManager.shared.failed(f, code: 0, cancelled: false) }
+        }
     }
 
     func urlSession(_ s: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        if let error { s.finishTasksAndInvalidate(); onDone(.failure(error as NSError)) }
+        guard let error = error as NSError?,
+              let f = task.originalRequest?.url?.lastPathComponent else { return }
+        let cancelled = error.code == NSURLErrorCancelled
+        Task { @MainActor in ModelDownloadManager.shared.failed(f, code: 0, cancelled: cancelled) }
+    }
+
+    // All background events for this session delivered — let the app finish (relaunch case).
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        Task { @MainActor in
+            ModelDownloadManager.shared.backgroundCompletion?()
+            ModelDownloadManager.shared.backgroundCompletion = nil
+        }
+    }
+}
+
+/// Captures the system's background-URLSession relaunch so a download that finished while the app was
+/// suspended/terminated is completed and the OS is told we're done.
+final class HoldSpeakAppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication,
+                     handleEventsForBackgroundURLSession identifier: String,
+                     completionHandler: @escaping () -> Void) {
+        guard identifier == ModelDownloadManager.sessionId else { completionHandler(); return }
+        Task { @MainActor in
+            ModelDownloadManager.shared.backgroundCompletion = completionHandler
+            ModelDownloadManager.shared.ensureSession()
+        }
     }
 }
 
@@ -215,6 +272,7 @@ struct ModelDownloadRow: View {
     let repo: String
     let fileName: String
     @ObservedObject private var dl = ModelDownloadManager.shared
+    @State private var showReadme = false
 
     var body: some View {
         let installed = dl.isInstalled(fileName)
@@ -232,8 +290,11 @@ struct ModelDownloadRow: View {
                     ProgressView(value: p).tint(Sig.accent)
                     Text("Downloading… \(Int(p * 100))%").font(.system(size: 11.5, weight: .semibold)).foregroundStyle(Sig.muted)
                 } else {
-                    Text(installed ? "Installed · on this iPad" : detail)
-                        .font(.system(size: 12, weight: .semibold)).foregroundStyle(installed ? Sig.ok : Sig.faint).lineLimit(1)
+                    HStack(spacing: 5) {
+                        Text(installed ? "Installed · on this \(DeviceLabel.current)" : detail)
+                            .font(.system(size: 12, weight: .semibold)).foregroundStyle(installed ? Sig.ok : Sig.faint).lineLimit(1)
+                        Image(systemName: "info.circle").font(.system(size: 11, weight: .bold)).foregroundStyle(Sig.faint.opacity(0.7))
+                    }
                 }
             }
             Spacer(minLength: 4)
@@ -242,6 +303,11 @@ struct ModelDownloadRow: View {
         .padding(13)
         .background(Sig.s1, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(active ? Sig.accent.opacity(0.5) : Sig.line, lineWidth: 1))
+        .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .onTapGesture { tactile(); showReadme = true }   // open the model's README/card
+        .sheet(isPresented: $showReadme) {
+            NavigationStack { ModelReadmeView(repo: repo, fileName: fileName, name: name) }.preferredColorScheme(.dark)
+        }
     }
 
     @ViewBuilder private func trailing(installed: Bool, active: Bool) -> some View {
@@ -266,6 +332,12 @@ struct ModelDownloadRow: View {
 /// The "Search Hugging Face" section: query → repos → tap a repo → pick a .gguf to download.
 struct HFSearchSection: View {
     @StateObject private var hf = HFSearch()
+    @State private var size: String? = nil
+    private static let sizes = ["1B", "2B", "3B", "4B", "7B", "8B", "12B", "27B", "70B"]
+    private var shownRepos: [String] {
+        guard let s = size?.lowercased() else { return hf.repos }
+        return hf.repos.filter { $0.lowercased().contains(s) }
+    }
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("SEARCH HUGGING FACE").font(.system(size: 11, weight: .heavy)).tracking(1.2).foregroundStyle(Sig.faint)
@@ -281,13 +353,26 @@ struct HFSearchSection: View {
             .background(Sig.s2, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
             .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Color.white.opacity(0.08), lineWidth: 1))
 
+            // Size filter — narrow the results to a parameter class (matches the size token in the repo id).
+            if !hf.repos.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 7) {
+                        sizeChip("All", value: nil)
+                        ForEach(Self.sizes, id: \.self) { sizeChip($0, value: $0) }
+                    }
+                }
+            }
+
             switch hf.state {
             case .empty:  Text("No GGUF repositories found.").font(.system(size: 12)).foregroundStyle(Sig.faint)
             case .failed: Text("Search failed. Check your connection.").font(.system(size: 12)).foregroundStyle(Sig.warn)
-            default: EmptyView()
+            default:
+                if !hf.repos.isEmpty && shownRepos.isEmpty {
+                    Text("No \(size ?? "") models in these results.").font(.system(size: 12)).foregroundStyle(Sig.faint)
+                }
             }
 
-            ForEach(hf.repos, id: \.self) { repo in
+            ForEach(shownRepos, id: \.self) { repo in
                 VStack(alignment: .leading, spacing: 8) {
                     Button { tactile(); Task { await hf.loadFiles(repo) } } label: {
                         HStack(spacing: 8) {
@@ -313,6 +398,176 @@ struct HFSearchSection: View {
                 .padding(12)
                 .background(Sig.s1, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).stroke(Sig.line, lineWidth: 1))
+            }
+        }
+    }
+
+    @ViewBuilder private func sizeChip(_ label: String, value: String?) -> some View {
+        let on = size == value
+        Button { tactile(); withAnimation(.easeOut(duration: 0.15)) { size = value } } label: {
+            Text(label).font(.system(size: 12.5, weight: .heavy))
+                .foregroundStyle(on ? .black : Sig.muted)
+                .padding(.horizontal, 12).frame(height: 30)
+                .background(on ? AnyShapeStyle(Sig.accent) : AnyShapeStyle(Sig.s2), in: Capsule())
+                .overlay(Capsule().strokeBorder(Color.white.opacity(on ? 0 : 0.08), lineWidth: 1))
+        }.buttonStyle(.plain)
+    }
+}
+
+// MARK: - Model README (the HF model card, rendered)
+
+/// Pulls a repo's README.md from Hugging Face and renders it as a clean card, with a Download
+/// button for the specific file. Reachable by tapping any model row.
+struct ModelReadmeView: View {
+    let repo: String
+    let fileName: String
+    let name: String
+    @ObservedObject private var dl = ModelDownloadManager.shared
+    @Environment(\.dismiss) private var dismiss
+    @State private var markdown: String? = nil
+    @State private var failed = false
+    @State private var loading = true
+
+    var body: some View {
+        ZStack {
+            Sig.bg.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(name).font(.system(size: 26, weight: .heavy)).foregroundStyle(Sig.text)
+                        Link(destination: URL(string: "https://huggingface.co/\(repo)")!) {
+                            HStack(spacing: 5) {
+                                Text(repo).font(.system(size: 12.5, weight: .semibold)).foregroundStyle(Sig.accent).lineLimit(1)
+                                Image(systemName: "arrow.up.right.square").font(.system(size: 11, weight: .bold)).foregroundStyle(Sig.accent)
+                            }
+                        }
+                    }
+                    downloadBar
+                    Divider().overlay(Sig.line)
+                    if loading {
+                        HStack(spacing: 8) { ProgressView().tint(Sig.accent); Text("Loading the model card…").font(.system(size: 13)).foregroundStyle(Sig.muted) }
+                    } else if failed {
+                        Text("Couldn't load this model's README.").font(.system(size: 13)).foregroundStyle(Sig.faint)
+                    } else if let md = markdown {
+                        MarkdownText(raw: md)
+                    }
+                }
+                .padding(20).frame(maxWidth: 760).frame(maxWidth: .infinity)
+            }
+        }
+        .navigationTitle("Model card").navigationBarTitleDisplayMode(.inline)
+        .toolbar { ToolbarItem(placement: .topBarLeading) { Button("Done") { dismiss() } } }
+        .task { await load() }
+    }
+
+    @ViewBuilder private var downloadBar: some View {
+        let installed = dl.isInstalled(fileName)
+        let active = dl.activeFile == fileName
+        let p = dl.progress[fileName]
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(fileName).font(.system(size: 12.5, weight: .semibold, design: .monospaced)).foregroundStyle(Sig.muted).lineLimit(1)
+                if active, let p { Text("Downloading… \(Int(p * 100))%").font(.system(size: 11, weight: .heavy)).foregroundStyle(Sig.accent) }
+            }
+            Spacer(minLength: 8)
+            if active {
+                Button { tactile(); dl.cancel() } label: { Text("Cancel").font(.system(size: 13, weight: .heavy)).foregroundStyle(Sig.muted).padding(.horizontal, 14).frame(height: 36).background(Sig.s2, in: Capsule()) }
+            } else if installed {
+                HStack(spacing: 5) { Image(systemName: "checkmark.seal.fill"); Text("Installed").font(.system(size: 13, weight: .heavy)) }.foregroundStyle(Sig.ok)
+            } else {
+                Button { tactile(); dl.start(repo: repo, fileName: fileName) } label: {
+                    Text("Get").font(.system(size: 14, weight: .heavy)).foregroundStyle(.black).padding(.horizontal, 18).frame(height: 36).background(Sig.accent, in: Capsule())
+                }.disabled(dl.activeFile != nil).opacity(dl.activeFile != nil ? 0.4 : 1)
+            }
+        }
+        .padding(12).background(Sig.s1, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).stroke(active ? Sig.accent.opacity(0.5) : Sig.line, lineWidth: 1))
+        .animation(.easeOut(duration: 0.2), value: active)
+    }
+
+    private func load() async {
+        guard let url = URL(string: "https://huggingface.co/\(repo)/raw/main/README.md") else { failed = true; loading = false; return }
+        do {
+            let (data, resp) = try await URLSession.shared.data(from: url)
+            guard let http = resp as? HTTPURLResponse, (200...299).contains(http.statusCode),
+                  let text = String(data: data, encoding: .utf8) else { failed = true; loading = false; return }
+            markdown = MarkdownText.strip(text); loading = false
+        } catch { failed = true; loading = false }
+    }
+}
+
+/// A lightweight Markdown renderer good enough for HF model cards: headings, paragraphs (with inline
+/// bold/code/links), bullet lists, and fenced code. Avoids a dependency; not a full CommonMark engine.
+struct MarkdownText: View {
+    let raw: String
+
+    /// Strip YAML frontmatter + image/HTML badge lines that don't render as text.
+    static func strip(_ s: String) -> String {
+        var lines = s.components(separatedBy: "\n")
+        if lines.first?.trimmingCharacters(in: .whitespaces) == "---" {
+            if let end = lines.dropFirst().firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == "---" }) {
+                lines = Array(lines[(end + 1)...])
+            }
+        }
+        return lines
+            .filter { l in
+                let t = l.trimmingCharacters(in: .whitespaces)
+                if t.hasPrefix("<") { return false }            // raw HTML / badges
+                if t.hasPrefix("![") { return false }           // images
+                return true
+            }
+            .joined(separator: "\n")
+    }
+
+    private enum Block { case h(Int, String), p(String), bullet(String), code(String) }
+
+    private func blocks() -> [Block] {
+        var out: [Block] = []; var inCode = false; var code = ""; var para = ""
+        func flushPara() { let t = para.trimmingCharacters(in: .whitespacesAndNewlines); if !t.isEmpty { out.append(.p(t)) }; para = "" }
+        for line in raw.components(separatedBy: "\n") {
+            let t = line.trimmingCharacters(in: .whitespaces)
+            if t.hasPrefix("```") {
+                if inCode { out.append(.code(code)); code = ""; inCode = false } else { flushPara(); inCode = true }
+                continue
+            }
+            if inCode { code += (code.isEmpty ? "" : "\n") + line; continue }
+            if t.isEmpty { flushPara(); continue }
+            if t.hasPrefix("### ") { flushPara(); out.append(.h(3, String(t.dropFirst(4)))) }
+            else if t.hasPrefix("## ") { flushPara(); out.append(.h(2, String(t.dropFirst(3)))) }
+            else if t.hasPrefix("# ") { flushPara(); out.append(.h(1, String(t.dropFirst(2)))) }
+            else if t.hasPrefix("- ") || t.hasPrefix("* ") { flushPara(); out.append(.bullet(String(t.dropFirst(2)))) }
+            else { para += (para.isEmpty ? "" : " ") + t }
+        }
+        if inCode { out.append(.code(code)) }
+        flushPara()
+        return out
+    }
+
+    private func inline(_ s: String) -> AttributedString {
+        (try? AttributedString(markdown: s, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))) ?? AttributedString(s)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 11) {
+            ForEach(Array(blocks().enumerated()), id: \.offset) { _, b in
+                switch b {
+                case .h(let lvl, let t):
+                    Text(t).font(.system(size: lvl == 1 ? 22 : lvl == 2 ? 18 : 15.5, weight: .heavy))
+                        .foregroundStyle(Sig.text).padding(.top, lvl == 1 ? 4 : 2)
+                case .p(let t):
+                    Text(inline(t)).font(.system(size: 14)).foregroundStyle(Sig.muted).tint(Sig.accent)
+                        .fixedSize(horizontal: false, vertical: true)
+                case .bullet(let t):
+                    HStack(alignment: .top, spacing: 8) {
+                        Text("•").font(.system(size: 14, weight: .black)).foregroundStyle(Sig.accent)
+                        Text(inline(t)).font(.system(size: 14)).foregroundStyle(Sig.muted).tint(Sig.accent)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                case .code(let t):
+                    Text(t).font(.system(size: 12.5, design: .monospaced)).foregroundStyle(Sig.text)
+                        .frame(maxWidth: .infinity, alignment: .leading).padding(12)
+                        .background(Sig.s2, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                }
             }
         }
     }

--- a/apple/App/MeetingCapture/ModelManager.swift
+++ b/apple/App/MeetingCapture/ModelManager.swift
@@ -87,7 +87,7 @@ struct ModelsView: View {
                         }
                     }
                     if !models.isEmpty {
-                        Text("ON THIS IPAD").font(.system(size: 11, weight: .heavy)).tracking(1.2).foregroundStyle(Sig.faint).padding(.top, 4)
+                        Text("ON THIS \(DeviceLabel.current.uppercased())").font(.system(size: 11, weight: .heavy)).tracking(1.2).foregroundStyle(Sig.faint).padding(.top, 4)
                         ForEach(models) { modelCard($0) }
                     }
                 }
@@ -102,7 +102,7 @@ struct ModelsView: View {
                 var ok = 0
                 for u in urls { if (try? ModelFiles.importModel(from: u)) != nil { ok += 1 } }
                 await MainActor.run {
-                    busy = false; note = "Imported \(ok) model\(ok == 1 ? "" : "s"). They're on this iPad now."; refresh()
+                    busy = false; note = "Imported \(ok) model\(ok == 1 ? "" : "s")."; refresh()
                 }
             }
         }

--- a/apple/App/MeetingCapture/SketchDiagram.swift
+++ b/apple/App/MeetingCapture/SketchDiagram.swift
@@ -578,7 +578,7 @@ struct SketchToDiagramView: View {
     }
 
     /// The egress reality for the badge: local keeps everything on the iPad; an endpoint sends to its host.
-    var egressLabel: String { isLocal ? "On-device · nothing leaves" : "Sends to \(endpointConfig?.baseURL.host ?? "your endpoint")" }
+    var egressLabel: String { isLocal ? "On-device" : "Sends to \(endpointConfig?.baseURL.host ?? "your endpoint")" }
 
     private struct ModelsResponse: Decodable { let data: [Entry]; struct Entry: Decodable { let id: String } }
 

--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -18,12 +18,18 @@ import WebKit
 
 @main
 struct MeetingCaptureApp: App {
+    // Captures iOS's background-URLSession relaunch so model downloads survive lock/suspend/terminate.
+    @UIApplicationDelegateAdaptor(HoldSpeakAppDelegate.self) private var appDelegate
     var body: some Scene {
         WindowGroup {
             ZStack(alignment: .top) {
                 // HS_DEMO_NOTEBOOK opens straight onto the notebook surface for a
                 // screenshot run (no mic/taps needed); the real entry is the meeting list.
-                if ProcessInfo.processInfo.environment["HS_DEMO_MODELS"] != nil {
+                if ProcessInfo.processInfo.environment["HS_DEMO_AGENT"] != nil {
+                    DioAgentBuilder(draft: .blank(), knowledgeBases: ["Q3 Planning", "Customer calls"], onSave: { _ in }, onCancel: {}, isNew: true, contextLimit: 8192, zoneTokens: 1800)
+                } else if ProcessInfo.processInfo.environment["HS_DEMO_README"] != nil {
+                    NavigationStack { ModelReadmeView(repo: "unsloth/gemma-3n-E4B-it-GGUF", fileName: "gemma-3n-E4B-it-Q4_K_M.gguf", name: "Gemma 3n E4B") }
+                } else if ProcessInfo.processInfo.environment["HS_DEMO_MODELS"] != nil {
                     NavigationStack { ModelsView() }
                 } else if ProcessInfo.processInfo.environment["HS_DEMO_NOTEBOOK"] != nil {
                     DemoNotebookView()
@@ -67,6 +73,7 @@ struct MeetingCaptureApp: App {
             }
             .preferredColorScheme(.dark)
             .onAppear {
+                ModelDownloadManager.shared.ensureSession()   // reattach any in-flight model download
                 #if targetEnvironment(simulator)
                 let env = ProcessInfo.processInfo.environment
                 // LIVE SYNC in-code proof (no App-layer test target): run the desk store's
@@ -580,7 +587,7 @@ struct MeetingListView: View {
                             .accessibilityLabel("New recording — capture a meeting on-device")
                         Button { tactile(.medium); showDictate = true } label: { dictateCta }
                             .buttonStyle(PressableCard())
-                            .accessibilityLabel("Dictate to your desktop — talk on this iPad, the words land on your desktop")
+                            .accessibilityLabel("Dictate to your desktop — talk on this \(DeviceLabel.current), the words land on your desktop")
                         Button { tactile(.medium); showConnect = true } label: { connectCta }
                             .buttonStyle(PressableCard())
                             .accessibilityLabel("Your Desktop — find and pair with your desktop on your network")
@@ -808,7 +815,7 @@ struct MeetingListView: View {
         let n = ModelFiles.installed().count
         return tile(chip: GlyphChip(system: "cpu.fill"),
                     title: "Models",
-                    subtitle: n == 0 ? "Import to enable intelligence" : "\(n) on this iPad")
+                    subtitle: n == 0 ? "Tap to download one" : "\(n) on this \(DeviceLabel.current)")
     }
 
     private var sketchCta: some View {

--- a/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
+++ b/pm/roadmap/holdspeak-mobile/EQUILIBRIUM.md
@@ -214,3 +214,16 @@ Integrated: the github + primitives + guard tests **49 passed**; cross-checked t
 Fleet WEB's new pages (green) before either landed, so the two fleets stay compatible on main.
 
 See [[project_primitive_framework]], [[project_phase15_the_mesh]], [[project_phase17_agent_sync]].
+
+---
+
+## Pre-GA extension — Phase 24: Runtime profiles
+
+The same discipline ("honor the contract on every surface, honest `n/a` otherwise") applied to
+*where intelligence runs*. Today the inference choice is one global target; Phase 24 splits it into
+**basic** (pick one active profile) vs **advanced** (named `RuntimeProfile`s + per-agent
+assignment), in equilibrium across desktop / web / iPad / iPhone. The crux is a security invariant:
+the profile *shape* syncs as `SyncKind.profile`; **the API key never does** (device Keychain / hub
+secrets, joined at request time). Authored 2026-06-28 from BACKLOG entry **S**; charter at
+[`phase-24-runtime-profiles/current-phase-status.md`](./phase-24-runtime-profiles/current-phase-status.md).
+A pre-GA call because retrofitting the contract after sync solidifies means a migration.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -1,0 +1,106 @@
+# Phase 24 — Runtime profiles (basic + advanced), in equilibrium
+
+**Status:** planned (authored 2026-06-28) — a pre-GA extension of
+[`EQUILIBRIUM.md`](../EQUILIBRIUM.md): the same "honor the contract on every surface" discipline,
+applied to *where intelligence runs*.
+
+**Last updated:** 2026-06-28 (authored from the owner's call: split the single global
+inference choice into **basic** (pick one active target) vs **advanced** (named runtime
+profiles + per-agent assignment), and bring it to desktop / iPad / iPhone / web. Grounded in
+BACKLOG entry **S**.)
+
+## Why this phase exists
+
+Today the app **conflates** "where intelligence runs" into one global choice. On Apple it is
+`InferenceConfigStore` (`apple/App/MeetingCapture/SketchDiagram.swift`): a single `mode`
+(`.local` / `.endpoint`) + a single endpoint (`url` / `model` / `key`) in `UserDefaults`. One
+target, app-wide. You cannot say "Scout runs on-device, Editor runs on OpenRouter, Critic runs
+on Claude." For a framework whose whole point is *many tailored agents*, that is the wrong shape.
+
+The good news: the abstraction that makes this cheap **already exists** — the `ILLMProvider`
+seam. `makeProvider` already returns `LlamaProvider` (on-device) or `OpenAIEndpointProvider`
+(OpenAI-compatible). Profiles do not add a runtime; they turn the single config into a **list +
+a default**, and let an agent point at one.
+
+It is a pre-GA call because retrofitting a profile contract **after** sync + GA solidify means a
+migration. Land the contract first.
+
+## What "a profile" is
+
+A **`RuntimeProfile`** — a named, reusable connectivity target:
+
+```
+RuntimeProfile {
+  id, name,
+  kind: .onDevice | .openAICompatible,
+  onDevice:        { modelFile }                       // a downloaded .gguf
+  openAICompatible:{ baseURL, model, apiKeyRef }       // a ref, NOT the key
+  contextLimit: Int,                                   // the usable window
+  egressScope                                          // feeds the trust badge
+}
+```
+
+- **Basic configuration** = pick ONE active profile ("Run on: [This iPhone ▾]"). Today's
+  experience, reframed; the casual user meets no new concept.
+- **Advanced configuration** = manage a LIST of profiles + assign one **per agent**
+  (`AgentRecord.profileId`, empty = the active default).
+
+**Closes the gauge loop (Phase shipped the gauge already):** the GROUNDING CONTEXT ring reads the
+*assigned profile's* `contextLimit` — "Scout on Claude (200k) = 1% full; Scout on a local 3B (8k)
+= 22%."
+
+## The one hard rule (security / robustness)
+
+**API keys are credentials and MUST NOT sync.** The profile *shape* (name/kind/baseURL/model/
+contextLimit/egress) syncs as a primitive; the **key lives only in the device Keychain**,
+referenced by profile id, never in the synced payload. Each surface holds its own key for a shared
+profile. (Same principle as the connector "credential stays on the desktop" rule and the existing
+"API key never leaves this store" comment.)
+
+## Equilibrium (the cross-surface point)
+
+Add `SyncKind.profile` so desktop hub / iPad / iPhone / web share the same named profiles (shape
+only). Each surface honors the profile **contract** through its own runtime, with honest `n/a`
+where a surface cannot host a kind (an on-device GGUF profile is `n/a` on web). The egress badge
+reads `profile.egressScope` so trust stays honest per profile.
+
+## Story status
+
+| Story | One-liner | Status |
+|-------|-----------|--------|
+| HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | planned |
+| HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | planned |
+| HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | planned |
+| HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | planned |
+| HSM-24-05 | Web authors + uses profiles (the flagship surface) | planned |
+| HSM-24-06 | Cross-surface parity proof + the docs story | planned |
+
+## Sequencing
+
+```
+24-01 (contract + Keychain) ─► 24-02 (Apple basic) ─► 24-03 (Apple advanced + per-agent)
+                            └─► 24-04 (desktop hub) ─► 24-05 (web) ─► 24-06 (proof + docs)
+```
+
+24-01 is load-bearing — every surface depends on the contract + the never-sync key rule. 24-02
+(basic) is a near-pure refactor of `InferenceConfigStore` into "a list with one active" and must
+stay byte-identical for the single-target user. 24-03 unlocks the per-agent power (and lights up
+the gauge). 24-04/05 bring the other surfaces into parity. 24-06 is the parity gate + docs.
+
+## Carried context
+
+- Seam: `apple/Sources/Providers/Inference/` — `ILLMProvider`, `OpenAIEndpointProvider`,
+  `EndpointConfig`; `LlamaProvider` in `InferenceLlama`. `makeProvider` is in
+  `SketchDiagram.swift` (`InferenceConfigStore`).
+- Per-agent: `AgentRecord` (`apple/App/MeetingCapture/DeskAgents.swift`) — add `profileId`.
+- Gauge: `ContextGauge` + `DioAgentBuilder.contextLimit` (already reads a limit; point it at the
+  profile).
+- Sync: `apple/Sources/Contracts/Sync.swift` — the `SyncKind` enum + `ChangeSet`.
+- Grounding assembly (the gauge's truth): `agentRoleAndContext` in `DeskDioramaStage.swift`.
+- Related but SEPARATE (kept out of this phase unless the owner folds it in): "make KB grounding
+  actually inject content" — today the KB only adds a one-line hint, so the gauge shows ~0 for a
+  KB. See BACKLOG.
+
+## Source of record
+
+BACKLOG entry **S** (`pm/roadmap/holdspeak/BACKLOG.md`). This phase is its execution plan.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-01-profile-contract-keychain.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-01-profile-contract-keychain.md
@@ -1,0 +1,57 @@
+# HSM-24-01 — The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store
+
+**Status:** planned — **leads, load-bearing** (every surface depends on it).
+
+## Problem
+
+`InferenceConfigStore` (`SketchDiagram.swift`) holds ONE target: `mode` + a single endpoint
+`url`/`model`/`key` in `UserDefaults`. There is no notion of a *named, reusable* target, no list,
+and no per-agent assignment. And the API key currently lives in `UserDefaults` — fine for one
+device, unsafe to sync.
+
+## The design
+
+A new contract type in `Sources/Contracts` (so every surface shares it, like `Agent`):
+
+```
+public struct RuntimeProfile: Codable, Identifiable, Equatable, Sendable {
+    public var id: String
+    public var name: String
+    public var kind: Kind            // .onDevice | .openAICompatible
+    public var modelFile: String     // onDevice: the .gguf filename
+    public var baseURL: String       // openAICompatible
+    public var model: String         // openAICompatible
+    public var contextLimit: Int     // usable window (on-device computed; endpoint known/declared)
+    public var egress: EgressScope   // .local | .cloud(host)
+    // NO apiKey field. The key is referenced by id and read from the Keychain at request time.
+}
+```
+
+- Add `case profile` to `SyncKind` (`Sources/Contracts/Sync.swift`) and carry profiles in
+  `ChangeSet` like agents/notes/kbs.
+- A `ProfileKeyStore` (Keychain-backed) keyed by `profile.id` → the API key. **The key is never a
+  field on `RuntimeProfile` and never enters a `ChangeSet`.** `EndpointConfig` is assembled at
+  request time by joining the synced shape + the local key (mirrors how the connector joins the
+  credential at execute time).
+- A migration: the existing single `InferenceConfigStore` config becomes one seed profile
+  ("This device" if local, or "My endpoint" if an endpoint was set), so existing users land on an
+  equivalent active profile with zero visible change.
+
+## Scope
+
+- `RuntimeProfile` + `EgressScope` in Contracts; `SyncKind.profile` + `ChangeSet.profiles`.
+- `ProfileKeyStore` (Keychain wrapper) with get/set/delete by profile id.
+- The one-time migration from the legacy `InferenceConfigStore` fields → a seed profile + active id.
+- Pure unit tests for the contract, the never-sync invariant, and the migration.
+
+## Test plan
+
+- `swift test`: `RuntimeProfile` round-trips Codable; a `ChangeSet` carrying a profile **never**
+  serializes a key (assert the encoded JSON contains no key material); migration produces the
+  equivalent active profile from each legacy state (local / endpoint / endpoint+key).
+- Keychain store: set → get → delete by id (device test; sim acceptable for the API shape).
+
+## Done when
+
+The contract + sync kind + Keychain store exist and are tested; the never-sync invariant has an
+explicit test; legacy config migrates to a seed active profile with no behavior change. No UI yet.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-02-apple-basic-config.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-02-apple-basic-config.md
@@ -1,0 +1,41 @@
+# HSM-24-02 — Apple basic config: the active-profile picker over the existing seam
+
+**Status:** planned (after 24-01).
+
+## Problem
+
+Settings → Intelligence currently shows "Where intelligence runs" as a two-card choice (This
+device / LAN endpoint) wired straight to `InferenceConfigStore.mode`. With profiles, "basic" should
+simply be: **pick one active profile** — no new concepts for the single-target user.
+
+## The design
+
+- `InferenceConfigStore` keeps a `profiles: [RuntimeProfile]` (synced) + `activeProfileId`. The
+  legacy `mode`/endpoint fields become computed views over the active profile (kept until callers
+  migrate).
+- `makeProvider` switches on the **active profile's** `kind`, not the global `mode`:
+  - `.onDevice` → `LlamaProvider.make(modelPath:)` (the auto-template factory).
+  - `.openAICompatible` → `OpenAIEndpointProvider(config:)`, where `config` joins the synced shape +
+    the Keychain key at call time.
+- The basic Settings UI: one row, "Run on: [active profile ▾]", the menu listing profiles; an
+  "Advanced…" entry opens 24-03. The egress badge reads the active profile's `egress`.
+- Byte-identical for a user who has exactly one profile (the migrated default).
+
+## Scope
+
+- `InferenceConfigStore`: `profiles` + `activeProfileId`; `makeProvider(active)`; legacy fields as
+  computed shims.
+- Basic Settings row (active picker) + the egress badge from the profile.
+- The on-device-budget `contextLimit` is computed for on-device profiles (reuse `OnDeviceBudget`).
+
+## Test plan
+
+- `swift test`: `makeProvider` returns the right provider for each active profile kind; the endpoint
+  provider's `EndpointConfig` carries the key from the Keychain (not the synced shape).
+- Sim: Settings shows the active picker; selecting a profile switches the runtime; egress badge
+  matches.
+
+## Done when
+
+A single-profile user sees no change; switching the active profile switches the runtime through the
+existing seam; the API key is sourced from the Keychain at request time. Verified on the iPad.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-03-apple-advanced-profiles.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-03-apple-advanced-profiles.md
@@ -1,0 +1,46 @@
+# HSM-24-03 — Apple advanced config: manage profiles + per-agent assignment + the gauge
+
+**Status:** planned (after 24-02). The power-user payoff.
+
+## Problem
+
+The owner's exact ask: "one thing running locally, another against an OpenRouter endpoint with an
+API key, a third against Claude" — and different agents on different backends.
+
+## The design
+
+- **Advanced config screen** (in-world, not a modal hell — see the no-modals rule): a list of
+  `RuntimeProfile`s with add / edit / delete. The editor:
+  - Name; kind toggle (On-device / OpenAI-compatible).
+  - On-device → the downloaded-model picker (reuse `ModelsView` data).
+  - OpenAI-compatible → base URL + model (the `fetchModels()` picker) + an **API key field that
+    writes to the Keychain via `ProfileKeyStore`**, never to the synced shape. A voice mic on text
+    fields (the every-input rule).
+  - `contextLimit`: on-device computed; endpoint declared (with sensible presets, e.g. 8k/32k/128k/
+    200k) since we can't always introspect an endpoint's window.
+  - The egress badge previews `local` vs `cloud(host)`.
+- **Per-agent assignment:** add `AgentRecord.profileId` (empty = active default). The agent builder's
+  GROUNDING CONTEXT section gains a "Runs on" chip row (the profiles) so you pick the agent's backend
+  right where you set its grounding.
+- **The gauge closes the loop:** `DioAgentBuilder.contextLimit` is sourced from the *assigned
+  profile* (not just the global active one), so the ring reflects that agent's real window.
+
+## Scope
+
+- The advanced profiles screen (list + in-world editor, voice mics, Keychain key write).
+- `AgentRecord.profileId` (+ contract `Agent.profileId`, sync-safe) + a "Runs on" picker in the
+  builder.
+- The gauge reads the assigned profile's `contextLimit`.
+
+## Test plan
+
+- `swift test`: editing a profile updates the synced shape but writes the key only to the Keychain;
+  an agent with `profileId` resolves to that profile's provider + `contextLimit`.
+- Real metal (per the verify-on-device rule): create an on-device profile and an OpenAI-compatible
+  profile (a real key), assign two agents to different profiles, run each, confirm each hits its
+  backend and the gauge shows each agent's true fill.
+
+## Done when
+
+You can define multiple profiles (local + endpoint(s) with keys), assign agents to them, and the
+gauge reflects each agent's window — proven on a cabled device with at least one real endpoint.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-04-desktop-hub-honors-profiles.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-04-desktop-hub-honors-profiles.md
@@ -1,0 +1,38 @@
+# HSM-24-04 — The desktop hub honors profiles
+
+**Status:** planned (after 24-01; parallel with the Apple stories).
+
+## Problem
+
+The desktop hub is the execution + persistence center (per Equilibrium). For profiles to be in
+equilibrium, the hub must store/serve them and run an agent on its assigned profile — otherwise an
+agent assigned to "Claude" on the iPad would silently fall back to the hub's default when run on the
+hub.
+
+## The design
+
+- The hub persists `RuntimeProfile`s (shape only) alongside agents, and serves them on the sync
+  routes the mesh already uses (`SyncKind.profile` rides the same `ChangeSet`).
+- The hub's own key store is its existing secrets path (env / its keyring) — the synced shape never
+  carries the key here either; the hub joins the key at request time, exactly like the Apple side.
+- The hub's agent-run path resolves `agent.profileId` → the profile → the right backend
+  (its local runtime for `.onDevice`, an OpenAI-compatible client for `.openAICompatible`). Unknown/
+  absent profile → the hub's active default (graceful).
+- Honest `n/a`: an `.onDevice` profile that names a GGUF the hub doesn't have is a rendered
+  "unavailable here," not a crash.
+
+## Scope
+
+- Hub persistence + sync of `RuntimeProfile`.
+- Hub-side key resolution (its secrets path; never from the synced payload).
+- The agent-run path honors `agent.profileId`.
+
+## Test plan
+
+- `uv run pytest`: a synced profile round-trips without a key; an agent run resolves its profileId to
+  the right backend; absent profile → default; the never-sync invariant holds on the hub serializer.
+
+## Done when
+
+The hub stores/serves profiles, resolves keys from its own secrets (never the payload), and runs an
+agent on its assigned profile — tested.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-05-web-profiles.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-05-web-profiles.md
@@ -1,0 +1,37 @@
+# HSM-24-05 — Web authors + uses profiles
+
+**Status:** planned (after 24-01; needs the hub from 24-04 as its backend).
+
+## Problem
+
+Web is the flagship surface. With profiles synced, the web app must let you author/manage them and
+assign agents to them, honoring the same contract + the same never-sync key rule — or web users are
+stuck on a single backend while iPad users aren't (an equilibrium break).
+
+## The design
+
+- A web "Runtime profiles" surface mirroring the Apple advanced screen: list + editor (kind, model/
+  endpoint, declared context limit, egress preview). Same `RuntimeProfile` shape over the same sync.
+- **Key handling on web:** the key is a credential — it is held by the **hub** (its secrets path),
+  not stored in the browser or the synced shape. The web UI sets a key by handing it to the hub over
+  the authenticated session for that profile id; the browser never persists it. (Web has no Keychain;
+  the hub is its key custodian.)
+- Per-agent "Runs on" picker in the web agent editor → `agent.profileId`.
+- Honest `n/a`: an `.onDevice` GGUF profile is shown as "device-only" on web (it can't run a local
+  GGUF in a browser); web defaults such agents to a cloud/endpoint profile when run from web.
+
+## Scope
+
+- Web profiles list + editor; per-agent assignment.
+- Key-to-hub flow (browser never persists the key).
+- The `n/a` rendering for device-only kinds.
+
+## Test plan
+
+- Web smoke + a route test: profiles list/create/assign; the key is never returned to the browser in
+  any payload; an agent assigned a cloud profile runs via the hub.
+
+## Done when
+
+Web can author profiles, assign agents, and run them — with the key custodian being the hub, never
+the browser — at parity with Apple advanced.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-06-proof-and-docs.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-06-proof-and-docs.md
@@ -1,0 +1,40 @@
+# HSM-24-06 — Cross-surface parity proof + the docs story
+
+**Status:** planned (the phase gate; after 24-02..05).
+
+## Problem
+
+Equilibrium isn't "it builds on each surface" — it's "the contract is honored on each surface, or
+honest `n/a`." This story is the proof gate + the docs (every phase gets its own docs story).
+
+## The design
+
+- **The parity proof:** one named profile authored once, observed in equilibrium:
+  - Create a "Claude" OpenAI-compatible profile on the iPad (key → Keychain).
+  - It appears (shape only) on the desktop hub and on web via sync; **no surface ever received the
+    key** (assert on each serializer/payload).
+  - Assign an agent to it on each surface; run the agent; confirm it hits the right backend, with
+    each surface sourcing the key from its own custodian (iPad Keychain / hub secrets).
+  - An `.onDevice` GGUF profile renders honest `n/a` on web.
+  - The egress badge reads each profile's scope on each surface.
+- **The never-sync invariant** gets a dedicated cross-surface assertion (the security crux).
+- **Docs:** update the entry points — README (the "where intelligence runs" story: basic vs
+  advanced), `docs/` model/runtime page, and the iOS/web settings help — plus a short
+  `SECURITY`-style note that keys are device/hub-custodial and never sync.
+
+## Scope
+
+- The cross-surface proof script/checklist (real metal where applicable).
+- The never-sync cross-surface test.
+- Entry-point docs + the security note.
+
+## Test plan
+
+- The full suites green (`swift test`, `uv run pytest`, web smoke).
+- The proof walked: one profile, three surfaces, key never crosses; agents run on their assigned
+  backends; `n/a` honest.
+
+## Done when
+
+Profiles are demonstrably in equilibrium across desktop / iPad / iPhone / web, the key never syncs
+(proven), and the entry-point docs + security note ship in the same closing commit.

--- a/pm/roadmap/holdspeak/BACKLOG.md
+++ b/pm/roadmap/holdspeak/BACKLOG.md
@@ -249,3 +249,44 @@ so Apple-system / PCC / cloud / Core AI all sit behind one protocol.
 
 *Lands on:* the existing `ILLMProvider` seam (Contracts/RuntimeCore depend on the protocol, not the
 engine) + the per-device model policy. Owner action gates the start: install Xcode 27 / iOS 27.
+
+---
+### S. Runtime / connectivity profiles (cross-surface, pre-GA) — PARKED (design ready)
+Today the app conflates "where intelligence runs" into ONE global choice (`InferenceConfigStore`:
+mode = local | endpoint, a single endpoint URL/model/key). Owner's call (pre-GA): split it.
+
+- **Basic configuration** = today's experience, reframed: pick ONE active profile ("Run on: [This
+  iPhone ▾]"). Zero new concepts for the casual user.
+- **Advanced configuration** = a LIST of named **runtime profiles** (e.g. on-device Qwen3-4B; an
+  OpenRouter endpoint + key; a Claude endpoint + key; a LAN box) AND **per-agent assignment** so
+  agent A runs local, agent B on OpenRouter, agent C on Claude.
+
+**The model — `RuntimeProfile`** (a reusable connectivity target):
+`{ id, name, kind: .onDevice | .openAICompatible, onDevice: modelFile, openAICompatible: {baseURL,
+model, apiKeyRef}, contextLimit, egressScope }`. This is a clean generalization of the EXISTING
+`ILLMProvider` seam: `makeProvider(profile)` → `LlamaProvider` (onDevice) or `OpenAIEndpointProvider`
+(openAICompatible). The seam already exists; profiles turn the single config into a list + a default.
+
+**Ties to the context gauge (just shipped):** `AgentRecord.profileId` (empty = active/default). The
+GROUNDING CONTEXT ring then reads THAT profile's `contextLimit` — "Scout on Claude (200k) = 1% full;
+Scout on a local 3B (8k) = 22% full." Closes the loop.
+
+**Hard security rule (robustness):** API keys are credentials and MUST NOT sync across the mesh. The
+profile SHAPE (name/kind/baseURL/model/contextLimit) syncs as a primitive; the **key lives only in
+the device Keychain, referenced by profile id, never in the synced payload** — each surface holds its
+own key for a shared profile. (Matches the existing "API key never leaves this store" + the connector
+"credential stays on the desktop" pattern.)
+
+**Equilibrium (cross-surface, the whole point):** add `SyncKind.profile` so desktop hub / iPad /
+iPhone / web share the same named profiles (shape only). Each surface honors the profile CONTRACT via
+its own runtime (desktop → web_runtime; web → its inference path; Apple → the seam), honest `n/a`
+where a surface can't host a kind (an on-device GGUF profile is n/a on web). The egress badge reads
+`profile.egressScope` so trust stays honest per profile. See EQUILIBRIUM.md.
+
+**Why pre-GA:** retrofitting a profile contract AFTER sync + GA solidify means a migration; land it
+before. **Suggested phasing:** (1) `RuntimeProfile` contract + `SyncKind.profile` + Keychain key
+store; (2) Apple Basic (pick active) + Advanced (manage list + per-agent `profileId`) + gauge reads
+profile; (3) desktop hub honors profiles; (4) web authors/uses them. Each surface proven (parity).
+
+*Lands on:* the `ILLMProvider` seam (Contracts/RuntimeCore), `InferenceConfigStore`, the sync
+primitive framework, the per-agent `AgentRecord`, and the egress-badge canon.


### PR DESCRIPTION
Follow-up to #180 — the agent-builder pass + the Phase 24 plan it motivated.

## Agent builder → a two-step wizard (owner-picked)
- **Step 1 "What should it do?"** — describe-in-words (voice) + recipe cards that jump to naming.
- **Step 2 "Name & face"** — hero, name/vibe, **GROUNDING CONTEXT**, personality traits, the 100-face gallery **collapsed** behind "Change face", advanced = just the `{input}` template.
- **GROUNDING CONTEXT** (was buried in Advanced): *"Stuff your agent always knows"* — KB chips (tap to point), grounding **NOTES** (voice), read-the-zone toggle.
- **ContextGauge** — a live ring of how much of the model's context the grounding eats at rest (role + notes + zone vs the model's usable window), green→amber→red.

## Device-walk fixes folded in
- Movable note window (drag handle + persisted position); Record orb/FAB hidden while editing; **Record + New aligned** as one bottom row.
- **Background `URLSession`** model download (survives screen-lock; `AppDelegate` + session re-attach) + keep-awake during foreground.
- Device-aware labels (**"This iPhone"/"This iPad"**); HF search **size filters**; **model README viewer** (markdown render); egress badge → "On-device".

## Roadmap — Phase 24: Runtime profiles (pre-GA, Equilibrium-aligned)
**basic** (pick one active profile) vs **advanced** (named `RuntimeProfile`s + per-agent `profileId`), generalizing the existing `ILLMProvider` seam. Hard rule: **API keys never sync** — shape syncs as `SyncKind.profile`, key stays device/hub-custodial. Charter + 6 stories + BACKLOG entry **S** + EQUILIBRIUM.md pointer. *Authored only — not built.*

## Validation
- `swift test` — 0 failures (engine; full run this session 381/0).
- `xcodebuild` device build **succeeded and launched on a real iPhone 17 Pro Max**.
- Every visible change sim-screenshot-verified.

## Not verified here (owner device walk in progress)
Interaction behaviors — note dragging, games mid-meeting, an actual model download surviving a lock, per-template generation — are the on-device gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)