### PR TITLE
HSM-24-03 (core): advanced profiles CRUD + per-agent profile + gauge-per-profile + agent routing

### DIFF
--- a/apple/App/MeetingCapture/AppSettings.swift
+++ b/apple/App/MeetingCapture/AppSettings.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @State private var models: [String] = []
     @State private var localModels: [InstalledModel] = []     // installed on-device GGUF language models
     @State private var showModels = false                     // present the model manager (import/delete)
+    @State private var showProfiles = false                   // present the runtime-profiles manager (Phase 24)
     enum Field: Hashable { case url, key }
     enum FetchState: Equatable { case idle, loading, ok(Int), fail }
 
@@ -29,9 +30,18 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     header
                     label("WHERE INTELLIGENCE RUNS")
-                    if cfg.profiles.count >= 1 {
-                        // The active profile is the default for everything that isn't overridden inline.
-                        RunsOnPicker(selectedId: $cfg.activeProfileId, label: "Active profile")
+                    // The active profile is the default for everything not overridden inline — always exposed.
+                    RunsOnPicker(selectedId: $cfg.activeProfileId, label: "Active profile")
+                    Button { tactile(); showProfiles = true } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "rectangle.stack.fill").font(.system(size: 13, weight: .bold)).foregroundStyle(Sig.accent)
+                            Text("Manage profiles").font(.system(size: 13.5, weight: .heavy)).foregroundStyle(Sig.text)
+                            Text("\(cfg.profiles.count)").font(.system(size: 12, weight: .heavy)).foregroundStyle(Sig.faint)
+                            Spacer(); Image(systemName: "chevron.right").font(.system(size: 12, weight: .bold)).foregroundStyle(Sig.faint)
+                        }
+                        .padding(.horizontal, 13).padding(.vertical, 11)
+                        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Sig.line, lineWidth: 1))
                     }
                     targetCard(.local, "This \(DeviceLabel.current)", "Runs on this \(DeviceLabel.current)", DeviceLabel.current == "iPhone" ? "iphone" : "ipad", Sig.localGradient)
                     if cfg.isLocal { onDeviceModelCard }
@@ -52,6 +62,7 @@ struct SettingsView: View {
         .onTapGesture { focused = nil }
         .onAppear { refreshLocalModels() }
         .sheet(isPresented: $showModels, onDismiss: { refreshLocalModels() }) { NavigationStack { ModelsView() }.preferredColorScheme(.dark) }
+        .sheet(isPresented: $showProfiles) { NavigationStack { ProfilesView() }.preferredColorScheme(.dark) }
     }
 
     private func refreshLocalModels() { localModels = ModelFiles.installed().filter { $0.kind == .language } }

--- a/apple/App/MeetingCapture/DeskAgents.swift
+++ b/apple/App/MeetingCapture/DeskAgents.swift
@@ -21,6 +21,24 @@ struct AgentRecord: Codable, Identifiable, Equatable {
     var manualContext: String       // always-on context the user pins
     var useZoneContext: Bool        // also feed the current zone's meetings
     var kb: String                  // an optional knowledge-base name ("" = none)
+    var profileId: String = ""      // Phase 24 — the RuntimeProfile this agent runs on ("" = active default)
+
+    // Tolerant decode: persisted agents predate `profileId` (and earlier fields), so absent keys
+    // default rather than fail — a missing field must never wipe a user's saved agents.
+    private enum CodingKeys: String, CodingKey { case id, name, avatar, role, systemPrompt, userTemplate, manualContext, useZoneContext, kb, profileId }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        avatar = try c.decode(String.self, forKey: .avatar)
+        role = try c.decode(String.self, forKey: .role)
+        systemPrompt = try c.decode(String.self, forKey: .systemPrompt)
+        userTemplate = try c.decode(String.self, forKey: .userTemplate)
+        manualContext = try c.decodeIfPresent(String.self, forKey: .manualContext) ?? ""
+        useZoneContext = try c.decodeIfPresent(Bool.self, forKey: .useZoneContext) ?? false
+        kb = try c.decodeIfPresent(String.self, forKey: .kb) ?? ""
+        profileId = try c.decodeIfPresent(String.self, forKey: .profileId) ?? ""
+    }
 
     static func blank() -> AgentRecord {
         AgentRecord(id: UUID().uuidString, name: "", avatar: AgentAvatars.all.first!.id, role: "",
@@ -34,19 +52,21 @@ struct AgentRecord: Codable, Identifiable, Equatable {
         Agent(id: id, name: name, avatar: avatar, role: role, systemPrompt: systemPrompt,
               userTemplate: userTemplate, tools: [], kbId: kb.isEmpty ? nil : kb,
               manualContext: manualContext, useZoneContext: useZoneContext,
+              profileId: profileId.isEmpty ? nil : profileId,
               createdAt: now, updatedAt: now)
     }
     init(contract a: Agent) {
         self.id = a.id; self.name = a.name; self.avatar = a.avatar; self.role = a.role
         self.systemPrompt = a.systemPrompt; self.userTemplate = a.userTemplate
         self.manualContext = a.manualContext; self.useZoneContext = a.useZoneContext
-        self.kb = a.kbId ?? ""
+        self.kb = a.kbId ?? ""; self.profileId = a.profileId ?? ""
     }
     init(id: String, name: String, avatar: String, role: String, systemPrompt: String,
-         userTemplate: String, manualContext: String, useZoneContext: Bool, kb: String) {
+         userTemplate: String, manualContext: String, useZoneContext: Bool, kb: String, profileId: String = "") {
         self.id = id; self.name = name; self.avatar = avatar; self.role = role
         self.systemPrompt = systemPrompt; self.userTemplate = userTemplate
         self.manualContext = manualContext; self.useZoneContext = useZoneContext; self.kb = kb
+        self.profileId = profileId
     }
     // sync-ready envelope (carried by ChangeSet.agents)
     func synced(at: Date = Date()) -> Synced<Agent> {
@@ -417,12 +437,29 @@ struct DioAgentBuilder: View {
             .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).strokeBorder(.white.opacity(0.1), lineWidth: 1)))
     }
 
-    // STEP 2 — make it yours: the hero, name + vibe, personality, a collapsed face picker, advanced.
+    // The model this agent runs on (per-agent override of the active default). Empty = the active
+    // profile. The gauge below reads THIS profile's window — Scout on Claude vs a local 3B differ.
+    private var runsOnSection: some View {
+        section("RUNS ON") {
+            RunsOnPicker(selectedId: $draft.profileId, allowsDefault: true, label: "Model")
+        }
+    }
+
+    /// The context window the gauge measures against: the agent's chosen profile's limit, or — when it
+    /// uses the active default — the accurate RAM-aware budget the host passed in.
+    private var effectiveLimit: Int {
+        let cfg = InferenceConfigStore.shared
+        let p = cfg.resolveProfile(agentProfileId: draft.profileId.isEmpty ? nil : draft.profileId)
+        return p.id == cfg.activeProfile.id ? contextLimit : p.contextLimit
+    }
+
+    // STEP 2 — make it yours: the hero, name + vibe, where it runs, grounding, personality, face.
     private var step2Identity: some View {
         VStack(alignment: .leading, spacing: 22) {
             heroRow
             section("NAME") { field("Name", text: $draft.name, placeholder: "e.g. Scout") }
             section("VIBE · ONE LINE") { field("Vibe", text: $draft.role, placeholder: "e.g. digs for the facts") }
+            runsOnSection
             knowsSection
             personality
             faceCollapsible
@@ -435,7 +472,7 @@ struct DioAgentBuilder: View {
     private var knowsSection: some View {
         section("GROUNDING CONTEXT") {
             Text("Stuff your agent always knows.").font(.system(size: 12, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted)
-            ContextGauge(used: groundingTokens, limit: contextLimit)
+            ContextGauge(used: groundingTokens, limit: effectiveLimit)
                 .padding(11)
                 .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(.white.opacity(0.04)).overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(.white.opacity(0.07), lineWidth: 1)))
             Text("KNOWLEDGE BASE").font(.system(size: 9.5, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.muted.opacity(0.8)).padding(.top, 2)

--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -4536,13 +4536,13 @@ struct DioStage: View {
     // the shared inference tail: theater → callLLM → printed card (keep/bin). Used by routes and agents.
     // `provenance` is the run lineage (input card + the agent/chain that produced it) for routed runs;
     // nil for direct lens routes (their `source` is the lineage).
-    private func runAssembled(lens: String, source: String, fullPrompt: String, provenance: RunProvenance? = nil) {
+    private func runAssembled(lens: String, source: String, fullPrompt: String, provenance: RunProvenance? = nil, profileId: String? = nil) {
         routeLensRun = lens
         let zpath = pathKey
         haptic(.heavy)
         withAnimation { routing = true }
         Task { @MainActor in
-            let result = await callLLM(fullPrompt)
+            let result = await callLLM(fullPrompt, profileId: profileId)
             withAnimation { routing = false }
             switch result {
             case .success(let raw):
@@ -4603,7 +4603,7 @@ struct DioStage: View {
         let template = a.userTemplate.isEmpty ? "{input}" : a.userTemplate
         blocks.append("[TASK]\n" + template.replacingOccurrences(of: "{input}", with: String(input.prefix(6000))))
         routeSourceId = nil
-        runAssembled(lens: a.name, source: inputTitle, fullPrompt: blocks.joined(separator: "\n\n"), provenance: provenance)
+        runAssembled(lens: a.name, source: inputTitle, fullPrompt: blocks.joined(separator: "\n\n"), provenance: provenance, profileId: a.profileId)
     }
 
     // one conversational turn — role + context + the running transcript + the new message.
@@ -4614,7 +4614,7 @@ struct DioStage: View {
             blocks.append("[CONVERSATION SO FAR]\n" + convo)
         }
         blocks.append("[USER]\n" + String(question.prefix(6000)) + "\n\nReply as \(a.name).")
-        switch await callLLM(blocks.joined(separator: "\n\n")) {
+        switch await callLLM(blocks.joined(separator: "\n\n"), profileId: a.profileId) {
         case .success(let raw):
             let c = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             return c.isEmpty ? "⚠️ The model returned nothing — try rephrasing." : c
@@ -4910,12 +4910,17 @@ struct DioStage: View {
         withAnimation { sentToast = "Saved to desk" }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) { withAnimation { sentToast = nil } }
     }
-    @MainActor private func callLLM(_ prompt: String) async -> Result<String, Error> {
+    // `profileId` (an agent's assignment) resolves which runtime executes this — override → agent →
+    // active. For an on-device profile, its `modelFile` chooses the GGUF; the key (endpoint) is joined
+    // from the Keychain inside makeProvider.
+    @MainActor private func callLLM(_ prompt: String, profileId: String? = nil) async -> Result<String, Error> {
         do {
             let cfg = InferenceConfigStore.shared
+            let profile = cfg.resolveProfile(agentProfileId: profileId)
             let langModels = ModelFiles.installed().filter { $0.kind == .language }
-            let chosen = langModels.first { $0.id == cfg.localModelId } ?? langModels.first
-            let provider = try cfg.makeProvider(localModelPath: chosen?.url.path, context: 8192)
+            let wantFile = profile.modelFile.isEmpty ? cfg.localModelId : profile.modelFile
+            let chosen = langModels.first { $0.id == wantFile } ?? langModels.first
+            let provider = try cfg.makeProvider(profile: profile, localModelPath: chosen?.url.path, context: 8192)
             let text = try await provider.complete(prompt: prompt)
             return .success(text)
         } catch { return .failure(error) }

--- a/apple/App/MeetingCapture/ProfilesView.swift
+++ b/apple/App/MeetingCapture/ProfilesView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+
+// Phase 24 (HSM-24-03) — advanced: manage runtime profiles. Add an on-device profile or any
+// OpenAI-compatible endpoint (OpenRouter, Claude, a LAN box) with its own key. The key is written to
+// the Keychain (ProfileKeyStore), never onto the profile shape. Reached from Settings.
+struct ProfilesView: View {
+    @ObservedObject private var cfg = InferenceConfigStore.shared
+    @Environment(\.dismiss) private var dismiss
+    @State private var editing: RuntimeProfile? = nil
+    @State private var showEditor = false
+
+    var body: some View {
+        ZStack {
+            Sig.bg.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Button { dismiss() } label: {
+                        HStack(spacing: 6) { Image(systemName: "chevron.left"); Text("Settings") }
+                            .font(.system(size: 15, weight: .bold)).foregroundStyle(Sig.muted).padding(.vertical, 8)
+                    }
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Profiles").font(.system(size: 32, weight: .heavy)).foregroundStyle(Sig.text)
+                        Text("Where your agents run. Set one as the default; pick per-agent in the builder.")
+                            .font(.system(size: 14)).foregroundStyle(Sig.faint)
+                    }
+                    ForEach(cfg.profiles) { p in row(p) }
+                    Button { editing = nil; showEditor = true; tactile() } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "plus.circle.fill").font(.system(size: 20, weight: .bold)).foregroundStyle(Sig.accent)
+                            Text("New profile").font(.system(size: 16, weight: .heavy)).foregroundStyle(Sig.text)
+                            Spacer()
+                        }
+                        .padding(16).frame(maxWidth: .infinity)
+                        .background(Sig.accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [7, 5])).foregroundStyle(Sig.accent.opacity(0.5)))
+                    }
+                }
+                .padding(20).frame(maxWidth: 760).frame(maxWidth: .infinity)
+            }
+        }
+        .toolbar(.hidden, for: .navigationBar)
+        .sheet(isPresented: $showEditor) {
+            NavigationStack { ProfileEditor(existing: editing) }.preferredColorScheme(.dark)
+        }
+    }
+
+    private func row(_ p: RuntimeProfile) -> some View {
+        let active = cfg.activeProfileId == p.id
+        return HStack(spacing: 13) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous).fill((p.isLocal ? Sig.local : Sig.accent).opacity(0.16))
+                Image(systemName: p.isLocal ? "iphone" : "cloud.fill").font(.system(size: 18, weight: .bold)).foregroundStyle(p.isLocal ? Sig.local : Sig.accent)
+            }.frame(width: 44, height: 44)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(p.name).font(.system(size: 15.5, weight: .bold)).foregroundStyle(Sig.text).lineLimit(1)
+                Text(p.isLocal ? "On-device · \(p.contextLimit / 1000)k ctx" : "\(p.egressHost ?? "endpoint") · \(p.contextLimit / 1000)k ctx")
+                    .font(.system(size: 12, weight: .semibold)).foregroundStyle(Sig.faint).lineLimit(1)
+            }
+            Spacer(minLength: 4)
+            if active {
+                Text("ACTIVE").font(.system(size: 9.5, weight: .black)).tracking(0.8).foregroundStyle(.black)
+                    .padding(.horizontal, 8).frame(height: 22).background(Sig.ok, in: Capsule())
+            } else {
+                Button { tactile(); cfg.activeProfileId = p.id } label: {
+                    Text("Set active").font(.system(size: 12, weight: .heavy)).foregroundStyle(Sig.accent)
+                        .padding(.horizontal, 11).frame(height: 30).background(Sig.s2, in: Capsule())
+                }
+            }
+        }
+        .padding(13)
+        .background(Sig.s1, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(active ? Sig.ok.opacity(0.4) : Sig.line, lineWidth: 1))
+        .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .onTapGesture { editing = p; showEditor = true; tactile() }
+        .contextMenu {
+            if cfg.profiles.count > 1 { Button(role: .destructive) { cfg.deleteProfile(p.id) } label: { Label("Delete", systemImage: "trash") } }
+        }
+    }
+}
+
+/// Add or edit one profile. The API key writes to the Keychain on save, never onto the shape.
+struct ProfileEditor: View {
+    let existing: RuntimeProfile?
+    @ObservedObject private var cfg = InferenceConfigStore.shared
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var isLocal = true
+    @State private var modelFile = ""
+    @State private var baseURL = ""
+    @State private var model = ""
+    @State private var apiKey = ""
+    @State private var contextLimit = 16_384
+    private let limits = [8_192, 16_384, 32_768, 131_072, 200_000]
+    private var localModels: [InstalledModel] { ModelFiles.installed().filter { $0.kind == .language } }
+
+    var body: some View {
+        ZStack {
+            Sig.bg.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(existing == nil ? "New profile" : "Edit profile").font(.system(size: 26, weight: .heavy)).foregroundStyle(Sig.text)
+                    field("NAME", text: $name, placeholder: "e.g. Claude, OpenRouter, Studio box")
+                    Picker("", selection: $isLocal) { Text("On-device").tag(true); Text("OpenAI-compatible").tag(false) }
+                        .pickerStyle(.segmented)
+                    if isLocal {
+                        label("MODEL")
+                        Menu {
+                            ForEach(localModels) { m in Button(m.name) { modelFile = m.id } }
+                        } label: { pickerChip(modelFile.isEmpty ? (localModels.first?.name ?? "No models — download one") : modelFile) }
+                    } else {
+                        field("BASE URL", text: $baseURL, placeholder: "https://openrouter.ai/api/v1")
+                        field("MODEL", text: $model, placeholder: "anthropic/claude-3.5-sonnet")
+                        label("API KEY · stored in this device's Keychain, never synced")
+                        SecureField("sk-…", text: $apiKey)
+                            .padding(13).background(Sig.s2, in: RoundedRectangle(cornerRadius: 12)).foregroundStyle(Sig.text)
+                            .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Color.white.opacity(0.08), lineWidth: 1))
+                        label("CONTEXT WINDOW")
+                        Menu {
+                            ForEach(limits, id: \.self) { l in Button("\(l / 1000)k tokens") { contextLimit = l } }
+                        } label: { pickerChip("\(contextLimit / 1000)k tokens") }
+                    }
+                    Button { save() } label: {
+                        Text("Save profile").font(.system(size: 16, weight: .heavy)).foregroundStyle(.black)
+                            .frame(maxWidth: .infinity).frame(height: 52).background(Sig.accent, in: Capsule())
+                            .opacity(canSave ? 1 : 0.4)
+                    }.disabled(!canSave)
+                }
+                .padding(20).frame(maxWidth: 640).frame(maxWidth: .infinity)
+            }
+        }
+        .toolbar { ToolbarItem(placement: .topBarLeading) { Button("Cancel") { dismiss() } } }
+        .navigationTitle(existing == nil ? "New" : "Edit").navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: load)
+    }
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty &&
+        (isLocal || URL(string: baseURL.trimmingCharacters(in: .whitespaces))?.host != nil)
+    }
+
+    private func load() {
+        guard let e = existing else { modelFile = localModels.first?.id ?? ""; return }
+        name = e.name; isLocal = e.isLocal; modelFile = e.modelFile; baseURL = e.baseURL
+        model = e.model; contextLimit = e.contextLimit
+        apiKey = ProfileKeyStore.get(e.id) ?? ""
+    }
+
+    private func save() {
+        let id = existing?.id ?? "profile.\(UUID().uuidString.prefix(8))"
+        let p = RuntimeProfile(id: id, name: name.trimmingCharacters(in: .whitespaces),
+                               kind: isLocal ? .onDevice : .openAICompatible,
+                               modelFile: isLocal ? modelFile : "",
+                               baseURL: isLocal ? "" : baseURL.trimmingCharacters(in: .whitespaces),
+                               model: isLocal ? "" : model.trimmingCharacters(in: .whitespaces),
+                               contextLimit: isLocal ? 16_384 : contextLimit,
+                               requiresKey: !isLocal && !apiKey.trimmingCharacters(in: .whitespaces).isEmpty,
+                               createdAt: existing?.createdAt ?? Date(), updatedAt: Date())
+        if !isLocal { ProfileKeyStore.set(apiKey, for: id) }   // key → Keychain, never on `p`
+        cfg.upsertProfile(p)
+        tactile(.medium); dismiss()
+    }
+
+    private func field(_ l: String, text: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            label(l)
+            HStack(spacing: 8) {
+                TextField(placeholder, text: text).font(.system(size: 15, weight: .semibold)).foregroundStyle(Sig.text)
+                    .textInputAutocapitalization(.never).autocorrectionDisabled()
+                VoiceFillMic(text: text, tint: Sig.local, size: 26)
+            }
+            .padding(13).background(Sig.s2, in: RoundedRectangle(cornerRadius: 12))
+            .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Color.white.opacity(0.08), lineWidth: 1))
+        }
+    }
+    private func label(_ s: String) -> some View {
+        Text(s).font(.system(size: 9.5, weight: .black, design: .rounded)).tracking(1).foregroundStyle(Sig.faint)
+    }
+    private func pickerChip(_ s: String) -> some View {
+        HStack { Text(s).font(.system(size: 15, weight: .semibold)).foregroundStyle(Sig.text).lineLimit(1); Spacer(); Image(systemName: "chevron.up.chevron.down").font(.system(size: 12, weight: .bold)).foregroundStyle(Sig.faint) }
+            .padding(13).background(Sig.s2, in: RoundedRectangle(cornerRadius: 12)).overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Color.white.opacity(0.08), lineWidth: 1))
+    }
+}

--- a/apple/App/MeetingCapture/SketchDiagram.swift
+++ b/apple/App/MeetingCapture/SketchDiagram.swift
@@ -588,6 +588,24 @@ struct SketchToDiagramView: View {
 
     private func persistProfiles() { if let data = try? JSONEncoder().encode(profiles) { d.set(data, forKey: K.profiles) } }
 
+    /// Add or replace a profile (advanced management). First profile becomes active.
+    func upsertProfile(_ p: RuntimeProfile) {
+        if let i = profiles.firstIndex(where: { $0.id == p.id }) { profiles[i] = p } else { profiles.append(p) }
+        if activeProfileId.isEmpty { activeProfileId = p.id }
+        else if activeProfileId == p.id { applyActive() }   // active edited → re-mirror to legacy
+    }
+
+    /// Delete a profile (and its Keychain key). Never leaves zero profiles — re-seeds a local default.
+    func deleteProfile(_ id: String) {
+        profiles.removeAll { $0.id == id }
+        ProfileKeyStore.delete(id)
+        if profiles.isEmpty {
+            profiles = [RuntimeProfile(id: RuntimeProfileMigration.localId, name: "This device",
+                                       kind: .onDevice, modelFile: localModelId, createdAt: Date(), updatedAt: Date())]
+        }
+        if !profiles.contains(where: { $0.id == activeProfileId }) { activeProfileId = profiles.first!.id }
+    }
+
     /// The resolved active profile (falls back to the first, then a synthesized on-device default).
     var activeProfile: RuntimeProfile {
         profiles.first { $0.id == activeProfileId } ?? profiles.first

--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -25,7 +25,9 @@ struct MeetingCaptureApp: App {
             ZStack(alignment: .top) {
                 // HS_DEMO_NOTEBOOK opens straight onto the notebook surface for a
                 // screenshot run (no mic/taps needed); the real entry is the meeting list.
-                if ProcessInfo.processInfo.environment["HS_DEMO_AGENT"] != nil {
+                if ProcessInfo.processInfo.environment["HS_DEMO_PROFILES"] != nil {
+                    NavigationStack { ProfilesView() }
+                } else if ProcessInfo.processInfo.environment["HS_DEMO_AGENT"] != nil {
                     DioAgentBuilder(draft: .blank(), knowledgeBases: ["Q3 Planning", "Customer calls"], onSave: { _ in }, onCancel: {}, isNew: true, contextLimit: 8192, zoneTokens: 1800)
                 } else if ProcessInfo.processInfo.environment["HS_DEMO_README"] != nil {
                     NavigationStack { ModelReadmeView(repo: "unsloth/gemma-3n-E4B-it-GGUF", fileName: "gemma-3n-E4B-it-Q4_K_M.gguf", name: "Gemma 3n E4B") }
@@ -76,6 +78,16 @@ struct MeetingCaptureApp: App {
                 ModelDownloadManager.shared.ensureSession()   // reattach any in-flight model download
                 #if targetEnvironment(simulator)
                 let env = ProcessInfo.processInfo.environment
+                // Seed a second (Claude) profile so the profiles list + the "Runs on" chips are
+                // meaningful in a screenshot run.
+                if env["HS_DEMO_PROFILES"] != nil || env["HS_DEMO_AGENT"] != nil {
+                    let cfg = InferenceConfigStore.shared
+                    if !cfg.profiles.contains(where: { $0.id == "demo.claude" }) {
+                        cfg.upsertProfile(RuntimeProfile(id: "demo.claude", name: "Claude", kind: .openAICompatible,
+                                                         baseURL: "https://api.anthropic.com/v1", model: "claude-3.5-sonnet",
+                                                         contextLimit: 200_000, requiresKey: true, createdAt: Date(), updatedAt: Date()))
+                    }
+                }
                 // LIVE SYNC in-code proof (no App-layer test target): run the desk store's
                 // 7-kind snapshot→push→pull→apply + tombstone + LWW round-trip and log it.
                 if env["HS_SYNC_SELFCHECK"] == "1" { DeskSyncStore.selfCheck() }

--- a/apple/Sources/Contracts/Primitives.swift
+++ b/apple/Sources/Contracts/Primitives.swift
@@ -126,13 +126,14 @@ public struct Agent: Codable, Equatable, Sendable, Identifiable {
     public var kbId: String?             // grounded in this KB when set
     public var manualContext: String     // always-on pinned context
     public var useZoneContext: Bool      // also feed the current zone's meetings (per-device hint)
+    public var profileId: String?        // Phase 24 — the RuntimeProfile this agent runs on (nil = active default)
     public var createdAt: Date
     public var updatedAt: Date
 
     public init(id: String, name: String, avatar: String, role: String,
                 systemPrompt: String, userTemplate: String, tools: [String] = [],
                 kbId: String? = nil, manualContext: String = "", useZoneContext: Bool = false,
-                createdAt: Date, updatedAt: Date) {
+                profileId: String? = nil, createdAt: Date, updatedAt: Date) {
         self.id = id
         self.name = name
         self.avatar = avatar
@@ -143,6 +144,7 @@ public struct Agent: Codable, Equatable, Sendable, Identifiable {
         self.kbId = kbId
         self.manualContext = manualContext
         self.useZoneContext = useZoneContext
+        self.profileId = profileId
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -88,7 +88,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 |-------|-----------|--------|
 | HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | **done** (contract + migration + tolerant `ChangeSet` decode + `ProfileKeyStore`; never-sync invariant tested; `swift test` 389/0) |
 | HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | **done** (profile-backed `InferenceConfigStore` + migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile` + the reusable `RunsOnPicker`; `swift test` 389/0) |
-| HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | planned |
+| HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | in-progress (CRUD screen + `Agent.profileId` + builder "Runs on" chip + gauge-per-profile + agent-run routing land; inline chips on dictation/generate/the Ask gesture remain) |
 | HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | planned |
 | HSM-24-05 | Web authors + uses profiles (the flagship surface) | planned |
 | HSM-24-06 | Cross-surface parity proof + the docs story | planned |
@@ -120,10 +120,17 @@ fields so every existing reader is unchanged; `makeProvider(profile:)` + `resolv
 agent → active) are in; and the **reusable `RunsOnPicker`** ships — shown in Settings as the always-
 exposed "Active profile" chip (the owner's "the default is always exposed + changeable" principle).
 
-Next: **24-03** (Apple advanced) — the profiles management screen (add/edit/delete, key→Keychain),
-per-agent `Agent.profileId`, the `RunsOnPicker` dropped at every model-touch point (dictation,
-generate, agent run/chat, the Ask gesture, the builder), and the gauge reading the assigned profile's
-`contextLimit`. That story also enables the live multi-profile switch walk 24-02 deferred.
+**24-03 in progress.** Landed: `Agent.profileId` (+ `AgentRecord.profileId`, tolerant decode so saved
+agents are never wiped); the **advanced Profiles screen** (`ProfilesView` — add/edit/delete on-device
++ OpenAI-compatible endpoints, **key→Keychain via `ProfileKeyStore`**, set-active), reached from
+Settings → "Manage profiles"; the builder's **"Runs on" chip** (per-agent profile) with the gauge now
+reading the *assigned* profile's `contextLimit`; and **agent-run routing** (`callLLM`/`runAssembled`/
+`agentReply` resolve the agent's profile → `makeProvider(profile:)`). Verified in the sim (2-profile
+list, the chip, the gauge).
+
+Remaining in 24-03: drop the inline `RunsOnPicker` at the OTHER model-touch points (dictation,
+meeting-generate, the desk "Ask"/route-to-AI-core gesture) so the principle is literally everywhere,
+plus the live multi-profile run walk on device. Then 24-04 (hub) / 24-05 (web) / 24-06 (proof).
 
 ## Carried context
 


### PR DESCRIPTION
Phase 24, story 3 — the **core** (in-progress; the inline-selector principle made real for agents).

- **`Agent.profileId`** (contract) + **`AgentRecord.profileId`** — both with **tolerant decoders** so a missing field never wipes saved agents.
- **`ProfilesView`** — the advanced manager: add/edit/delete on-device + OpenAI-compatible endpoints (OpenRouter/Claude/LAN), set-active; **the API key writes to the Keychain (`ProfileKeyStore`), never onto the shape**. Reached from Settings → "Manage profiles".
- **Agent builder "RUNS ON" chip** (per-agent profile), and the **context gauge now reads the assigned profile's window** (Scout on Claude 200k vs a local 3B 8k).
- **Agent runs honor the assignment** — `callLLM(profileId:)` / `runAssembled` / `runAgent` / `agentReply` resolve override → agent → active and build the provider from that profile (key joined from the Keychain at call time).

**Verified (sim):** 2-profile CRUD list (active / set-active), the "Runs on" chip, the gauge.

**In-progress (remaining before 24-03 done):** drop the inline `RunsOnPicker` on the other model-touch points (dictation, meeting-generate, the desk "Ask" gesture) so it's literally everywhere, + the live device walk.

**Validation:** `swift test` 389/0 (no regression); app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)