### PR TITLE
Phase 19 (HSM-19-07, docs half): entry points current + the walk staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,16 @@ types (an opt-in receipt: what you approve is exactly what lands, verbatim),
 authors the voice command board itself (every action still runs on the Mac,
 and the board says so), pins your spoken language and your spoken-symbol
 dictionary on that dictation path, reads a meeting back with its artifacts,
-confidence, and sources, keeps proposing an action separate from approving it
-(the human gate stays its own step), reads the faceted archive, and pulls
+confidence, and sources, closes the meeting's loop from the aftercare digest
+(an accepted action item becomes a GitHub issue proposal, typed against a
+repo you name inline), reviews every pending proposal for a meeting wherever
+it was created (the human gate stays its own step, and approving a Slack
+send carries the cloud mark because that approval executes), searches and
+filters the archive with the same facets the web has (narrowed on the hub,
+never a stale page filtered locally), imports a recording or transcript file
+into the hub's full intelligence pipeline (the new meeting appears
+immediately, honestly marked importing), reads the learning digest and the
+dictation journal with their real "learned from N similar" reach, and pulls
 activity pre-briefing nudges whose "Dictate with this" grounds the next
 utterance in the cited record. Its on-device storage is schema safe the same
 way the desktop is: it backs an older database up before migrating, and

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -10,12 +10,14 @@
 > gotchas, and the exact remaining work to finish **Phase 8** and **Phase 14** (top priority).
 
 **Current phase:** [Phase 19 — The iPad joins the meeting contracts](./phase-19-ipad-meeting-contracts/current-phase-status.md)
-— **OPENED 2026-07-03**, the Equilibrium program's designed pair to Phase 18 (disjoint client
-surfaces: meetings vs dictation). Survey-corrected on open: the entire client layer already
-landed via Equilibrium Waves 3–6 (PRs #151/#155/#156/#159 + the import/learning commits), so
-the phase is **screens over shipped clients** in `CompanionShellApp.swift` — the file-issue
-action, the faceted archive, import, the proposals review queue, the learning reader — plus
-the staged metal walk.
+— **OPENED AND BUILT TO 6/7 SAME-DAY (2026-07-03), the gate staged.** The open survey
+corrected the draft (the client layer already landed via Equilibrium Waves 3–6), so the
+phase was screens over shipped clients in `CompanionShellApp.swift`: the aftercare
+file-issue action, the four-state proposals review queue (with the `decided_by:
+ipad-companion` audit fix the live proof surfaced), search + facet chips, the Import file
+picker, and the learning reader — every story live-hub proven from the connected simulator.
+[`HSM-19-07-WALK.md`](./phase-19-ipad-meeting-contracts/HSM-19-07-WALK.md) (W1–W6) is
+press-play; the owner's device walk closes the phase.
 [Phase 18](./phase-18-ipad-dictation-contracts/current-phase-status.md) stands at **6/7 with
 the gate staged**: only the owner's device walk
 ([`HSM-18-06-WALK.md`](./phase-18-ipad-dictation-contracts/HSM-18-06-WALK.md)) remains; the
@@ -31,14 +33,23 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-07-03 (**PHASE 19 OPENED — the iPad joins the meeting contracts.**
-After the two-track day closed Phase 18 to 6/7 (gate staged) and Phase 79 same-day, the
-handover's top headless pick opened: the meetings half of audit theme 2. The open survey
-corrected the 2026-06-27 draft — every story's client + contract type already merged
-(EQ Waves 3–6), 19-04 is fully wired and sim-proven, so the seven re-grounded stories are
-UI wiring: 19-01 the aftercare file-issue action leads, then facets / import / provenance
-evidence / the proposals review queue / the learning reader / docs + a press-play walk
-staged to join the owner's 18-06 couch session. Earlier: **Phase 18 RESUMED + the Desk-Era rider HSM-18-07 authored** —
+**Last updated:** 2026-07-03 (**PHASE 19 OPENED AND BUILT TO 6/7 THE SAME EVENING — the
+iPad joins the meeting contracts; the gate is staged.** The handover's top headless pick,
+opened survey-corrected (the client layer had already merged in EQ Waves 3–6) and built as
+screens over shipped clients, each story proven against a live scratch hub from the
+connected simulator: **19-04** provenance flipped on verified evidence; **19-01** the
+accepted-only File issue action (inline repo row, honest proposed pill; live proof:
+proposed/idempotent/400); **19-05** the four-state proposals review queue with the slack
+cloud mark — its live proof surfaced a REAL audit gap (iPad decisions read as `web-user`),
+fixed as `decided_by: "ipad-companion"`, test-locked; **19-02** search + facet chips
+narrowing server-side (a real narrowed render, same code path as the chips); **19-06** the
+learning card (digest chips, correction reach, journal signals, honest no-reach edge);
+**19-03** Import file — the running app itself uploaded a .vtt end to end and the parsed
+speakers fed the facet chips on the same live screen. Docs half of **19-07** done (README's
+six new abilities, voice guard green) and
+[`HSM-19-07-WALK.md`](./phase-19-ipad-meeting-contracts/HSM-19-07-WALK.md) staged W1–W6 to
+join the 18-06 couch session. Both Phase 18 and 19 now sit at 6/7, closed by one device
+session. PRs #223–#229. Earlier: **Phase 18 RESUMED + the Desk-Era rider HSM-18-07 authored** —
 the owner picked iPad parity as the next platform step after the Desk Era; scope = the six
 authored stories + the rider. Prior, 2026-06-27: **PHASE 20 ON REAL METAL — the device pass began.** The whole iPhone
 size-class pass (20-01..04) is merged, and the app is now **built + installed + launched on a real

--- a/pm/roadmap/holdspeak-mobile/phase-19-ipad-meeting-contracts/HSM-19-07-WALK.md
+++ b/pm/roadmap/holdspeak-mobile/phase-19-ipad-meeting-contracts/HSM-19-07-WALK.md
@@ -1,0 +1,91 @@
+# HSM-19-07 — the real-metal walk (press-play protocol)
+
+The owner's device session, prepared. Everything below was staged headless on
+2026-07-03; every check was already proven end to end against a live scratch hub
+from the simulator (see the per-story evidence), so this walk verifies the same
+loops with a finger on real glass. Budget: ~25 minutes. **Designed to share the
+couch session with [`HSM-18-06-WALK.md`](../phase-18-ipad-dictation-contracts/HSM-18-06-WALK.md)** —
+same hub, same pairing, same `.43` setup (W4 needs it; the other checks don't
+touch the rewriter).
+
+## 0. Pre-flight
+
+- Hub: `holdspeak web` bound for the LAN, iPad paired the HSM-12 way (host/port +
+  Bearer token). For W4, `dictation.runtime`/intel pointed at `.43` per the 18-06
+  pre-flight (`~/run-qwythos-vision.sh`, NOT the `-intel` script).
+- A meeting archive with some history (any real day works): at least one meeting
+  with **accepted** action items, speakers, and a tag or two. A quick maker if
+  the archive is bare: import two transcripts in W3 first, then accept an action
+  item on the web review screen.
+- Install the current CompanionShell build on the iPad (device must be UNLOCKED):
+
+```bash
+cd apple && ruby scripts/gen-companion-shell.rb
+xcodebuild -project build/HoldSpeakCompanionShell.xcodeproj -scheme HoldSpeakMobile \
+  -destination "platform=iOS,id=<UDID>" -derivedDataPath build/dd-shell-device \
+  -allowProvisioningUpdates build
+xcrun devicectl device install app --device <UDID> \
+  build/dd-shell-device/Build/Products/Debug-iphoneos/HoldSpeakMobile.app
+```
+
+(UDID list: `xcrun devicectl list devices`.)
+
+## 1. The walk — six checks, one per story
+
+Capture a device screenshot per check into `screenshots/` and fill the trace.
+
+**W1 — file the issue (19-01).** Meetings → tap a meeting with an accepted open
+item. EXPECT: the aftercare digest renders (open by owner, decided, the diff
+chips) and the accepted item alone wears **File issue**. Tap it, type a real
+`owner/name`, File. EXPECT: the item flips to the **proposed** pill. CONTROL: a
+pending (not accepted) item shows no File issue chip.
+
+**W2 — the archive narrows (19-02).** On the Meetings tab, tap a speaker chip.
+EXPECT: the list narrows to meetings that speaker spoke in (the chip lights;
+the hub does the narrowing). Type a word you know was said, submit. EXPECT: the
+transcript hit. Clear (xmark). EXPECT: the full list returns.
+
+**W3 — import from Files (19-03).** Tap **Import file**, pick a `.vtt`/`.srt`/
+`.txt` from Files. EXPECT: "Importing on your desktop", the new row appears
+(marked importing, then settles), tap it later and the digest is real. BONUS
+(real audio): pick a `.wav` recording — same loop through Whisper. CONTROL: an
+unsupported file is refused with the format reason.
+
+**W4 — the ring is earned (19-04).** Tap a meeting whose intel ran on `.43`
+(or run/import one now). EXPECT: the ARTIFACTS card shows each artifact's
+confidence ring banded by value and "Synthesized from …" naming its real
+sources; a needs-review artifact wears the amber edge.
+
+**W5 — the queue decides (19-05).** After W1, the PROPOSALS card lists your
+filed issue as **proposed** with Approve/Reject. Approve it. EXPECT: the pill
+flips to **approved** (github only flips state). Verify the audit on the hub:
+
+```bash
+curl -s http://127.0.0.1:8000/api/meetings/<id>/proposals | python3 -m json.tool | grep decided_by
+```
+
+EXPECT: `"decided_by": "ipad-companion"`. BONUS (if a Slack webhook is
+configured): approve a slack proposal — its Approve wears **Cloud · slack**
+and the message lands; the pill reads **executed**.
+
+**W6 — the loop reads back (19-06).** Dictate tab. EXPECT: the LEARNED card
+shows your real digest numbers, the correction rows with their reach, and the
+journal with "learned from N similar" where the router would actually nudge.
+Toggle **All**. EXPECT: the wider window's numbers.
+
+## 2. The trace (fill during the walk)
+
+```
+Date/build:              <commit>
+Hub / endpoint:          <host + .43 model for W4>
+W1 file-issue + ctrl:    PASS/FAIL — <note>
+W2 narrow + search:      PASS/FAIL — <speaker/word used>
+W3 import (+audio?):     PASS/FAIL — <file(s), settle time>
+W4 ring + sources:       PASS/FAIL — <artifact types seen>
+W5 decide + audit (+slack?): PASS/FAIL — <decided_by verified?>
+W6 learned card:         PASS/FAIL — <totals seen>
+Bugs found:              <list — file them; the walk is a bug hunt too>
+```
+
+PASS on all six closes HSM-19-07 and the phase (entry-point docs land with this
+runway). Any FAIL: fix, re-walk the failed check, then close.

--- a/pm/roadmap/holdspeak-mobile/phase-19-ipad-meeting-contracts/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-19-ipad-meeting-contracts/current-phase-status.md
@@ -53,7 +53,7 @@ autonomous.
 | HSM-19-04 | Artifact provenance — confidence ring + sources | done — [`evidence-story-04.md`](./evidence-story-04.md) (shipped #151/#159; verified today, metal joins the 19-07 walk) |
 | HSM-19-05 | The proposals review queue (the split, made visible) | done — [`evidence-story-05.md`](./evidence-story-05.md) (live-hub proven with 19-01; `decided_by` audit fix; the tap rides the walk W5) |
 | HSM-19-06 | The learning-loop reader (read-first) | done — [`evidence-story-06.md`](./evidence-story-06.md) (live-hub proven; read-only by shape) |
-| HSM-19-07 | Docs + the staged metal walk | todo |
+| HSM-19-07 | Docs + the staged metal walk | in-progress — docs half done; [`HSM-19-07-WALK.md`](./HSM-19-07-WALK.md) staged (W1–W6, joins the 18-06 couch session); the walk is the owner's |
 
 ## Where we are
 
@@ -71,6 +71,9 @@ digest chips, week/all, correction reach, the journal with per-entry learning si
 live-hub proven on real repository rows (scratch config; the honest no-reach edge
 rendered). **19-03 followed** (6/7): the Import file picker + honest states; the running
 app itself uploaded a .vtt end to end (202 → parsed segments → the file's speakers feeding
-the 19-02 facets live). Only **19-07** (docs + the staged walk) remains. The metal gate (19-07's walk) is
-staged press-play so it can join the owner's 18-06 couch session. The `SpokenSymbols` port
-(18-04) is reused for any meeting-side symbol application — do not re-implement it.
+the 19-02 facets live). **19-07's docs half is done and the gate is STAGED** — README
+carries the six new abilities (voice guard green), ARCHITECTURE verified current, and
+[`HSM-19-07-WALK.md`](./HSM-19-07-WALK.md) is press-play (W1–W6 with controls, sharing the
+owner's 18-06 couch session). **The phase now mirrors Phase 18: 6/7 with the gate staged —
+what closes it is the owner's device walk.** The `SpokenSymbols` port (18-04) is reused for
+any meeting-side symbol application — do not re-implement it.

--- a/pm/roadmap/holdspeak-mobile/phase-19-ipad-meeting-contracts/story-07-docs-and-walk.md
+++ b/pm/roadmap/holdspeak-mobile/phase-19-ipad-meeting-contracts/story-07-docs-and-walk.md
@@ -2,7 +2,11 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 19
-- **Status:** todo
+- **Status:** in-progress — the docs half is DONE (README companion section carries the
+  six new abilities, voice guard green; ARCHITECTURE's client-layer section verified
+  current) and the walk is STAGED press-play at [`HSM-19-07-WALK.md`](./HSM-19-07-WALK.md)
+  (six checks W1–W6 with controls, sharing the 18-06 couch session). What remains is the
+  owner's device walk; PASS×6 closes this story and the phase.
 - **Depends on:** 19-01…19-06 (documents what shipped; the walk exercises it).
 - **Unblocks:** phase close (the owner's device walk is the gate).
 - **Owner:** unassigned


### PR DESCRIPTION
## What

- **README's companion section** carries the six new meeting-contract abilities (file-issue, the proposals review with the cloud mark, faceted search, import, the learning reader) — doc drift guard 15/15 green. ARCHITECTURE's client-layer section verified already current (the route list is generated).
- **`HSM-19-07-WALK.md` staged press-play**: six checks W1–W6 with controls, one per story, sharing the owner's 18-06 couch session (same hub, same `.43` pre-flight; includes the `decided_by=ipad-companion` audit verification and the optional real-slack execute).

Phase 19 now mirrors Phase 18: **6/7 with the gate staged** — one device session closes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ