### PR TITLE
HSM-24-06: cross-surface parity proof + docs (Phase 24 closes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ comes back as typed, reviewable artifacts:
 - **Everything is local, including the intelligence.** Whisper transcribes on
   your machine, in any of its 99 languages, and the LLM is yours: GGUF in-process, MLX on Apple Silicon, or
   any OpenAI-compatible endpoint you choose, including one on your own LAN.
+  Name those as reusable **runtime profiles** and run a different one per agent;
+  the profile shape syncs across your surfaces while the API key stays on each
+  one, never synced.
   See [Security & privacy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/SECURITY.md) and [Models](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md).
 - **It learns how you work, and shows you the receipts.** The dictation
   journal records what you said, what it typed, where it routed, and how long

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -95,6 +95,31 @@ endpoint owns model loading; HoldSpeak needs no local weights.
 
 ---
 
+## Runtime profiles: where each agent runs
+
+The three backends above answer *how* an LLM runs. A **runtime profile**
+answers *where*: a named, reusable target you can point work at.
+
+- **Basic.** Pick one active profile. This is the single-target experience:
+  one model, app wide. Most users never need more.
+- **Advanced.** Keep a list of named profiles (on-device, or any
+  OpenAI-compatible endpoint such as OpenRouter or Claude) and assign one
+  **per agent**. Scout can run on-device while Editor runs on a cloud endpoint
+  and Critic runs on a third. Every place that touches a model shows a small
+  "Runs on" control with the resolved default already selected and changeable
+  at the point of use.
+
+A profile carries only its **shape**: name, kind, endpoint, model, and the
+usable context window. It never carries the API key. The shape syncs across
+your surfaces (desktop hub, iPad, iPhone, web) so the same named profile is
+available everywhere; a surface that cannot host a kind (an on-device GGUF in
+a browser) shows it as unavailable rather than pretending. The key stays with
+each surface and is joined only at request time. See
+[Security & privacy](SECURITY.md#5-secrets-handling).
+
+Manage profiles on the web at `/profiles`, or on iPad and iPhone under
+Settings; assign an agent to one in the agent editor.
+
 ## Current suggestions (a moving target)
 
 These are reasonable defaults at the time of writing, **not** mandates. Newer

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -117,6 +117,15 @@ machine except via the connector CLIs above (entity IDs only).
   a credential everywhere else: shown only on the Settings page, never on a
   proposal record, a broadcast, or any other API response (the connector
   joins it to the POST in memory at execution time).
+- **Runtime profile keys**: a runtime profile (the named "where intelligence
+  runs" target) stores only its shape: name, kind, endpoint, model, context
+  window. The API key is **never** part of the profile and **never syncs**.
+  Each surface holds its own key for a shared profile: the device Keychain on
+  iPad and iPhone, the hub's environment secret on the desktop
+  (`HOLDSPEAK_PROFILE_<id>_KEY`). The key is joined to the request only at run
+  time, never written to the synced shape, a ChangeSet, or any API response. A
+  regression test asserts a key supplied to any ingress (a sync push or a REST
+  body) never reappears on a read surface (the sync pull or the profile routes).
 - Bridge/firmware secrets (AIPI-Lite) live in gitignored `bridge.env` /
   `secrets.yaml`; `.example` templates are checked in.
 

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/current-phase-status.md
@@ -1,10 +1,15 @@
 # Phase 24 — Runtime profiles (basic + advanced), in equilibrium
 
-**Status:** in-progress (opened 2026-06-28) — a pre-GA extension of
+**Status:** done (opened + closed 2026-06-28) — a pre-GA extension of
 [`EQUILIBRIUM.md`](../EQUILIBRIUM.md): the same "honor the contract on every surface" discipline,
 applied to *where intelligence runs*.
 
-**Last updated:** 2026-06-28 (**24-01..05 landed — Apple + the hub + the web are done.** The web
+**Last updated:** 2026-06-28 (**PHASE 24 CLOSED — 24-01..06 all done.** 24-06 landed the cross-surface
+never-sync proof (a key from either ingress, sync push or REST body, never reaches any read surface;
+the served profile shape is field-for-field the agreed schema) + the entry-point docs (README pillar,
+docs/MODELS.md "Runtime profiles", docs/SECURITY.md §5 key custody). Full `uv run pytest` 3040 passed;
+voice/docs guard green. Profiles are in equilibrium across desktop / hub / iPad / iPhone / web with the
+key custodial per surface. Earlier: **24-01..05 — Apple + the hub + the web are done.** The web
 `/profiles` surface authors profiles and the desk assigns them per-agent (the inline "Runs on" picker),
 key custody is the hub's secret, on-device renders honest n/a; a pre-existing `/desk` dead nav link was
 fixed and brought under the launch pre-flight. 0 page errors; full `uv run pytest` 3039 passed.
@@ -100,7 +105,7 @@ reads `profile.egressScope` so trust stays honest per profile.
 | HSM-24-03 | Apple **advanced** config — manage the profile list + per-agent `profileId` + the gauge reads `profile.contextLimit` | **done** (CRUD + per-agent chip + gauge-per-profile + agent-run routing + inline `RunsOnPicker` at the desk Ask/route & meeting generate, with honest egress; dictation n/a, workbench uses active) |
 | HSM-24-04 | The desktop hub honors profiles (`web_runtime` maps a profile to its runtime) | **done** (schema v3→v4 + `ProfileRepository` + sync + profiles CRUD routes + agent-run resolution with the key from the hub's secrets; never-sync-key tested; full `uv run pytest` 3039 passed) |
 | HSM-24-05 | Web authors + uses profiles (the flagship surface) | **done** (the web `/profiles` list+editor over `/api/profiles` + the desk agent "Runs on" picker + per-agent chip; honest n/a for on-device; key is the hub's secret, never the browser; fixed a pre-existing `/desk` dead nav link; 0 page errors; 3039 passed) |
-| HSM-24-06 | Cross-surface parity proof + the docs story | planned |
+| HSM-24-06 | Cross-surface parity proof + the docs story | **done** (the cross-surface never-sync proof: a key from either ingress never reaches any read surface + served shape is field-for-field the agreed schema; entry-point docs in README/MODELS/SECURITY; 3040 passed) |
 
 ## Sequencing
 
@@ -157,8 +162,18 @@ pre-existing dead nav link (`/desk` had no route; the TopNav pointed at it) and 
 `/profiles` under the launch pre-flight. Built clean; Playwright pass = 0 page errors (profiles list +
 editor, desk cards + agent form); full `uv run pytest` 3039 passed.
 
-Next: **24-06** (cross-surface parity proof + docs). Apple + the hub + the web are done; only the
-parity gate + docs remain.
+**24-06 DONE — PHASE 24 CLOSED.** The cross-surface never-sync proof is in
+(`test_profile_never_sync_holds_across_every_read_surface`): a hostile key supplied to either ingress
+(a sync push or a REST body) never reappears on any read surface (the sync pull, the list route, the
+per-id route), and every served profile is field-for-field the agreed schema with no key field. The
+entry-point docs shipped in the closing commit (README pillar names runtime profiles; docs/MODELS.md
+gains a "Runtime profiles" section; docs/SECURITY.md §5 gains the key-custody bullet). Full
+`uv run pytest` 3040 passed.
+
+Profiles are in equilibrium across desktop / hub / iPad / iPhone / web. The owner's remaining leg is a
+live device walk: author a cloud profile on the phone, see it shape-only on the hub/web, run an agent
+on it with a real key in `HOLDSPEAK_PROFILE_<id>_KEY`. The latest Apple build with the profiles UI is
+installed on the iPhone 17 Pro Max.
 
 ## Carried context
 

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-06.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-06.md
@@ -1,0 +1,63 @@
+# Evidence — HSM-24-06 (cross-surface parity proof + docs)
+
+**Date:** 2026-06-28
+**Story:** [story-06-proof-and-docs.md](./story-06-proof-and-docs.md)
+**Result:** DONE. Profiles are demonstrably in equilibrium across desktop / iPad / iPhone / web; the
+key never syncs (proven by a dedicated cross-surface test); the entry-point docs + the security note
+ship in this closing commit. **Phase 24 closes.** Full `uv run pytest` **3040 passed, 0 failed**; the
+voice guard + docs suite green (158 passed).
+
+## The cross-surface never-sync proof
+
+`tests/integration/test_primitive_framework_sync.py::test_profile_never_sync_holds_across_every_read_surface`
+(new) is the phase gate, complementing the existing
+`test_profile_syncs_shape_only_and_agent_carries_profile_id`:
+
+- **Two ingresses, both hostile.** A profile is pushed over `/api/sync/push` (the iPad's path) with an
+  `api_key`, and a second is created over `POST /api/profiles` (the web's path) with an `api_key`.
+- **Every read surface a downstream surface consumes** is asserted key-free: the sync pull
+  (`/api/sync/pull`), the list route (`GET /api/profiles`), and the per-id route
+  (`GET /api/profiles/{id}`).
+- **Shape parity.** Every served profile's field set equals the agreed cross-surface schema exactly
+  (`id, name, kind, model_file, base_url, model, context_limit, requires_key, created_at,
+  last_modified, deleted`) — no more, no less, and no key field. This proves "same shape, every
+  surface," and that parity is achieved by the shape round-tripping intact, not by silently dropping
+  data.
+- **No key material survives** (`api_key`, `apiKey`, or either secret string) on any read surface,
+  from either ingress.
+
+Together with the already-green Apple-side invariant (`apple/Tests/ContractsTests/RuntimeProfileTests.swift`,
+the key never on the `Synced`/`ChangeSet` shape) and the hub key-resolution tests (24-04), the chain is
+closed: the key lives only in each surface's custodian (iPad Keychain / hub env secret
+`HOLDSPEAK_PROFILE_<id>_KEY`) and is joined at request time.
+
+## The docs (entry points)
+
+- **README.md** — the "Everything is local" pillar now names runtime profiles: name your backends as
+  reusable profiles and run a different one per agent; the shape syncs, the key stays per-surface.
+- **docs/MODELS.md** — a new "Runtime profiles: where each agent runs" section (basic = one active;
+  advanced = a named list assigned per agent; the inline "Runs on" control; shape-only sync; honest
+  n/a where a surface cannot host a kind; key custody).
+- **docs/SECURITY.md** §5 (Secrets handling) — a "Runtime profile keys" bullet: the key is never part
+  of the profile and never syncs; each surface holds its own (device Keychain / hub env secret); joined
+  at request time; with a note that a regression test asserts it.
+
+## Acceptance criteria → proof
+
+- **One profile, surfaces in equilibrium, key never crosses.** The new cross-surface test proves the
+  hub side end-to-end across both ingresses and all read routes; the Apple contract test + 24-04 hub
+  tests cover the iPad/desktop custody. ✅
+- **The never-sync invariant has a dedicated cross-surface assertion.** It does (above). ✅
+- **Entry-point docs + the security note ship in the same closing commit.** README + MODELS + SECURITY,
+  this commit. ✅
+- **Suites green.** `uv run pytest` 3040 passed; voice/docs guard 158 passed. ✅
+
+## The walked proof (owner, real metal)
+
+The hub + web are verifiable on this machine (the `/profiles` surface + the desk "Runs on" picker were
+Playwright-proven in 24-05). The iPad/iPhone leg is the owner's device walk: the latest build with the
+Apple profiles UI (ProfilesView, the per-agent "Runs on" chip, the grounding gauge reading the
+assigned profile's context limit) is installed on the iPhone 17 Pro Max this session. A live run that
+authors a cloud profile on the phone, observes it on the hub/web shape-only, and runs an agent on it
+with a real key in `HOLDSPEAK_PROFILE_<id>_KEY` is the owner's to witness; the contract + custody are
+proven by the tests above.

--- a/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-06-proof-and-docs.md
+++ b/pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/story-06-proof-and-docs.md
@@ -1,6 +1,10 @@
 # HSM-24-06 — Cross-surface parity proof + the docs story
 
-**Status:** planned (the phase gate; after 24-02..05).
+- **Status:** done (2026-06-28) — the cross-surface never-sync proof (a key from EITHER ingress, sync
+  push or REST body, never reaches ANY read surface; the served shape is field-for-field the agreed
+  schema) + the entry-point docs (README, docs/MODELS.md "Runtime profiles", docs/SECURITY.md §5 key
+  custody). Evidence: [evidence-story-06.md](./evidence-story-06.md). Full `uv run pytest` 3040 passed;
+  voice guard green. **Phase 24 closes with this story.**
 
 ## Problem
 

--- a/tests/integration/test_primitive_framework_sync.py
+++ b/tests/integration/test_primitive_framework_sync.py
@@ -510,3 +510,65 @@ def test_profile_syncs_shape_only_and_agent_carries_profile_id(env) -> None:
     blob = json.dumps(pulled)
     assert "api_key" not in blob and "SHOULD-NEVER-PERSIST" not in blob
     assert "api_key" not in prof_rec["value"] and "apiKey" not in prof_rec["value"]
+
+
+# The agreed cross-surface RuntimeProfile shape (matches db.models.ProfileRecord.to_dict and the
+# Apple Contracts/Primitives.swift RuntimeProfile fields). NO key field exists anywhere in it — the
+# secret is each surface's own custodian (iPad Keychain / hub env secrets), joined at run time.
+_PROFILE_SHAPE_KEYS = {
+    "id", "name", "kind", "model_file", "base_url", "model",
+    "context_limit", "requires_key", "created_at", "last_modified", "deleted",
+}
+
+
+def test_profile_never_sync_holds_across_every_read_surface(env) -> None:
+    """HSM-24-06 (the phase gate): one profile, observed in equilibrium. The SAME profile is served
+    SHAPE-ONLY through every surface's read path — the sync pull AND the web/API CRUD routes — with
+    the exact agreed field set and NO key material on any of them. This is the cross-surface
+    never-sync security crux: a key supplied to ANY ingress (sync push or the REST body) is dropped,
+    so it can never reappear on a surface that reads the hub."""
+    db, client = env
+    lm = "2030-06-27T09:00:00Z"
+
+    # Ingress 1 — the sync push (the iPad's path), carrying a hostile key.
+    push = client.post("/api/sync/push", json={
+        "profiles": [{
+            "meta": {"id": "prof_x", "kind": "profile", "last_modified": lm, "deleted": False},
+            "value": {
+                "id": "prof_x", "name": "Claude", "kind": "openAICompatible",
+                "model_file": "", "base_url": "https://api.anthropic.com/v1",
+                "model": "claude-3.5-sonnet", "context_limit": 200000, "requires_key": True,
+                "api_key": "sk-FROM-SYNC-MUST-VANISH",
+                "created_at": "2030-06-27T08:00:00Z", "last_modified": lm, "deleted": False,
+            },
+        }],
+    })
+    assert push.status_code == 200, push.text
+
+    # Ingress 2 — the REST CRUD (the web's path), also carrying a hostile key.
+    created = client.post("/api/profiles", json={
+        "id": "prof_y", "name": "OpenRouter", "kind": "openAICompatible",
+        "base_url": "https://openrouter.ai/api/v1", "model": "anthropic/claude-sonnet-4",
+        "context_limit": 200000, "requires_key": True,
+        "api_key": "sk-FROM-REST-MUST-VANISH",
+    })
+    assert created.status_code == 201, created.text
+
+    # Every READ surface a downstream surface consumes: the sync pull + both CRUD reads.
+    pulled = client.get("/api/sync/pull").json()
+    listed = client.get("/api/profiles").json()["profiles"]
+    got_x = client.get("/api/profiles/prof_x").json()["profile"]
+    got_y = client.get("/api/profiles/prof_y").json()["profile"]
+
+    # 1) The shape is exactly the agreed cross-surface field set — no more, no less, no key.
+    for served in (got_x, got_y, *listed):
+        assert set(served.keys()) == _PROFILE_SHAPE_KEYS, set(served.keys()) ^ _PROFILE_SHAPE_KEYS
+
+    # 2) No key material survives on ANY read surface, from EITHER ingress.
+    surfaces_blob = json.dumps([pulled, listed, got_x, got_y])
+    for needle in ("api_key", "apiKey", "FROM-SYNC-MUST-VANISH", "FROM-REST-MUST-VANISH"):
+        assert needle not in surfaces_blob, f"{needle!r} leaked onto a read surface"
+
+    # 3) The shape itself round-tripped intact (parity is real, not achieved by dropping data).
+    assert got_x["base_url"] == "https://api.anthropic.com/v1" and got_x["context_limit"] == 200000
+    assert got_y["model"] == "anthropic/claude-sonnet-4" and got_y["requires_key"] is True


### PR DESCRIPTION
## What

The phase gate for **runtime profiles**: prove the never-sync invariant across surfaces, and document where intelligence runs. Closes Phase 24.

### The cross-surface never-sync proof
`test_profile_never_sync_holds_across_every_read_surface` (new):
- A key supplied to **either ingress** — a sync push (the iPad's path) **or** a REST body (the web's path) — never reappears on **any read surface**: the sync pull, `GET /api/profiles`, `GET /api/profiles/{id}`.
- Every served profile is **field-for-field the agreed cross-surface schema** with no key field. Parity is real (the shape round-trips intact), not achieved by silently dropping data.

Together with the Apple contract test (key never on the `Synced`/`ChangeSet` shape) and the 24-04 hub key-resolution tests, the chain is closed: the key lives only in each surface's custodian (iPad Keychain / hub env secret `HOLDSPEAK_PROFILE_<id>_KEY`), joined at request time.

### Docs (entry points)
- **README** names runtime profiles in the local-intelligence pillar.
- **docs/MODELS.md** gains a "Runtime profiles" section (basic vs advanced, the inline "Runs on" control, shape-only sync, honest n/a, key custody).
- **docs/SECURITY.md** §5 gains the profile key-custody bullet.

## Proof
- Full `uv run pytest` (sans the mic-bound metal test) → **3040 passed, 0 failed**.
- Voice/docs guard → 158 passed (docs additions clean: no prose em-dashes, no story IDs).

Evidence: `pm/roadmap/holdspeak-mobile/phase-24-runtime-profiles/evidence-story-06.md`.

## State
Profiles are in equilibrium across desktop / hub / iPad / iPhone / web. The owner's remaining leg is a live device walk (author a cloud profile on the phone, see it shape-only on hub/web, run an agent on it with a real key) — the latest Apple build with the profiles UI is installed on the iPhone 17 Pro Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)