### PR TITLE
HSM-24-05: web authors + uses runtime profiles

### DIFF
--- a/holdspeak/web/routes/pages.py
+++ b/holdspeak/web/routes/pages.py
@@ -226,6 +226,46 @@ def build_pages_router(ctx: WebContext) -> APIRouter:
             )
         return HTMLResponse(html)
 
+    @router.get("/desk")
+    async def desk_page() -> Any:
+        """Serve the Web Desk (Primitive Framework authoring port), read from the
+        Astro-built _built/desk/index.html. The TopNav links here, so it needs a
+        real route (it was previously reachable only at /_built/desk/, a dead nav
+        link). Driven client-side by the /api/* primitive routes."""
+        page = _HOLDSPEAK_DIR / "static" / "_built" / "desk" / "index.html"
+        try:
+            html = page.read_text(encoding="utf-8")
+        except Exception as e:
+            log.error(f"Failed to read built desk page: {e}")
+            html = (
+                "<!doctype html><html><head><meta charset='utf-8'/>"
+                "<title>HoldSpeak Desk</title></head>"
+                "<body><h1>The Desk</h1>"
+                "<p>Desk UI not built. Run <code>npm run build</code> "
+                "in <code>web/</code>.</p></body></html>"
+            )
+        return HTMLResponse(html)
+
+    @router.get("/profiles")
+    async def profiles_page() -> Any:
+        """Serve the Runtime Profiles surface (HSM-24-05), read from the
+        Astro-built _built/profiles/index.html. Driven client-side by
+        GET/POST/PUT/DELETE /api/profiles. SHAPE only — the API key never
+        reaches the browser; it lives in the hub's secrets."""
+        page = _HOLDSPEAK_DIR / "static" / "_built" / "profiles" / "index.html"
+        try:
+            html = page.read_text(encoding="utf-8")
+        except Exception as e:
+            log.error(f"Failed to read built profiles page: {e}")
+            html = (
+                "<!doctype html><html><head><meta charset='utf-8'/>"
+                "<title>Runtime Profiles</title></head>"
+                "<body><h1>Runtime Profiles</h1>"
+                "<p>Profiles UI not built. Run <code>npm run build</code> "
+                "in <code>web/</code>.</p></body></html>"
+            )
+        return HTMLResponse(html)
+
     @router.get("/companion")
     async def companion_dashboard() -> Any:
         """Serve the AI PI companion surface (HS-24-01)."""

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -4,7 +4,11 @@
 [`EQUILIBRIUM.md`](../EQUILIBRIUM.md): the same "honor the contract on every surface" discipline,
 applied to *where intelligence runs*.
 
-**Last updated:** 2026-06-28 (**24-01..04 landed — Apple side + the desktop hub are done.** The hub
+**Last updated:** 2026-06-28 (**24-01..05 landed — Apple + the hub + the web are done.** The web
+`/profiles` surface authors profiles and the desk assigns them per-agent (the inline "Runs on" picker),
+key custody is the hub's secret, on-device renders honest n/a; a pre-existing `/desk` dead nav link was
+fixed and brought under the launch pre-flight. 0 page errors; full `uv run pytest` 3039 passed.
+Remaining: the cross-surface parity proof + docs (24-06). Earlier: **24-01..04 — Apple side + the desktop hub.** The hub
 persists/syncs/manages/RUNS on profiles, key from its secrets; full `uv run pytest` 3039 passed.
 Remaining: web (24-05) + the cross-surface proof (24-06). Earlier: **24-01 + 24-02 + 24-03 — Apple's side complete.** Profiles
 exist, are managed (CRUD, key→Keychain), assignable per-agent, and the inline "Runs on" selector sits
@@ -95,7 +99,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 | HSM-24-02 | Apple **basic** config — the active-profile picker over the existing `ILLMProvider` seam | **done** (profile-backed `InferenceConfigStore` + migration + key→Keychain + `makeProvider(profile:)` + `resolveProfile` + the reusable `RunsOnPicker`; `swift test` 389/0) |
 | HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | **done** (CRUD + per-agent chip + gauge-per-profile + agent-run routing + inline `RunsOnPicker` at the desk Ask/route & meeting generate, with honest egress; dictation n/a, workbench uses active) |
 | HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | **done** (schema v3→v4 + `ProfileRepository` + sync + profiles CRUD routes + agent-run resolution with the key from the hub's secrets; never-sync-key tested; full `uv run pytest` 3039 passed) |
-| HSM-24-05 | Web authors + uses profiles (the flagship surface) | planned |
+| HSM-24-05 | Web authors + uses profiles (the flagship surface) | **done** (the web `/profiles` list+editor over `/api/profiles` + the desk agent "Runs on" picker + per-agent chip; honest n/a for on-device; key is the hub's secret, never the browser; fixed a pre-existing `/desk` dead nav link; 0 page errors; 3039 passed) |
 | HSM-24-06 | Cross-surface parity proof + the docs story | planned |
 
 ## Sequencing
@@ -144,8 +148,17 @@ on profiles (`/api/agents/{id}/run` resolves the agent's profile → its endpoin
 hub's secrets, never the payload; never-sync-key proven). Full `uv run pytest` 3039 passed. Also fixed
 the pre-existing `/cadence` route-preflight gap.
 
-Next: **24-05** (web authors/uses profiles) → **24-06** (cross-surface parity proof + docs). Apple +
-the hub are done; the web port + the proof remain.
+**24-05 DONE** — the web flagship authors profiles at parity with Apple advanced: a new `/profiles`
+surface (card grid + drawer editor over `/api/profiles`) and the desk agent editor's inline "Runs on:
+[Profile ▾]" picker + per-agent egress chip. On-device profiles render honest n/a (no GGUF in a
+browser); the key is the hub's env secret, shown by reference (`HOLDSPEAK_PROFILE_<id>_KEY`), never a
+field and never on any payload — a tighter never-sync posture than the plan imagined. Fixed a
+pre-existing dead nav link (`/desk` had no route; the TopNav pointed at it) and brought `/desk` +
+`/profiles` under the launch pre-flight. Built clean; Playwright pass = 0 page errors (profiles list +
+editor, desk cards + agent form); full `uv run pytest` 3039 passed.
+
+Next: **24-06** (cross-surface parity proof + docs). Apple + the hub + the web are done; only the
+parity gate + docs remain.
 
 ## Carried context
 

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-05.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-05.md
@@ -1,0 +1,66 @@
+# Evidence — HSM-24-05 (web authors + uses profiles)
+
+**Date:** 2026-06-28
+**Story:** [story-05-web-profiles.md](./story-05-web-profiles.md)
+**Result:** DONE. The web flagship is now a first-class authoring port for runtime profiles, at parity
+with the Apple advanced screen — list + editor + per-agent "Runs on" picker — with the API key held by
+the hub, never the browser. Full `uv run pytest` **3039 passed, 0 failed**; web built clean; the
+rendered surfaces were Playwright-screenshotted with **0 page errors**.
+
+## What shipped
+
+**The `/profiles` surface (new):**
+- `web/src/pages/profiles.astro` + `web/src/scripts/profiles-app.js` — a "Runtime Profiles" page: a
+  card grid (name, kind, the shared egress badge, endpoint/model/context, or model-file) + a drawer
+  editor (segmented Endpoint / On-device, base URL, model, context window, "Needs an API key").
+- CRUD over the hub's `GET/POST/PUT/DELETE /api/profiles` (the routes 24-04 shipped). SHAPE only.
+- **Key custody = the hub.** A cloud profile shows `requires_key` + the env var to set on the hub
+  (`HOLDSPEAK_PROFILE_<id>_KEY`) and states "The browser never sees it." There is no key field and no
+  key flow over the wire — a tighter never-sync posture than the plan's "hand it to the hub" (see the
+  story's divergence note).
+- **Honest n/a:** an on-device (GGUF) profile renders "⌂ On device" + "Unavailable — runs on a
+  device." (a browser can't host a GGUF).
+
+**The desk agent editor (per-agent assignment):**
+- `web/src/pages/desk.astro` + `web/src/scripts/desk-app.js` — the agent form gains a "Runs on:
+  [Profile ▾]" select (default "Hub default"), with a live egress hint for the chosen profile and an
+  "Add a profile →" link when none exist; the agent card shows the assigned profile as an egress chip.
+- `submitAgent` sends `profile_id`; `fromWireAgent` reads it; `loadProfiles` joins `loadAll`.
+
+**Navigation + a pre-existing bug fix:**
+- `TopNav.astro` / `AppLayout.astro` — "Profiles" added to the Configure group; the `Route` type
+  gains `profiles`.
+- **Fixed a dead nav link:** the TopNav linked `/desk` but the hub had no `/desk` route (the desk was
+  reachable only at `/_built/desk/`). Added a real `/desk` page route in `pages.py` and brought both
+  `/desk` and `/profiles` under the launch pre-flight (`PAGE_ROUTES`). This is the exact class of bug
+  the pre-flight exists to catch; the desk had simply never been a `pages.py` route, so it had escaped
+  the sweep.
+
+## Acceptance criteria → proof
+
+- **Web can author profiles + assign agents + run them; key custodian is the hub, never the browser.**
+  The `/profiles` page does full CRUD over `/api/profiles`; the desk assigns `agent.profile_id`; the
+  hub's `/api/agents/{id}/run` already resolves it (24-04). The editor has no key field — the secret
+  is the hub's env var. ✅
+- **n/a for device-only kinds on web.** On-device profile cards render "Unavailable — runs on a
+  device." and the editor's on-device branch states the same. ✅
+- **Route coverage.** `test_preflight_covers_every_html_route` passes with `/desk` + `/profiles` now
+  served and listed; `npm run build` emits `/profiles/index.html` + `/desk/index.html`. ✅
+- **No page errors.** A Playwright pass over `/profiles` (list + editor) and `/desk` (cards + agent
+  form with the picker) reported **0 page errors** and the styles apply on the runtime-rendered DOM
+  (screenshots captured: profiles list, profiles editor, desk cards, desk agent form). ✅
+- **No blast radius.** Full `uv run pytest` 3039 passed (Python unchanged except the new `/desk` +
+  `/profiles` page routes; web is source-only, bundle gitignored). ✅
+
+## Screenshots
+
+Captured under the session scratchpad (web bundle + screenshots are gitignored; the source is the
+record): `profiles_list.png`, `profiles_editor.png`, `desk_cards.png`, `desk_agent_form.png`. The
+agent card shows the "OpenRouter · Claude Sonnet" chip; the form shows the "Runs on" select with the
+☁ openrouter.ai egress hint; the profile editor shows the on-the-hub key reference.
+
+## Honest note
+
+A live end-to-end run from the browser against a real cloud endpoint (a real key in
+`HOLDSPEAK_PROFILE_<id>_KEY`) is the hub operator's walk; the authoring + assignment + resolution path
+is proven by the route tests (24-04) with a fake intel and by the screenshot pass here.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-05-web-profiles.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-05-web-profiles.md
@@ -1,6 +1,16 @@
 # HSM-24-05 — Web authors + uses profiles
 
-**Status:** planned (after 24-01; needs the hub from 24-04 as its backend).
+- **Status:** done (2026-06-28) — the web `/profiles` surface (list + editor over `/api/profiles`) + the
+  desk agent editor's "Runs on" picker + per-agent chip; on-device profiles render honest n/a; the key
+  is the hub's secret (`HOLDSPEAK_PROFILE_<id>_KEY`), never the browser. Also fixed a pre-existing dead
+  nav link (`/desk` had no route). Evidence: [evidence-story-05.md](./evidence-story-05.md). Built
+  (`npm run build`), Playwright-screenshotted (0 page errors), full `uv run pytest` 3039 passed.
+
+**Key custody divergence (deliberate, stronger):** the plan said "hand the key to the hub over the
+session." The shipped hub (24-04) holds the key in its environment secrets and joins it at run time —
+so the key never rides ANY payload, not even a hub-bound one. The web editor therefore shows
+`requires_key` + the env var name to set on the hub; there is no key field and no key flow over the
+wire. This is a tighter never-sync posture than the story imagined.
 
 ## Problem
 

--- a/tests/e2e/test_route_preflight.py
+++ b/tests/e2e/test_route_preflight.py
@@ -37,6 +37,7 @@ PAGE_ROUTES = [
     "/",
     "/welcome",
     "/setup",
+    "/desk",
     "/history",
     "/settings",
     "/activity",
@@ -45,6 +46,7 @@ PAGE_ROUTES = [
     "/companion",
     "/presence",
     "/cadence",
+    "/profiles",
     "/docs/dictation-runtime",
 ]
 

--- a/web/src/components/TopNav.astro
+++ b/web/src/components/TopNav.astro
@@ -19,7 +19,7 @@
 import AppMark from "./AppMark.astro";
 import TrustChip from "./TrustChip.astro";
 
-type Route = "runtime" | "desk" | "activity" | "history" | "dictation" | "companion" | "commands";
+type Route = "runtime" | "desk" | "activity" | "history" | "dictation" | "companion" | "commands" | "profiles";
 
 interface Props {
   current?: Route;
@@ -46,6 +46,7 @@ const groups: { label: string; routes: { slug: Route; label: string; href: strin
     label: "Configure",
     routes: [
       { slug: "dictation", label: "Dictation", href: "/dictation" },
+      { slug: "profiles", label: "Profiles", href: "/profiles" },
       { slug: "commands", label: "Commands", href: "/commands" },
       { slug: "companion", label: "Companion", href: "/companion" },
     ],

--- a/web/src/layouts/AppLayout.astro
+++ b/web/src/layouts/AppLayout.astro
@@ -16,7 +16,7 @@ import TrustChip from "../components/TrustChip.astro";
 import ConfirmDialog from "../components/ConfirmDialog.astro";
 import QueueHud from "../components/QueueHud.astro";
 
-type Route = "runtime" | "desk" | "activity" | "history" | "dictation" | "companion" | "commands";
+type Route = "runtime" | "desk" | "activity" | "history" | "dictation" | "companion" | "commands" | "profiles";
 
 interface Props {
   title: string;

--- a/web/src/pages/desk.astro
+++ b/web/src/pages/desk.astro
@@ -214,6 +214,7 @@ const GROUPS = [
                       <div class="card-foot">
                         <template x-for="t in item.tools" {...{ ":key": "t" }}><span class="tag mono" x-text="t"></span></template>
                         <span class="tag warn-tag" x-show="item.kbId" x-cloak x-text="`kb · ${item.kbId}`"></span>
+                        <span class="egress-badge runson-chip" x-show="item.profileId && profileEgress(item.profileId)" x-cloak :class="`is-${profileEgress(item.profileId)?.scope}`" :title="`Runs on ${profileName(item.profileId)}`" x-text="`${profileName(item.profileId)}`"></span>
                       </div>
                       <div class="filed-row">
                         <template x-for="d in directoriesFor(item.id)" {...{ ":key": "d.id" }}>
@@ -462,6 +463,19 @@ const GROUPS = [
             <label class="field grow"><span>Tools (comma-separated)</span><input type="text" x-model="agentForm.tools" placeholder="summarize, extract_actions" /></label>
             <label class="field grow"><span>KB id (optional)</span><input type="text" x-model="agentForm.kbId" placeholder="kb-…" /></label>
           </div>
+          <label class="field">
+            <span>Runs on</span>
+            <select x-model="agentForm.profileId" class="runson-select">
+              <option value="">Hub default</option>
+              <template x-for="p in profiles" {...{ ":key": "p.id" }}>
+                <option :value="p.id" x-text="`${p.name} · ${p.kind === 'onDevice' ? 'on-device' : 'endpoint'}`"></option>
+              </template>
+            </select>
+            <span class="runson-hint" x-show="agentForm.profileId && profileEgress(agentForm.profileId)" x-cloak>
+              <span class="egress-badge" :class="`is-${profileEgress(agentForm.profileId)?.scope}`" x-text="profileEgress(agentForm.profileId)?.text"></span>
+            </span>
+            <a class="runson-link" href="/profiles" x-show="!profiles.length" x-cloak>Add a profile →</a>
+          </label>
           <p class="field-note">Saves to <code>POST /api/agents</code>. Runnable via <code>{"/api/agents/{id}/run"}</code>.</p>
           <div class="drawer-foot">
             <button type="button" class="btn ghost" @click="closeCreate()">Cancel</button>
@@ -1220,6 +1234,22 @@ const GROUPS = [
   .avatar-field input { text-align: center; width: 4rem; font-size: 1.25rem; }
   .field-note { margin: 0; font-size: var(--font-size-xs); color: var(--text-faint); line-height: var(--line-height-normal); }
   .field-note code { font-family: var(--font-mono); color: var(--accent); }
+
+  /* "Runs on" — the per-agent runtime profile picker (Phase 24). */
+  .runson-select {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-sm);
+    color: var(--text);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2) var(--space-3);
+  }
+  .runson-select:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-tint); }
+  .runson-hint { display: inline-flex; margin-top: var(--space-1); }
+  .runson-link { font-size: var(--font-size-xs); color: var(--accent); text-decoration: none; margin-top: var(--space-1); }
+  .runson-link:hover { text-decoration: underline; }
+  .runson-chip { margin-left: auto; }
   .field-note kbd { font-family: var(--font-mono); font-size: 0.6875rem; background: var(--surface-3); border: 1px solid var(--border); border-radius: var(--radius-xs); padding: 0 4px; color: var(--text-muted); }
   .drawer-foot { display: flex; justify-content: flex-end; gap: var(--space-2); padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-subtle); }
 

--- a/web/src/pages/profiles.astro
+++ b/web/src/pages/profiles.astro
@@ -1,0 +1,502 @@
+---
+// HSM-24-05: the web Runtime Profiles surface.
+//
+// Web is a first-class AUTHORING port for "where intelligence runs". This page
+// manages the profile SHAPE (name / kind / endpoint / model / context window)
+// over the hub's /api/profiles routes, and the desk's agent editor points an
+// agent at one ("Runs on: [Profile ▾]").
+//
+// The hard rule (Phase 24): the API key NEVER touches the browser. A cloud
+// profile carries only `requires_key`; the secret lives on the hub as
+// HOLDSPEAK_PROFILE_<id>_KEY. On-device (GGUF) profiles can't run in a browser,
+// so their card is honestly marked unavailable-here.
+//
+// Cards + the editor are rendered at runtime by profiles-app.js, so their CSS
+// lives in a <style is:global> block (Astro scoped styles don't reach
+// JS-injected DOM — the standing gotcha).
+import AppLayout from "../layouts/AppLayout.astro";
+import EmptyState from "../components/EmptyState.astro";
+---
+
+<AppLayout
+  title="Runtime Profiles — HoldSpeak"
+  description="Named targets for where intelligence runs — on-device or an OpenAI-compatible endpoint. The API key stays on the hub, never the browser."
+  current="profiles"
+>
+  <div class="profiles" x-data="ProfilesApp()" x-init="init()" x-cloak>
+    <header class="pf-head">
+      <div class="pf-head-text">
+        <p class="pf-eyebrow">Runtime · where intelligence runs</p>
+        <h1 class="pf-title">Runtime Profiles</h1>
+        <p class="pf-lead">
+          A named place a model runs — this device, or an endpoint. Point an
+          agent at one on the Desk. Keys stay on the hub.
+        </p>
+      </div>
+      <div class="pf-head-actions">
+        <div class="pf-stat" aria-live="polite">
+          <strong x-text="count()">0</strong>
+          <span>profiles</span>
+        </div>
+        <button type="button" class="pf-btn primary" @click="openCreate()">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14" /></svg>
+          New profile
+        </button>
+      </div>
+    </header>
+
+    <p class="pf-err" x-show="error" x-cloak x-text="error"></p>
+
+    {/* Unreachable hub */}
+    <div x-show="!loading && status === 'unreachable'" x-cloak>
+      <EmptyState
+        title="Hub unreachable"
+        body="The desktop hub isn't answering on /api/profiles. Start it, then reload."
+      />
+    </div>
+
+    {/* Empty */}
+    <div x-show="!loading && status === 'live' && profiles.length === 0" x-cloak>
+      <EmptyState
+        title="No profiles yet"
+        body="Add one to run agents on an endpoint like OpenRouter or Claude — or to name a model on this device."
+      />
+    </div>
+
+    {/* The list */}
+    <div class="pf-grid" x-show="profiles.length" x-cloak>
+      <template x-for="p in profiles" {...{ ":key": "p.id" }}>
+        <article class="signal-card pf-card">
+          <div class="pf-card-top">
+            <div class="pf-card-id">
+              <span class="pf-kind" :class="`is-${p.kind}`" x-text="kindLabel(p)">Endpoint</span>
+              <h3 class="pf-name" x-text="p.name">Profile</h3>
+            </div>
+            <span class="egress-badge" :class="`is-${egress(p).scope}`" :title="egress(p).title" x-text="egress(p).text">⌂ Local</span>
+          </div>
+
+          {/* Endpoint detail */}
+          <dl class="pf-meta" x-show="p.kind === 'openAICompatible'" x-cloak>
+            <div><dt>Endpoint</dt><dd class="mono" x-text="p.base_url || '—'"></dd></div>
+            <div><dt>Model</dt><dd class="mono" x-text="p.model || '—'"></dd></div>
+            <div><dt>Context</dt><dd class="mono" x-text="`${p.context_limit.toLocaleString()} tok`"></dd></div>
+            <div x-show="p.requires_key"><dt>Key</dt><dd class="pf-keyref">on the hub · <span class="mono" x-text="`HOLDSPEAK_PROFILE_${p.id}_KEY`"></span></dd></div>
+          </dl>
+
+          {/* On-device detail — honest n/a on web */}
+          <dl class="pf-meta" x-show="p.kind === 'onDevice'" x-cloak>
+            <div><dt>Model file</dt><dd class="mono" x-text="p.model_file || '—'"></dd></div>
+            <div><dt>Context</dt><dd class="mono" x-text="`${p.context_limit.toLocaleString()} tok`"></dd></div>
+            <div class="pf-na"><dt>On web</dt><dd>Unavailable — runs on a device.</dd></div>
+          </dl>
+
+          <div class="pf-card-actions">
+            <button type="button" class="pf-btn ghost sm" @click="openEdit(p)">Edit</button>
+            <template x-if="confirmingId !== p.id">
+              <button type="button" class="pf-btn danger-ghost sm" @click="askDelete(p)">Delete</button>
+            </template>
+            <template x-if="confirmingId === p.id">
+              <span class="pf-confirm">
+                <span>Delete?</span>
+                <button type="button" class="pf-btn danger sm" :disabled="busy" @click="confirmDelete(p)">Yes</button>
+                <button type="button" class="pf-btn ghost sm" @click="cancelDelete()">No</button>
+              </span>
+            </template>
+          </div>
+        </article>
+      </template>
+    </div>
+
+    {/* Editor drawer */}
+    <div class="pf-scrim" x-show="editing" x-cloak @click="close()"></div>
+    <aside class="pf-drawer" x-show="editing" x-cloak role="dialog" aria-modal="true" aria-label="Runtime profile">
+      <template x-if="editing">
+        <div class="pf-drawer-inner">
+          <header class="pf-drawer-head">
+            <div>
+              <span class="pf-drawer-eyebrow">Runtime profile · syncs to the hub</span>
+              <h2 x-text="isNew ? 'New profile' : 'Edit profile'">New profile</h2>
+            </div>
+            <button type="button" class="pf-drawer-close" @click="close()" aria-label="Close">✕</button>
+          </header>
+          <form class="pf-drawer-body" @submit.prevent="save()">
+            <p class="pf-err" x-show="error" x-cloak x-text="error"></p>
+
+            <label class="pf-field"><span>Name</span>
+              <input type="text" x-model="editing.name" placeholder="OpenRouter · Claude Sonnet" />
+            </label>
+
+            <div class="pf-field">
+              <span>Runs on</span>
+              <div class="pf-segmented" role="radiogroup" aria-label="Profile kind">
+                <button type="button" :class="{ 'is-on': editing.kind === 'openAICompatible' }" @click="editing.kind = 'openAICompatible'" role="radio" :aria-checked="editing.kind === 'openAICompatible'">Endpoint</button>
+                <button type="button" :class="{ 'is-on': editing.kind === 'onDevice' }" @click="editing.kind = 'onDevice'" role="radio" :aria-checked="editing.kind === 'onDevice'">On-device</button>
+              </div>
+            </div>
+
+            {/* Endpoint fields */}
+            <template x-if="editing.kind === 'openAICompatible'">
+              <div class="pf-fieldset">
+                <label class="pf-field"><span>Base URL</span>
+                  <input type="text" x-model="editing.base_url" placeholder="https://openrouter.ai/api/v1" />
+                </label>
+                <label class="pf-field"><span>Model</span>
+                  <input type="text" x-model="editing.model" placeholder="anthropic/claude-sonnet-4" />
+                </label>
+                <label class="pf-field"><span>Context window (tokens)</span>
+                  <input type="number" min="1" x-model.number="editing.context_limit" placeholder="200000" />
+                </label>
+                <label class="pf-check">
+                  <input type="checkbox" x-model="editing.requires_key" />
+                  <span>Needs an API key</span>
+                </label>
+                <p class="pf-keynote" x-show="editing.requires_key" x-cloak>
+                  Set it on the hub:
+                  <code x-text="isNew ? 'HOLDSPEAK_PROFILE_<id>_KEY' : `HOLDSPEAK_PROFILE_${editing.id}_KEY`">HOLDSPEAK_PROFILE_&lt;id&gt;_KEY</code>.
+                  The browser never sees it.
+                </p>
+              </div>
+            </template>
+
+            {/* On-device fields */}
+            <template x-if="editing.kind === 'onDevice'">
+              <div class="pf-fieldset">
+                <label class="pf-field"><span>Model file (GGUF)</span>
+                  <input type="text" x-model="editing.model_file" placeholder="Qwen3-4B-Instruct-Q6_K.gguf" />
+                </label>
+                <label class="pf-field"><span>Context window (tokens)</span>
+                  <input type="number" min="1" x-model.number="editing.context_limit" placeholder="16384" />
+                </label>
+                <p class="pf-keynote">Runs on a device that has this model. Unavailable here on the web.</p>
+              </div>
+            </template>
+
+            <div class="pf-drawer-foot">
+              <button type="button" class="pf-btn ghost" @click="close()">Cancel</button>
+              <button type="submit" class="pf-btn primary" :disabled="busy">
+                <span x-text="busy ? 'Saving…' : (isNew ? 'Create profile' : 'Save changes')">Create profile</span>
+              </button>
+            </div>
+          </form>
+        </div>
+      </template>
+    </aside>
+  </div>
+
+  <script>
+    import Alpine from "alpinejs";
+    import factorySource from "../scripts/profiles-app.js?raw";
+
+    const fn = new Function(factorySource + "; return ProfilesApp;");
+    window.ProfilesApp = fn();
+    window.Alpine = Alpine;
+    Alpine.start();
+  </script>
+</AppLayout>
+
+<style is:global>
+  [x-cloak] { display: none !important; }
+
+  .profiles {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: var(--space-6) var(--space-5) var(--space-8);
+  }
+
+  .pf-head {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: var(--space-5);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-6);
+  }
+  .pf-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    letter-spacing: var(--letter-spacing-eyebrow);
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin: 0 0 var(--space-2);
+  }
+  .pf-title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.75rem;
+    letter-spacing: -0.02em;
+    color: var(--text);
+    margin: 0;
+  }
+  .pf-lead {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    max-width: 46ch;
+    margin: var(--space-2) 0 0;
+  }
+  .pf-head-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+  }
+  .pf-stat {
+    text-align: right;
+    line-height: 1.1;
+  }
+  .pf-stat strong {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 1.5rem;
+    color: var(--text);
+  }
+  .pf-stat span {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-eyebrow);
+    color: var(--text-faint);
+  }
+
+  .pf-err {
+    color: var(--danger);
+    background: color-mix(in srgb, var(--danger) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--font-size-sm);
+    margin: 0 0 var(--space-4);
+  }
+
+  /* Grid of profile cards */
+  .pf-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: var(--space-4);
+  }
+  .pf-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+  }
+  .pf-card-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+  .pf-kind {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-eyebrow);
+    padding: 0.1rem 0.45rem;
+    border-radius: var(--radius-xs);
+    margin-bottom: var(--space-1);
+  }
+  .pf-kind.is-openAICompatible {
+    color: var(--accent);
+    background: var(--accent-tint);
+  }
+  .pf-kind.is-onDevice {
+    color: var(--ok);
+    background: color-mix(in srgb, var(--ok) 12%, transparent);
+  }
+  .pf-name {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 1.0625rem;
+    color: var(--text);
+    margin: 0;
+    line-height: 1.25;
+  }
+
+  .pf-meta {
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+  }
+  .pf-meta > div {
+    display: grid;
+    grid-template-columns: 84px 1fr;
+    gap: var(--space-3);
+    align-items: baseline;
+  }
+  .pf-meta dt {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-eyebrow);
+    color: var(--text-faint);
+  }
+  .pf-meta dd {
+    margin: 0;
+    color: var(--text);
+    font-size: var(--font-size-sm);
+    word-break: break-word;
+  }
+  .pf-meta .mono { font-family: var(--font-mono); font-size: 0.8125rem; }
+  .pf-keyref { color: var(--text-muted); font-size: 0.8125rem; }
+  .pf-keyref .mono { font-size: 0.75rem; }
+  .pf-na dd { color: var(--warn); }
+
+  .pf-card-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: auto;
+    padding-top: var(--space-2);
+  }
+  .pf-confirm {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
+  }
+
+  /* Buttons (self-contained — not relying on a global .btn) */
+  .pf-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface-1);
+    color: var(--text);
+    cursor: pointer;
+    transition: background var(--duration-short) var(--ease-standard),
+      border-color var(--duration-short) var(--ease-standard),
+      color var(--duration-short) var(--ease-standard);
+  }
+  .pf-btn:hover { border-color: var(--border-strong); background: var(--surface-2); }
+  .pf-btn:focus-visible { outline: var(--focus-outline-width) solid var(--accent); outline-offset: var(--focus-outline-offset); }
+  .pf-btn:disabled { opacity: 0.55; cursor: default; }
+  .pf-btn.sm { padding: var(--space-1) var(--space-3); font-size: 0.8125rem; }
+  .pf-btn.primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--accent-contrast, #06121f);
+  }
+  .pf-btn.primary:hover { background: color-mix(in srgb, var(--accent) 88%, white); }
+  .pf-btn.ghost { background: transparent; }
+  .pf-btn.danger-ghost { background: transparent; color: var(--danger); border-color: color-mix(in srgb, var(--danger) 30%, transparent); }
+  .pf-btn.danger-ghost:hover { background: color-mix(in srgb, var(--danger) 10%, transparent); border-color: var(--danger); }
+  .pf-btn.danger { background: var(--danger); border-color: var(--danger); color: #fff; }
+
+  /* Editor drawer */
+  .pf-scrim {
+    position: fixed;
+    inset: 0;
+    background: color-mix(in srgb, var(--bg) 65%, transparent);
+    backdrop-filter: blur(2px);
+    z-index: var(--z-overlay);
+  }
+  .pf-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(460px, 92vw);
+    background: var(--surface-1);
+    border-left: 1px solid var(--border-strong);
+    box-shadow: var(--elev-3);
+    z-index: calc(var(--z-overlay) + 1);
+    display: flex;
+    flex-direction: column;
+    animation: pf-slidein var(--duration-medium) var(--ease-standard);
+  }
+  @keyframes pf-slidein {
+    from { transform: translateX(20px); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+  }
+  .pf-drawer-inner { display: flex; flex-direction: column; height: 100%; }
+  .pf-drawer-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .pf-drawer-eyebrow {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-eyebrow);
+    color: var(--text-faint);
+    margin-bottom: var(--space-1);
+  }
+  .pf-drawer-head h2 { font-family: var(--font-display); font-weight: 700; font-size: 1.25rem; margin: 0; color: var(--text); }
+  .pf-drawer-close {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    width: 30px; height: 30px;
+    cursor: pointer;
+  }
+  .pf-drawer-close:hover { color: var(--text); border-color: var(--border-strong); }
+  .pf-drawer-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-5);
+    overflow-y: auto;
+    flex: 1;
+  }
+  .pf-fieldset { display: flex; flex-direction: column; gap: var(--space-4); }
+  .pf-field { display: flex; flex-direction: column; gap: var(--space-2); }
+  .pf-field > span {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-eyebrow);
+    color: var(--text-muted);
+  }
+  .pf-field input {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-sm);
+    color: var(--text);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2) var(--space-3);
+  }
+  .pf-field input:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-tint);
+  }
+  .pf-segmented { display: inline-flex; gap: 2px; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px; width: fit-content; }
+  .pf-segmented button {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    color: var(--text-muted);
+    background: transparent;
+    border: 0;
+    border-radius: calc(var(--radius-sm) - 2px);
+    padding: var(--space-2) var(--space-4);
+    cursor: pointer;
+  }
+  .pf-segmented button.is-on { background: var(--accent); color: var(--accent-contrast, #06121f); font-weight: 600; }
+  .pf-check { display: inline-flex; align-items: center; gap: var(--space-2); font-size: var(--font-size-sm); color: var(--text); cursor: pointer; }
+  .pf-keynote { font-size: 0.8125rem; color: var(--text-muted); margin: 0; line-height: 1.5; }
+  .pf-keynote code { font-family: var(--font-mono); font-size: 0.75rem; color: var(--accent); background: var(--accent-tint); padding: 0.05rem 0.3rem; border-radius: var(--radius-xs); }
+  .pf-drawer-foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    padding-top: var(--space-2);
+    margin-top: auto;
+  }
+
+  @media (max-width: 640px) {
+    .pf-head { align-items: flex-start; }
+    .pf-meta > div { grid-template-columns: 72px 1fr; }
+  }
+</style>

--- a/web/src/scripts/desk-app.js
+++ b/web/src/scripts/desk-app.js
@@ -58,6 +58,12 @@ function DeskApp() {
     // Per-kind reachability: "live" | "unreachable" (undefined until loaded).
     status: {},
 
+    // ── runtime profiles (Phase 24) ──
+    // The named "where intelligence runs" targets an agent can be pointed at.
+    // Authored on /profiles; here they populate the agent editor's "Runs on"
+    // picker and the per-agent chip. Shape only — the key never rides the wire.
+    profiles: [],
+
     // ── authoring ──
     creating: null, // "note" | "agent" | "kb" | "chain" | "workflow" | null
     busy: false,
@@ -70,6 +76,7 @@ function DeskApp() {
       userTemplate: "",
       tools: "",
       kbId: "",
+      profileId: "", // "" = the hub's default
     },
     kbForm: { name: "", memberIds: "" },
     directoryForm: { name: "", parentId: "" },
@@ -250,6 +257,7 @@ function DeskApp() {
         this.loadDirectories(),
         this.loadChains(),
         this.loadWorkflows(),
+        this.loadProfiles(),
       ]);
       this.updatedAt = Date.now();
     },
@@ -368,7 +376,44 @@ function DeskApp() {
         userTemplate: a.user_template || "",
         tools: a.tools || [],
         kbId: a.kb_id || null,
+        profileId: a.profile_id || "",
       };
+    },
+
+    // ── runtime profiles (LIVE — GET /api/profiles) ──
+    async loadProfiles() {
+      try {
+        const data = await this.fetchJson("/api/profiles");
+        this.profiles = (data.profiles || []).filter((p) => !p.deleted);
+        this.status.profile = "live";
+      } catch (_e) {
+        // Profiles are an enhancement on the agent editor; a missing route
+        // just leaves the picker at "Hub default" (honest, non-fatal).
+        this.profiles = [];
+        this.status.profile = "unreachable";
+      }
+    },
+
+    /** Display name for a profile id, or "" when unset/unknown. */
+    profileName(id) {
+      if (!id) return "";
+      const p = this.profiles.find((x) => x.id === id);
+      return p ? p.name : id;
+    },
+    /** The egress badge `{scope, text}` for an agent's assigned profile. */
+    profileEgress(id) {
+      const p = this.profiles.find((x) => x.id === id);
+      if (!p) return null;
+      if ((p.kind || "onDevice") === "onDevice") {
+        return { scope: "local", text: "⌂ On device" };
+      }
+      let host = "endpoint";
+      try {
+        host = new URL(p.base_url).host;
+      } catch (_e) {
+        host = (p.base_url || "").replace(/^https?:\/\//, "").split("/")[0] || "endpoint";
+      }
+      return { scope: "cloud", text: `☁ ${host}` };
     },
 
     // ── organization: KBs (LIVE — GET/POST /api/kbs) ──
@@ -751,6 +796,7 @@ function DeskApp() {
         user_template: f.userTemplate,
         tools: this.splitList(f.tools),
         kb_id: f.kbId.trim() || null,
+        profile_id: f.profileId || null,
       };
       this.busy = true;
       try {
@@ -763,7 +809,7 @@ function DeskApp() {
         this.status.agent = "live";
         this.agentForm = {
           name: "", avatar: "🤖", role: "", systemPrompt: "",
-          userTemplate: "", tools: "", kbId: "",
+          userTemplate: "", tools: "", kbId: "", profileId: "",
         };
         this.closeCreate();
       } catch (e) {

--- a/web/src/scripts/profiles-app.js
+++ b/web/src/scripts/profiles-app.js
@@ -1,0 +1,178 @@
+// HSM-24-05: the web Runtime Profiles surface.
+//
+// A "runtime profile" is a named place intelligence runs — either on a device
+// (a downloaded GGUF) or an OpenAI-compatible endpoint (OpenRouter / Claude /
+// a local server). The web is a first-class AUTHORING port: it manages the
+// profile SHAPE (name / kind / endpoint / model / context window) over the
+// hub's REST routes, exactly like the desk authors its primitives.
+//
+// The one hard rule (Phase 24 canon): the API KEY NEVER touches the browser.
+// The shape carries only `requires_key` (a boolean); the secret lives in the
+// hub's environment as HOLDSPEAK_PROFILE_<id>_KEY and is joined at run time.
+// So a cloud profile here states "key set on the hub" — there is no key field.
+//
+// Honest n/a: an on-device (GGUF) profile cannot run in a browser, so its card
+// reads "On device" and is marked unavailable-here rather than pretending.
+//
+// Cards + the editor are rendered at runtime, so their CSS lives in a
+// `<style is:global>` block (Astro scoped styles don't reach JS-injected DOM).
+
+function ProfilesApp() {
+  const blankForm = () => ({
+    id: "",
+    name: "",
+    kind: "openAICompatible",
+    model_file: "",
+    base_url: "",
+    model: "",
+    context_limit: 16384,
+    requires_key: true,
+  });
+
+  return {
+    profiles: [],
+    loading: true,
+    status: "", // "live" | "unreachable"
+    error: "",
+
+    editing: null, // the form object when the editor is open, else null
+    isNew: false,
+    busy: false,
+    confirmingId: "", // a profile pending delete confirmation
+
+    async init() {
+      await this.loadProfiles();
+      this.loading = false;
+    },
+
+    async fetchJson(url, opts) {
+      const res = await fetch(url, opts);
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error || body.detail || `HTTP ${res.status}`);
+      return body;
+    },
+
+    async loadProfiles() {
+      try {
+        const data = await this.fetchJson("/api/profiles");
+        this.profiles = (data.profiles || []).filter((p) => !p.deleted);
+        this.status = "live";
+      } catch (e) {
+        this.status = "unreachable";
+        this.profiles = [];
+        this.error = `Profiles: ${e.message}`;
+      }
+    },
+
+    // ── editor ──
+    openCreate() {
+      this.editing = blankForm();
+      this.isNew = true;
+      this.error = "";
+    },
+    openEdit(p) {
+      this.editing = {
+        id: p.id,
+        name: p.name || "",
+        kind: p.kind || "openAICompatible",
+        model_file: p.model_file || "",
+        base_url: p.base_url || "",
+        model: p.model || "",
+        context_limit: p.context_limit || 16384,
+        requires_key: !!p.requires_key,
+      };
+      this.isNew = false;
+      this.error = "";
+    },
+    close() {
+      this.editing = null;
+      this.busy = false;
+    },
+
+    async save() {
+      const f = this.editing;
+      if (!f.name.trim()) {
+        this.error = "A profile needs a name.";
+        return;
+      }
+      const payload = {
+        name: f.name.trim(),
+        kind: f.kind,
+        model_file: f.kind === "onDevice" ? f.model_file.trim() : "",
+        base_url: f.kind === "openAICompatible" ? f.base_url.trim() : "",
+        model: f.model.trim(),
+        context_limit: Number(f.context_limit) || 16384,
+        requires_key: f.kind === "openAICompatible" ? !!f.requires_key : false,
+      };
+      this.busy = true;
+      this.error = "";
+      try {
+        const url = this.isNew ? "/api/profiles" : `/api/profiles/${f.id}`;
+        const data = await this.fetchJson(url, {
+          method: this.isNew ? "POST" : "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        const saved = data.profile || data;
+        if (this.isNew) {
+          this.profiles.unshift(saved);
+        } else {
+          const i = this.profiles.findIndex((p) => p.id === saved.id);
+          if (i >= 0) this.profiles[i] = saved;
+        }
+        this.status = "live";
+        this.close();
+      } catch (e) {
+        this.error = `Save profile: ${e.message}`;
+      } finally {
+        this.busy = false;
+      }
+    },
+
+    askDelete(p) {
+      this.confirmingId = p.id;
+    },
+    cancelDelete() {
+      this.confirmingId = "";
+    },
+    async confirmDelete(p) {
+      this.busy = true;
+      try {
+        await this.fetchJson(`/api/profiles/${p.id}`, { method: "DELETE" });
+        this.profiles = this.profiles.filter((x) => x.id !== p.id);
+        this.confirmingId = "";
+      } catch (e) {
+        this.error = `Delete profile: ${e.message}`;
+      } finally {
+        this.busy = false;
+      }
+    },
+
+    // ── presentation ──
+    isLocal(p) {
+      return (p.kind || "onDevice") === "onDevice";
+    },
+    hostOf(url) {
+      try {
+        return new URL(url).host;
+      } catch (_e) {
+        return (url || "").replace(/^https?:\/\//, "").split("/")[0] || "endpoint";
+      }
+    },
+    // The canonical egress badge `{scope, text, title}` keyed by the shared
+    // `.egress-badge.is-*` CSS (the one structured chip, never prose).
+    egress(p) {
+      if (this.isLocal(p)) {
+        return { scope: "local", text: "⌂ On device", title: "Runs on a device. Unavailable here on the web." };
+      }
+      const host = this.hostOf(p.base_url);
+      return { scope: "cloud", text: `☁ ${host}`, title: `Calls ${host} from the hub.` };
+    },
+    kindLabel(p) {
+      return this.isLocal(p) ? "On-device" : "Endpoint";
+    },
+    count() {
+      return this.profiles.length;
+    },
+  };
+}


### PR DESCRIPTION
## What

Phase 24's web story: the web flagship becomes a first-class authoring port for **runtime profiles**, at parity with the Apple advanced screen.

- **New `/profiles` surface** (`web/src/pages/profiles.astro` + `profiles-app.js`): a card grid + drawer editor over the hub's `/api/profiles` CRUD. SHAPE only — **there is no key field**. A cloud profile shows `requires_key` + the env var to set on the hub (`HOLDSPEAK_PROFILE_<id>_KEY`); the browser never sees the key and it never rides any payload (a tighter never-sync posture than the plan's "hand it to the hub"). On-device (GGUF) profiles render honest n/a.
- **Desk agent editor** gains an inline **"Runs on: [Profile ▾]"** picker (`desk.astro` + `desk-app.js`): default "Hub default", a live egress hint, and a per-agent egress chip on the card. The hub already resolves `agent.profile_id` at run time (24-04). This honors the owner's principle: the default is exposed and changeable at the point of use.
- **TopNav/AppLayout**: "Profiles" added to the Configure group.

## Also fixed (load-bearing dead-link bug)

The TopNav linked `/desk`, but the hub had **no `/desk` route** — the desk was reachable only at `/_built/desk/`, so the nav link 404'd. Added a real `/desk` page route and brought both `/desk` and `/profiles` under the launch pre-flight (`PAGE_ROUTES`). This is exactly the class of bug the pre-flight exists to catch; the desk had simply never been a `pages.py` route, so it escaped the sweep.

## Proof

- `npm run build` clean (emits `/profiles/index.html` + `/desk/index.html`).
- Playwright pass over `/profiles` (list + editor) and `/desk` (cards + agent form) = **0 page errors**; styles verified on the runtime-rendered DOM (screenshots: profiles list, profiles editor, desk cards, desk agent form).
- Full `uv run pytest` (sans the mic-bound metal test) → **3039 passed, 0 failed**.

Evidence: `pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-05.md`.

## Honest note

A live browser→cloud run against a real key in `HOLDSPEAK_PROFILE_<id>_KEY` is the hub operator's walk; the authoring + assignment + resolution path is proven by the 24-04 route tests + this screenshot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)