### PR TITLE
HSM-24-04 (data layer): hub profiles table + agents.profile_id + sync (key never crosses)

### DIFF
--- a/holdspeak/db/core.py
+++ b/holdspeak/db/core.py
@@ -27,6 +27,7 @@ from .primitives import (
     DirectoryRepository,
     KBRepository,
     NoteRepository,
+    ProfileRepository,
     WorkflowRepository,
 )
 
@@ -37,7 +38,7 @@ log = get_logger("db")
 
 # Default database location
 DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "holdspeak" / "holdspeak.db"
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4   # v4 (Phase 24): runtime profiles table + agents.profile_id
 
 
 class SchemaVersionError(RuntimeError):
@@ -745,6 +746,7 @@ CREATE TABLE IF NOT EXISTS agents (
     user_template TEXT NOT NULL DEFAULT '',
     tools_json TEXT NOT NULL DEFAULT '[]',
     kb_id TEXT,
+    profile_id TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     last_modified TEXT NOT NULL DEFAULT (datetime('now')),
     deleted INTEGER NOT NULL DEFAULT 0
@@ -766,6 +768,23 @@ CREATE TABLE IF NOT EXISTS workflows (
     name TEXT NOT NULL DEFAULT '',
     prompt TEXT NOT NULL DEFAULT '',
     graph_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_modified TEXT NOT NULL DEFAULT (datetime('now')),
+    deleted INTEGER NOT NULL DEFAULT 0
+);
+
+-- Runtime profile (capability/synced, Phase 24): a named "where intelligence runs"
+-- target. SHAPE ONLY — the API key NEVER lives here and never syncs; the hub joins
+-- its own secret at request time (mirrors the connector credential rule).
+CREATE TABLE IF NOT EXISTS profiles (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL DEFAULT '',
+    kind TEXT NOT NULL DEFAULT 'onDevice',
+    model_file TEXT NOT NULL DEFAULT '',
+    base_url TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    context_limit INTEGER NOT NULL DEFAULT 16384,
+    requires_key INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     last_modified TEXT NOT NULL DEFAULT (datetime('now')),
     deleted INTEGER NOT NULL DEFAULT 0
@@ -907,6 +926,7 @@ class Database:
         self.notes = NoteRepository(self._connection, self)
         self.kbs = KBRepository(self._connection, self)
         self.agents = AgentRepository(self._connection, self)
+        self.profiles = ProfileRepository(self._connection, self)
         self.chains = ChainRepository(self._connection, self)
         self.workflows = WorkflowRepository(self._connection, self)
         self.directories = DirectoryRepository(self._connection, self)
@@ -988,6 +1008,12 @@ class Database:
         notes/kbs/agents/chains/workflows/directories/directory_memberships this way.
         """
         conn.executescript(SCHEMA_SQL)
+        # Re-applying SCHEMA_SQL adds missing TABLES idempotently but not new COLUMNS on existing
+        # tables. v4 (Phase 24) adds agents.profile_id — apply it here, guarded, so an upgraded
+        # (backed-up) v3 database gains the column. Fresh DBs already have it from SCHEMA_SQL.
+        agent_cols = {row[1] for row in conn.execute("PRAGMA table_info(agents)").fetchall()}
+        if "profile_id" not in agent_cols:
+            conn.execute("ALTER TABLE agents ADD COLUMN profile_id TEXT")
         conn.execute(
             """
             INSERT OR IGNORE INTO activity_privacy_settings

--- a/holdspeak/db/models.py
+++ b/holdspeak/db/models.py
@@ -493,6 +493,7 @@ class AgentRecord:
     user_template: str = ""
     tools: list[str] = field(default_factory=list)
     kb_id: Optional[str] = None
+    profile_id: Optional[str] = None   # Phase 24 — the RuntimeProfile this agent runs on
     created_at: str = ""
     last_modified: str = ""
     deleted: bool = False
@@ -507,6 +508,41 @@ class AgentRecord:
             "user_template": self.user_template,
             "tools": list(self.tools),
             "kb_id": self.kb_id,
+            "profile_id": self.profile_id,
+            "created_at": self.created_at,
+            "last_modified": self.last_modified,
+            "deleted": self.deleted,
+        }
+
+
+@dataclass
+class ProfileRecord:
+    """A RuntimeProfile — capability/synced primitive (Phase 24): a named "where
+    intelligence runs" target. SHAPE ONLY — the API key never lives here and never
+    syncs; the hub joins its own secret at request time."""
+
+    id: str
+    name: str = ""
+    kind: str = "onDevice"          # onDevice | openAICompatible
+    model_file: str = ""
+    base_url: str = ""
+    model: str = ""
+    context_limit: int = 16384
+    requires_key: bool = False
+    created_at: str = ""
+    last_modified: str = ""
+    deleted: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "kind": self.kind,
+            "model_file": self.model_file,
+            "base_url": self.base_url,
+            "model": self.model,
+            "context_limit": self.context_limit,
+            "requires_key": self.requires_key,
             "created_at": self.created_at,
             "last_modified": self.last_modified,
             "deleted": self.deleted,

--- a/holdspeak/db/primitives.py
+++ b/holdspeak/db/primitives.py
@@ -31,6 +31,7 @@ from .models import (
     DirectoryRecord,
     KBRecord,
     NoteRecord,
+    ProfileRecord,
     WorkflowRecord,
 )
 
@@ -267,6 +268,7 @@ class AgentRepository(BaseRepository):
         user_template: str = "",
         tools: Optional[list[str]] = None,
         kb_id: Optional[str] = None,
+        profile_id: Optional[str] = None,
         last_modified: Optional[str] = None,
         deleted: bool = False,
         created_at: Optional[str] = None,
@@ -283,8 +285,8 @@ class AgentRepository(BaseRepository):
             conn.execute(
                 """
                 INSERT INTO agents (id, name, avatar, role, system_prompt, user_template,
-                                    tools_json, kb_id, created_at, last_modified, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                    tools_json, kb_id, profile_id, created_at, last_modified, deleted)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
                     avatar = excluded.avatar,
@@ -293,6 +295,7 @@ class AgentRepository(BaseRepository):
                     user_template = excluded.user_template,
                     tools_json = excluded.tools_json,
                     kb_id = excluded.kb_id,
+                    profile_id = excluded.profile_id,
                     last_modified = excluded.last_modified,
                     deleted = excluded.deleted
                 """,
@@ -305,6 +308,7 @@ class AgentRepository(BaseRepository):
                     str(user_template or ""),
                     self._json_dumps(tools or [], fallback="[]"),
                     str(kb_id).strip() if kb_id else None,
+                    str(profile_id).strip() if profile_id else None,
                     created,
                     last_modified or now,
                     1 if deleted else 0,
@@ -364,6 +368,121 @@ class AgentRepository(BaseRepository):
             user_template=row["user_template"],
             tools=self._json_loads_list(row["tools_json"]),
             kb_id=row["kb_id"],
+            profile_id=row["profile_id"] if "profile_id" in row.keys() else None,
+            created_at=row["created_at"],
+            last_modified=row["last_modified"],
+            deleted=bool(row["deleted"]),
+        )
+
+
+class ProfileRepository(BaseRepository):
+    """CRUD + sync access for RuntimeProfiles (capability/synced, Phase 24).
+
+    SHAPE ONLY — the API key is never stored here; the hub joins its own secret at
+    request time. Mirrors the other primitive repos (soft-delete tombstones).
+    """
+
+    def upsert(
+        self,
+        *,
+        profile_id: str,
+        name: str = "",
+        kind: str = "onDevice",
+        model_file: str = "",
+        base_url: str = "",
+        model: str = "",
+        context_limit: int = 16384,
+        requires_key: bool = False,
+        last_modified: Optional[str] = None,
+        deleted: bool = False,
+        created_at: Optional[str] = None,
+    ) -> ProfileRecord:
+        clean_id = str(profile_id or "").strip()
+        if not clean_id:
+            raise ValueError("profile id is required")
+        now = _now_iso()
+        with self._connection() as conn:
+            existing = conn.execute(
+                "SELECT created_at FROM profiles WHERE id = ?", (clean_id,)
+            ).fetchone()
+            created = created_at or (existing["created_at"] if existing else now)
+            conn.execute(
+                """
+                INSERT INTO profiles (id, name, kind, model_file, base_url, model,
+                                      context_limit, requires_key, created_at, last_modified, deleted)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name = excluded.name,
+                    kind = excluded.kind,
+                    model_file = excluded.model_file,
+                    base_url = excluded.base_url,
+                    model = excluded.model,
+                    context_limit = excluded.context_limit,
+                    requires_key = excluded.requires_key,
+                    last_modified = excluded.last_modified,
+                    deleted = excluded.deleted
+                """,
+                (
+                    clean_id,
+                    str(name or ""),
+                    str(kind or "onDevice"),
+                    str(model_file or ""),
+                    str(base_url or ""),
+                    str(model or ""),
+                    int(context_limit or 16384),
+                    1 if requires_key else 0,
+                    created,
+                    last_modified or now,
+                    1 if deleted else 0,
+                ),
+            )
+        return self.get(clean_id, include_deleted=True)  # type: ignore[return-value]
+
+    def get(self, profile_id: str, *, include_deleted: bool = False) -> Optional[ProfileRecord]:
+        clean_id = str(profile_id or "").strip()
+        if not clean_id:
+            return None
+        with self._connection() as conn:
+            row = conn.execute("SELECT * FROM profiles WHERE id = ?", (clean_id,)).fetchone()
+        if not row:
+            return None
+        if row["deleted"] and not include_deleted:
+            return None
+        return self._row(row)
+
+    def list(self, *, include_deleted: bool = False, limit: int = 500) -> list[ProfileRecord]:
+        bounded = max(1, min(int(limit), 2000))
+        with self._connection() as conn:
+            sql = "SELECT * FROM profiles" + ("" if include_deleted else " WHERE deleted = 0")
+            rows = conn.execute(sql + " ORDER BY name ASC LIMIT ?", (bounded,)).fetchall()
+        return [self._row(r) for r in rows]
+
+    def delete(self, profile_id: str) -> bool:
+        clean_id = str(profile_id or "").strip()
+        if not clean_id:
+            return False
+        now = _now_iso()
+        with self._connection() as conn:
+            cur = conn.execute(
+                "UPDATE profiles SET deleted = 1, last_modified = ? WHERE id = ? AND deleted = 0", (now, clean_id)
+            )
+            return bool(cur.rowcount and cur.rowcount > 0)
+
+    def purge(self, profile_id: str) -> bool:
+        with self._connection() as conn:
+            cur = conn.execute("DELETE FROM profiles WHERE id = ?", (str(profile_id).strip(),))
+            return bool(cur.rowcount and cur.rowcount > 0)
+
+    def _row(self, row: Any) -> ProfileRecord:
+        return ProfileRecord(
+            id=row["id"],
+            name=row["name"],
+            kind=row["kind"],
+            model_file=row["model_file"],
+            base_url=row["base_url"],
+            model=row["model"],
+            context_limit=int(row["context_limit"]),
+            requires_key=bool(row["requires_key"]),
             created_at=row["created_at"],
             last_modified=row["last_modified"],
             deleted=bool(row["deleted"]),

--- a/holdspeak/web/routes/sync.py
+++ b/holdspeak/web/routes/sync.py
@@ -41,7 +41,7 @@ log = get_logger("web.routes.sync")
 # repository on the hub. Keep this in lockstep with the mobile/web SyncKind enum.
 SYNC_KINDS = frozenset(
     {"meeting", "artifact", "note", "kb", "agent", "chain", "workflow",
-     "directory", "directory_membership"}
+     "directory", "directory_membership", "profile"}
 )
 
 # Repository-backed primitives the push route merges into the live store (the key
@@ -55,7 +55,13 @@ _MERGEABLE: dict[str, tuple[str, str, dict[str, str]]] = {
     "agents": ("agents", "agent_id", {
         "name": "name", "avatar": "avatar", "role": "role",
         "system_prompt": "system_prompt", "user_template": "user_template",
-        "tools": "tools", "kb_id": "kb_id",
+        "tools": "tools", "kb_id": "kb_id", "profile_id": "profile_id",
+    }),
+    # Runtime profiles (Phase 24) — SHAPE ONLY; no api key field crosses the wire.
+    "profiles": ("profiles", "profile_id", {
+        "name": "name", "kind": "kind", "model_file": "model_file",
+        "base_url": "base_url", "model": "model",
+        "context_limit": "context_limit", "requires_key": "requires_key",
     }),
     "chains": ("chains", "chain_id", {"name": "name", "steps": "steps"}),
     "workflows": ("workflows", "workflow_id", {
@@ -76,6 +82,7 @@ _BUCKET_KIND = {
     "meetings": "meeting", "artifacts": "artifact", "notes": "note",
     "kbs": "kb", "agents": "agent", "chains": "chain", "workflows": "workflow",
     "directories": "directory", "directory_memberships": "directory_membership",
+    "profiles": "profile",
 }
 
 
@@ -370,6 +377,8 @@ def build_sync_router(ctx: WebContext) -> APIRouter:
                   for c in db.chains.list(include_deleted=True, limit=bounded)]
         workflows = [_primitive_record(w, "workflow")
                      for w in db.workflows.list(include_deleted=True, limit=bounded)]
+        profiles = [_primitive_record(p, "profile")
+                    for p in db.profiles.list(include_deleted=True, limit=bounded)]
         directories = [_primitive_record(d, "directory")
                        for d in db.directories.list(include_deleted=True, limit=bounded)]
         # Membership rides the wire too (organization, not layout). The record's
@@ -388,6 +397,7 @@ def build_sync_router(ctx: WebContext) -> APIRouter:
             "agents": agents,
             "chains": chains,
             "workflows": workflows,
+            "profiles": profiles,
             "directories": directories,
             "directory_memberships": directory_memberships,
         })

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -92,7 +92,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 | HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | **done** (contract + migration + tolerant `ChangeSet` decode + `ProfileKeyStore`; never-sync invariant tested; `swift test` 389/0) |
 | HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | **done** (profile-backed `InferenceConfigStore` + migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile` + the reusable `RunsOnPicker`; `swift test` 389/0) |
 | HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | **done** (CRUD + per-agent chip + gauge-per-profile + agent-run routing + inline `RunsOnPicker` at the desk Ask/route & meeting generate, with honest egress; dictation n/a, workbench uses active) |
-| HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | planned |
+| HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | in-progress (DB layer done: `profiles` table + `agents.profile_id` + guarded migration v3→v4 + snapshot regen + `ProfileRepository` + sync push/pull with the never-sync-key test; CRUD routes + agent-run resolution remain) |
 | HSM-24-05 | Web authors + uses profiles (the flagship surface) | planned |
 | HSM-24-06 | Cross-surface parity proof + the docs story | planned |
 

--- a/tests/fixtures/db_schema_canonical.txt
+++ b/tests/fixtures/db_schema_canonical.txt
@@ -222,6 +222,7 @@ table agents: CREATE TABLE agents (
     user_template TEXT NOT NULL DEFAULT '',
     tools_json TEXT NOT NULL DEFAULT '[]',
     kb_id TEXT,
+    profile_id TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     last_modified TEXT NOT NULL DEFAULT (datetime('now')),
     deleted INTEGER NOT NULL DEFAULT 0
@@ -507,6 +508,19 @@ table plugin_runs: CREATE TABLE plugin_runs (
     deduped INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+table profiles: CREATE TABLE profiles (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL DEFAULT '',
+    kind TEXT NOT NULL DEFAULT 'onDevice',
+    model_file TEXT NOT NULL DEFAULT '',
+    base_url TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    context_limit INTEGER NOT NULL DEFAULT 16384,
+    requires_key INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_modified TEXT NOT NULL DEFAULT (datetime('now')),
+    deleted INTEGER NOT NULL DEFAULT 0
 )
 table project_detection_log: CREATE TABLE project_detection_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/integration/test_primitive_framework_sync.py
+++ b/tests/integration/test_primitive_framework_sync.py
@@ -21,6 +21,7 @@ exact-key agreement IS the cross-surface contract.
 """
 from __future__ import annotations
 
+import json
 import shutil
 import tempfile
 from pathlib import Path
@@ -48,7 +49,7 @@ from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
 NOTE_KEYS = {"id", "title", "body_markdown", "tags",
              "created_at", "updated_at", "last_modified", "deleted"}
 AGENT_KEYS = {"id", "name", "avatar", "role", "system_prompt", "user_template",
-              "tools", "kb_id", "created_at", "last_modified", "deleted"}
+              "tools", "kb_id", "profile_id", "created_at", "last_modified", "deleted"}
 KB_KEYS = {"id", "name", "member_ids", "created_at", "last_modified", "deleted"}
 META_KEYS = {"id", "kind", "last_modified", "deleted"}
 
@@ -464,3 +465,48 @@ def test_pushed_artifact_lww_and_tombstone(env) -> None:
     })
     assert resp.json()["received"]["artifacts"] == 1
     assert client.get("/api/meetings/a_meet/artifacts").json()["artifacts"] == []
+
+
+def test_profile_syncs_shape_only_and_agent_carries_profile_id(env) -> None:
+    """Phase 24 (HSM-24-04): a RuntimeProfile pushed from the iPad round-trips through the hub
+    SHAPE ONLY — the API key NEVER persists or appears in a pull — and an agent's profile_id rides."""
+    db, client = env
+    lm = "2030-06-27T09:00:00Z"
+    changeset = {
+        "profiles": [{
+            "meta": {"id": "prof_claude", "kind": "profile", "last_modified": lm, "deleted": False},
+            "value": {
+                "id": "prof_claude", "name": "Claude", "kind": "openAICompatible",
+                "model_file": "", "base_url": "https://api.anthropic.com/v1",
+                "model": "claude-3.5-sonnet", "context_limit": 200000, "requires_key": True,
+                # A hostile/extra key field MUST NOT be persisted — the field map has no key.
+                "api_key": "sk-SHOULD-NEVER-PERSIST",
+                "created_at": "2030-06-27T08:00:00Z", "last_modified": lm, "deleted": False,
+            },
+        }],
+        "agents": [{
+            "meta": {"id": "ag_on_claude", "kind": "agent", "last_modified": lm, "deleted": False},
+            "value": {
+                "id": "ag_on_claude", "name": "Scout", "avatar": "a21", "role": "researcher",
+                "system_prompt": "Be precise.", "user_template": "{input}", "tools": [],
+                "kb_id": None, "profile_id": "prof_claude",
+                "created_at": "2030-06-27T08:00:00Z", "last_modified": lm, "deleted": False,
+            },
+        }],
+    }
+    push = client.post("/api/sync/push", json=changeset)
+    assert push.status_code == 200, push.text
+    assert push.json()["received"]["profiles"] == 1 and push.json()["received"]["agents"] == 1
+
+    # The profile is stored as shape; the agent carries its profile_id.
+    stored = db.profiles.get("prof_claude")
+    assert stored is not None and stored.kind == "openAICompatible" and stored.context_limit == 200000
+    assert db.agents.get("ag_on_claude").profile_id == "prof_claude"
+
+    # THE NEVER-SYNC INVARIANT: no key material persisted, and none appears in a pull.
+    pulled = client.get("/api/sync/pull").json()
+    prof_rec = _bucket_by_id(pulled["profiles"], "prof_claude")
+    assert prof_rec is not None
+    blob = json.dumps(pulled)
+    assert "api_key" not in blob and "SHOULD-NEVER-PERSIST" not in blob
+    assert "api_key" not in prof_rec["value"] and "apiKey" not in prof_rec["value"]

--- a/tests/unit/test_web_routes_sync.py
+++ b/tests/unit/test_web_routes_sync.py
@@ -84,6 +84,7 @@ def _fake_db(tmp_path, *, meetings=(), artifacts=None):
         notes=_empty_primitive_repo(),
         kbs=_empty_primitive_repo(),
         agents=_empty_primitive_repo(),
+        profiles=_empty_primitive_repo(),
         chains=_empty_primitive_repo(),
         workflows=_empty_primitive_repo(),
         directories=_empty_primitive_repo(),


### PR DESCRIPTION
Phase 24 → the hub. The desktop persistence center now carries runtime profiles. **Data layer slice** (CRUD routes + agent-run resolution land next).

- **Schema v3 → v4** (`db/core.py`): a `profiles` table (**shape only — no key column**) + `agents.profile_id`. Follows the backup-then-apply model; because re-applying `SCHEMA_SQL` adds tables but not columns, a **guarded `ALTER TABLE agents ADD COLUMN profile_id`** (PRAGMA-checked) lands the column on upgraded DBs. Canonical snapshot regenerated.
- **`ProfileRecord` + `ProfileRepository`** (+ agents carry `profile_id`).
- **Sync** (`web/routes/sync.py`): `SyncKind` `profile`, a profiles merge map + pull bucket, agents gain `profile_id` on the wire.

**The crux holds on the hub too: the profile is shape-only — there is no api-key field, so none can sync.** Tested: a hostile `api_key` in a pushed payload is neither persisted nor present in any pull.

**Validation:** full `uv run pytest` = **3035 passed** (the lone failure, `test_route_preflight /cadence`, is **pre-existing on clean main** — confirmed by stashing my diff — and unrelated; a Cadence-page gap in `PAGE_ROUTES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)