### PR TITLE
Phase 18 (HSM-18-07): the Desk-Era rider — origin on the artifact contract + run-born artifacts land on the iPad desk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
 - **Preview before it types** (Settings, Voice; off by default): a
   finished dictation shows its text on a card first, on every page. Type
   it commits; Discard drops it.
+- Artifacts now say where they came from on every API surface: an
+  `origin` field (`meeting` or `run`) rides sync pull and the meeting
+  artifacts route, so clients no longer infer a run's output from an
+  empty meeting id.
 
 ### Fixed
 - The preview card no longer renders as an empty box on pages with no

--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -3722,8 +3722,11 @@ struct DioStage: View {
                 if ProcessInfo.processInfo.environment["HS_DESK_ARRIVE"] == "1" {
                     let m = Meeting(id: "demoNew", startedAt: Date(), title: "Q3 kickoff", segments: [Segment(text: "Welcome to the kickoff.", speaker: "Speaker 1", startTime: 0, endTime: 2)])
                     model.meetings = [m] + model.meetings
-                    outputs = [OutputRecord(id: "delivNew", title: "Summary", body: "Shipping the desk to the web is the Q3 bet; Karol owns mesh sync and the approval contract; air-gapped proof due Friday.", source: "Q3 kickoff", lens: "Summary", path: "")]
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { withAnimation(.spring(response: 0.55, dampingFraction: 0.7)) { arrivedIds = ["m:demoNew", "out:delivNew"]; flash = 0.5 }; withAnimation(.easeOut(duration: 0.9)) { flash = 0 } }
+                    outputs = [OutputRecord(id: "delivNew", title: "Summary", body: "Shipping the desk to the web is the Q3 bet; Karol owns mesh sync and the approval contract; air-gapped proof due Friday.", source: "Q3 kickoff", lens: "Summary", path: ""),
+                               // A run-born card (HSM-18-07): no meeting anchor, so it
+                               // sits loose on the desk instead of a meeting's drawer.
+                               OutputRecord(id: "runNew", title: "Scout: the mesh risks", body: "Top risk: the approval contract drifts between surfaces. Lock it with the parity guard before the air-gapped proof.", source: "your ask", lens: "Agent · your desktop", path: "")]
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { withAnimation(.spring(response: 0.55, dampingFraction: 0.7)) { arrivedIds = ["m:demoNew", "out:delivNew", "out:runNew"]; flash = 0.5 }; withAnimation(.easeOut(duration: 0.9)) { flash = 0 } }
                 }
                 // IN-WORLD editing + pairing demos (layout checks for the device punch-list).
                 // HS_DESK_NOTE=1 → a fresh note, edited in place on the desk (no modal).
@@ -4898,7 +4901,10 @@ struct DioStage: View {
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
                 #endif
                 withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
-                    printed = OutputRecord(id: UUID().uuidString,
+                    // The hub persisted this run as a run-born artifact (v6) —
+                    // the card shares its id so Keep reconciles on sync instead
+                    // of duplicating.
+                    printed = OutputRecord(id: result.artifactId ?? UUID().uuidString,
                                            title: title,
                                            body: clean.isEmpty ? "(your desktop returned nothing)" : clean,
                                            source: source,
@@ -5109,6 +5115,15 @@ struct DioStage: View {
         UINotificationFeedbackGenerator().notificationOccurred(.success)
         #endif
         withAnimation(focusSpring) { outputs.append(rec); printed = nil }
+        // The kept run result materializes on the stage with the same arrival
+        // beat woven deliverables and synced peers get (HSM-18-07).
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.7)) {
+            arrivedIds.insert("out:\(rec.id)"); flash = 0.45
+        }
+        withAnimation(.easeOut(duration: 0.9)) { flash = 0 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6) {
+            withAnimation { arrivedIds.subtract(["out:\(rec.id)"]) }
+        }
         routeSourceId = nil; persistOutputs(); stampSync(rec.id)
     }
     private func binPrinted() { haptic(.light); withAnimation { printed = nil }; routeSourceId = nil }

--- a/apple/Sources/Contracts/MeetingArtifact.swift
+++ b/apple/Sources/Contracts/MeetingArtifact.swift
@@ -69,13 +69,17 @@ public struct MeetingArtifact: Codable, Equatable, Sendable {
     /// route always sends both, but optional keeps the read model tolerant.
     public var createdAt: String?
     public var updatedAt: String?
+    /// v6 (Phase 74): "meeting" | "run" as a raw wire string; optional so an
+    /// origin-less payload (an older hub) still decodes. On this route it is
+    /// always "meeting" today (the route lists a meeting's own artifacts).
+    public var origin: String?
 
     public init(
         id: String, meetingId: String, artifactType: String,
         title: String, bodyMarkdown: String, structuredJson: JSONValue? = nil,
         confidence: Double? = nil, status: String, pluginId: String? = nil,
         pluginVersion: String? = nil, sources: [MeetingArtifactSource] = [],
-        createdAt: String? = nil, updatedAt: String? = nil
+        createdAt: String? = nil, updatedAt: String? = nil, origin: String? = nil
     ) {
         self.id = id
         self.meetingId = meetingId
@@ -90,6 +94,7 @@ public struct MeetingArtifact: Codable, Equatable, Sendable {
         self.sources = sources
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.origin = origin
     }
 }
 

--- a/apple/Sources/Contracts/Models.swift
+++ b/apple/Sources/Contracts/Models.swift
@@ -166,13 +166,23 @@ public struct Artifact: Codable, Equatable, Sendable {
     public var updatedAt: Date?
     // Reserved optional egress scope (contract §8); unpopulated in v0.
     public var egress: JSONValue?
+    /// v6 (Phase 74): "meeting" | "run". Raw wire string kept optional so an
+    /// origin-less payload (an older hub, a client push) still decodes.
+    public var origin: String?
+
+    /// The effective origin — the hub's own derivation (`plugins.py`:
+    /// no meeting anchor ⇒ run-born) applied when the wire omits `origin`.
+    public var isRunBorn: Bool {
+        (origin ?? (meetingId.isEmpty ? "run" : "meeting")) == "run"
+    }
 
     public init(
         id: String, meetingId: String, artifactType: ArtifactType,
         title: String, bodyMarkdown: String, structuredJson: JSONValue,
         confidence: Double, status: ArtifactStatus, pluginId: String,
         pluginVersion: String, sources: [ArtifactSource] = [],
-        createdAt: Date? = nil, updatedAt: Date? = nil, egress: JSONValue? = nil
+        createdAt: Date? = nil, updatedAt: Date? = nil, egress: JSONValue? = nil,
+        origin: String? = nil
     ) {
         self.id = id
         self.meetingId = meetingId
@@ -188,6 +198,7 @@ public struct Artifact: Codable, Equatable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.egress = egress
+        self.origin = origin
     }
 }
 

--- a/apple/Sources/Providers/Providers.swift
+++ b/apple/Sources/Providers/Providers.swift
@@ -123,9 +123,14 @@ public protocol IDesktopClient: Sendable {
 public struct HubRunResult: Sendable, Equatable, Decodable {
     public var output: String
     public var steps: [String]?
+    /// v6 (Phase 74): the hub persists the run's output as a run-born artifact
+    /// and returns its id. Optional so an older hub still decodes. The desk
+    /// card minted from this result must reuse it — a locally-invented id
+    /// would duplicate against the hub's own artifact on the next sync.
+    public var artifactId: String?
 
-    public init(output: String, steps: [String]? = nil) {
-        self.output = output; self.steps = steps
+    public init(output: String, steps: [String]? = nil, artifactId: String? = nil) {
+        self.output = output; self.steps = steps; self.artifactId = artifactId
     }
 }
 

--- a/apple/Sources/RuntimeCore/Desk/DeskRecords.swift
+++ b/apple/Sources/RuntimeCore/Desk/DeskRecords.swift
@@ -261,7 +261,11 @@ public struct OutputRecord: Codable, Identifiable, Equatable, Sendable {
         self.contract = Artifact(id: id, meetingId: "", artifactType: .pluginOutput, title: title,
                                  bodyMarkdown: body, structuredJson: .object(structured),
                                  confidence: 1.0, status: .draft, pluginId: "ipad.desk", pluginVersion: "0",
-                                 sources: sources, createdAt: now, updatedAt: now)
+                                 sources: sources, createdAt: now, updatedAt: now,
+                                 // Every desk-minted card is a run's output — say so
+                                 // explicitly (v6) instead of leaving the wire to infer
+                                 // it from the empty meeting anchor.
+                                 origin: "run")
         self.path = path
     }
 

--- a/apple/Tests/ContractsTests/RoundTripTests.swift
+++ b/apple/Tests/ContractsTests/RoundTripTests.swift
@@ -45,6 +45,8 @@ final class RoundTripTests: XCTestCase {
         XCTAssertEqual(s.artifact.artifactType, .decisions)          // tagged-union discriminator
         XCTAssertEqual(s.artifact.status, .draft)
         XCTAssertNil(s.artifact.createdAt)                           // draft omits it
+        XCTAssertEqual(s.artifact.origin, "meeting")                 // v6, explicit on the wire
+        XCTAssertFalse(s.artifact.isRunBorn)
 
         XCTAssertEqual(s.intelJob.status, "ready")
         XCTAssertEqual(s.intelJob.attempts, 1)
@@ -88,6 +90,46 @@ final class RoundTripTests: XCTestCase {
         XCTAssertEqual(s.actuatorProposal.target, "github")
         XCTAssertEqual(s.actuatorProposal.requiredCapabilities, ["github:write"])
         XCTAssertFalse(s.actuatorProposal.reversible)
+    }
+
+    /// HSM-18-07: `origin` ("meeting" | "run", v6) decodes when present and the
+    /// run-born derivation matches the hub's own (`plugins.py`: no meeting
+    /// anchor ⇒ run-born) when the wire omits it — an older hub, a client push.
+    func testArtifactOriginDecodesAndDerivesRunBorn() throws {
+        let dec = HoldSpeakContracts.decoder()
+
+        func artifactJSON(meetingId: String, origin: String?) -> Data {
+            var fields = [
+                "\"id\":\"a1\"", "\"meeting_id\":\"\(meetingId)\"",
+                "\"artifact_type\":\"plugin_output\"", "\"title\":\"t\"",
+                "\"body_markdown\":\"b\"", "\"structured_json\":{}",
+                "\"confidence\":0.5", "\"status\":\"draft\"",
+                "\"plugin_id\":\"p\"", "\"plugin_version\":\"1\"", "\"sources\":[]",
+            ]
+            if let origin { fields.append("\"origin\":\"\(origin)\"") }
+            return Data("{\(fields.joined(separator: ","))}".utf8)
+        }
+
+        // Explicit on the wire — the hub always emits it now.
+        let run = try dec.decode(Artifact.self, from: artifactJSON(meetingId: "", origin: "run"))
+        XCTAssertEqual(run.origin, "run")
+        XCTAssertTrue(run.isRunBorn)
+
+        let anchored = try dec.decode(Artifact.self, from: artifactJSON(meetingId: "m1", origin: "meeting"))
+        XCTAssertFalse(anchored.isRunBorn)
+
+        // Absent — tolerated, derived from the meeting anchor.
+        let bareRun = try dec.decode(Artifact.self, from: artifactJSON(meetingId: "", origin: nil))
+        XCTAssertNil(bareRun.origin)
+        XCTAssertTrue(bareRun.isRunBorn)
+
+        let bareAnchored = try dec.decode(Artifact.self, from: artifactJSON(meetingId: "m1", origin: nil))
+        XCTAssertFalse(bareAnchored.isRunBorn)
+
+        // An unknown raw value never fails the decode (tolerant String?).
+        let odd = try dec.decode(Artifact.self, from: artifactJSON(meetingId: "m1", origin: "weird"))
+        XCTAssertEqual(odd.origin, "weird")
+        XCTAssertFalse(odd.isRunBorn)
     }
 
     /// LIVE SYNC (THE PRIMITIVE FRAMEWORK, wave 2): a full-kind `ChangeSet` — the exact

--- a/apple/Tests/ProvidersTests/DesktopClientTests.swift
+++ b/apple/Tests/ProvidersTests/DesktopClientTests.swift
@@ -221,4 +221,28 @@ final class DesktopClientTests: XCTestCase {
         catch HTTPDesktopClient.DesktopClientError.http(let code) { XCTAssertEqual(code, 401) }
         catch { XCTFail("wrong error: \(error)") }
     }
+
+    // MARK: hub runs return the run-born artifact id (HSM-18-07)
+
+    func testRunAgentDecodesArtifactId() async throws {
+        // v6 (Phase 74): the hub persists the run's output as a run-born
+        // artifact and returns its id — the desk card must reuse it so a kept
+        // card reconciles with the hub's artifact on sync, never duplicates.
+        StubProtocol.routes = ["/api/agents/a-owl/run": (200,
+            Data(#"{"output":"the run output","artifact_id":"art_run_1"}"#.utf8))]
+        let result = try await client(token: "tok").runAgent(id: "a-owl", input: "say hi")
+        XCTAssertEqual(StubProtocol.lastMethod, "POST")
+        XCTAssertEqual(result.output, "the run output")
+        XCTAssertEqual(result.artifactId, "art_run_1")
+    }
+
+    func testRunChainWithoutArtifactIdStillDecodes() async throws {
+        // An older hub omits artifact_id — the decode stays tolerant.
+        StubProtocol.routes = ["/api/chains/c1/run": (200,
+            Data(#"{"output":"crew says hi","steps":["Scout: hi"]}"#.utf8))]
+        let result = try await client().runChain(id: "c1", input: "go")
+        XCTAssertEqual(result.output, "crew says hi")
+        XCTAssertEqual(result.steps, ["Scout: hi"])
+        XCTAssertNil(result.artifactId)
+    }
 }

--- a/apple/Tests/RuntimeCoreTests/DeskRecordsTests.swift
+++ b/apple/Tests/RuntimeCoreTests/DeskRecordsTests.swift
@@ -57,6 +57,10 @@ final class DeskRecordsTests: XCTestCase {
         XCTAssertEqual(back.provenance, prov)
         XCTAssertEqual(back.lineageLine, "from Q3 kickoff · via Scout")
         XCTAssertEqual(back.path, "Atlas")
+        // HSM-18-07: every desk-minted card is a run's output — origin is
+        // explicit on the embedded contract (v6), and the derivation agrees.
+        XCTAssertEqual(back.contract.origin, "run")
+        XCTAssertTrue(back.contract.isRunBorn)
     }
 
     func testWorkflowRecordRoundTrip() throws {

--- a/holdspeak/db/models.py
+++ b/holdspeak/db/models.py
@@ -201,6 +201,9 @@ class ArtifactSummary:
     sources: list[dict[str, str]]
     created_at: datetime
     updated_at: datetime
+    # 'meeting' | 'run' (v6, Phase 74). Run-born rows have no meeting anchor:
+    # meeting_id stores NULL and reads back "" here.
+    origin: str = "meeting"
 
 
 @dataclass

--- a/holdspeak/db/plugins.py
+++ b/holdspeak/db/plugins.py
@@ -800,6 +800,7 @@ class PluginArtifactRepository(BaseRepository):
             sources=sources,
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
+            origin=str(row["origin"] or "meeting"),
         )
 
     def delete_artifact(self, artifact_id: str) -> bool:
@@ -856,6 +857,7 @@ class PluginArtifactRepository(BaseRepository):
             sources=sources,
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
+            origin=str(row["origin"] or "meeting"),
         )
 
     def list_run_artifacts(self, *, limit: int = 200) -> list[ArtifactSummary]:
@@ -944,6 +946,7 @@ class PluginArtifactRepository(BaseRepository):
                     sources=sources_by_artifact.get(str(row["id"]), []),
                     created_at=datetime.fromisoformat(row["created_at"]),
                     updated_at=datetime.fromisoformat(row["updated_at"]),
+                    origin=str(row["origin"] or "meeting"),
                 )
             )
         return output

--- a/holdspeak/web/routes/meetings/insights.py
+++ b/holdspeak/web/routes/meetings/insights.py
@@ -150,6 +150,7 @@ def build_insights_router(ctx: WebContext) -> APIRouter:
                             "sources": artifact.sources,
                             "created_at": artifact.created_at.isoformat(),
                             "updated_at": artifact.updated_at.isoformat(),
+                            "origin": artifact.origin,
                         }
                         for artifact in artifacts
                     ],

--- a/holdspeak/web/routes/sync.py
+++ b/holdspeak/web/routes/sync.py
@@ -125,6 +125,9 @@ def _artifact_value(artifact: Any) -> dict[str, Any]:
         "plugin_id": artifact.plugin_id,
         "plugin_version": artifact.plugin_version,
         "sources": artifact.sources,
+        # 'meeting' | 'run' (v6). Explicit on the wire so a decoder never has
+        # to infer run-born from the empty meeting_id.
+        "origin": artifact.origin,
     }
 
 

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -10,10 +10,15 @@
 > gotchas, and the exact remaining work to finish **Phase 8** and **Phase 14** (top priority).
 
 **Current phase:** [Phase 18 — The iPad joins the dictation contracts](./phase-18-ipad-dictation-contracts/current-phase-status.md)
-— **THE EQUILIBRIUM PROGRAM HAS BEGUN** ([`EQUILIBRIUM.md`](./EQUILIBRIUM.md)), built against the
-[Experience Vision](./EXPERIENCE-VISION-2026-06-27.md). First fix landed: voice-command macros now fire
-on the remote relay (HSM-18-02 hub half, tested), the backend behind the "macro fires as an object"
-signature moment. Phases 16/17 (web parity + mesh sync; agent sync) remain open in parallel.
+— **RESUMED 2026-07-03 as the owner-picked next platform step** after the web/hub Desk Era closed
+(Phases 72–78, PRs #207–#214): the six authored stories plus the new Desk-Era rider
+**HSM-18-07** (run-born artifacts join the artifact contract + materialize on the iPad desk; a
+guard locks `HTTPDesktopClient` paths against `docs/api-surface.json`). THE EQUILIBRIUM PROGRAM
+([`EQUILIBRIUM.md`](./EQUILIBRIUM.md)) continues, built against the
+[Experience Vision](./EXPERIENCE-VISION-2026-06-27.md). First fix landed 2026-06-27:
+voice-command macros now fire on the remote relay (HSM-18-02 hub half, tested), the backend
+behind the "macro fires as an object" signature moment. Phases 16/17 (web parity + mesh sync;
+agent sync) remain open in parallel.
 
 **📐 The program — THE EQUILIBRIUM:**
 [`EQUILIBRIUM.md`](./EQUILIBRIUM.md) — bringing every original HoldSpeak feature into full
@@ -24,7 +29,9 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-06-27 (**PHASE 20 ON REAL METAL — the device pass began.** The whole iPhone
+**Last updated:** 2026-07-03 (**Phase 18 RESUMED + the Desk-Era rider HSM-18-07 authored** —
+the owner picked iPad parity as the next platform step after the Desk Era; scope = the six
+authored stories + the rider. Prior, 2026-06-27: **PHASE 20 ON REAL METAL — the device pass began.** The whole iPhone
 size-class pass (20-01..04) is merged, and the app is now **built + installed + launched on a real
 iPhone 17 Pro Max** — which immediately caught a device-only build bug the simulator hid (`DictateDemo`
 sim-only, fixed #178) and surfaced a batch of usability issues. **Next session is the iPad walk + the

--- a/pm/roadmap/holdspeak-mobile/contracts/fixtures/meeting-sample.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/fixtures/meeting-sample.json
@@ -80,7 +80,8 @@
         "source_type": "segment",
         "source_ref": "seg_0"
       }
-    ]
+    ],
+    "origin": "meeting"
   },
   "intel_job": {
     "meeting_id": "mtg_001",

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/artifact.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/artifact.schema.json
@@ -102,6 +102,13 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "origin": {
+      "description": "v6 (Phase 74). 'run' = run-born (a persona/chain/workflow run's output; no meeting anchor, meeting_id is the empty string). Optional: a client push may omit it and the hub derives it from meeting_id on merge; hub emissions always carry it.",
+      "enum": [
+        "meeting",
+        "run"
+      ]
     }
   }
 }

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
@@ -77,18 +77,21 @@ reuses three proven seams:
 | HSM-18-04 | The spoken-symbol dictionary, ported to Swift | in-progress (built-ins ported + tested + on the dictation path; user-symbol editor + metal proof remain) |
 | HSM-18-05 | Activity pre-briefing — the source-cited nudge client | todo |
 | HSM-18-06 | The real-metal proof + entry-point docs | todo |
-| HSM-18-07 | The Desk-Era rider: run-born artifacts on the iPad desk + the route-surface lock | in-progress (contract half landed: `origin` on the wire + schema + Swift models; the route-surface lock verified already shipped as HS-72-02; desk materialization remains) |
+| HSM-18-07 | The Desk-Era rider: run-born artifacts on the iPad desk + the route-surface lock | **done** ([evidence](./evidence-story-07.md): `origin` explicit on every serialized surface + schema + Swift models; `HubRunResult.artifactId` shared identity kills a real duplicate-on-sync bug; the kept run result fires the arrival beat, Simulator-proven; the route-surface lock verified already shipped as HS-72-02) |
 
 ## Where we are
 
 **Resumed 2026-07-03 as the owner-picked next platform step**, scoped to the six authored
-stories plus the Desk-Era rider (HSM-18-07). HSM-18-02's hub half is done + tested (the macro
-relay; see Last updated). Remaining: 18-02's iPad CommandsBoard; 18-01 (the dictation pipeline
-client + teleprompter preview screen, the phase's experience hero); 18-03/18-04 (the
-independent on-device language + symbol ports, parallel-startable); 18-05 (activity nudges,
-needs 18-01's dictate path); 18-07 (parallel-startable, contract-first); 18-06 (the
-real-metal gate). The audit supplies every story's starting `file:symbol` evidence. The
-owner's Phase-72 iPad device walk stays owner-gated and outside this phase (tracked in
+stories plus the Desk-Era rider (HSM-18-07). **18-07 is done** (the rider closed same-day:
+`origin` explicit on every artifact surface, the hub's `artifact_id` reconciles instead of
+duplicating, the kept run result materializes with the arrival beat — evidence in
+[evidence-story-07.md](./evidence-story-07.md)). HSM-18-02's hub half is done + tested (the
+macro relay; see the 2026-06-27 update). Remaining: 18-02's iPad CommandsBoard; 18-01 (the
+dictation pipeline client + teleprompter preview screen, the phase's experience hero);
+18-03/18-04 (the independent on-device language + symbol ports, parallel-startable); 18-05
+(activity nudges, needs 18-01's dictate path); 18-06 (the real-metal gate). The audit
+supplies every story's starting `file:symbol` evidence. The owner's Phase-72 iPad device
+walk stays owner-gated and outside this phase (tracked in
 `pm/roadmap/holdspeak/HANDOVER-2026-07-03-desk-era.md`).
 
 ## Carried context

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
@@ -5,7 +5,15 @@
 [Experience Vision](../EXPERIENCE-VISION-2026-06-27.md) (the dictation teleprompter + the
 "macro fires as an object" signature moment).
 
-**Last updated:** 2026-06-27 (**OPENED + first fix landed.** HSM-18-02's hub half shipped:
+**Last updated:** 2026-07-03 (**RESUMED, owner-picked, + the Desk-Era rider added.** After
+the web/hub Desk Era closed (Phases 72–78, PRs #207–#214), the owner chose iPad parity as
+the next platform step and scoped it as *this phase as authored plus one rider*:
+**HSM-18-07** — run-born artifacts (hub schema v6, `origin='run'`) join the cross-surface
+artifact contract and materialize on the iPad desk, plus a guard locking
+`HTTPDesktopClient` paths against `docs/api-surface.json` (the durable form of verifying
+the Phase-72 route rename). Grounded findings: `artifact.schema.json` carries no `origin`
+field; Swift already calls `/api/coders/*` with zero stale `api/companion` literals but
+nothing locks it. Prior update, 2026-06-27: **OPENED + first fix landed.** HSM-18-02's hub half shipped:
 `api_dictation_remote` now fires voice-command macros on the remote relay (it never did, so a
 macro spoken from the iPad was silently dictated as prose). The macro fires through the same
 bounded/guarded connector as the local path; a `type_text` macro free-types into the focused
@@ -69,15 +77,19 @@ reuses three proven seams:
 | HSM-18-04 | The spoken-symbol dictionary, ported to Swift | in-progress (built-ins ported + tested + on the dictation path; user-symbol editor + metal proof remain) |
 | HSM-18-05 | Activity pre-briefing — the source-cited nudge client | todo |
 | HSM-18-06 | The real-metal proof + entry-point docs | todo |
+| HSM-18-07 | The Desk-Era rider: run-born artifacts on the iPad desk + the route-surface lock | todo |
 
 ## Where we are
 
-**Opened, with the first fix landed.** HSM-18-02's hub half is done + tested (the macro
+**Resumed 2026-07-03 as the owner-picked next platform step**, scoped to the six authored
+stories plus the Desk-Era rider (HSM-18-07). HSM-18-02's hub half is done + tested (the macro
 relay; see Last updated). Remaining: 18-02's iPad CommandsBoard; 18-01 (the dictation pipeline
 client + teleprompter preview screen, the phase's experience hero); 18-03/18-04 (the
 independent on-device language + symbol ports, parallel-startable); 18-05 (activity nudges,
-needs 18-01's dictate path); 18-06 (the real-metal gate). The audit supplies every story's
-starting `file:symbol` evidence.
+needs 18-01's dictate path); 18-07 (parallel-startable, contract-first); 18-06 (the
+real-metal gate). The audit supplies every story's starting `file:symbol` evidence. The
+owner's Phase-72 iPad device walk stays owner-gated and outside this phase (tracked in
+`pm/roadmap/holdspeak/HANDOVER-2026-07-03-desk-era.md`).
 
 ## Carried context
 

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
@@ -77,7 +77,7 @@ reuses three proven seams:
 | HSM-18-04 | The spoken-symbol dictionary, ported to Swift | in-progress (built-ins ported + tested + on the dictation path; user-symbol editor + metal proof remain) |
 | HSM-18-05 | Activity pre-briefing — the source-cited nudge client | todo |
 | HSM-18-06 | The real-metal proof + entry-point docs | todo |
-| HSM-18-07 | The Desk-Era rider: run-born artifacts on the iPad desk + the route-surface lock | todo |
+| HSM-18-07 | The Desk-Era rider: run-born artifacts on the iPad desk + the route-surface lock | in-progress (contract half landed: `origin` on the wire + schema + Swift models; the route-surface lock verified already shipped as HS-72-02; desk materialization remains) |
 
 ## Where we are
 

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/evidence-story-07.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/evidence-story-07.md
@@ -1,0 +1,65 @@
+# Evidence — HSM-18-07 — The Desk-Era rider
+
+**Status:** done (2026-07-03). Two commits on `holdspeak-mobile/hsm-18-07-desk-era-rider`:
+the contract half (`origin` on the wire), then the desk half (identity + the beat).
+
+## 1. `origin` joins the artifact contract
+
+- **Hub:** `ArtifactSummary.origin` (`holdspeak/db/models.py`, default `"meeting"`), populated
+  from the row at all three mapper sites (`holdspeak/db/plugins.py`); emitted by
+  `_artifact_value` (sync pull, `holdspeak/web/routes/sync.py`) and the meeting-artifacts
+  route (`holdspeak/web/routes/meetings/insights.py`).
+- **Schema:** `contracts/schemas/artifact.schema.json` gains `origin` as an **optional**
+  enum (`meeting` | `run`) — optional because a client push may omit it (the hub derives it
+  from `meeting_id` on merge, `plugins.py:691`); hub emissions always carry it. Fixture
+  updated (kept canonical — the validator's round-trip rule requires exact
+  `json.dumps(indent=2)` form).
+- **Swift:** `Artifact.origin: String?` + `Artifact.isRunBorn` (the hub's own derivation as
+  fallback when the wire omits the field); `MeetingArtifact.origin: String?`. iPad SQLite
+  stores artifacts as JSON blobs, so `origin` persists with zero storage changes.
+- **Proven:** `uv run pytest -q tests/unit` **2397 passed** (incl. the new
+  `test_origin_explicit_on_every_serialized_surface` — both surfaces, schema-validated,
+  origin-less back-compat); `swift test` **416 passed** (incl.
+  `testArtifactOriginDecodesAndDerivesRunBorn` — present / absent / unknown);
+  `contracts/validate.py` ALL CHECKS PASSED.
+
+## 2. The route-surface lock — already shipped, recorded not duplicated
+
+Design item 3 was verified to already exist as **HS-72-02**:
+`scripts/gen_api_surface.py` sweeps `apple/**/*.swift` for `api/…` path literals and
+`tests/unit/test_api_surface.py` fails CI unless every extracted iOS call matches a served
+route (`unmatched_calls` must be empty; `/api/coders/dismiss` shows `"ios"` as a consumer in
+the committed `docs/api-surface.json`). Zero stale `api/companion` literals remain in Swift.
+Building a second guard would have been duplication; the story records the finding instead.
+
+## 3. Run-born artifacts land on the iPad desk
+
+Grounded in a full map of the desk's artifact path (the sync bridge upserts hub artifacts
+into `outputs`; `derivativesOf` groups meeting-anchored ones into the drawer; a run-born
+card falls through and sits loose — correct). The three real gaps, fixed:
+
+- **The hub's `artifact_id` was silently dropped.** `HubRunResult` never decoded it, so
+  `runOnHub` minted a throwaway UUID and a kept card would **duplicate** against the hub's
+  own artifact on the next sync. Now: `HubRunResult.artifactId` decodes (tolerant — an older
+  hub omits it) and the printed card reuses the hub's id, so Keep reconciles instead of
+  duplicating. Proven: `testRunAgentDecodesArtifactId` /
+  `testRunChainWithoutArtifactIdStillDecodes` (stubbed transport).
+- **No arrival beat on a kept run result.** `keepPrinted()` now fires the exact beat woven
+  deliverables and synced peers get (`arrivedIds` halo + NEW badge + flash, 6s clear).
+- **Desk-minted cards now say `origin: "run"`** on their embedded contract
+  (`DeskRecords.swift` desk-authored init) instead of leaving the wire to infer it.
+  Proven: `testOutputRecordRoundTrip` asserts `origin == "run"` and `isRunBorn`.
+
+**Simulator proof:** full `xcodebuild` (iphonesimulator, iPad Air 13-inch (M4)) green; the
+`HS_DESK_ARRIVE=1` seed extended with a genuine run-born card (agent lens, non-meeting
+source). Screenshot: [`screenshots/hsm-18-07-run-born-arrival.png`](./screenshots/hsm-18-07-run-born-arrival.png)
+— the run-born card **loose on the desk** (not in a meeting drawer) with the arrival halo +
+NEW badge, beside the meeting cassette with the same beat.
+
+## Honest boundaries
+
+- The beat on a real hub run (tap Run on a paired desk → Keep) is Simulator-verified logic
+  reusing a proven mechanism; the on-device walk is the phase gate (HSM-18-06) plus the
+  owner's standing device pass — not claimed here.
+- The web agent editor still doesn't surface `manual_context` (a Desk-Era handover note,
+  hub-side; out of this story's scope).

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-07-desk-era-rider.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-07-desk-era-rider.md
@@ -2,12 +2,14 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 18
-- **Status:** in-progress — the contract half landed (`origin` on the wire + schema + both
-  Swift models, all suites green); the desk materialization remains. **Verified during
-  build:** design item 3 (the route-surface lock) already ships as HS-72-02
-  (`tests/unit/test_api_surface.py` + `scripts/gen_api_surface.py` sweep `apple/**/*.swift`;
-  `unmatched_calls` must be empty) — nothing to build, recorded here instead of duplicating
-  the guard.
+- **Status:** done — see [`evidence-story-07.md`](./evidence-story-07.md). The contract half
+  (`origin` on every serialized surface + schema + both Swift models) and the desk half
+  (`HubRunResult.artifactId` shared identity kills the duplicate-on-sync; `keepPrinted`
+  fires the arrival beat; desk-minted cards stamp `origin: "run"`), Simulator-proven.
+  **Verified during build:** design item 3 (the route-surface lock) already ships as
+  HS-72-02 (`tests/unit/test_api_surface.py` + `scripts/gen_api_surface.py` sweep
+  `apple/**/*.swift`; `unmatched_calls` must be empty) — recorded, not duplicated. The
+  on-device beat walk rides the phase gate (18-06).
 - **Depends on:** nothing in this phase (parallel-startable); hub schema v6 (run-born
   artifacts, Phase 74) and the Phase-72 route rename + `docs/api-surface.json` manifest,
   both already on `main`.

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-07-desk-era-rider.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-07-desk-era-rider.md
@@ -2,7 +2,12 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 18
-- **Status:** todo — the Desk-Era catch-up rider (owner-scoped into this phase, 2026-07-03).
+- **Status:** in-progress — the contract half landed (`origin` on the wire + schema + both
+  Swift models, all suites green); the desk materialization remains. **Verified during
+  build:** design item 3 (the route-surface lock) already ships as HS-72-02
+  (`tests/unit/test_api_surface.py` + `scripts/gen_api_surface.py` sweep `apple/**/*.swift`;
+  `unmatched_calls` must be empty) — nothing to build, recorded here instead of duplicating
+  the guard.
 - **Depends on:** nothing in this phase (parallel-startable); hub schema v6 (run-born
   artifacts, Phase 74) and the Phase-72 route rename + `docs/api-surface.json` manifest,
   both already on `main`.

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-07-desk-era-rider.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-07-desk-era-rider.md
@@ -1,0 +1,66 @@
+# HSM-18-07 — The Desk-Era rider: run-born artifacts land on the iPad desk + the route-surface lock
+
+- **Project:** holdspeak-mobile
+- **Phase:** 18
+- **Status:** todo — the Desk-Era catch-up rider (owner-scoped into this phase, 2026-07-03).
+- **Depends on:** nothing in this phase (parallel-startable); hub schema v6 (run-born
+  artifacts, Phase 74) and the Phase-72 route rename + `docs/api-surface.json` manifest,
+  both already on `main`.
+- **Unblocks:** the iPad desk staying honest against the Desk-Era hub; every future hub
+  route rename breaking loudly instead of silently.
+- **Owner:** unassigned
+
+## Problem
+
+The web/hub Desk Era (Phases 72–78, 2026-07-02/03) moved two contracts out from under the
+iPad:
+
+1. **Run-born artifacts exist and the iPad cannot say so.** Phase 74 made runs persist as
+   real artifacts (hub schema v6: `origin='run'`, lineage, DB `meeting_id` NULL serialized
+   as `""` on every wire — a rule written *for* the iPad's non-optional decode). The web
+   desk materializes a finished run's results on the stage. On the iPad: the cross-surface
+   contract schema (`pm/roadmap/holdspeak-mobile/contracts/schemas/artifact.schema.json`)
+   carries **no `origin` field**, neither Swift read model
+   (`Contracts/Models.swift::Artifact`, `Contracts/MeetingArtifact.swift`) decodes it, and
+   a run-born artifact syncing in is an orphan with an empty `meetingId` — no lineage, no
+   arrival, indistinguishable from bad data.
+2. **The Phase-72 route rename is honored but unlocked.** `HTTPDesktopClient` moved to
+   `/api/coders/*` + `/api/desk/actuators/*` (zero `api/companion` literals remain), but
+   nothing machine-checks the Swift client against the hub's declared API surface
+   (`docs/api-surface.json`). The rename shipped safely this time because one session did
+   both sides; the next one won't be.
+
+## The design
+
+1. **`origin` joins the artifact contract.** Add `origin` (`"meeting" | "run"`) to
+   `artifact.schema.json` and both Swift read models — decode-tolerant (absent ⇒
+   `"meeting"`, unknown string never fails the decode, matching the `MeetingArtifact`
+   convention). The `meeting_id ""` wire rule stays exactly as written.
+2. **A run-born artifact materializes on the iPad desk.** When one arrives (sync or read),
+   it lands on the stage with the arrival beat — the same grammar as the web desk's
+   Phase-74 materialization — and its pull-out shows the run lineage the same way the
+   meeting drawer groups derivatives by provenance. Filed stays filed (the filed-object
+   grammar is the iPad's own contract; do not re-litigate it).
+3. **The route-surface lock.** A hub-side guard test that parses the path literals out of
+   `HTTPDesktopClient.swift` and asserts every one exists in `docs/api-surface.json` —
+   the `test_primitive_contract.py` Swift-parsing pattern, pointed at routes. This is the
+   durable form of "verify the renamed routes": it locks Phase 72's rename and every
+   future one.
+
+## Scope
+
+- **In:** the schema + both Swift models; the desk materialization beat + run lineage in
+  the pull-out; the route-surface guard test.
+- **Out:** the owner's Phase-72 device walk (legacy `@AppStorage` decode in anger,
+  coder-board and desk-relay taps — owner-gated, tracked in the Desk-Era handover);
+  starting runs *from* the iPad (the agent/chain run path already exists); intel token
+  streaming (the hub honestly emits running→ready only).
+
+## Test plan
+
+- Schema validator round-trips an `origin: "run"` artifact on all validating surfaces;
+  an origin-less payload still validates (back-compat).
+- Swift decode tests: `origin` present/absent/unknown; `meetingId == ""` accepted.
+- The route-surface guard: red against a fabricated stale path, green on `main`.
+- Simulator screenshot: a run-born artifact materialized on the desk with its lineage
+  pull-out open.

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -1274,6 +1274,7 @@ class TestMirHistoryApiEndpoints:
                         ],
                         created_at=now,
                         updated_at=now,
+                        origin="meeting",
                     )
                 ]
 
@@ -1288,6 +1289,7 @@ class TestMirHistoryApiEndpoints:
         assert len(payload["artifacts"]) == 1
         artifact = payload["artifacts"][0]
         assert artifact["artifact_type"] == "requirements"
+        assert artifact["origin"] == "meeting"  # explicit since HSM-18-07
         assert artifact["confidence"] == pytest.approx(0.82)
         refs = {(source["source_type"], source["source_ref"]) for source in artifact["sources"]}
         assert ("intent_window", "m-001:w0001") in refs

--- a/tests/unit/test_run_artifacts.py
+++ b/tests/unit/test_run_artifacts.py
@@ -118,6 +118,69 @@ def test_agent_run_persists_and_responds_with_artifact_id(db, monkeypatch) -> No
     value = arts[0]["value"]
     assert value["meeting_id"] == ""  # a plain string on the wire, never null
     assert value["body_markdown"] == "the run output"
+    assert value["origin"] == "run"  # explicit since HSM-18-07, not inferred
+
+
+def test_origin_explicit_on_every_serialized_surface(db) -> None:
+    """HSM-18-07 — `origin` rides the wire ('run' | 'meeting') on both artifact
+    surfaces (sync pull + the meeting artifacts route), and the emitted values
+    still validate against the cross-surface artifact contract schema — with
+    `origin` absent staying valid (a client push may omit it)."""
+    import json as jsonlib
+
+    jsonschema = pytest.importorskip("jsonschema")
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from holdspeak.meeting_session import MeetingState
+    from holdspeak.web.context import WebContext
+    from holdspeak.web.routes import build_sync_router
+    from holdspeak.web.routes.sync import _artifact_value
+
+    db.meetings.save_meeting(
+        MeetingState(id="m1", started_at=datetime.now(), title="M")
+    )
+    db.plugins.record_artifact(
+        artifact_id="anchored-1", meeting_id="m1", artifact_type="decisions",
+        title="Anchored", body_markdown="b", status="draft",
+        plugin_id="decision_capture", plugin_version="1",
+    )
+    db.plugins.record_artifact(
+        artifact_id="run-1", meeting_id="", artifact_type="plugin_output",
+        title="Run-born", body_markdown="answer", status="draft",
+        plugin_id="agent_run", plugin_version="1",
+        sources=[{"source_type": "agent", "source_ref": "a-owl"}],
+    )
+
+    app = FastAPI()
+    app.include_router(build_sync_router(WebContext(get_state=lambda: {})))
+    pull = TestClient(app).get("/api/sync/pull?limit=50").json()
+    values = {r["meta"]["id"]: r["value"] for r in pull["artifacts"]}
+    assert values["anchored-1"]["origin"] == "meeting"
+    assert values["run-1"]["origin"] == "run"
+    assert values["run-1"]["meeting_id"] == ""
+
+    # The other serialized surface — a stored summary through the meetings
+    # route's dict shape (the route emits `artifact.origin` verbatim).
+    stored = db.plugins.get_artifact("anchored-1")
+    assert stored.origin == "meeting"
+    assert db.plugins.get_artifact("run-1").origin == "run"
+
+    # Both emitted values validate against the contract schema; an origin-less
+    # copy (a client push) stays valid too.
+    schema_path = (
+        Path(__file__).parents[2]
+        / "pm/roadmap/holdspeak-mobile/contracts/schemas/artifact.schema.json"
+    )
+    schema = jsonlib.loads(schema_path.read_text())
+    validator = jsonschema.Draft202012Validator(schema)
+    for aid in ("anchored-1", "run-1"):
+        validator.validate(values[aid])
+        originless = dict(values[aid])
+        originless.pop("origin")
+        validator.validate(originless)
+    assert _artifact_value(stored)["origin"] == "meeting"
 
 
 def test_v5_to_v6_upgrade_rebuilds_without_losing_rows(tmp_path) -> None:

--- a/tests/unit/test_web_routes_sync.py
+++ b/tests/unit/test_web_routes_sync.py
@@ -43,6 +43,7 @@ def _artifact(aid: str, mid: str):
         id=aid, meeting_id=mid, artifact_type="decisions", title="t",
         body_markdown="b", structured_json={}, confidence=0.8, status="draft",
         plugin_id="p", plugin_version="1", sources=[], updated_at=datetime(2026, 1, 2),
+        origin="meeting" if mid else "run",
     )
 
 


### PR DESCRIPTION
## What

The Desk-Era catch-up rider for the resumed Phase 18 (owner-scoped 2026-07-03). Two halves:

**1. `origin` joins the artifact contract.** Run-born artifacts (hub schema v6) are now explicit on every serialized surface instead of inferred from an empty `meeting_id`: `ArtifactSummary.origin` → sync pull + the meeting-artifacts route emit it, `artifact.schema.json` gains it as an optional enum (client pushes may omit it; the hub derives it on merge), and both Swift read models decode it tolerantly with `Artifact.isRunBorn` applying the hub's own derivation as fallback.

**2. Run-born artifacts land on the iPad desk.** `HubRunResult` now decodes the hub's `artifact_id` and the printed card reuses it — a kept hub-run result **reconciles with the hub's own artifact on sync instead of duplicating** (a real latent bug). `keepPrinted()` fires the same arrival beat woven deliverables get (halo + NEW badge), and desk-minted cards stamp `origin: "run"`.

**Recorded, not duplicated:** the story's route-surface lock was verified already shipped as HS-72-02 (`test_api_surface.py` sweeps `apple/**/*.swift`; `unmatched_calls` must be empty).

## Proof

- `uv run pytest -q tests/unit` — **2397 passed** (new: `test_origin_explicit_on_every_serialized_surface`, schema-validated + origin-less back-compat)
- `swift test` — **416 passed** (new: artifactId present/absent decode, origin decode present/absent/unknown, origin round-trip)
- `contracts/validate.py` — ALL CHECKS PASSED (fixture kept canonical)
- Full `xcodebuild` iphonesimulator green; committed screenshot: the run-born card **loose on the desk** with the arrival halo + NEW badge (`evidence-story-07.md`)

The on-device beat walk rides the phase gate (HSM-18-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ