### PR TITLE
Phase 18 (HSM-18-06, docs half): entry-point docs current + the real-metal walk staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,14 +255,18 @@ The iPad is a first-class client of both modes, not a remote control for one.
 It talks to the hub through typed clients over the existing API: it dictates an
 answer into your desk (the hub runs that text through the full dictation
 pipeline, applying your corrections and routing, and types the result, and a
-matching voice command fires there too), pins your spoken language and your
-spoken-symbol dictionary on that dictation path, reads a meeting back with its
-artifacts, confidence, and sources, keeps proposing an action separate from
-approving it (the human gate stays its own step), reads the faceted archive, and
-pulls activity pre-briefing nudges. Its on-device storage is schema safe the
-same way the desktop is: it backs an older database up before migrating, and
-refuses to open one written by a newer build. The on-device screens for these
-are still coming together; the client layer they ride on is shipped and tested.
+matching voice command fires there too), previews the rewrite before anything
+types (an opt-in receipt: what you approve is exactly what lands, verbatim),
+authors the voice command board itself (every action still runs on the Mac,
+and the board says so), pins your spoken language and your spoken-symbol
+dictionary on that dictation path, reads a meeting back with its artifacts,
+confidence, and sources, keeps proposing an action separate from approving it
+(the human gate stays its own step), reads the faceted archive, and pulls
+activity pre-briefing nudges whose "Dictate with this" grounds the next
+utterance in the cited record. Its on-device storage is schema safe the same
+way the desktop is: it backs an older database up before migrating, and
+refuses to open one written by a newer build. The app itself is not released
+yet; the screens and the typed client layer they ride on are built and tested.
 
 ### AIPI-Lite
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,18 +178,19 @@ The iPad joins the same hub over your own network (LAN or Tailscale, no
 hosted relay). It is a typed client of the FastAPI routes, built around one
 HTTP client (`apple/Sources/Providers/Desktop/HTTPDesktopClient.swift`)
 split into one base client (meeting control, the coder board, remote
-dictation delivery) plus nine focused extensions (aftercare, facets,
-artifacts, proposals, dictation, dictation blocks, activity, learning,
-meeting import); the sync transport rides its own provider on the same
-pairing.
+dictation delivery) plus ten focused extensions (aftercare, facets,
+artifacts, proposals, dictation, dictation blocks, voice commands,
+activity, learning, meeting import); the sync transport rides its own
+provider on the same pairing.
 
 The full surface it consumes is generated, not hand-listed: see
 [API_SURFACE.md](API_SURFACE.md), where every route the app serves carries
 its consumers as extracted from the real call sites. As of the last
-generation the iPad consumes 44 routes, spanning meetings (list, facets,
+generation the iPad consumes 47 routes, spanning meetings (list, facets,
 detail, artifacts, aftercare, file-issue, proposals + decisions, start,
 stop, import), dictation (dry-run, readiness, remote delivery, journal,
-blocks + templates, learning digest, project context), activity (briefing,
+blocks + templates, learning digest, project context), the voice command
+board (settings read and write, test one action), activity (briefing,
 nudges, select, dismiss), capability runs (agents, chains), the coder board
 (`api/coders/*`: which live coding session receives a spoken answer), the
 desk actuator relay (`api/desk/actuators/*`: a desk card becomes a hub

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/HSM-18-06-WALK.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/HSM-18-06-WALK.md
@@ -1,0 +1,90 @@
+# HSM-18-06 — the real-metal walk (press-play protocol)
+
+The owner's device session, prepared. Everything below was staged headless on
+2026-07-03; the walk itself needs the cabled iPad, a live hub, and a working
+rewriter endpoint. Budget: ~30 minutes once the endpoint answers.
+
+## 0. Pre-flight — the ONE decision: the rewriter endpoint
+
+The dictation pipeline's configured runtime is `openai_compatible` at
+`http://127.0.0.1:8082/v1`, which is **down**. Three options, pick one:
+
+- **(a) Stand up llama-server on this Mac at :8082** (matches the config as-is):
+  `llama-server -m ~/Models/gguf/Qwen3-4B-Instruct-2507-Q6_K.gguf --port 8082`
+  (the model file exists; `llama-server` is not installed — `brew install llama.cpp`).
+- **(b) Un-grammar `.43`**: its llama-server forces a constrained JSON grammar that
+  corrupts the intent-router's classify (`extra key 'ai_prompt_context'`). Restart it
+  without the grammar flag, then point `dictation.runtime.openai_compatible_base_url`
+  at `http://192.168.1.43:8080/v1`.
+- **(c) Any other OpenAI-compatible server** + the same config knob.
+
+Do NOT use in-process `llama_cpp` — it segfaults (exit 139) loading the local
+Qwen3-4B-2507 GGUF on this machine.
+
+**Verify before walking** (a rewrite with no warnings):
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/api/dictation/dry-run \
+  -H 'Content-Type: application/json' \
+  -d '{"utterance": "hey can you umm add a retry to the sync push like three attempts"}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['final_text']); print(d.get('warnings'))"
+```
+
+## 1. Hub + device
+
+- Hub: `holdspeak web` bound for the LAN, iPad paired the HSM-12 way (host/port +
+  the mirrored Bearer token in the pairing sheet).
+- Install the current build on the iPad:
+  `apple/scripts/meeting-capture-device.sh <UDID>` (list: `xcrun devicectl list devices`;
+  the device must be UNLOCKED). For a guaranteed-fresh build, first:
+  `rm -rf apple/build/meeting-capture-dd apple/build/meeting-capture-sources apple/build/HoldSpeakMeetingCapture.xcodeproj`.
+
+## 2. The walk — five checks, one per story
+
+Capture a screenshot per check into `screenshots/` (device screenshots, not
+Simulator) and fill the trace at the bottom.
+
+**W1 — the teleprompter receipt (18-01).** Dictate screen: the readiness strip
+shows the live verdict. Toggle **Preview first ON**. Hold, speak
+"hey can you umm add a retry to the sync push like three attempts", release.
+EXPECT: the receipt card shows the REWRITTEN text (not your ums). Tap Send.
+EXPECT: the focused Mac app receives **exactly the receipt text, byte-identical**
+(the raw lane — compare character-for-character).
+
+**W2 — the macro fires as an object (18-02).** On the iPad: Commands → author
+`standup` → Type text → `## Standup` → Save. Preview first OFF. Speak "standup".
+EXPECT: `## Standup` types on the Mac (the macro FIRED); the read-back shows the
+fired chip, not dictated prose. CONTROL: toggle Voice commands off on the board,
+speak "standup" again → the word "standup" is dictated. This is the
+control-vs-treatment pair.
+
+**W3 — the language took (18-03).** Settings → Spoken language → your non-English
+pick. Dictate a native sentence. EXPECT: the transcript is in that language with
+correct orthography. CONTROL: back to Auto, same sentence, compare.
+
+**W4 — the symbol renders (18-04).** Settings → Your symbols → add
+`tilde` → `~`. Speak-to-fill any field (e.g. a Commands payload): "config tilde
+slash test". EXPECT: `config ~/test`-shaped output (your symbol, user-wins).
+
+**W5 — the grounding changes the model (18-05).** Open the Dictate screen with a
+nudge showing. CONTROL first: Preview ON, speak "draft a reply to that", capture
+the receipt. Then tap **Dictate with this** on the nudge (card flips to Armed),
+speak the SAME utterance. EXPECT: the second receipt visibly references the
+cited record (title/domain) where the first could not — the Phase-53
+control-vs-treatment bar, now over the relay.
+
+## 3. The trace (fill during the walk)
+
+```
+Date/build:            <commit>
+Endpoint used:         <a | b | c + URL/model>
+W1 receipt verbatim:   PASS/FAIL — <note>
+W2 macro fired + ctrl: PASS/FAIL — <note>
+W3 language + ctrl:    PASS/FAIL — <language, note>
+W4 symbol:             PASS/FAIL — <note>
+W5 grounded vs ctrl:   PASS/FAIL — <what the grounded receipt referenced>
+Bugs found:            <list — file them; the walk is a bug hunt too>
+```
+
+PASS on all five closes HSM-18-06 and the phase (entry-point docs already landed
+with the runway). Any FAIL: fix, re-walk the failed check, then close.

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/current-phase-status.md
@@ -76,7 +76,7 @@ reuses three proven seams:
 | HSM-18-03 | Spoken language at every WhisperKit call site | **done** ([evidence](./evidence-story-03.md): the ONE resolver `WhisperLanguage.configuredCode()` + all three call sites wired; real non-English speech in the aux apps rides 18-06) |
 | HSM-18-04 | The spoken-symbol dictionary, ported to Swift | **done** ([evidence](./evidence-story-04.md): user symbols persist + apply at the fill site (user-wins test-proven) + the Settings editor with a mic on every field; the real-mic walk rides 18-06) |
 | HSM-18-05 | Activity pre-briefing — the source-cited nudge client | **done** ([evidence](./evidence-story-05.md): nudge cards + "Dictate with this"→Armed on the dictate surface, live-hub proven on a real ledger; the remote lane now consumes the Phase-53 pin — the third silent relay hole, fixed + test-locked) |
-| HSM-18-06 | The real-metal proof + entry-point docs | todo |
+| HSM-18-06 | The real-metal proof + entry-point docs | in-progress (docs half landed: README iPad section current, ARCHITECTURE at ten extensions / 47 routes; [the walk protocol](./HSM-18-06-WALK.md) staged — five checks + controls + trace; remaining: the owner device walk, pre-flight = the rewriter endpoint decision) |
 | HSM-18-07 | The Desk-Era rider: run-born artifacts on the iPad desk + the route-surface lock | **done** ([evidence](./evidence-story-07.md): `origin` explicit on every serialized surface + schema + Swift models; `HubRunResult.artifactId` shared identity kills a real duplicate-on-sync bug; the kept run result fires the arrival beat, Simulator-proven; the route-surface lock verified already shipped as HS-72-02) |
 
 ## Where we are

--- a/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-06-proof-and-docs.md
+++ b/pm/roadmap/holdspeak-mobile/phase-18-ipad-dictation-contracts/story-06-proof-and-docs.md
@@ -2,7 +2,13 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 18
-- **Status:** todo — the phase gate.
+- **Status:** in-progress — the docs half landed headless (README iPad section refreshed
+  to the shipped screens + the receipt; ARCHITECTURE's client map at ten extensions /
+  47 routes; guards green) and the walk is staged:
+  [`HSM-18-06-WALK.md`](./HSM-18-06-WALK.md) is the press-play protocol (five checks,
+  controls included, trace template). Remaining: the owner's device walk, gated on the
+  ONE pre-flight decision (the rewriter endpoint — options and exact commands in the
+  walk doc).
 - **Depends on:** 18-01 … 18-05.
 - **Unblocks:** closing Phase 18.
 - **Owner:** unassigned


### PR DESCRIPTION
## What

The headless half of the phase gate:

- **README** — the iPad companion section catches up to the shipped Phase-18 screens: the preview receipt ("what you approve is exactly what lands, verbatim"), authoring the voice command board from the iPad, grounded nudges; and the honest status line (the app is not released; the screens and client layer are built and tested).
- **ARCHITECTURE** — the typed client map moves to **ten extensions / 47 consumed routes** and names the voice command board in the generated-surface list.
- **`HSM-18-06-WALK.md`** — the owner's device session, staged press-play: the one pre-flight decision (the rewriter endpoint; three options with exact commands, plus the llama_cpp segfault warning), hub + device setup, **five checks with controls** (receipt byte-identical, macro fires vs dictates, language took, symbol renders, grounded vs ungrounded receipt), and the fillable trace. PASS on all five closes HSM-18-06 and the phase.

No behavior changes. Doc guards green (voice guard, doc drift, api surface); full unit suite 2403 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ