### PR TITLE
HSM-24-04 (finish): profiles CRUD + agent-run resolution (key from hub secrets) + /cadence fix

### DIFF
--- a/holdspeak/intel/providers.py
+++ b/holdspeak/intel/providers.py
@@ -222,6 +222,37 @@ def build_configured_meeting_intel() -> "MeetingIntel":
     return MeetingIntel(**kwargs)
 
 
+def profile_key_env(profile_id: str) -> str:
+    """The hub env var that holds a runtime profile's API key (Phase 24). The key lives in
+    the hub's SECRETS (env), never on the synced profile shape or in the payload."""
+    safe = "".join(ch if ch.isalnum() else "_" for ch in str(profile_id or "").upper())
+    return f"HOLDSPEAK_PROFILE_{safe}_KEY"
+
+
+def build_meeting_intel_for_profile(
+    *, kind: str, base_url: Optional[str], model: Optional[str], profile_id: str
+) -> "MeetingIntel":
+    """Build a `MeetingIntel` for a specific RuntimeProfile (Phase 24).
+
+    An ``openAICompatible`` profile runs on its endpoint, with the key resolved from the hub's
+    secrets — a per-profile env var (``HOLDSPEAK_PROFILE_<ID>_KEY``), falling back to the default
+    cloud key env. An ``onDevice`` (or unknown) profile falls back to the hub's configured default
+    (the hub can't host another device's GGUF — honest n/a, never a crash).
+    """
+    from .engine import MeetingIntel
+
+    if kind == "openAICompatible" and str(base_url or "").strip():
+        env = profile_key_env(profile_id)
+        key_env = env if os.environ.get(env) else DEFAULT_INTEL_CLOUD_API_KEY_ENV
+        return MeetingIntel(
+            provider="cloud",
+            cloud_model=(model or DEFAULT_INTEL_CLOUD_MODEL),
+            cloud_base_url=str(base_url).strip(),
+            cloud_api_key_env=key_env,
+        )
+    return build_configured_meeting_intel()
+
+
 def intel_egress_posture(provider: str = DEFAULT_INTEL_PROVIDER) -> tuple[bool, str]:
     """Describe whether the configured provider can send transcripts off-machine.
 

--- a/holdspeak/web/routes/primitives.py
+++ b/holdspeak/web/routes/primitives.py
@@ -262,6 +262,7 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
             "user_template": str(pick("user_template", existing.user_template if existing else "")),
             "tools": list(pick("tools", existing.tools if existing else [])),
             "kb_id": (pick("kb_id", existing.kb_id if existing else None) or None),
+            "profile_id": (pick("profile_id", existing.profile_id if existing else None) or None),
         }
 
     @router.get("/api/agents")
@@ -359,10 +360,26 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
             max_tokens = body.get("max_tokens")
             temperature = body.get("temperature")
 
-            from ...intel.providers import build_configured_meeting_intel
+            from ...intel.providers import (
+                build_configured_meeting_intel,
+                build_meeting_intel_for_profile,
+            )
             from ...intel.models import MeetingIntelError
 
-            intel = build_configured_meeting_intel()
+            # Phase 24: run on the agent's assigned profile when set (its endpoint, key from the
+            # hub's secrets), else the hub's configured default.
+            ran_profile_id = (agent.profile_id or "").strip() or None
+            if ran_profile_id:
+                prof = get_database().profiles.get(ran_profile_id)
+                if prof is not None and not prof.deleted:
+                    intel = build_meeting_intel_for_profile(
+                        kind=prof.kind, base_url=prof.base_url, model=prof.model, profile_id=prof.id
+                    )
+                else:
+                    ran_profile_id = None
+                    intel = build_configured_meeting_intel()
+            else:
+                intel = build_configured_meeting_intel()
             try:
                 output = intel.run_prompt(
                     system_prompt=agent.system_prompt,
@@ -395,10 +412,91 @@ def build_primitives_router(ctx: WebContext) -> APIRouter:
                 "agent_id": agent_id,
                 "output": output,
                 "provider": intel.active_provider,
+                "profile_id": ran_profile_id,
                 "sources": sources,
             })
         except Exception as exc:
             return error_500(exc, log, "Failed to run agent")
+
+    # ── Runtime profiles (Phase 24) ───────────────────────────────────────
+    # SHAPE ONLY over the API. The api key never rides a profile body; it lives in
+    # the hub's secrets (env: HOLDSPEAK_PROFILE_<ID>_KEY) and is joined at run time.
+    def _profile_fields(body: dict[str, Any], existing=None) -> dict[str, Any]:
+        def pick(key: str, default: Any) -> Any:
+            return body[key] if key in body else default
+        return {
+            "name": str(pick("name", existing.name if existing else "")),
+            "kind": str(pick("kind", existing.kind if existing else "onDevice")),
+            "model_file": str(pick("model_file", existing.model_file if existing else "")),
+            "base_url": str(pick("base_url", existing.base_url if existing else "")),
+            "model": str(pick("model", existing.model if existing else "")),
+            "context_limit": int(pick("context_limit", existing.context_limit if existing else 16384)),
+            "requires_key": bool(pick("requires_key", existing.requires_key if existing else False)),
+        }
+
+    @router.get("/api/profiles")
+    async def api_list_profiles() -> Any:
+        try:
+            from ...db import get_database
+            return JSONResponse({"profiles": [p.to_dict() for p in get_database().profiles.list()]})
+        except Exception as exc:
+            return error_500(exc, log, "Failed to list profiles")
+
+    @router.post("/api/profiles")
+    async def api_create_profile(request: Request) -> Any:
+        body = await _json_body(request)
+        if body is None:
+            return JSONResponse({"error": "expected a JSON object"}, status_code=400)
+        if not str(body.get("name") or "").strip():
+            return JSONResponse({"error": "profile name is required"}, status_code=400)
+        try:
+            from ...db import get_database
+            profile = get_database().profiles.upsert(
+                profile_id=str(body.get("id") or _new_id("profile")),
+                **_profile_fields(body),
+            )
+            return JSONResponse({"profile": profile.to_dict()}, status_code=201)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except Exception as exc:
+            return error_500(exc, log, "Failed to create profile")
+
+    @router.get("/api/profiles/{profile_id}")
+    async def api_get_profile(profile_id: str) -> Any:
+        try:
+            from ...db import get_database
+            profile = get_database().profiles.get(profile_id)
+            if profile is None:
+                return JSONResponse({"error": f"Unknown profile: {profile_id}"}, status_code=404)
+            return JSONResponse({"profile": profile.to_dict()})
+        except Exception as exc:
+            return error_500(exc, log, "Failed to get profile")
+
+    @router.put("/api/profiles/{profile_id}")
+    async def api_update_profile(profile_id: str, request: Request) -> Any:
+        body = await _json_body(request)
+        if body is None:
+            return JSONResponse({"error": "expected a JSON object"}, status_code=400)
+        try:
+            from ...db import get_database
+            db = get_database()
+            existing = db.profiles.get(profile_id)
+            if existing is None:
+                return JSONResponse({"error": f"Unknown profile: {profile_id}"}, status_code=404)
+            profile = db.profiles.upsert(profile_id=profile_id, **_profile_fields(body, existing))
+            return JSONResponse({"profile": profile.to_dict()})
+        except Exception as exc:
+            return error_500(exc, log, "Failed to update profile")
+
+    @router.delete("/api/profiles/{profile_id}")
+    async def api_delete_profile(profile_id: str) -> Any:
+        try:
+            from ...db import get_database
+            if not get_database().profiles.delete(profile_id):
+                return JSONResponse({"error": f"Unknown profile: {profile_id}"}, status_code=404)
+            return JSONResponse({"success": True})
+        except Exception as exc:
+            return error_500(exc, log, "Failed to delete profile")
 
     # ── KBs (knowledge bases) ─────────────────────────────────────────────
     @router.get("/api/kbs")

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -4,7 +4,9 @@
 [`EQUILIBRIUM.md`](../EQUILIBRIUM.md): the same "honor the contract on every surface" discipline,
 applied to *where intelligence runs*.
 
-**Last updated:** 2026-06-28 (**24-01 + 24-02 + 24-03 landed — Apple's side is complete.** Profiles
+**Last updated:** 2026-06-28 (**24-01..04 landed — Apple side + the desktop hub are done.** The hub
+persists/syncs/manages/RUNS on profiles, key from its secrets; full `uv run pytest` 3039 passed.
+Remaining: web (24-05) + the cross-surface proof (24-06). Earlier: **24-01 + 24-02 + 24-03 — Apple's side complete.** Profiles
 exist, are managed (CRUD, key→Keychain), assignable per-agent, and the inline "Runs on" selector sits
 at every model-touch point with honest egress. Next: the hub (24-04), web (24-05), proof (24-06).
 Earlier: **24-01 + 24-02 landed.** `InferenceConfigStore` is profile-backed
@@ -92,7 +94,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 | HSM-24-01 | The `RuntimeProfile` contract + `SyncKind.profile` + the Keychain key store (key never syncs) — **leads, load-bearing** | **done** (contract + migration + tolerant `ChangeSet` decode + `ProfileKeyStore`; never-sync invariant tested; `swift test` 389/0) |
 | HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | **done** (profile-backed `InferenceConfigStore` + migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile` + the reusable `RunsOnPicker`; `swift test` 389/0) |
 | HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | **done** (CRUD + per-agent chip + gauge-per-profile + agent-run routing + inline `RunsOnPicker` at the desk Ask/route & meeting generate, with honest egress; dictation n/a, workbench uses active) |
-| HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | in-progress (DB layer done: `profiles` table + `agents.profile_id` + guarded migration v3→v4 + snapshot regen + `ProfileRepository` + sync push/pull with the never-sync-key test; CRUD routes + agent-run resolution remain) |
+| HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | **done** (schema v3→v4 + `ProfileRepository` + sync + profiles CRUD routes + agent-run resolution with the key from the hub's secrets; never-sync-key tested; full `uv run pytest` 3039 passed) |
 | HSM-24-05 | Web authors + uses profiles (the flagship surface) | planned |
 | HSM-24-06 | Cross-surface parity proof + the docs story | planned |
 
@@ -137,9 +139,13 @@ made honest — was hardcoded "On device"), and **meeting generate** (the hardco
 dropped). Dictation is remote → honest n/a; the Workbench uses the active default (per-node chips a
 noted follow-up). `swift test` 389/0; device-SDK compiles.
 
-Next: **24-04** (the desktop hub honors profiles), then **24-05** (web), **24-06** (cross-surface
-parity proof + docs). Apple's side of the phase is complete; the remaining stories carry the contract
-to the other surfaces.
+**24-04 DONE** — the desktop hub now persists (schema v4), syncs, manages (profiles CRUD), and RUNS
+on profiles (`/api/agents/{id}/run` resolves the agent's profile → its endpoint with the key from the
+hub's secrets, never the payload; never-sync-key proven). Full `uv run pytest` 3039 passed. Also fixed
+the pre-existing `/cadence` route-preflight gap.
+
+Next: **24-05** (web authors/uses profiles) → **24-06** (cross-surface parity proof + docs). Apple +
+the hub are done; the web port + the proof remain.
 
 ## Carried context
 

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-04.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-04.md
@@ -1,0 +1,49 @@
+# Evidence — HSM-24-04 (the desktop hub honors profiles)
+
+**Date:** 2026-06-28
+**Story:** [story-04-desktop-hub-honors-profiles.md](./story-04-desktop-hub-honors-profiles.md)
+**Result:** DONE. The hub persists, syncs, manages, and RUNS on runtime profiles — with the API key
+in the hub's secrets, never the payload. Full `uv run pytest` **3039 passed, 0 failed**.
+
+## What shipped
+
+**Data layer (PR #187):**
+- Schema **v3 → v4** (`db/core.py`): `profiles` table (SHAPE only — no key column) + `agents.profile_id`;
+  backup-then-apply migration + a guarded `ALTER TABLE agents ADD COLUMN profile_id` (re-applying
+  SCHEMA_SQL adds tables, not columns); canonical snapshot regenerated.
+- `ProfileRecord` + `ProfileRepository` (`db/models.py`, `db/primitives.py`); agents carry `profile_id`.
+- Sync (`web/routes/sync.py`): `SyncKind` `profile`, a merge map + pull bucket, agent `profile_id` on
+  the wire.
+
+**CRUD + run (this commit):**
+- Agents CRUD (`_agent_fields`) carry `profile_id`; **profiles CRUD routes** `GET/POST/PUT/DELETE
+  /api/profiles` (shape only).
+- **Agent-run resolution** (`/api/agents/{id}/run`): resolves the agent's `profile_id` →
+  `build_meeting_intel_for_profile` — an `openAICompatible` profile runs on its endpoint with the key
+  from the **hub's secrets** (`HOLDSPEAK_PROFILE_<ID>_KEY`, falling back to the default cloud key env),
+  never the payload; an `onDevice`/absent profile falls back to the hub default (honest n/a). The run
+  reports the resolved `profile_id`.
+
+## Acceptance criteria → proof
+
+- **A synced profile round-trips without a key; agent runs resolve to the right backend; absent →
+  default; never-sync holds on the hub serializer.** `test_primitive_framework_sync` (profiles
+  round-trip + the hostile-`api_key`-never-persisted/pulled assertion);
+  `test_web_routes_primitives` (`test_profile_crud_roundtrip`,
+  `test_run_agent_resolves_assigned_profile` — asserts the per-profile builder is used and the default
+  is NOT, `test_run_agent_falls_back_when_profile_missing`). ✅
+- **Key from the hub's secrets, never the payload.** `build_meeting_intel_for_profile` resolves the key
+  from an env var by profile id; the profile shape (DB + wire + API) has no key field. ✅
+- **No blast radius.** Full suite 3039 passed (the schema/run changes ripple through the whole DB +
+  intel paths cleanly). ✅
+
+## Also fixed (owner-requested)
+
+`tests/e2e/test_route_preflight.py` was failing on clean `main` (the Cadence page `/cadence` was
+served but missing from `PAGE_ROUTES`, so it was never swept). Added `/cadence` to `PAGE_ROUTES`; the
+preflight now renders it too — green.
+
+## Honest note
+
+A live run against a real cloud endpoint (a real key in `HOLDSPEAK_PROFILE_<ID>_KEY`) is the hub
+operator's walk; the resolution + custody are proven by the route tests with a fake intel.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-04-desktop-hub-honors-profiles.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-04-desktop-hub-honors-profiles.md
@@ -1,6 +1,6 @@
 # HSM-24-04 — The desktop hub honors profiles
 
-**Status:** planned (after 24-01; parallel with the Apple stories).
+- **Status:** done (2026-06-28) — schema v3→v4 + ProfileRepository + sync + profiles CRUD + agent-run resolution (key from the hub's secrets). Evidence: [evidence-story-04.md](./evidence-story-04.md). Full `uv run pytest` 3039 passed.
 
 ## Problem
 

--- a/tests/e2e/test_route_preflight.py
+++ b/tests/e2e/test_route_preflight.py
@@ -44,6 +44,7 @@ PAGE_ROUTES = [
     "/commands",
     "/companion",
     "/presence",
+    "/cadence",
     "/docs/dictation-runtime",
 ]
 

--- a/tests/unit/test_web_routes_primitives.py
+++ b/tests/unit/test_web_routes_primitives.py
@@ -111,6 +111,7 @@ def test_run_agent_invokes_engine(client: TestClient, monkeypatch) -> None:
         "agent_id": aid,
         "output": "ANSWER",
         "provider": "local",
+        "profile_id": None,
         "sources": [{"source_type": "agent", "source_ref": aid}],
     }
     # The persona's system prompt + rendered template reached the engine.
@@ -664,3 +665,77 @@ def test_directory_reads_include_member_ids(client: TestClient) -> None:
     client.delete(f"/api/directories/{did}/members/note_1")
     assert client.get(f"/api/directories/{did}").json()["member_ids"] == ["agent_2"]
     assert client.get("/api/directories").json()["directories"][0]["member_ids"] == ["agent_2"]
+
+
+def test_profile_crud_roundtrip(client: TestClient) -> None:
+    """Phase 24 — profiles CRUD over the API (shape only; no key field)."""
+    created = client.post("/api/profiles", json={
+        "name": "Claude", "kind": "openAICompatible",
+        "base_url": "https://api.anthropic.com/v1", "model": "claude-3.5-sonnet",
+        "context_limit": 200000, "requires_key": True,
+    })
+    assert created.status_code == 201, created.text
+    pid = created.json()["profile"]["id"]
+    assert "api_key" not in created.json()["profile"] and "apiKey" not in created.json()["profile"]
+
+    assert client.get("/api/profiles").json()["profiles"][0]["id"] == pid
+    got = client.get(f"/api/profiles/{pid}").json()["profile"]
+    assert got["kind"] == "openAICompatible" and got["context_limit"] == 200000
+
+    upd = client.put(f"/api/profiles/{pid}", json={"name": "Claude 3.7", "context_limit": 128000})
+    assert upd.status_code == 200 and upd.json()["profile"]["name"] == "Claude 3.7"
+    assert upd.json()["profile"]["context_limit"] == 128000
+
+    assert client.delete(f"/api/profiles/{pid}").status_code == 200
+    assert client.get(f"/api/profiles/{pid}").status_code == 404
+
+
+def test_run_agent_resolves_assigned_profile(client: TestClient, monkeypatch) -> None:
+    """An agent assigned a profile runs on THAT profile (the per-profile builder is used),
+    and the run reports the resolved profile_id."""
+    pid = client.post("/api/profiles", json={
+        "name": "OpenRouter", "kind": "openAICompatible",
+        "base_url": "https://openrouter.ai/api/v1", "model": "x", "requires_key": True,
+    }).json()["profile"]["id"]
+    aid = client.post("/api/agents", json={
+        "name": "Scout", "system_prompt": "S", "user_template": "{input}", "profile_id": pid,
+    }).json()["agent"]["id"]
+    assert client.get(f"/api/agents/{aid}").json()["agent"]["profile_id"] == pid
+
+    seen = {}
+
+    class _FakeIntel:
+        active_provider = "cloud"
+        def run_prompt(self, **kwargs):
+            return "OUT"
+
+    def _for_profile(*, kind, base_url, model, profile_id):
+        seen.update(kind=kind, base_url=base_url, profile_id=profile_id)
+        return _FakeIntel()
+
+    monkeypatch.setattr("holdspeak.intel.providers.build_meeting_intel_for_profile", _for_profile)
+    monkeypatch.setattr(
+        "holdspeak.intel.providers.build_configured_meeting_intel",
+        lambda: (_ for _ in ()).throw(AssertionError("default builder must NOT be used when a profile is assigned")),
+    )
+    resp = client.post(f"/api/agents/{aid}/run", json={"input": "hi"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["profile_id"] == pid
+    assert seen == {"kind": "openAICompatible", "base_url": "https://openrouter.ai/api/v1", "profile_id": pid}
+
+
+def test_run_agent_falls_back_when_profile_missing(client: TestClient, monkeypatch) -> None:
+    """A dangling profile_id (e.g. deleted) falls back to the hub default, reporting profile_id=None."""
+    aid = client.post("/api/agents", json={
+        "name": "Ghost", "system_prompt": "S", "user_template": "{input}", "profile_id": "gone",
+    }).json()["agent"]["id"]
+
+    class _FakeIntel:
+        active_provider = "local"
+        def run_prompt(self, **kwargs):
+            return "OUT"
+
+    monkeypatch.setattr("holdspeak.intel.providers.build_configured_meeting_intel", lambda: _FakeIntel())
+    resp = client.post(f"/api/agents/{aid}/run", json={"input": "hi"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["profile_id"] is None


### PR DESCRIPTION
Completes **HSM-24-04** (data layer merged in #187). The desktop hub now fully honors profiles.

- **Profiles CRUD** `GET/POST/PUT/DELETE /api/profiles` (shape only); agents CRUD carry `profile_id`.
- **Agent-run resolution** — `/api/agents/{id}/run` resolves the agent's `profile_id` → `build_meeting_intel_for_profile`: an `openAICompatible` profile runs on its endpoint with the **key from the hub's secrets** (`HOLDSPEAK_PROFILE_<ID>_KEY`, fallback to the default cloud key env), **never the payload**; `onDevice`/absent → the hub default (honest n/a). The run reports the resolved `profile_id`.
- **Tests:** profiles CRUD round-trip; an assigned profile uses the per-profile builder (and the default is **not**); a dangling `profile_id` falls back. Full `uv run pytest` **3039 passed, 0 failed**.

**Also fixed (you asked):** the pre-existing `/cadence` route-preflight gap — added it to `PAGE_ROUTES`; the sweep now renders it too. No more hand-waving. 🙂

**Phase 24: Apple side + the desktop hub are done.** Next: web (24-05) → cross-surface proof (24-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)