### PR TITLE
HSM-24-01: RuntimeProfile contract + SyncKind.profile + Keychain key store

### DIFF
--- a/apple/App/MeetingCapture/ProfileKeyStore.swift
+++ b/apple/App/MeetingCapture/ProfileKeyStore.swift
@@ -1,0 +1,56 @@
+import Foundation
+#if canImport(Security)
+import Security
+#endif
+
+// Phase 24 (HSM-24-01) — the device-local custodian for a RuntimeProfile's API key.
+//
+// The KEY NEVER LIVES ON `RuntimeProfile` AND NEVER SYNCS. The profile's *shape* travels the mesh
+// (`SyncKind.profile`); the key is stored here in the Keychain, keyed by the profile id, and joined
+// to an `EndpointConfig` only at request time. Each device holds its own key for a shared profile.
+enum ProfileKeyStore {
+    private static let service = "dev.holdspeak.runtimeprofile.key"
+
+    /// Store (or replace) the API key for a profile. An empty key deletes it.
+    static func set(_ key: String, for profileId: String) {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { delete(profileId); return }
+        #if canImport(Security)
+        let base: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                   kSecAttrService as String: service,
+                                   kSecAttrAccount as String: profileId]
+        SecItemDelete(base as CFDictionary)
+        var add = base
+        add[kSecValueData as String] = Data(trimmed.utf8)
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly  // never leaves this device
+        SecItemAdd(add as CFDictionary, nil)
+        #endif
+    }
+
+    /// The API key for a profile, or nil if none is stored.
+    static func get(_ profileId: String) -> String? {
+        #if canImport(Security)
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                    kSecAttrService as String: service,
+                                    kSecAttrAccount as String: profileId,
+                                    kSecReturnData as String: true,
+                                    kSecMatchLimit as String: kSecMatchLimitOne]
+        var out: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data, let s = String(data: data, encoding: .utf8) else { return nil }
+        return s
+        #else
+        return nil
+        #endif
+    }
+
+    static func delete(_ profileId: String) {
+        #if canImport(Security)
+        SecItemDelete([kSecClass as String: kSecClassGenericPassword,
+                       kSecAttrService as String: service,
+                       kSecAttrAccount as String: profileId] as CFDictionary)
+        #endif
+    }
+
+    static func has(_ profileId: String) -> Bool { get(profileId) != nil }
+}

--- a/apple/Sources/Contracts/Primitives.swift
+++ b/apple/Sources/Contracts/Primitives.swift
@@ -167,6 +167,66 @@ public struct Chain: Codable, Equatable, Sendable, Identifiable {
     }
 }
 
+// MARK: - RuntimeProfile (capability / synced) — a named "where intelligence runs" target (Phase 24)
+
+/// A named, reusable inference target: on-device, or any OpenAI-compatible endpoint. The app keeps a
+/// LIST of these plus one active; an `Agent` may point at one (`Agent.profileId`).
+///
+/// **Security invariant (load-bearing):** the API key is NEVER a field here and NEVER syncs. It lives
+/// in the device Keychain (or, on the hub, its secrets), referenced by `id`, and is joined to an
+/// `EndpointConfig` only at request time. Only the SHAPE below crosses the wire.
+public struct RuntimeProfile: Codable, Equatable, Sendable, Identifiable {
+    public enum Kind: String, Codable, Sendable { case onDevice, openAICompatible }
+    public var id: String
+    public var name: String
+    public var kind: Kind
+    public var modelFile: String        // onDevice: the .gguf filename ("" = first installed)
+    public var baseURL: String          // openAICompatible: the OpenAI-compatible root
+    public var model: String            // openAICompatible: the served model id
+    public var contextLimit: Int        // usable window (on-device computed at run time; endpoint declared)
+    public var requiresKey: Bool        // openAICompatible: a key is expected in the Keychain (never here)
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(id: String, name: String, kind: Kind, modelFile: String = "", baseURL: String = "",
+                model: String = "", contextLimit: Int = 16_384, requiresKey: Bool = false,
+                createdAt: Date, updatedAt: Date) {
+        self.id = id; self.name = name; self.kind = kind; self.modelFile = modelFile
+        self.baseURL = baseURL; self.model = model; self.contextLimit = contextLimit
+        self.requiresKey = requiresKey; self.createdAt = createdAt; self.updatedAt = updatedAt
+    }
+
+    public var isLocal: Bool { kind == .onDevice }
+    /// The endpoint host for the egress badge (nil when on-device → "local").
+    public var egressHost: String? { kind == .openAICompatible ? URL(string: baseURL)?.host : nil }
+}
+
+/// Pure mapping from the legacy single inference config (one mode + one endpoint) to a profile list
+/// plus the active id. Deterministic (takes `now`) so the one-time app migration is testable. No key
+/// flows through here — `endpointHasKey` only signals the caller to move the key into the Keychain.
+public enum RuntimeProfileMigration {
+    public static let localId = "profile.local"
+    public static let endpointId = "profile.endpoint"
+
+    public static func migrate(legacyModeIsLocal: Bool, endpointURL: String, endpointModel: String,
+                               localModelFile: String, endpointHasKey: Bool, now: Date)
+        -> (profiles: [RuntimeProfile], activeId: String) {
+        var profiles: [RuntimeProfile] = [
+            RuntimeProfile(id: localId, name: "This device", kind: .onDevice,
+                           modelFile: localModelFile, createdAt: now, updatedAt: now)
+        ]
+        let url = endpointURL.trimmingCharacters(in: .whitespaces)
+        if !url.isEmpty {
+            let host = URL(string: url)?.host ?? "endpoint"
+            profiles.append(RuntimeProfile(id: endpointId, name: host, kind: .openAICompatible,
+                                           baseURL: url, model: endpointModel, requiresKey: endpointHasKey,
+                                           createdAt: now, updatedAt: now))
+        }
+        let activeId = (!legacyModeIsLocal && !url.isEmpty) ? endpointId : localId
+        return (profiles, activeId)
+    }
+}
+
 // MARK: - WorkflowDefinition (capability / synced) — a saved Ask or graph
 //
 // RECONCILIATION (THE PRIMITIVE FRAMEWORK, tab 1) — two DISTINCT, deliberately-separate types:

--- a/apple/Sources/Contracts/Sync.swift
+++ b/apple/Sources/Contracts/Sync.swift
@@ -25,6 +25,7 @@ public enum SyncKind: String, Codable, Sendable, CaseIterable {
     case agent
     case chain
     case workflow
+    case profile        // a runtime/connectivity target (Phase 24); SHAPE only — the API key never syncs
 }
 
 /// The sync header for one entity: which entity, when it last changed, and whether
@@ -81,12 +82,13 @@ public struct ChangeSet: Codable, Equatable, Sendable {
     public var agents: [Synced<Agent>]
     public var chains: [Synced<Chain>]
     public var workflows: [Synced<WorkflowDefinition>]
+    public var profiles: [Synced<RuntimeProfile>]   // runtime targets — SHAPE only (key never synced)
 
     public init(meetings: [Synced<Meeting>] = [], artifacts: [Synced<Artifact>] = [],
                 notes: [Synced<Note>] = [], kbs: [Synced<KB>] = [],
                 directories: [Synced<Directory>] = [], directoryMemberships: [Synced<Membership>] = [],
                 agents: [Synced<Agent>] = [], chains: [Synced<Chain>] = [],
-                workflows: [Synced<WorkflowDefinition>] = []) {
+                workflows: [Synced<WorkflowDefinition>] = [], profiles: [Synced<RuntimeProfile>] = []) {
         self.meetings = meetings
         self.artifacts = artifacts
         self.notes = notes
@@ -96,16 +98,37 @@ public struct ChangeSet: Codable, Equatable, Sendable {
         self.agents = agents
         self.chains = chains
         self.workflows = workflows
+        self.profiles = profiles
+    }
+
+    // Decode tolerantly: any array absent from the payload defaults to []. A surface that doesn't yet
+    // know a kind (e.g. the hub before it learns `profiles`) sends a subset, and the others must still
+    // decode — the whole point of cross-surface equilibrium. (Encoding stays synthesized: all keys out.)
+    private enum CodingKeys: String, CodingKey {
+        case meetings, artifacts, notes, kbs, directories, directoryMemberships, agents, chains, workflows, profiles
+    }
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        meetings = try c.decodeIfPresent([Synced<Meeting>].self, forKey: .meetings) ?? []
+        artifacts = try c.decodeIfPresent([Synced<Artifact>].self, forKey: .artifacts) ?? []
+        notes = try c.decodeIfPresent([Synced<Note>].self, forKey: .notes) ?? []
+        kbs = try c.decodeIfPresent([Synced<KB>].self, forKey: .kbs) ?? []
+        directories = try c.decodeIfPresent([Synced<Directory>].self, forKey: .directories) ?? []
+        directoryMemberships = try c.decodeIfPresent([Synced<Membership>].self, forKey: .directoryMemberships) ?? []
+        agents = try c.decodeIfPresent([Synced<Agent>].self, forKey: .agents) ?? []
+        chains = try c.decodeIfPresent([Synced<Chain>].self, forKey: .chains) ?? []
+        workflows = try c.decodeIfPresent([Synced<WorkflowDefinition>].self, forKey: .workflows) ?? []
+        profiles = try c.decodeIfPresent([Synced<RuntimeProfile>].self, forKey: .profiles) ?? []
     }
 
     public var isEmpty: Bool {
         meetings.isEmpty && artifacts.isEmpty && notes.isEmpty && kbs.isEmpty
             && directories.isEmpty && directoryMemberships.isEmpty
-            && agents.isEmpty && chains.isEmpty && workflows.isEmpty
+            && agents.isEmpty && chains.isEmpty && workflows.isEmpty && profiles.isEmpty
     }
     public var count: Int {
         meetings.count + artifacts.count + notes.count + kbs.count
             + directories.count + directoryMemberships.count
-            + agents.count + chains.count + workflows.count
+            + agents.count + chains.count + workflows.count + profiles.count
     }
 }

--- a/apple/Tests/ContractsTests/RuntimeProfileTests.swift
+++ b/apple/Tests/ContractsTests/RuntimeProfileTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Contracts
+
+/// HSM-24-01 — the `RuntimeProfile` contract, its sync envelope, the never-sync-the-key invariant,
+/// and the legacy → profiles migration.
+final class RuntimeProfileTests: XCTestCase {
+    private let t = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func sampleEndpoint() -> RuntimeProfile {
+        RuntimeProfile(id: "p1", name: "OpenRouter", kind: .openAICompatible,
+                       baseURL: "https://openrouter.ai/api/v1", model: "anthropic/claude-3.5",
+                       contextLimit: 200_000, requiresKey: true, createdAt: t, updatedAt: t)
+    }
+
+    func testRoundTrip() throws {
+        let p = sampleEndpoint()
+        let data = try JSONEncoder().encode(p)
+        let back = try JSONDecoder().decode(RuntimeProfile.self, from: data)
+        XCTAssertEqual(p, back)
+        XCTAssertEqual(back.egressHost, "openrouter.ai")
+        XCTAssertFalse(back.isLocal)
+    }
+
+    func testOnDeviceEgressIsLocal() {
+        let p = RuntimeProfile(id: "l", name: "This device", kind: .onDevice,
+                               modelFile: "Qwen3-4B-Instruct-2507-Q4_K_M.gguf", createdAt: t, updatedAt: t)
+        XCTAssertTrue(p.isLocal)
+        XCTAssertNil(p.egressHost)   // on-device → no egress host → the badge stays "local"
+    }
+
+    func testChangeSetCarriesProfilesAndRoundTrips() throws {
+        let cs = ChangeSet(profiles: [.live(sampleEndpoint(), id: "p1", kind: .profile, modifiedAt: t)])
+        XCTAssertEqual(cs.count, 1)
+        XCTAssertFalse(cs.isEmpty)
+        let back = try JSONDecoder().decode(ChangeSet.self, from: try JSONEncoder().encode(cs))
+        XCTAssertEqual(back.profiles.first?.value, sampleEndpoint())
+    }
+
+    /// A payload from a surface that doesn't know `profiles` yet (the hub pre-24-04) must still decode.
+    func testChangeSetDecodesWhenProfilesAbsent() throws {
+        let legacy = #"{"agents":[],"meetings":[]}"#.data(using: .utf8)!
+        let cs = try JSONDecoder().decode(ChangeSet.self, from: legacy)
+        XCTAssertTrue(cs.profiles.isEmpty)
+        XCTAssertTrue(cs.isEmpty)
+    }
+
+    /// THE security invariant: the profile shape can carry no key. There is no `apiKey` field, and a
+    /// secret handed to the Keychain never appears in the synced bytes (proven by construction here).
+    func testKeyNeverInThePayload() throws {
+        let p = sampleEndpoint()   // requiresKey == true, but no key value lives on the shape
+        let json = String(data: try JSONEncoder().encode(p), encoding: .utf8)!
+        XCTAssertTrue(json.contains("requiresKey"))
+        XCTAssertFalse(json.contains("apiKey"))
+        XCTAssertFalse(json.lowercased().contains("sk-"))   // no API-key-shaped material can be present
+        // And in a ChangeSet:
+        let cs = ChangeSet(profiles: [.live(p, id: "p1", kind: .profile, modifiedAt: t)])
+        let csJSON = String(data: try JSONEncoder().encode(cs), encoding: .utf8)!
+        XCTAssertFalse(csJSON.contains("apiKey"))
+    }
+
+    func testMigrateLocalOnly() {
+        let (profiles, active) = RuntimeProfileMigration.migrate(
+            legacyModeIsLocal: true, endpointURL: "", endpointModel: "",
+            localModelFile: "model.gguf", endpointHasKey: false, now: t)
+        XCTAssertEqual(profiles.count, 1)
+        XCTAssertEqual(active, RuntimeProfileMigration.localId)
+        XCTAssertEqual(profiles.first?.kind, .onDevice)
+        XCTAssertEqual(profiles.first?.modelFile, "model.gguf")
+    }
+
+    func testMigrateEndpointActive() {
+        let (profiles, active) = RuntimeProfileMigration.migrate(
+            legacyModeIsLocal: false, endpointURL: "https://api.openrouter.ai/v1",
+            endpointModel: "gpt", localModelFile: "", endpointHasKey: true, now: t)
+        XCTAssertEqual(profiles.count, 2)   // local is always seeded; endpoint added + active
+        XCTAssertEqual(active, RuntimeProfileMigration.endpointId)
+        let ep = profiles.first { $0.id == RuntimeProfileMigration.endpointId }
+        XCTAssertEqual(ep?.kind, .openAICompatible)
+        XCTAssertEqual(ep?.name, "api.openrouter.ai")
+        XCTAssertTrue(ep?.requiresKey ?? false)
+    }
+
+    /// A configured endpoint is preserved as a profile even if the user was on local (active = local).
+    func testMigrateLocalActiveButEndpointPreserved() {
+        let (profiles, active) = RuntimeProfileMigration.migrate(
+            legacyModeIsLocal: true, endpointURL: "https://x.test/v1", endpointModel: "m",
+            localModelFile: "", endpointHasKey: false, now: t)
+        XCTAssertEqual(profiles.count, 2)
+        XCTAssertEqual(active, RuntimeProfileMigration.localId)
+    }
+}

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -1,13 +1,14 @@
 # Phase 24 — Runtime profiles (basic + advanced), in equilibrium
 
-**Status:** planned (authored 2026-06-28) — a pre-GA extension of
+**Status:** in-progress (opened 2026-06-28) — a pre-GA extension of
 [`EQUILIBRIUM.md`](../EQUILIBRIUM.md): the same "honor the contract on every surface" discipline,
 applied to *where intelligence runs*.
 
-**Last updated:** 2026-06-28 (authored from the owner's call: split the single global
-inference choice into **basic** (pick one active target) vs **advanced** (named runtime
-profiles + per-agent assignment), and bring it to desktop / iPad / iPhone / web. Grounded in
-BACKLOG entry **S**.)
+**Last updated:** 2026-06-28 (**24-01 landed.** The `RuntimeProfile` contract +
+`SyncKind.profile` + tolerant `ChangeSet` decode + the Keychain `ProfileKeyStore` + the
+legacy→profiles migration all ship, with the **never-sync-the-key invariant proven in a test**
+and a back-compat test for payloads that predate `profiles`. `swift test` 389/0; the app
+compiles with the additions. No UI yet — that's 24-02.)
 
 ## Why this phase exists
 
@@ -68,7 +69,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 
 | Story | One-liner | Status |
 |-------|-----------|--------|
-| HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | planned |
+| HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | **done** (contract + migration + tolerant `ChangeSet` decode + `ProfileKeyStore`; never-sync invariant tested; `swift test` 389/0) |
 | HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | planned |
 | HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | planned |
 | HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | planned |
@@ -86,6 +87,18 @@ reads `profile.egressScope` so trust stays honest per profile.
 (basic) is a near-pure refactor of `InferenceConfigStore` into "a list with one active" and must
 stay byte-identical for the single-target user. 24-03 unlocks the per-agent power (and lights up
 the gauge). 24-04/05 bring the other surfaces into parity. 24-06 is the parity gate + docs.
+
+## Where we are
+
+**Opened; the foundation is in.** 24-01 landed the load-bearing contract with zero behavior change:
+`RuntimeProfile` + `RuntimeProfileMigration` (Contracts/Primitives.swift), `SyncKind.profile` +
+`ChangeSet.profiles` with a **tolerant decoder** (any absent array → `[]`, so a surface that doesn't
+yet know `profiles` still decodes), and `ProfileKeyStore` (App-layer Keychain; the key is keyed by
+profile id with `…ThisDeviceOnly` accessibility and **never** appears on the shape or in a
+`ChangeSet`). Eight tests, including the never-sync invariant and the back-compat decode.
+
+Next: **24-02** (Apple basic) — refactor `InferenceConfigStore` into "a list of profiles + one
+active," route `makeProvider` through the active profile, and run the migration on first launch.
 
 ## Carried context
 

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-01.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-01.md
@@ -1,0 +1,42 @@
+# Evidence — HSM-24-01 (RuntimeProfile contract + SyncKind.profile + Keychain key store)
+
+**Date:** 2026-06-28
+**Story:** [story-01-profile-contract-keychain.md](./story-01-profile-contract-keychain.md)
+**Result:** DONE. The load-bearing contract foundation ships with zero behavior change.
+`swift test` **389 passed / 8 skipped / 0 failed** (was 381; +8 this story). Contracts target
+builds; the app (iphonesimulator) builds with the additions.
+
+## What shipped
+
+- **`RuntimeProfile`** (`Sources/Contracts/Primitives.swift`) — a named inference target:
+  `kind: .onDevice | .openAICompatible`, `modelFile` / `baseURL` / `model`, `contextLimit`,
+  `requiresKey`, timestamps. **No `apiKey` field by design.** `isLocal` + `egressHost` derive the
+  trust scope (on-device → no host → "local").
+- **`RuntimeProfileMigration`** (same file) — a pure, deterministic mapping (takes `now`) from the
+  legacy single config (mode + one endpoint) → `(profiles, activeId)`. Always seeds a local profile;
+  preserves a configured endpoint as a second profile even if the user was on local; `endpointHasKey`
+  only flags the caller to move the key into the Keychain (no key flows through).
+- **Sync** (`Sources/Contracts/Sync.swift`) — `SyncKind.profile`; `ChangeSet.profiles:
+  [Synced<RuntimeProfile>]` wired into `init` / `isEmpty` / `count`. A **custom tolerant
+  `init(from:)`** decodes any absent array to `[]` — so a surface that doesn't yet know `profiles`
+  (the hub pre-24-04) still decodes, and old payloads keep working.
+- **`ProfileKeyStore`** (`App/MeetingCapture/ProfileKeyStore.swift`) — the device-local Keychain
+  custodian (`kSecClassGenericPassword`, `…AfterFirstUnlockThisDeviceOnly`), keyed by profile id.
+  The key lives ONLY here, joined to an `EndpointConfig` at request time, never on the shape.
+
+## Acceptance criteria → proof
+
+- **Contract round-trips Codable.** `RuntimeProfileTests.testRoundTrip` ✅
+- **A `ChangeSet` carries a profile and round-trips.** `testChangeSetCarriesProfilesAndRoundTrips` ✅
+- **Back-compat: a payload without `profiles` still decodes.** `testChangeSetDecodesWhenProfilesAbsent`
+  (and the full sync suite stayed green — no regression from the custom decoder). ✅
+- **The never-sync invariant.** `testKeyNeverInThePayload` — the encoded profile + a `ChangeSet`
+  carrying it contain no `apiKey` and no `sk-`-shaped material; the shape *cannot* carry a key. ✅
+- **Migration.** local-only / endpoint-active / local-active-but-endpoint-preserved all map as
+  specified. ✅
+- **No UI / no behavior change.** The contract + store exist; nothing wires them yet (that is 24-02).
+
+## Notes
+
+- The Keychain store itself is not exercised by `swift test` (no keychain in the macOS test context);
+  its API shape is verified by compilation and will be walked on device in 24-02/24-03.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-01-profile-contract-keychain.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-01-profile-contract-keychain.md
@@ -1,6 +1,6 @@
 # HSM-24-01 — The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store
 
-**Status:** planned — **leads, load-bearing** (every surface depends on it).
+- **Status:** done (2026-06-28) — **leads, load-bearing** (every surface depends on it). Evidence: [evidence-story-01.md](./evidence-story-01.md). `swift test` 389/0 (+8).
 
 ## Problem
 


### PR DESCRIPTION
Phase 24 — Runtime profiles, story 1 (the load-bearing foundation). **No UI, no behavior change.**

- **`RuntimeProfile`** (Contracts) — a named inference target (`.onDevice` / `.openAICompatible`); **no `apiKey` field by design**; `isLocal` + `egressHost` derive the trust scope.
- **`RuntimeProfileMigration`** — pure legacy(mode+endpoint) → `(profiles, activeId)`; always seeds local, preserves a configured endpoint, never carries a key.
- **Sync** — `SyncKind.profile` + `ChangeSet.profiles` with a **tolerant decoder** (absent array → `[]`), so a surface that doesn't yet know `profiles` still decodes (the equilibrium requirement).
- **`ProfileKeyStore`** — device-local Keychain custodian (`…ThisDeviceOnly`); the key lives only here, joined at request time, **never on the shape or in a `ChangeSet`**.

**Validation:** `swift test` **389/0** (+8: round-trip, the **never-sync invariant**, back-compat decode, migration). Contracts + app build green. Evidence: `evidence-story-01.md`.

Next: 24-02 (Apple basic — refactor `InferenceConfigStore` to a profile list + active, route `makeProvider` through it, run the migration on first launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)