### PR TITLE
Fix: filed objects leave the open stage (owner video feedback)

### DIFF
--- a/web/src/desk/__tests__/desk.test.ts
+++ b/web/src/desk/__tests__/desk.test.ts
@@ -65,7 +65,10 @@ describe("world math", () => {
     coder: [],
   };
   it("flattens in the canonical order and filters on dive", () => {
-    expect(worldObjects(items, null).map((o) => o.id)).toEqual(["m1", "n1"]);
+    // m1 is FILED into z: the root stage shows only the unfiled note (the
+    // iPad grammar — a filed object lives on its shelf; owner feedback
+    // 2026-07-02); diving shows the member.
+    expect(worldObjects(items, null).map((o) => o.id)).toEqual(["n1"]);
     expect(worldObjects(items, "z").map((o) => o.id)).toEqual(["m1"]);
   });
   it("looseHome is deterministic and clamped", () => {

--- a/web/src/desk/components/World.tsx
+++ b/web/src/desk/components/World.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useDesk } from "../store";
 import {
-  objGlow, objUnit, worldObjects, worldRows, worldZones,
+  allObjects, objGlow, objUnit, worldObjects, worldRows, worldZones,
 } from "../world";
 import { DeskObject } from "./DeskObject";
 import { InlineEditor } from "./InlineEditor";
@@ -27,7 +27,7 @@ export function World() {
   const editing = editingIdx >= 0 ? objects[editingIdx] : null;
   const pulloutId = useDesk((s) => s.pulloutId);
   const pullout = pulloutId
-    ? worldObjects(items, null).find((x) => x.id === pulloutId) || null
+    ? allObjects(items).find((x) => x.id === pulloutId) || null
     : null;
 
   const { surface } = useDesk.getState();

--- a/web/src/desk/world.ts
+++ b/web/src/desk/world.ts
@@ -16,7 +16,10 @@ const ORDER: Kind[] = [
   "meeting", "note", "kb", "agent", "artifact", "chain", "workflow", "coder",
 ];
 
-export function worldObjects(items: Items, divedZone: string | null): WorldObject[] {
+/** Every primitive as a world object, unfiltered — the lookup surface for
+ * pull-outs/editors (a FILED object still opens; it just doesn't float on
+ * the root stage). */
+export function allObjects(items: Items): WorldObject[] {
   const out: WorldObject[] = [];
   for (const kind of ORDER) {
     for (const it of items[kind] || []) {
@@ -29,12 +32,25 @@ export function worldObjects(items: Items, divedZone: string | null): WorldObjec
       });
     }
   }
+  return out;
+}
+
+export function worldObjects(items: Items, divedZone: string | null): WorldObject[] {
+  const out = allObjects(items);
   if (divedZone) {
     const dir = (items.directory || []).find((d) => d.id === divedZone);
     const members = new Set(((dir as any)?.memberIds as string[]) || []);
     return out.filter((o) => members.has(o.id));
   }
-  return out;
+  // The iPad grammar (owner feedback, 2026-07-02): a filed object lives on
+  // its shelf, not on the open desk — the root stage shows only unfiled
+  // objects; dive to see a zone's members. (Live coder sessions are never
+  // filed and always show.)
+  const filed = new Set<string>();
+  for (const d of items.directory || []) {
+    for (const mid of (((d as any).memberIds as string[]) || [])) filed.add(mid);
+  }
+  return out.filter((o) => o.kind === "coder" || !filed.has(o.id));
 }
 
 export interface WorldZone {


### PR DESCRIPTION
The owner's video review caught double representation: a note dragged onto a zone stayed floating on the root stage while the tray also counted it. The iPad grammar is the contract: **a filed object lives on its shelf** — the open desk shows only unfiled objects, dive shows a zone's members, un-filing returns the object to the stage.

- `worldObjects` filters directory members out of the root stage (coder sessions never filter — live sessions are never filed).
- The pull-out/editor lookup moves to a new unfiltered `allObjects` (the first fix attempt filtered the lookup too, making filed objects unopenable — the proof run caught it).
- Proven live end to end: file → gone from the stage + on the tray; dive → opens; un-file → returns. vitest contract updated; full suite 3095/37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ