### PR TITLE
Cloud intel streaming: forward endpoint SSE deltas (completes the theater pulse on real metal)

### DIFF
--- a/holdspeak/intel/engine.py
+++ b/holdspeak/intel/engine.py
@@ -220,6 +220,89 @@ class MeetingIntel:
         raw = response.choices[0].message.content if response.choices else ""
         return _extract_openai_message_text(raw)
 
+    def _chat_completion_stream(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float,
+        max_tokens: int,
+    ) -> Iterator[str]:
+        """Stream text deltas from the active provider (local GGUF OR cloud).
+
+        The streaming twin of `_chat_completion_text`. The cloud branch forwards
+        the OpenAI-compatible endpoint's SSE deltas (`.43`/llama.cpp, Ollama,
+        vLLM, a real API), so endpoint intel streams token-by-token like the
+        local model — which is what lights the generation theater's "thinking"
+        pulse and the Queue HUD heartbeat for endpoint users.
+        """
+        self._ensure_model_loaded()
+
+        if self._active_provider == "local":
+            assert self._llm is not None
+            stream_iter = self._llm.create_chat_completion(
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=True,
+            )
+            for chunk in stream_iter:
+                try:
+                    choice0 = (chunk.get("choices") or [{}])[0]
+                    delta = choice0.get("delta") or {}
+                    piece = delta.get("content")
+                    if piece is None:
+                        piece = choice0.get("text")
+                except Exception:
+                    continue
+                if piece:
+                    yield str(piece)
+            return
+
+        assert self._openai_client is not None
+        base_kwargs: dict[str, object] = {
+            "model": self.cloud_model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "extra_body": {"thinking": False},
+            "stream": True,
+        }
+        if self.cloud_reasoning_effort:
+            base_kwargs["reasoning_effort"] = self.cloud_reasoning_effort
+        if self.cloud_store:
+            base_kwargs["store"] = True
+
+        try:
+            try:
+                stream_iter = self._openai_client.chat.completions.create(**base_kwargs)
+            except TypeError as exc:
+                if "max_tokens" not in str(exc):
+                    raise
+                fallback_kwargs = dict(base_kwargs)
+                fallback_kwargs.pop("max_tokens", None)
+                fallback_kwargs["max_completion_tokens"] = max_tokens
+                stream_iter = self._openai_client.chat.completions.create(**fallback_kwargs)
+        except Exception as exc:
+            raise MeetingIntelError(
+                _describe_cloud_exception(
+                    exc,
+                    model=self.cloud_model,
+                    base_url=self.cloud_base_url,
+                )
+            ) from exc
+
+        for chunk in stream_iter:
+            try:
+                choices = getattr(chunk, "choices", None) or []
+                if not choices:
+                    continue
+                delta = getattr(choices[0], "delta", None)
+                piece = getattr(delta, "content", None) if delta is not None else None
+            except Exception:
+                continue
+            if piece:
+                yield str(piece)
+
     def run_prompt(
         self,
         *,
@@ -315,74 +398,23 @@ class MeetingIntel:
         return self._analyze_stream(transcript)
 
     def _analyze_stream(self, transcript: str) -> Iterator[Union[str, IntelResult]]:
-        """Stream analysis when available.
+        """Stream analysis token-by-token, then a final parsed IntelResult.
 
-        Cloud mode currently emits only the final IntelResult.
+        Both providers stream now: the local GGUF and the cloud/endpoint path
+        (the latter forwards the endpoint's SSE deltas via
+        `_chat_completion_stream`). So the live meeting intel broadcasts
+        `intel_token` for endpoint users too — lighting the generation theater's
+        "thinking" pulse and the Queue HUD heartbeat, not only for local models.
         """
         raw_parts: list[str] = []
+        messages = _json_only_messages(transcript)
 
         try:
-            self._ensure_model_loaded()
-        except Exception as exc:
-            log.error(f"Intel analyze(stream=True) failed to start: {exc}", exc_info=True)
-            yield IntelResult(
-                topics=[],
-                action_items=[],
-                summary="",
-                raw_response=f"ERROR: {exc}",
-                error=str(exc),
-            )
-            return
-
-        if self._active_provider == "cloud":
-            try:
-                yield self._analyze_once(transcript)
-            except Exception as exc:
-                yield IntelResult(
-                    topics=[],
-                    action_items=[],
-                    summary="",
-                    raw_response=f"ERROR: {exc}",
-                    error=str(exc),
-                )
-            return
-
-        try:
-            assert self._llm is not None
-            messages = _json_only_messages(transcript)
-            stream_iter = self._llm.create_chat_completion(
-                messages=messages,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                stream=True,
-            )
-        except Exception as exc:
-            log.error(f"Intel analyze(stream=True) failed to start: {exc}", exc_info=True)
-            yield IntelResult(
-                topics=[],
-                action_items=[],
-                summary="",
-                raw_response=f"ERROR: {exc}",
-                error=str(exc),
-            )
-            return
-
-        try:
-            for chunk in stream_iter:
-                try:
-                    choice0 = (chunk.get("choices") or [{}])[0]
-                    delta = choice0.get("delta") or {}
-                    piece = delta.get("content")
-                    if piece is None:
-                        piece = choice0.get("text")
-                    if not piece:
-                        continue
-                    text_piece = str(piece)
-                except Exception:
-                    continue
-
-                raw_parts.append(text_piece)
-                yield text_piece
+            for piece in self._chat_completion_stream(
+                messages, temperature=self.temperature, max_tokens=self.max_tokens
+            ):
+                raw_parts.append(piece)
+                yield piece
         except Exception as exc:
             log.error(f"Intel streaming failed: {exc}", exc_info=True)
             yield IntelResult(

--- a/pm/roadmap/holdspeak/phase-69-web-recrafted/final-summary.md
+++ b/pm/roadmap/holdspeak/phase-69-web-recrafted/final-summary.md
@@ -55,9 +55,11 @@ gate with screenshot — and, for the LLM-shaped theater, real-metal — proof.
 
 ## Honest follow-ups (surfaced, not dropped)
 
-- The mic waveform's real-mic e2e (the metal test is excluded); the theater's
-  token-pulse on real metal awaits the streaming `.13` endpoint (down this
-  session; `.43` returned buffered).
+- The mic waveform's real-mic e2e (the metal test is excluded).
+- ~~The theater's token-pulse awaits the streaming `.13` endpoint~~ — **resolved
+  in the `cloud-intel-streaming` follow-up**: that 0-token result was an engine
+  limitation (the cloud intel path buffered; only local GGUF streamed), now
+  fixed, and the pulse is proven on real `.43` metal (125 streamed chunks).
 - The egress badge on history/proposal cards needs a backend egress field.
 - The deeper iPad CompanionBoard live-session interactions (select/pin/inject).
 

--- a/pm/roadmap/holdspeak/phase-69-web-recrafted/theater-realmetal-transcript.txt
+++ b/pm/roadmap/holdspeak/phase-69-web-recrafted/theater-realmetal-transcript.txt
@@ -4,16 +4,16 @@ Using Qwythos-9B (.43, fallback)
   base_url=http://192.168.1.43:8080/v1
   model=Qwythos-9B-Claude-Mythos-5-1M-Q6_K.gguf
 
-
+.............................................................................................................................
 
 --- real-metal capture (1.7s) ---
-intel_token chunks streamed: 0  (drive the orb's 'thinking' pulse)
-streamed text length: 0 chars
+intel_token chunks streamed: 125  (drive the orb's 'thinking' pulse)
+streamed text length: 528 chars
 final.error: None
-summary: 'The team agreed on a token bucket per API key rate limiter design with a feature flag for gradual rollout. Bob will wire the flag by Friday. They also settled on Postgres as the primary store and will'
+summary: 'The team finalized the rate limiter design using a token bucket per API key behind a feature flag, with Bob to implement the flag by Friday. They also settled on Postgres as the primary store and will'
 action_items: 2
-topics: ['Rate limiter design', 'Feature flag', 'Service name', 'Database']
+topics: ['Rate limiter design', 'Feature flag implementation', 'Service name selection', 'Database choice']
 
 constellation nodes that would light: ['summary', 'actions', 'topics']
 
-RESULT: PARTIAL — real Qwythos-9B (.43, fallback) produced 0 streamed chunks + a snapshot lighting ['summary', 'actions', 'topics'].
+RESULT: PASS — real Qwythos-9B (.43, fallback) produced 125 streamed chunks + a snapshot lighting ['summary', 'actions', 'topics'].

--- a/tests/integration/test_intel_streaming.py
+++ b/tests/integration/test_intel_streaming.py
@@ -264,6 +264,7 @@ class TestMeetingIntelStreamingIntegration:
             with patch.object(MeetingIntel, "_ensure_model_loaded"):
                 intel = MeetingIntel()
                 intel._llm = mock_llm
+                intel._active_provider = "local"  # the real loader sets this
 
                 stream = intel.analyze("Test transcript", stream=True)
                 items = list(stream)
@@ -284,6 +285,7 @@ class TestMeetingIntelStreamingIntegration:
             with patch.object(MeetingIntel, "_ensure_model_loaded"):
                 intel = MeetingIntel()
                 intel._llm = mock_llm
+                intel._active_provider = "local"  # the real loader sets this
 
                 stream = intel.analyze("Test", stream=True)
                 items = list(stream)
@@ -291,6 +293,42 @@ class TestMeetingIntelStreamingIntegration:
                 assert len(items) == 1
                 assert isinstance(items[0], IntelResult)
                 assert "ERROR" in items[0].raw_response
+
+    def test_cloud_stream_forwards_endpoint_deltas(self):
+        """The cloud/endpoint path streams: it forwards the OpenAI-compatible
+        endpoint's SSE deltas as intel_token chunks (not one buffered call), so
+        the generation theater's pulse + the Queue HUD heartbeat light up for
+        endpoint users too."""
+        def make_chunk(content):
+            chunk = MagicMock()
+            delta = MagicMock()
+            delta.content = content
+            choice = MagicMock()
+            choice.delta = delta
+            chunk.choices = [choice]
+            return chunk
+
+        pieces = ['{"topics":', ' ["Rate"],', ' "action_items": [],', ' "summary": "OK"}']
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = MagicMock(
+            return_value=iter([make_chunk(p) for p in pieces])
+        )
+
+        with patch.object(MeetingIntel, "_ensure_model_loaded"):
+            intel = MeetingIntel(provider="cloud", cloud_base_url="http://example/v1")
+            intel._active_provider = "cloud"
+            intel._openai_client = mock_client
+
+            items = list(intel.analyze("Test transcript", stream=True))
+            tokens = [i for i in items if isinstance(i, str)]
+            results = [i for i in items if isinstance(i, IntelResult)]
+
+            assert tokens == pieces  # per-token streaming, not a single buffered yield
+            assert len(results) == 1
+            assert results[0].summary == "OK"
+            # the request was made with stream=True
+            _, kwargs = mock_client.chat.completions.create.call_args
+            assert kwargs.get("stream") is True
 
 
 # ============================================================
@@ -846,6 +884,7 @@ class TestEmptyTranscriptHandling:
             with patch.object(MeetingIntel, "_ensure_model_loaded"):
                 intel = MeetingIntel()
                 intel._llm = mock_llm
+                intel._active_provider = "local"  # the real loader sets this
 
                 stream = intel.analyze("", stream=True)
                 items = list(stream)


### PR DESCRIPTION
Follow-up to HS-69-09 (Phase 69). The generation theater's "thinking" pulse — and the Queue HUD heartbeat — never lit up for **endpoint** intel (the common path), because the engine **buffered** the cloud call: `_analyze_stream` short-circuited the cloud provider to `_analyze_once` (one call, zero `intel_token` chunks) while only the local GGUF streamed. The 0-token result on `.43` was an *engine* limitation, not the endpoint — `.43` streams fine over SSE.

## Change
- `holdspeak/intel/engine.py`: a new `_chat_completion_stream(messages)` that streams **both** providers — local GGUF and the cloud/endpoint path (forwarding the OpenAI-compatible endpoint's `delta.content` via `chat.completions.create(stream=True)`, with the same kwargs + the `max_completion_tokens` fallback). `_analyze_stream` is unified to use it; the `stream=False` path is untouched.
- `tests/integration/test_intel_streaming.py`: the streaming mocks now set `_active_provider="local"` (the real loader does), and a new test proves the cloud path forwards SSE deltas as `intel_token` chunks with `stream=True`.

## Proof
`scripts/theater_realmetal_proof.py` re-run on **real `.43` metal** now streams **125 `intel_token` chunks** + the snapshot (RESULT: PASS; `theater-realmetal-transcript.txt`). So the theater's full lifecycle (reveal → pulse → constellation) is proven on real metal. The Phase-69 final-summary records the correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)