### PR TITLE
Fix the recording UI overlapping the desk list (lane)

### DIFF
--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -3177,7 +3177,14 @@ struct DioStage: View {
                 // card column on iPhone (.lane). `positions[id]` is untouched either way, so rotating
                 // back to .wide restores the exact hand-arranged desk (HSM-20-02).
                 ForEach([pathKey], id: \.self) { _ in
-                    if camera.isLane { laneColumn(w, h, topInset, botInset) } else { level(w, h) }
+                    if camera.isLane {
+                        // While recording/weaving, the ambient recorder OWNS the lane surface. Hiding the
+                        // card column stops the live UI (transcript, ASK LIVE lenses, agent markers, STOP)
+                        // from rendering on top of the list and colliding with every row. (Device
+                        // punch-list: recording overlapped everything on the phone.) The iPad diorama keeps
+                        // the ambient-over-canvas design — its canvas is sparse, not a dense column.
+                        if !(capturing || weaving) { laneColumn(w, h, topInset, botInset) }
+                    } else { level(w, h) }
                 }
                     .transition(diveTransition)
 

--- a/pm/roadmap/holdspeak-mobile/HANDOVER-2026-06-28-desk-overlap-emptyzone.md
+++ b/pm/roadmap/holdspeak-mobile/HANDOVER-2026-06-28-desk-overlap-emptyzone.md
@@ -57,6 +57,21 @@ via a temporary `HS_DESK_DIVE=empty` seed, since removed). The fixed shots show 
 under the orbs, and "Nothing filed in Scratch yet" above the inherited connector rows. The device
 build was reinstalled on the iPhone 17 Pro Max.
 
+## 3. The whole recording UI overlapped the list (lane / iPhone)
+
+**Symptom (owner, "here's how it looks when I'm recording"):** during a recording the live-capture UI
+(the HEARING live transcript, the ASK LIVE lens chips, agent/crew markers, REC timer, STOP button) all
+floated ON TOP of the scrolling list — text-on-text everywhere.
+
+**Cause:** `DioAmbientRecorder` (zIndex 110) is a transparent bottom-anchored overlay, and `laneColumn`
+kept rendering *underneath* it during `capturing` — the recorder is designed to float over the iPad
+diorama (sparse canvas), but on the lane it floats over a dense list.
+
+**Fix:** on the lane, don't render `laneColumn` while `capturing || weaving` — the ambient recorder
+OWNS the surface (it floats over the desk gradient bg, no list behind). The iPad keeps the
+ambient-over-canvas design (its canvas is sparse). Verified: the recording state now shows only the
+live cards + transcript + ASK LIVE lenses/agents + STOP, cleanly, over a clean background.
+
 ## Still open (named, not fixed here)
 
 - **Qlippy on the lane** floats at `y = h*0.66` and overlaps a mid-list row at the right edge — the


### PR DESCRIPTION
Third bug from the owner device walk ("here's how it looks when I'm recording").

**Symptom:** during a recording, the live-capture UI — the HEARING live transcript, the ASK LIVE lens chips, agent/crew markers, the REC timer, and the STOP button — all rendered **on top of the scrolling list** (text-on-text everywhere).

**Cause:** `DioAmbientRecorder` (zIndex 110) is a transparent bottom-anchored overlay designed to float over the iPad diorama (a sparse canvas). On the lane, `laneColumn` kept rendering underneath it during `capturing`, so the dense card column collided with the recording UI.

**Fix:** on the lane, don't render `laneColumn` while `capturing || weaving` — the ambient recorder owns the surface and floats over the desk background, no list behind. The iPad keeps the ambient-over-canvas design (its canvas is sparse).

**Proof:** Simulator screenshot of the real app with a full list seeded + recording active — the list is hidden and the recorder (live cards + transcript + ASK LIVE lenses/agents + STOP) lays out cleanly. Device app reinstalled on the iPhone 17 Pro Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)