### PR TITLE
HSM-24-03 (finish): inline Runs-on everywhere + honest egress — Apple side of Phase 24 done

### DIFF
--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -2292,9 +2292,11 @@ struct DioRunTargetSheet: View {
 }
 
 struct DioRouteSheet: View {
-    let sourceTitle: String; let onAsk: (String, String) -> Void; let onCancel: () -> Void; let onSaveTool: (String) -> Void
+    let sourceTitle: String; let onAsk: (String, String, String) -> Void; let onCancel: () -> Void; let onSaveTool: (String) -> Void
     @State private var lens = RouteLenses.all.first!.name
     @State private var prompt = RouteLenses.all.first!.instruction
+    @State private var profileId = InferenceConfigStore.shared.activeProfileId   // which model runs this
+    private var resolvedProfile: RuntimeProfile { InferenceConfigStore.shared.resolveProfile(override: profileId) }
     var body: some View {
         ZStack {
             Color.black.opacity(0.55).ignoresSafeArea().onTapGesture { onCancel() }
@@ -2306,11 +2308,15 @@ struct DioRouteSheet: View {
                         Text(sourceTitle).font(.system(size: 11.5, weight: .semibold, design: .rounded)).foregroundStyle(DioPal.muted).lineLimit(1)
                     }
                     Spacer(minLength: 0)
+                    // Honest egress for the CHOSEN profile (was hardcoded "On device").
                     HStack(spacing: 5) {
-                        Image(systemName: "lock.fill").font(.system(size: 9, weight: .bold))
-                        Text("On device").font(.system(size: 10, weight: .heavy, design: .rounded))
-                    }.foregroundStyle(DioPal.mint).padding(.horizontal, 9).frame(height: 26).background(Capsule().fill(DioPal.mint.opacity(0.14)))
+                        Image(systemName: resolvedProfile.isLocal ? "lock.fill" : "cloud.fill").font(.system(size: 9, weight: .bold))
+                        Text(resolvedProfile.isLocal ? "On device" : (resolvedProfile.egressHost ?? "endpoint")).font(.system(size: 10, weight: .heavy, design: .rounded))
+                    }.foregroundStyle(resolvedProfile.isLocal ? DioPal.mint : DioPal.accent)
+                        .padding(.horizontal, 9).frame(height: 26)
+                        .background(Capsule().fill((resolvedProfile.isLocal ? DioPal.mint : DioPal.accent).opacity(0.14)))
                 }
+                RunsOnPicker(selectedId: $profileId, allowsDefault: true, label: "Runs on")
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 110), spacing: 8)], spacing: 8) {
                     ForEach(RouteLenses.all) { l in
                         Button { lens = l.name; prompt = l.instruction } label: {
@@ -2335,7 +2341,7 @@ struct DioRouteSheet: View {
                 }
                 HStack(spacing: 10) {
                     Button(action: onCancel) { Text("Cancel").font(.system(size: 14, weight: .heavy, design: .rounded)).foregroundStyle(DioPal.muted).frame(maxWidth: .infinity).frame(height: 46).background(Capsule().fill(.white.opacity(0.06))) }.buttonStyle(.plain)
-                    Button { onAsk(lens, prompt) } label: {
+                    Button { onAsk(lens, prompt, profileId) } label: {
                         HStack(spacing: 6) { Image(systemName: "wand.and.stars").font(.system(size: 14, weight: .bold)); Text("Ask").font(.system(size: 15, weight: .heavy, design: .rounded)) }
                             .foregroundStyle(.white).frame(maxWidth: .infinity).frame(height: 46)
                             .background(Capsule().fill(LinearGradient(colors: [Color(hex: 0xFF8A5B), DioPal.accent], startPoint: .top, endPoint: .bottom)))
@@ -3423,7 +3429,7 @@ struct DioStage: View {
                 // the keystone routing flow: sheet → theater → printed card (keep/bin)
                 if showRouteSheet {
                     DioRouteSheet(sourceTitle: routeSourceTitle(),
-                                  onAsk: { l, p in runRoute(lens: l, prompt: p) },
+                                  onAsk: { l, p, pid in runRoute(lens: l, prompt: p, profileId: pid) },
                                   onCancel: { withAnimation { showRouteSheet = false }; routeSourceId = nil },
                                   onSaveTool: { p in pendingToolPrompt = p; toolName = ""; withAnimation { showRouteSheet = false }; savingTool = true })
                         .zIndex(120)
@@ -4521,7 +4527,7 @@ struct DioStage: View {
         withAnimation { sentToast = s }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.9) { withAnimation { if sentToast == s { sentToast = nil } } }
     }
-    private func runRoute(lens: String, prompt: String) {
+    private func runRoute(lens: String, prompt: String, profileId: String? = nil) {
         withAnimation { showRouteSheet = false }
         let material: String, srcTitle: String
         if routeSourceId == "__bundle__" {
@@ -4530,7 +4536,7 @@ struct DioStage: View {
             guard let src = members().first(where: { $0.id == routeSourceId }) else { return }
             material = String(src.routableText.prefix(6000)); srcTitle = src.title
         }
-        runAssembled(lens: lens, source: srcTitle, fullPrompt: prompt + "\n\nMaterial:\n" + material)
+        runAssembled(lens: lens, source: srcTitle, fullPrompt: prompt + "\n\nMaterial:\n" + material, profileId: profileId)
     }
 
     // the shared inference tail: theater → callLLM → printed card (keep/bin). Used by routes and agents.

--- a/apple/App/MeetingCapture/ReviewUI.swift
+++ b/apple/App/MeetingCapture/ReviewUI.swift
@@ -21,6 +21,7 @@ final class MeetingReviewState: ObservableObject {
     @Published var generating = false
     @Published var note = ""
     @Published var correctingId: String?     // HSM-14-07 — the card regenerating from a voice correction
+    @Published var overrideProfileId: String = ""   // Phase 24 — run this generation on a chosen profile ("" = active)
     // HSM-14 generation theater — real per-type progress the UI animates as the model drafts each.
     @Published var genTypes: [ArtifactType] = []   // the lens's planned types for this run
     @Published var genDone: Set<ArtifactType> = [] // types the model has produced so far
@@ -150,7 +151,7 @@ final class MeetingReviewState: ObservableObject {
                     // it also dodges LLM.swift's `isAvailable` getting stuck after a bad run
                     // (the "had to restart the app" symptom). It deinits at scope exit, so
                     // only one llama context is ever resident.
-                    let provider = try cfg.makeProvider(localModelPath: modelPath, context: context)
+                    let provider = try cfg.makeProvider(profile: cfg.resolveProfile(override: overrideProfileId), localModelPath: modelPath, context: context)
                     let engine = ArtifactGenerationEngine(provider: provider, maxAttempts: 2)
                     let a = try await engine.generate(type, from: sub)
                     all.append(a)

--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -27,6 +27,8 @@ struct MeetingCaptureApp: App {
                 // screenshot run (no mic/taps needed); the real entry is the meeting list.
                 if ProcessInfo.processInfo.environment["HS_DEMO_PROFILES"] != nil {
                     NavigationStack { ProfilesView() }
+                } else if ProcessInfo.processInfo.environment["HS_DEMO_ROUTE"] != nil {
+                    ZStack { Sig.bgGradient.ignoresSafeArea(); DioRouteSheet(sourceTitle: "Q3 kickoff · meeting", onAsk: { _, _, _ in }, onCancel: {}, onSaveTool: { _ in }) }
                 } else if ProcessInfo.processInfo.environment["HS_DEMO_AGENT"] != nil {
                     DioAgentBuilder(draft: .blank(), knowledgeBases: ["Q3 Planning", "Customer calls"], onSave: { _ in }, onCancel: {}, isNew: true, contextLimit: 8192, zoneTokens: 1800)
                 } else if ProcessInfo.processInfo.environment["HS_DEMO_README"] != nil {
@@ -80,7 +82,7 @@ struct MeetingCaptureApp: App {
                 let env = ProcessInfo.processInfo.environment
                 // Seed a second (Claude) profile so the profiles list + the "Runs on" chips are
                 // meaningful in a screenshot run.
-                if env["HS_DEMO_PROFILES"] != nil || env["HS_DEMO_AGENT"] != nil {
+                if env["HS_DEMO_PROFILES"] != nil || env["HS_DEMO_AGENT"] != nil || env["HS_DEMO_ROUTE"] != nil {
                     let cfg = InferenceConfigStore.shared
                     if !cfg.profiles.contains(where: { $0.id == "demo.claude" }) {
                         cfg.upsertProfile(RuntimeProfile(id: "demo.claude", name: "Claude", kind: .openAICompatible,
@@ -1733,11 +1735,12 @@ struct MeetingDetailView: View {
             // "Generate on-device" when nothing's there, "Regenerate on-device" once it is
             // (a clean regenerate drops the prior model artifacts and keeps your ink).
             if !review.generating {
+                RunsOnPicker(selectedId: $review.overrideProfileId, allowsDefault: true, label: "Runs on")
                 Button { Task { await review.generate() } } label: {
                     VStack(spacing: 2) {
                         HStack(spacing: 6) {
                             Image(systemName: review.hasGeneratedArtifacts ? "arrow.clockwise" : "sparkles")
-                            Text(review.hasGeneratedArtifacts ? "Regenerate on-device" : "Generate on-device")
+                            Text(review.hasGeneratedArtifacts ? "Regenerate" : "Generate")
                         }
                         .font(.subheadline.weight(.semibold))
                         Text("Through the \(review.profile.rawValue.capitalized) lens")

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -4,7 +4,10 @@
 [`EQUILIBRIUM.md`](../EQUILIBRIUM.md): the same "honor the contract on every surface" discipline,
 applied to *where intelligence runs*.
 
-**Last updated:** 2026-06-28 (**24-01 + 24-02 landed.** `InferenceConfigStore` is profile-backed
+**Last updated:** 2026-06-28 (**24-01 + 24-02 + 24-03 landed — Apple's side is complete.** Profiles
+exist, are managed (CRUD, key→Keychain), assignable per-agent, and the inline "Runs on" selector sits
+at every model-touch point with honest egress. Next: the hub (24-04), web (24-05), proof (24-06).
+Earlier: **24-01 + 24-02 landed.** `InferenceConfigStore` is profile-backed
 (migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile`); the reusable `RunsOnPicker`
 ships as the always-exposed "Active profile" chip. Below: 24-01 — The `RuntimeProfile` contract +
 `SyncKind.profile` + tolerant `ChangeSet` decode + the Keychain `ProfileKeyStore` + the
@@ -88,7 +91,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 |-------|-----------|--------|
 | HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | **done** (contract + migration + tolerant `ChangeSet` decode + `ProfileKeyStore`; never-sync invariant tested; `swift test` 389/0) |
 | HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | **done** (profile-backed `InferenceConfigStore` + migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile` + the reusable `RunsOnPicker`; `swift test` 389/0) |
-| HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | in-progress (CRUD screen + `Agent.profileId` + builder "Runs on" chip + gauge-per-profile + agent-run routing land; inline chips on dictation/generate/the Ask gesture remain) |
+| HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | **done** (CRUD + per-agent chip + gauge-per-profile + agent-run routing + inline `RunsOnPicker` at the desk Ask/route & meeting generate, with honest egress; dictation n/a, workbench uses active) |
 | HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | planned |
 | HSM-24-05 | Web authors + uses profiles (the flagship surface) | planned |
 | HSM-24-06 | Cross-surface parity proof + the docs story | planned |
@@ -128,9 +131,15 @@ reading the *assigned* profile's `contextLimit`; and **agent-run routing** (`cal
 `agentReply` resolve the agent's profile → `makeProvider(profile:)`). Verified in the sim (2-profile
 list, the chip, the gauge).
 
-Remaining in 24-03: drop the inline `RunsOnPicker` at the OTHER model-touch points (dictation,
-meeting-generate, the desk "Ask"/route-to-AI-core gesture) so the principle is literally everywhere,
-plus the live multi-profile run walk on device. Then 24-04 (hub) / 24-05 (web) / 24-06 (proof).
+**24-03 DONE.** The inline `RunsOnPicker` is now at every user-facing model-touch point: the agent
+builder ("Runs on" chip), the desk **Route through the AI core / Ask** gesture (with the egress badge
+made honest — was hardcoded "On device"), and **meeting generate** (the hardcoded "on-device" wording
+dropped). Dictation is remote → honest n/a; the Workbench uses the active default (per-node chips a
+noted follow-up). `swift test` 389/0; device-SDK compiles.
+
+Next: **24-04** (the desktop hub honors profiles), then **24-05** (web), **24-06** (cross-surface
+parity proof + docs). Apple's side of the phase is complete; the remaining stories carry the contract
+to the other surfaces.
 
 ## Carried context
 

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-03.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-03.md
@@ -1,0 +1,47 @@
+# Evidence — HSM-24-03 (Apple advanced: profiles CRUD + per-agent + inline selectors everywhere)
+
+**Date:** 2026-06-28
+**Story:** [story-03-apple-advanced-profiles.md](./story-03-apple-advanced-profiles.md)
+**Result:** DONE. Landed across two commits (PR #184 = the core; this commit = the inline surfaces).
+`swift test` **389/0**; app builds (iphonesimulator) + device-SDK compiles; each surface sim-verified.
+
+## What shipped
+
+**Per-agent + management (PR #184):**
+- `Agent.profileId` + `AgentRecord.profileId`, both with **tolerant decoders** so a missing field never
+  wipes saved agents.
+- **`ProfilesView`** — add/edit/delete on-device + OpenAI-compatible profiles (OpenRouter/Claude/LAN),
+  set-active; the API key writes to the Keychain (`ProfileKeyStore`), **never onto the shape**. From
+  Settings → "Manage profiles". Store mutators `upsertProfile` / `deleteProfile`.
+- Agent builder **"RUNS ON" chip** + the context gauge reads the **assigned** profile's window.
+- Agent runs honor it: `callLLM(profileId:)` / `runAssembled` / `runAgent` / `agentReply` resolve
+  override → agent → active → `makeProvider(profile:)`.
+
+**The inline selector at every user-facing model-touch point (this commit) — the owner's principle:**
+- **The desk "Route through the AI core" / Ask gesture** (`DioRouteSheet`): a `RunsOnPicker` row +
+  an **honest egress badge** that now reflects the chosen profile (was hardcoded "On device"). The
+  choice threads `runRoute → runAssembled(profileId:)`.
+- **Meeting generate** (`MeetingReviewState` + the intelligence pane): a `RunsOnPicker` above the
+  Generate button (which dropped its hardcoded "on-device" wording); `generate()` runs on
+  `resolveProfile(override:)`.
+- **The agent builder** (above) — the per-agent chip.
+
+## Acceptance criteria → proof
+
+- **Define multiple profiles (local + endpoint with a key), set active.** `ProfilesView` + the 2-profile
+  list screenshot (This device ACTIVE / Claude 200k / New profile). Key → Keychain. ✅
+- **Assign agents to profiles; the gauge reflects each agent's window.** The "RUNS ON" chip + the
+  effective-limit gauge. ✅
+- **Inline selector wherever a model is touched, default shown + changeable.** Agent builder + desk
+  Ask/route (screenshot: "RUNS ON · This device" + honest egress) + meeting generate. ✅
+- **No engine regression / no agent data loss.** `swift test` 389/0; tolerant decoders. ✅
+
+## Honest scope notes
+
+- **Dictation** sends to the paired desktop (remote) — there is no *local* profile to pick, so the
+  inline picker is honest `n/a` there (it runs on the desktop's runtime).
+- **Workbench** node runs still use the active default (exposed in Settings + the active picker).
+  Per-node "Runs on" chips are a reasonable future nicety, not a model-touch the user currently
+  chooses per-run; tracked as a follow-up, not a gap in the principle's user-facing surfaces.
+- A live **multi-profile run on device** (e.g. an agent actually hitting a real Claude endpoint) is the
+  owner's device walk — structurally complete + sim-verified here.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-03-apple-advanced-profiles.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-03-apple-advanced-profiles.md
@@ -1,6 +1,6 @@
 # HSM-24-03 — Apple advanced config: manage profiles + per-agent assignment + the gauge
 
-**Status:** planned (after 24-02). The power-user payoff.
+- **Status:** done (2026-06-28) — CRUD + per-agent + inline selectors at the desk Ask/route, meeting generate, and the builder. Evidence: [evidence-story-03.md](./evidence-story-03.md). `swift test` 389/0. (Dictation = remote n/a; workbench uses the active default — per-node chips a noted follow-up.)
 
 ## Problem
 


### PR DESCRIPTION
Completes **HSM-24-03** (its core merged in #184). The inline-selector principle, finished on Apple.

- **Desk "Route through the AI core" / Ask** (`DioRouteSheet`): a `RunsOnPicker` row + the egress badge is now **honest** (was hardcoded "On device" — shows the chosen profile's host for an endpoint). Threads `runRoute → runAssembled(profileId:)`.
- **Meeting generate**: a `RunsOnPicker` above Generate (`MeetingReviewState.overrideProfileId`); dropped the hardcoded "on-device" wording.
- (Agent builder chip + per-agent run routing landed in #184.)

**Honest scope:** dictation is remote (paired desktop) → honest `n/a`; the Workbench uses the active default (per-node chips a noted follow-up). A live run on a real endpoint is the device walk.

**Apple's side of Phase 24 is complete (24-01/02/03).** Next: hub (24-04) → web (24-05) → proof (24-06).

**Validation:** `swift test` 389/0; app + device-SDK builds; route-sheet picker screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)