### PR TITLE
Anchor the Record/New orbs to the bottom edge

### DIFF
--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -3085,7 +3085,10 @@ struct DioStage: View {
         return fallback
     }
     // the record button's tucked-away corner home (bottom-left), shared by the button + the first-boot trail
-    private func orbPos(_ w: CGFloat, _ h: CGFloat) -> CGPoint { CGPoint(x: 58, y: h * 0.9) }
+    // The bottom controls hug the bottom safe edge, not a 0.9·h fraction (which left a big dead band
+    // below them — owner: "so much farther than the base bottom line"). `h` is the safe height, so the
+    // safe bottom is y == h; sit the orb+label VStack just above it.
+    private func orbPos(_ w: CGFloat, _ h: CGFloat) -> CGPoint { CGPoint(x: 58, y: h - 24) }
 
     private var diveTransition: AnyTransition {
         diveDir >= 0


### PR DESCRIPTION
Owner: "why is the record and new button so much farther than the base bottom line, I always wondered."

`orbPos` used a hardcoded `0.9·h` fraction in the safe-area coordinate space, so ~10% of the height (plus the bottom inset) sat empty below the controls — they were never anchored to the bottom.

**Fix:** anchor to the bottom (`h - 24`) so the Record/New orbs hug the bottom safe edge, labels just above the home indicator. `orbPos` is shared by the orbs, the record mode picker, and the ambient recorder, so they all move together.

**Proof:** Simulator screenshot of the real app — the orbs now sit at the bottom instead of floating at 90% height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)