### PR TITLE
Drop Qlippy from the phone lane (it overlapped the list)

### DIFF
--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -3265,10 +3265,13 @@ struct DioStage: View {
                     .allowsHitTesting(false).ignoresSafeArea().zIndex(71)
                 }
 
-                // Qlippy tucks up the right edge on the lane so it clears the accent FAB (both want
-                // the bottom-right thumb corner); the diorama keeps it bottom-right.
-                DioCompanion(landed: landed, excited: selected != nil)
-                    .position(x: w * 0.9, y: camera.isLane ? h * 0.66 : h * 0.86)
+                // Qlippy lives on the spacious iPad DIORAMA only. On the phone lane it floated over the
+                // scrolling card column and just got in the way (owner: "annoying af too"). It is purely
+                // decorative (no tap/gesture), so dropping it on the lane loses nothing.
+                if !camera.isLane {
+                    DioCompanion(landed: landed, excited: selected != nil)
+                        .position(x: w * 0.9, y: h * 0.86)
+                }
                 if landed && selected == nil && summonSource == nil && !capturing
                     && editingNote == nil && editingKB == nil && !connecting
                     && !showRouteSheet && !routing && printed == nil && !showSendCard && !showActSheet {

--- a/pm/roadmap/holdspeak-mobile/HANDOVER-2026-06-28-desk-overlap-emptyzone.md
+++ b/pm/roadmap/holdspeak-mobile/HANDOVER-2026-06-28-desk-overlap-emptyzone.md
@@ -72,9 +72,15 @@ OWNS the surface (it floats over the desk gradient bg, no list behind). The iPad
 ambient-over-canvas design (its canvas is sparse). Verified: the recording state now shows only the
 live cards + transcript + ASK LIVE lenses/agents + STOP, cleanly, over a clean background.
 
-## Still open (named, not fixed here)
+## 4. Qlippy overlapped the list (lane / iPhone)
 
-- **Qlippy on the lane** floats at `y = h*0.66` and overlaps a mid-list row at the right edge — the
-  same overlap class, smaller (a semi-transparent mascot). Not in the owner's named pair; a follow-up.
+**Symptom (owner):** "that clippy shit is annoying af too" — the `DioCompanion` mascot floated over the
+scrolling card column at the right edge, overlapping rows.
+
+**Fix:** Qlippy is now gated to the iPad DIORAMA only (`!camera.isLane`). It is purely decorative (no
+tap/gesture), so dropping it on the phone lane loses nothing and the spacious iPad keeps it.
+
+## Still open
+
 - The broader device-gap punch-list from [HANDOVER-2026-06-27-device-gap.md](./HANDOVER-2026-06-27-device-gap.md)
   (in-world editing for any remaining modals, mic on every input, etc.) continues.


### PR DESCRIPTION
Owner: "that clippy shit is annoying af too." The `DioCompanion` mascot floated over the scrolling card column at the right edge and overlapped rows.

**Fix:** Qlippy is now gated to the iPad diorama only (`!camera.isLane`). It's purely decorative (no tap/gesture), so the phone lane loses nothing and the spacious iPad keeps it.

**Proof:** Simulator screenshot of the real app + a full-desk seed — the lane rows are unobstructed, no mascot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)