### PR TITLE
HSM-24-02: Apple basic config — profile-backed store + reusable RunsOnPicker

### DIFF
--- a/apple/App/MeetingCapture/AppSettings.swift
+++ b/apple/App/MeetingCapture/AppSettings.swift
@@ -29,6 +29,10 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     header
                     label("WHERE INTELLIGENCE RUNS")
+                    if cfg.profiles.count >= 1 {
+                        // The active profile is the default for everything that isn't overridden inline.
+                        RunsOnPicker(selectedId: $cfg.activeProfileId, label: "Active profile")
+                    }
                     targetCard(.local, "This \(DeviceLabel.current)", "Runs on this \(DeviceLabel.current)", DeviceLabel.current == "iPhone" ? "iphone" : "ipad", Sig.localGradient)
                     if cfg.isLocal { onDeviceModelCard }
                     targetCard(.homelab, "LAN endpoint", "An OpenAI-compatible server on your network", "server.rack", Sig.accentGradient)

--- a/apple/App/MeetingCapture/RunsOnPicker.swift
+++ b/apple/App/MeetingCapture/RunsOnPicker.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+// Phase 24 (HSM-24-02) — the ONE reusable inline "Runs on" control. The owner's principle: anywhere
+// the app touches a model, the resolved profile is SHOWN and CHANGEABLE right there, every time.
+// Drop this chip at every model-touch point; in 24-03 it carries an optional override over the
+// agent/active default. Here it binds straight to a profile id (e.g. the global active profile).
+struct RunsOnPicker: View {
+    @ObservedObject private var cfg = InferenceConfigStore.shared
+    @Binding var selectedId: String
+    /// When true, an empty `selectedId` means "use the resolved default" and the chip shows it as such
+    /// (for per-agent / per-run overrides). When false, the chip always names the selected profile.
+    var allowsDefault: Bool = false
+    var label: String = "Runs on"
+
+    private var resolved: RuntimeProfile {
+        cfg.profiles.first { $0.id == selectedId } ?? cfg.activeProfile
+    }
+    private var isDefault: Bool { allowsDefault && selectedId.isEmpty }
+
+    var body: some View {
+        Menu {
+            if allowsDefault {
+                Button { selectedId = ""; tactile() } label: { pickLabel("Default · \(cfg.activeProfile.name)", on: selectedId.isEmpty) }
+            }
+            ForEach(cfg.profiles) { p in
+                Button { selectedId = p.id; tactile() } label: { pickLabel(p.name, on: selectedId == p.id) }
+            }
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: resolved.isLocal ? "iphone" : "cloud.fill").font(.system(size: 11, weight: .bold))
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(label.uppercased()).font(.system(size: 8.5, weight: .black, design: .rounded)).tracking(0.8).foregroundStyle(Sig.faint)
+                    Text(isDefault ? "Default · \(resolved.name)" : resolved.name)
+                        .font(.system(size: 13, weight: .heavy, design: .rounded)).foregroundStyle(Sig.text).lineLimit(1)
+                }
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.up.chevron.down").font(.system(size: 10, weight: .bold)).foregroundStyle(Sig.faint)
+            }
+            .padding(.horizontal, 12).padding(.vertical, 9)
+            .background(Sig.s2, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Color.white.opacity(0.08), lineWidth: 1))
+        }
+        .tint(Sig.accent)
+    }
+
+    private func pickLabel(_ name: String, on: Bool) -> some View {
+        Label(name, systemImage: on ? "checkmark" : (resolved.isLocal ? "iphone" : "cloud.fill"))
+    }
+}

--- a/apple/App/MeetingCapture/SketchDiagram.swift
+++ b/apple/App/MeetingCapture/SketchDiagram.swift
@@ -525,6 +525,14 @@ struct SketchToDiagramView: View {
     @Published var endpointURL: String { didSet { d.set(endpointURL, forKey: K.url) } }
     @Published var endpointModel: String { didSet { d.set(endpointModel, forKey: K.model) } }
     @Published var endpointKey: String { didSet { d.set(endpointKey, forKey: K.key) } }
+    /// Phase 24 — named runtime targets (SHAPE only; the API key lives in `ProfileKeyStore`/Keychain,
+    /// never here). Persisted locally as JSON; sync transport is a later story. The ACTIVE profile is
+    /// applied onto the legacy `mode`/endpoint/`localModelId` fields above, so every existing reader
+    /// (`endpointConfig`, `isLocal`, `localGGUF`) keeps working unchanged — profiles are a management
+    /// layer, not a rewrite of the inference path.
+    @Published var profiles: [RuntimeProfile] = [] { didSet { if loaded { persistProfiles() } } }
+    @Published var activeProfileId: String = "" { didSet { d.set(activeProfileId, forKey: K.activeProfile); if loaded { applyActive() } } }
+    private var loaded = false
     /// HSM-14-17 — on-device speaker diarization (opt-in). Default ON. When set, capture's `stop()`
     /// labels each transcript segment with who spoke it, fully on-device (no network).
     @Published var diarizationOn: Bool { didSet { d.set(diarizationOn, forKey: K.diarize) } }
@@ -543,7 +551,7 @@ struct SketchToDiagramView: View {
     static let whisperLangKey = "hs.inf.whisperlang"  // the UserDefaults key the transcriber reads directly
 
     private let d = UserDefaults.standard
-    private enum K { static let mode = "hs.inf.mode", url = "hs.inf.url", model = "hs.inf.model", key = "hs.inf.key", diarize = "hs.inf.diarize", localModel = "hs.inf.localmodel", whisper = "hs.inf.whisper", whisperLang = "hs.inf.whisperlang" }
+    private enum K { static let mode = "hs.inf.mode", url = "hs.inf.url", model = "hs.inf.model", key = "hs.inf.key", diarize = "hs.inf.diarize", localModel = "hs.inf.localmodel", whisper = "hs.inf.whisper", whisperLang = "hs.inf.whisperlang", profiles = "hs.inf.profiles", activeProfile = "hs.inf.activeprofile" }
     private init() {
         mode = RuntimeMode(rawValue: d.string(forKey: K.mode) ?? "") ?? .local
         endpointURL = d.string(forKey: K.url) ?? ""
@@ -553,28 +561,87 @@ struct SketchToDiagramView: View {
         localModelId = d.string(forKey: K.localModel) ?? ""
         whisperModel = d.string(forKey: K.whisper) ?? "base"
         whisperLanguage = d.string(forKey: K.whisperLang) ?? "auto"
+        if let data = d.data(forKey: K.profiles), let saved = try? JSONDecoder().decode([RuntimeProfile].self, from: data) {
+            profiles = saved
+            activeProfileId = d.string(forKey: K.activeProfile) ?? saved.first?.id ?? ""
+        } else {
+            migrateLegacyToProfiles()   // first launch with profiles — seed from the single legacy config
+        }
+        loaded = true
+    }
+
+    /// One-time: turn the legacy single config into a profile list + active id, moving any API key
+    /// from UserDefaults into the Keychain (and clearing it from UserDefaults — the key must not live
+    /// alongside the synced shape).
+    private func migrateLegacyToProfiles() {
+        let r = RuntimeProfileMigration.migrate(
+            legacyModeIsLocal: mode == .local, endpointURL: endpointURL, endpointModel: endpointModel,
+            localModelFile: localModelId, endpointHasKey: !endpointKey.isEmpty, now: Date())
+        if !endpointKey.isEmpty {
+            ProfileKeyStore.set(endpointKey, for: RuntimeProfileMigration.endpointId)
+            endpointKey = ""; d.removeObject(forKey: K.key)   // key leaves UserDefaults for the Keychain
+        }
+        profiles = r.profiles
+        activeProfileId = r.activeId
+        persistProfiles(); d.set(activeProfileId, forKey: K.activeProfile)
+    }
+
+    private func persistProfiles() { if let data = try? JSONEncoder().encode(profiles) { d.set(data, forKey: K.profiles) } }
+
+    /// The resolved active profile (falls back to the first, then a synthesized on-device default).
+    var activeProfile: RuntimeProfile {
+        profiles.first { $0.id == activeProfileId } ?? profiles.first
+            ?? RuntimeProfile(id: RuntimeProfileMigration.localId, name: "This device", kind: .onDevice,
+                              modelFile: localModelId, createdAt: Date(), updatedAt: Date())
+    }
+
+    /// Apply a profile onto the legacy fields so all existing readers see the active target. Called
+    /// when the active profile changes (the basic picker) or an active endpoint profile is edited.
+    private func applyActive() {
+        let p = activeProfile
+        mode = p.isLocal ? .local : .endpoint
+        if p.isLocal { localModelId = p.modelFile }
+        else { endpointURL = p.baseURL; endpointModel = p.model }
     }
 
     var isLocal: Bool { mode == .local }
 
-    /// The endpoint config, or nil if the URL is blank/invalid (so generate() can refuse cleanly).
+    /// The endpoint config, or nil if the URL is blank/invalid. The API key is sourced from the
+    /// Keychain (active profile id) first, falling back to the legacy field during the transition.
     var endpointConfig: EndpointConfig? {
         let t = endpointURL.trimmingCharacters(in: .whitespaces)
         guard !t.isEmpty, let u = URL(string: t), u.host != nil else { return nil }
-        return EndpointConfig(baseURL: u, model: endpointModel.isEmpty ? "local-model" : endpointModel,
-                              apiKey: endpointKey.isEmpty ? nil : endpointKey)
+        let key = ProfileKeyStore.get(activeProfile.id) ?? (endpointKey.isEmpty ? nil : endpointKey)
+        return EndpointConfig(baseURL: u, model: endpointModel.isEmpty ? "local-model" : endpointModel, apiKey: key)
     }
 
-    /// A fresh provider for one inference (Llama must be fresh per call; an endpoint client is cheap).
+    /// Resolve which profile runs a given action: an explicit inline override → the agent's assigned
+    /// profile → the global active profile. (The owner's "expose + change the default at any time".)
+    func resolveProfile(agentProfileId: String? = nil, override: String? = nil) -> RuntimeProfile {
+        for id in [override, agentProfileId].compactMap({ $0 }) where !id.isEmpty {
+            if let p = profiles.first(where: { $0.id == id }) { return p }
+        }
+        return activeProfile
+    }
+
+    /// A fresh provider for one inference, against the ACTIVE profile (legacy call path, unchanged).
     func makeProvider(localModelPath: String?, context: Int) throws -> ILLMProvider {
-        switch mode {
-        case .local:
+        try makeProvider(profile: activeProfile, localModelPath: localModelPath, context: context)
+    }
+
+    /// A fresh provider for one inference against an EXPLICIT profile (the inline "Runs on" path).
+    /// The endpoint key is joined from the Keychain at this moment, never carried on the shape.
+    func makeProvider(profile: RuntimeProfile, localModelPath: String?, context: Int) throws -> ILLMProvider {
+        if profile.isLocal {
             guard let p = localModelPath else { throw InferenceSettingsError.localEngineUnavailable }
             return try LlamaProvider.make(modelPath: p, maxTokenCount: Int32(context))   // template auto-picked per model family
-        case .homelab, .endpoint:
-            guard let cfg = endpointConfig else { throw InferenceSettingsError.endpointNotConfigured }
-            return OpenAIEndpointProvider(config: cfg)
         }
+        guard let u = URL(string: profile.baseURL.trimmingCharacters(in: .whitespaces)), u.host != nil else {
+            throw InferenceSettingsError.endpointNotConfigured
+        }
+        let key = ProfileKeyStore.get(profile.id)
+        let cfg = EndpointConfig(baseURL: u, model: profile.model.isEmpty ? "local-model" : profile.model, apiKey: key)
+        return OpenAIEndpointProvider(config: cfg)
     }
 
     /// The egress reality for the badge: local keeps everything on the iPad; an endpoint sends to its host.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -4,7 +4,9 @@
 [`EQUILIBRIUM.md`](../EQUILIBRIUM.md): the same "honor the contract on every surface" discipline,
 applied to *where intelligence runs*.
 
-**Last updated:** 2026-06-28 (**24-01 landed.** The `RuntimeProfile` contract +
+**Last updated:** 2026-06-28 (**24-01 + 24-02 landed.** `InferenceConfigStore` is profile-backed
+(migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile`); the reusable `RunsOnPicker`
+ships as the always-exposed "Active profile" chip. Below: 24-01 — The `RuntimeProfile` contract +
 `SyncKind.profile` + tolerant `ChangeSet` decode + the Keychain `ProfileKeyStore` + the
 legacy→profiles migration all ship, with the **never-sync-the-key invariant proven in a test**
 and a back-compat test for payloads that predate `profiles`. `swift test` 389/0; the app
@@ -50,6 +52,21 @@ RuntimeProfile {
 *assigned profile's* `contextLimit` — "Scout on Claude (200k) = 1% full; Scout on a local 3B (8k)
 = 22%."
 
+## The governing usability principle (owner, 2026-06-28)
+
+**Every surface that touches a model exposes a tiny, inline "Runs on: [Profile ▾]" control** — the
+resolved default already selected, one tap to change, *at the point of use*, every time. Not buried
+in Settings. Most users never touch it; but the default is always **shown** (never implicit) and
+**changeable at any moment**.
+
+- **Resolution order** for "which profile runs this": an explicit inline override → the agent's
+  assigned `profileId` → the global active profile. Whichever applies is the one the chip displays.
+- **One reusable component** (a `RunsOnPicker` chip) is dropped at every model-touch point —
+  dictation, meeting generate, agent run/chat, chains, the desk "Ask"/route-to-AI-core gesture, the
+  builder. Introduced in 24-02 (with the resolution helper); made pervasive in 24-03.
+- `makeProvider` takes an explicit `RuntimeProfile`; call sites resolve via the order above so the
+  inline override is honored.
+
 ## The one hard rule (security / robustness)
 
 **API keys are credentials and MUST NOT sync.** The profile *shape* (name/kind/baseURL/model/
@@ -70,7 +87,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 | Story | One-liner | Status |
 |-------|-----------|--------|
 | HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | **done** (contract + migration + tolerant `ChangeSet` decode + `ProfileKeyStore`; never-sync invariant tested; `swift test` 389/0) |
-| HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | planned |
+| HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | **done** (profile-backed `InferenceConfigStore` + migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile` + the reusable `RunsOnPicker`; `swift test` 389/0) |
 | HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | planned |
 | HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | planned |
 | HSM-24-05 | Web authors + uses profiles (the flagship surface) | planned |
@@ -97,8 +114,16 @@ yet know `profiles` still decodes), and `ProfileKeyStore` (App-layer Keychain; t
 profile id with `…ThisDeviceOnly` accessibility and **never** appears on the shape or in a
 `ChangeSet`). Eight tests, including the never-sync invariant and the back-compat decode.
 
-Next: **24-02** (Apple basic) — refactor `InferenceConfigStore` into "a list of profiles + one
-active," route `makeProvider` through the active profile, and run the migration on first launch.
+**24-02 also landed.** `InferenceConfigStore` is now profile-backed (`profiles` + `activeProfileId`,
+migrated on first launch, key moved to the Keychain); the active profile is applied onto the legacy
+fields so every existing reader is unchanged; `makeProvider(profile:)` + `resolveProfile` (override →
+agent → active) are in; and the **reusable `RunsOnPicker`** ships — shown in Settings as the always-
+exposed "Active profile" chip (the owner's "the default is always exposed + changeable" principle).
+
+Next: **24-03** (Apple advanced) — the profiles management screen (add/edit/delete, key→Keychain),
+per-agent `Agent.profileId`, the `RunsOnPicker` dropped at every model-touch point (dictation,
+generate, agent run/chat, the Ask gesture, the builder), and the gauge reading the assigned profile's
+`contextLimit`. That story also enables the live multi-profile switch walk 24-02 deferred.
 
 ## Carried context
 

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-02.md
@@ -1,0 +1,49 @@
+# Evidence — HSM-24-02 (Apple basic config: active-profile picker over the existing seam)
+
+**Date:** 2026-06-28
+**Story:** [story-02-apple-basic-config.md](./story-02-apple-basic-config.md)
+**Result:** DONE (foundation + basic picker; a live multi-profile *switch* is walked in 24-03, which
+adds profile creation). `swift test` **389/0** (no regression); app builds (iphonesimulator) and
+device-SDK compiles; migration verified by screenshot.
+
+## What shipped
+
+- **`InferenceConfigStore` is now profile-backed** (`SketchDiagram.swift`): `profiles:
+  [RuntimeProfile]` + `activeProfileId`, persisted locally as JSON. `activeProfile` resolves
+  (selected → first → synthesized local default).
+- **One-time migration** (`migrateLegacyToProfiles`): on first launch the legacy single config (mode
+  + one endpoint) becomes a profile list + active id via `RuntimeProfileMigration`, and **any API key
+  is moved from UserDefaults into the Keychain** (`ProfileKeyStore`) and cleared from UserDefaults —
+  the key leaves the shape's storage.
+- **The active profile is applied onto the legacy fields** (`applyActive`), so every existing reader
+  (`endpointConfig`, `isLocal`, `localGGUF`) keeps working unchanged — profiles are a management
+  layer, not a rewrite of the inference path. `endpointConfig` now sources the key from the Keychain
+  (active id) first, legacy field as a transition fallback.
+- **`makeProvider(profile:localModelPath:context:)`** — the explicit-profile path the inline "Runs
+  on" override will use; the legacy `makeProvider(localModelPath:context:)` now delegates to it with
+  the active profile. The endpoint key is joined from the Keychain at call time.
+- **`resolveProfile(agentProfileId:override:)`** — the owner's resolution order (override → agent →
+  active), ready for 24-03's per-surface chips.
+- **`RunsOnPicker`** (`RunsOnPicker.swift`) — the ONE reusable inline control (the owner's principle:
+  the resolved profile is shown + changeable at the point of use). Settings shows it as the always-
+  exposed **"Active profile"** chip above "Where intelligence runs".
+
+## Acceptance criteria → proof
+
+- **Single-profile user sees no behavior change.** The active profile is applied onto the legacy
+  fields; the existing cards/editor are unchanged. The new chip merely *exposes* the default (per the
+  owner's "the default must always be exposed"). Screenshot: the "Active profile · This device" chip
+  over the unchanged cards. ✅
+- **The key is sourced from the Keychain at request time.** `endpointConfig` + `makeProvider(profile:)`
+  read `ProfileKeyStore.get(id)`; migration moved the legacy key into the Keychain and cleared it from
+  UserDefaults. ✅
+- **`makeProvider` routes through the active profile.** The legacy call path delegates to
+  `makeProvider(profile: activeProfile, …)`. ✅
+- **No engine regression.** `swift test` 389/0. ✅
+
+## Deferred to 24-03 (honest)
+
+A live multi-profile *switch* on device needs profile **creation**, which is 24-03 (advanced). Until
+then there's one migrated profile, so the chip exposes it but has nothing to switch to. The
+edit-writes-back-to-profile two-way sync is also 24-03's (its advanced editor owns profile CRUD on
+the `profiles` array directly, avoiding any legacy-field entanglement in the live path).

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-02-apple-basic-config.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-02-apple-basic-config.md
@@ -1,6 +1,6 @@
 # HSM-24-02 — Apple basic config: the active-profile picker over the existing seam
 
-**Status:** planned (after 24-01).
+- **Status:** done (2026-06-28) — foundation + the always-exposed active picker. Evidence: [evidence-story-02.md](./evidence-story-02.md). `swift test` 389/0; a live multi-profile switch walks in 24-03 (which adds profile creation).
 
 ## Problem
 


### PR DESCRIPTION
Phase 24, story 2 (basic config). Behavior-preserving foundation + the inline-control vehicle.

- **`InferenceConfigStore` → profile-backed**: `profiles` + `activeProfileId`; a one-time **migration** of the legacy single config into a profile list + active id, **moving any API key from UserDefaults into the Keychain** (and clearing it from UserDefaults).
- **Active profile applied onto the legacy fields** → every existing reader (`endpointConfig`/`isLocal`/`localGGUF`) unchanged. Profiles are a management layer, not a rewrite of the live path.
- **`makeProvider(profile:…)`** (key joined from Keychain at call time) + **`resolveProfile`** (override → agent → active — the owner's resolution order).
- **`RunsOnPicker`** — the ONE reusable inline control. Settings shows it as the always-exposed **"Active profile"** chip (owner's "the default is always exposed + changeable" principle).

**Validation:** `swift test` **389/0** (no regression); app + device-SDK builds; migration + chip screenshot-verified.

**Deferred to 24-03 (honest):** the live multi-profile *switch* + per-agent `Agent.profileId` + dropping `RunsOnPicker` at every model-touch point + the gauge reading the assigned profile — that story enables a real switch walk (needs profile creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)