### PR TITLE
Phase 21 opened: Honest everywhere (trust, provenance, names)

### DIFF
--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -9,20 +9,21 @@
 > 🚀 **New agent (general):** [`HANDOVER.md`](./HANDOVER.md) — the build→deploy→show loop,
 > gotchas, and the exact remaining work to finish **Phase 8** and **Phase 14** (top priority).
 
-**Current phase:** [Phase 19 — The iPad joins the meeting contracts](./phase-19-ipad-meeting-contracts/current-phase-status.md)
-— **OPENED AND BUILT TO 6/7 SAME-DAY (2026-07-03), the gate staged.** The open survey
-corrected the draft (the client layer already landed via Equilibrium Waves 3–6), so the
-phase was screens over shipped clients in `CompanionShellApp.swift`: the aftercare
-file-issue action, the four-state proposals review queue (with the `decided_by:
-ipad-companion` audit fix the live proof surfaced), search + facet chips, the Import file
-picker, and the learning reader — every story live-hub proven from the connected simulator.
-[`HSM-19-07-WALK.md`](./phase-19-ipad-meeting-contracts/HSM-19-07-WALK.md) (W1–W6) is
-press-play; the owner's device walk closes the phase.
-[Phase 18](./phase-18-ipad-dictation-contracts/current-phase-status.md) stands at **6/7 with
-the gate staged**: only the owner's device walk
-([`HSM-18-06-WALK.md`](./phase-18-ipad-dictation-contracts/HSM-18-06-WALK.md)) remains; the
-19-07 walk is staged to join that couch session. Phases 16/17 (web parity + mesh sync; agent
-sync) remain open in parallel.
+**Current phase:** [Phase 21 — Honest everywhere](./phase-21-honest-everywhere/current-phase-status.md)
+— **OPENED 2026-07-03**, the same evening 18/19 reached 6/7 (its precondition, "the iPad
+surfaces exist", was satisfied hours earlier). Survey-corrected: Wave 1 already shipped the
+web banned-copy scan + all-three connector configs, so the five re-grounded stories are the
+iPad half of honesty: the ONE `EgressScope` contract (`DeskPrimitive.egress` + `.mixed` —
+kills the hard-coded "On device" capsule on cloud connectors AND the mixed-as-local drift
+the survey caught in the shell's own new chips), the Swift reassurance-prose guard, GitHub
+readiness truth, the iPad trust chip, and docs + a walk rider.
+[Phase 18](./phase-18-ipad-dictation-contracts/current-phase-status.md) and
+[Phase 19](./phase-19-ipad-meeting-contracts/current-phase-status.md) both stand at
+**6/7 with gates staged**
+([`HSM-18-06-WALK.md`](./phase-18-ipad-dictation-contracts/HSM-18-06-WALK.md),
+[`HSM-19-07-WALK.md`](./phase-19-ipad-meeting-contracts/HSM-19-07-WALK.md)); one owner
+device session closes both. Phases 16/17 (web parity + mesh sync; agent sync) remain open
+in parallel.
 
 **📐 The program — THE EQUILIBRIUM:**
 [`EQUILIBRIUM.md`](./EQUILIBRIUM.md) — bringing every original HoldSpeak feature into full
@@ -33,7 +34,10 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-07-03 (**PHASE 19 OPENED AND BUILT TO 6/7 THE SAME EVENING — the
+**Last updated:** 2026-07-03 (**PHASE 21 — HONEST EVERYWHERE — OPENED**, survey-corrected
+(Wave 1 pre-paid the web halves; the survey also caught fresh mixed-as-local drift in the
+shell chips Phase 18/19 added, proving the case for the one `EgressScope` contract).
+Earlier the same evening: **PHASE 19 OPENED AND BUILT TO 6/7 — the
 iPad joins the meeting contracts; the gate is staged.** The handover's top headless pick,
 opened survey-corrected (the client layer had already merged in EQ Waves 3–6) and built as
 screens over shipped clients, each story proven against a live scratch hub from the

--- a/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/current-phase-status.md
@@ -1,50 +1,66 @@
 # Phase 21 — Honest everywhere (trust, provenance, names)
 
-**Status:** planned — opens once the iPad surfaces from 18/19 exist (the badges need
-something real to describe). Stories detailed on open.
+**Status:** in-progress (opened 2026-07-03, the same evening Phases 18/19 reached 6/7) —
+audit theme 4, the cheapest-to-fix, highest-trust-cost class, non-negotiable per
+POSITIONING canon.
 
-**Last updated:** 2026-06-27 (**authored** from the parity audit, theme 4 + the web
-connector half of theme 3.)
+**Last updated:** 2026-07-03 (**OPENED, survey-corrected.** The 2026-06-27 draft partially
+predates Wave 1 and Phase 19: the web banned-copy scan EXISTS
+(`test_doc_drift_guard.py` scans `web/src/**/*.astro`; zero "intelligent typing" left in
+product copy), web settings binds ALL THREE connectors and the system package persists
+them, and the hub's github propose route has a `companion_github_repo` fallback. What
+remains is the iPad half of every story — plus fresh drift the survey caught in
+tonight's own Phase-18/19 shell work. Stories re-grounded below.)
 
 ## Why this phase exists
 
-Audit theme 4: *honesty drift in trust and provenance.* The badges and names exist; they are
-not consistently driven by the real posture. This is the cheapest-to-fix, highest-trust-cost
-class of gap, and it is non-negotiable per POSITIONING canon ([[feedback_no_privacy_novels]]):
+The badges and names exist; they are not consistently driven by the real posture:
 
-- **The iPad egress badge is cosmetic.** `DioPullout` (`DeskDioramaStage.swift:1221-1224`)
-  hard-codes a `lock.fill / On device` capsule for *every* primitive; `DeskPrimitive` has no
-  `egress` property. `EgressBadge.Scope` lacks the canonical `.mixed` case (the contract names
-  local / mixed / cloud); `CompanionMesh` hand-builds "ON-DEVICE · …" text instead.
-- **Artifacts render without provenance** (`confidence` / `sources`) on the iPad — carried in
-  Phase 19, surfaced here as the honesty line.
-- **Banned copy reappears.** Web uses "intelligent typing" (a banned synonym, `POSITIONING.md:105`)
-  in five strings; two Swift sites narrate forbidden "nothing leaves" reassurance prose
-  (`POSITIONING.md:140-143`). The voice guard does not scan `web/src/**/*.astro` or Swift.
-- **Web cannot configure two of three connectors** — `settings.astro` binds only
-  `slack_webhook_url`; `system.py` persists only Slack. The iPad GitHub tile presents ready
-  but `propose` never sends a repo.
+- **The iPad egress badge is cosmetic.** `DeskPrimitive` has no `egress` property;
+  `EgressBadge.Scope` (`DeskDioramaStage.swift:2541`) lacks the canonical `.mixed`;
+  `DioPullout` hard-codes `lock.fill / "On device"` for EVERY primitive
+  (`DeskDioramaStage.swift:1321-1324`) — including **connector primitives whose whole
+  purpose is cloud egress** (the sharpest honesty bug). `CompanionMesh` hand-builds
+  "ON-DEVICE · …" text (`CompanionMesh.swift:748-753`). Hub runs are honest only via a
+  one-off `@State` (`printedEgress`, `:2895`), not the primitive.
+- **Fresh drift, caught opening this phase:** the Companion shell grew a SECOND parallel
+  egress grammar tonight — `egressChip("Local + \(host)")` renders a **mixed** posture in
+  the local/green treatment (`CompanionShellApp.swift:970`), and `cloudChip` duplicates
+  the badge by hand (`:607`). Exactly the drift one contract prevents.
+- **No guard covers Swift.** ~6 "on-device · nothing leaves" label sites survive in
+  `apple/` (worst: the full reassurance sentence in `DeskHome.swift:318`), and nothing
+  stops them reappearing — the guard scans docs + web only.
+- **The GitHub tile fakes readiness.** The iPad `propose` never sends a repo
+  (`DeskHostLink.propose`, `DeskDioramaStage.swift:2699`); it works solely through the
+  host's `companion_github_repo` fallback (`desk_actuators.py:236`), and the tile presents
+  ready even when the host has no repo configured → a guaranteed 400 at send time.
+- **The ambient trust chip is web-only** (`TrustChip.astro`, HS-42-05, over
+  `/api/setup/status`); the iPad has no equivalent posture line.
 
 ## The load-bearing design call
 
-**Drive every badge and name from the real posture, and make the guard enforce it.** Add
-`egress` to the `DeskPrimitive` protocol (default `.local`, overridden on Mac-backed
-primitives) and the `.mixed(String)` scope; replace the hard-coded capsule with
-`EgressBadge(scope: prim.egress)`. Broaden the voice guard to scan `web/src/**/*.astro` and
-Swift so banned names/prose cannot reappear. Honest egress is a contract, not decoration.
+**One scope model, per-app chrome, driven from the real posture.** `EgressScope`
+(`local / mixed(target) / cloud(target)`) lives in Contracts (pure, UI-free: label +
+symbol name + tint key), so every surface renders the SAME grammar — the desk's
+`EgressBadge`, the mesh line, and the shell's chips all consume it. `DeskPrimitive` gains
+`egress: EgressScope` (default `.local`; connectors override to `.cloud(name)`; hub-run
+surfaces to `.mixed("your desktop")`). The guard learns Swift so banned names and
+reassurance prose cannot reappear (labels state the posture; the badge IS the privacy
+sentence, per canon).
 
 ## Stories
 
 | ID | Title | Status |
 |----|-------|--------|
-| HSM-21-01 | The egress contract on the iPad (`DeskPrimitive.egress` + `.mixed`) — **leads** | todo |
-| HSM-21-02 | The banned-copy + reassurance-prose guard (web + Swift) | todo |
-| HSM-21-03 | Web connector configs (webhook + GitHub) + the iPad GitHub-repo fix | todo |
-| HSM-21-04 | The ambient trust chip + setup-status adapter | todo |
+| HSM-21-01 | The one egress contract (`EgressScope` in Contracts + `DeskPrimitive.egress` + every surface consumes it) — **leads** | todo |
+| HSM-21-02 | The Swift banned-copy + reassurance-prose guard (+ fix the 6 sites) | todo |
+| HSM-21-03 | GitHub-repo honesty: the tile's ready state tells the truth; the host-fallback path ratified | todo (web+backend halves shipped pre-open) |
+| HSM-21-04 | The ambient trust chip on the iPad + the web-chip posture audit | todo |
+| HSM-21-05 | Docs + the walk rider (honesty checks join the staged couch session) | todo |
 
 ## Where we are
 
-Not started. **21-01 leads.** This phase intentionally overlaps the surfaces 18/19 build — do
-not let a new iPad screen ship with a hard-coded badge; once `DeskPrimitive.egress` lands,
-every new surface inherits the honest badge for free. The artifact provenance render is built
-in 19-04; this phase owns the *audit* that no surface fakes a posture.
+Opened 2026-07-03. **21-01 leads** — once `EgressScope` lands, every surface (including
+the ones 18/19 just built) inherits the honest badge for free, and 21-02's guard keeps it
+that way. Artifact provenance rendering shipped in 19-04; this phase owns the audit that
+no surface fakes a posture.

--- a/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-01-egress-contract.md
+++ b/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-01-egress-contract.md
@@ -1,0 +1,53 @@
+# HSM-21-01 — The one egress contract
+
+- **Project:** holdspeak-mobile
+- **Phase:** 21
+- **Status:** todo
+- **Depends on:** the 18/19 surfaces (they carry the drift this story kills); the canon
+  rule [[feedback_no_privacy_novels]] (one badge: local / local+cloud / cloud+target).
+- **Unblocks:** every current and future iPad surface inherits an honest badge; 21-02's
+  guard can then hold the line.
+- **Owner:** unassigned
+
+## Problem
+
+Three parallel, hand-built egress treatments disagree with reality:
+
+1. `DioPullout` hard-codes `lock.fill / "On device"` for every primitive
+   (`DeskDioramaStage.swift:1321-1324`) — connector primitives (Slack/GitHub/Webhook)
+   wear "On device" though their whole purpose is cloud egress.
+2. `CompanionMesh` hand-builds `"ON-DEVICE · " + label` text (`CompanionMesh.swift:748`).
+3. Tonight's shell chips: `egressChip("Local + \(host)")` renders a mixed posture green
+   (`CompanionShellApp.swift:970`); `cloudChip` re-implements the badge (`:607`).
+
+`EgressBadge.Scope` has no `.mixed` case, and `DeskPrimitive` carries no egress at all —
+the honest hub-run badge exists only as a one-off `@State` (`printedEgress`, `:2895`).
+
+## The design
+
+1. **`EgressScope` in Contracts** (pure, UI-free): `local`, `mixed(target)`,
+   `cloud(target)`; carries `label` ("On device" / "Local + \(target)" /
+   "Cloud · \(target)"), `symbolName` (lock / house-arrow / arrow-up-forward), and a
+   `tint` key (ok / warn / warn) so every app renders the same grammar with its own
+   chrome. Unit-tested in ContractsTests.
+2. **`DeskPrimitive.egress`** — protocol default `.local`; `ConnectorPrimitive`
+   overrides to `.cloud(name)`; hub-run/`RunsOn`-Mac surfaces resolve `.mixed("your
+   desktop")`. `DioPullout` renders `EgressBadge(scope: prim.egress)`; `EgressBadge`
+   consumes `EgressScope` (chrome unchanged, adds the mixed band).
+3. **The mesh + shell converge:** `CompanionMesh`'s hand-built text and both shell chips
+   render from `EgressScope` — the dictate-to-desktop chip becomes
+   `.mixed(host)` (amber, honest), the slack approve keeps `.cloud("slack")`.
+
+## Scope
+
+- **In:** the Contracts type + tests; `DeskPrimitive.egress` + overrides; DioPullout /
+  EgressBadge / CompanionMesh / shell chips consuming it; sim proof (a connector pullout
+  wearing Cloud, the dictate chip amber).
+- **Out:** web badges (already scope-driven since Phase 62); per-record persisted scopes
+  (the chip-that-refuses-to-lie moment is Vision backlog, not this story).
+
+## Test plan
+
+- `swift test` (new `EgressScopeTests` in ContractsTests; existing suites green).
+- Sim proofs: a connector primitive's pullout wearing `Cloud · slack`; the shell dictate
+  receipt wearing the amber `Local + <host>` chip.

--- a/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-02-swift-guard.md
+++ b/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-02-swift-guard.md
@@ -1,0 +1,45 @@
+# HSM-21-02 — The Swift banned-copy + reassurance-prose guard
+
+- **Project:** holdspeak-mobile
+- **Phase:** 21
+- **Status:** todo
+- **Depends on:** 21-01 (the badge grammar the fixed labels adopt);
+  `tests/unit/test_doc_drift_guard.py` (the guard this extends).
+- **Unblocks:** banned names and privacy prose cannot reappear on Apple surfaces.
+- **Owner:** unassigned
+
+## Problem
+
+The guard scans docs + `web/src/**/*.astro` (Wave 1) but not Swift. ~6 label sites still
+say "on-device · nothing leaves" (`LocalHarnessApp.swift:253`,
+`SpeakHarnessApp.swift:272`, `InferenceHarnessApp.swift:69`, `ReviewModel.swift:31`,
+`MeetingCapture.swift:90`) and `DeskHome.swift:318` carries a full reassurance sentence
+("… nothing leaves.") — the exact prose POSITIONING §140-143 bans: the badge IS the
+privacy statement.
+
+## The design
+
+1. **Fix the sites:** the `egressLabel` strings and harness labels adopt the badge
+   grammar ("on device"); the DeskHome snippet drops its ", nothing leaves." tail
+   (the no-prose rule: labels, not manuals).
+2. **Extend the guard:** `_swift_user_facing()` sweeps `apple/App/**/*.swift` +
+   `apple/Sources/**/*.swift` for (a) the banned feature names, (b) the
+   reassurance-prose pattern (`nothing leaves` / `never leaves` / `stays on this|your`)
+   inside string literals. Red-prove with a seeded violation test (the existing
+   `test_voice_guard_patterns_catch_seeded_violations` pattern).
+3. **Careful scoping:** the Qlippy doc test REQUIRES "nothing leaves" verbatim in its
+   doc (`test_doc_drift_guard.py:221-235`) — the Swift ban must not touch docs; code
+   comments are exempt (string literals only, best-effort line heuristic is fine if
+   red-proven).
+
+## Scope
+
+- **In:** the 6 label fixes; the Swift scan + seeded red-proof; guard green.
+- **Out:** web/docs scanning (shipped); renaming `docs/INTELLIGENT_TYPING_GUIDE.md`
+  (the known Wave-1 carve-out, still owner-gated).
+
+## Test plan
+
+- `uv run pytest -q tests/unit/test_doc_drift_guard.py` (new tests included, one seeded
+  red-proof).
+- `swift test` + both app sim builds green after the label changes.

--- a/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-03-github-repo-honesty.md
+++ b/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-03-github-repo-honesty.md
@@ -1,0 +1,45 @@
+# HSM-21-03 — GitHub-repo honesty on the desk
+
+- **Project:** holdspeak-mobile
+- **Phase:** 21
+- **Status:** todo — the audited web+backend halves shipped pre-open (web settings binds
+  `companion_github_repo`, `system/settings.py:429` persists it, the propose route falls
+  back to it, `desk_actuators.py:236`).
+- **Depends on:** the hub's desk-actuator status surface (whatever feeds the tile's
+  `configured` state today).
+- **Unblocks:** no dead-on-arrival GitHub sends from the desk.
+- **Owner:** unassigned
+
+## Problem
+
+The iPad's `DeskHostLink.propose` sends no repo (`DeskDioramaStage.swift:2699`), so a
+GitHub send works only through the host's `companion_github_repo` fallback — yet the
+GitHub tile presents ready regardless. With no repo configured on the host, the send is a
+guaranteed 400 discovered at approve time. The audit's literal fix ("iPad sends a repo")
+is one option; the honest minimum is that **readiness tells the truth**.
+
+## The design
+
+1. **Ratify the host-config path** (this story's design decision): the repo is desktop
+   configuration, like every credential — the iPad does not grow a repo field. Recorded
+   here; the propose body stays `{text, title}`.
+2. **The tile tells the truth:** the GitHub connector's ready state derives from the
+   hub's real posture (repo configured or not); unconfigured renders the same
+   not-configured treatment the other connectors use, and the act sheet routes to "set it
+   on your desktop" instead of a doomed send.
+3. **Hub side if needed:** if no existing status surface carries `github repo
+   configured`, extend the desk-actuator status payload minimally (a boolean, no
+   credential material — the repo name itself stays server-side unless already exposed).
+
+## Scope
+
+- **In:** the honest ready state + its data path; the ratified design note; proof (a
+  hub with and without `companion_github_repo`).
+- **Out:** an iPad repo input; web/settings changes (shipped); the actuator flow itself
+  (HS-38/49, unchanged).
+
+## Test plan
+
+- Hub-side: route/unit tests for the status boolean (if added).
+- Live-hub proof: tile state with and without the repo configured; `swift test` +
+  meeting-capture sim build green.

--- a/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-04-ipad-trust-chip.md
+++ b/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-04-ipad-trust-chip.md
@@ -1,0 +1,42 @@
+# HSM-21-04 — The ambient trust chip on the iPad
+
+- **Project:** holdspeak-mobile
+- **Phase:** 21
+- **Status:** todo
+- **Depends on:** the web `TrustChip.astro` (HS-42-05) + `/api/setup/status`
+  (`holdspeak/web/routes/setup.py:23`, `build_setup_status()`); 21-01's `EgressScope`
+  grammar.
+- **Unblocks:** the iPad states its posture ambiently, like the web has since Phase 42.
+- **Owner:** unassigned
+
+## Problem
+
+The web shell header carries an ambient posture chip ("Local only · Configured endpoint ·
+Writes need approval · Needs attention") driven by `/api/setup/status`. The iPad — the
+surface most likely to be trusted implicitly — has none; its only posture signals are
+per-card badges.
+
+## The design
+
+1. **A setup-status client** on `HTTPDesktopClient` (own extension file, the equilibrium
+   conflict rule): `setupStatus()` decoding the posture facts the chip needs.
+2. **The chip in the Companion shell's top bar**, beside the connection chip: one compact
+   posture line in the same grammar as the web chip; a degraded hub ("needs attention")
+   renders honestly; unreachable renders nothing new (the connection chip already owns
+   that state). Labels, never sentences.
+3. **The web-chip audit** (the story's second half): verify `TrustChip` renders from the
+   live `/api/setup/status` posture and never a hardcoded default once loaded — recorded
+   in evidence with the posture flipped for real (e.g. actuators enabled vs not).
+
+## Scope
+
+- **In:** the client + decode test; the shell chip; the web audit; live-hub proof with
+  two different postures.
+- **Out:** the desk app's diorama (its trust surface is the per-primitive badge from
+  21-01); any new hub route (the adapter exists).
+
+## Test plan
+
+- `swift test` (new `SetupStatusClientTests` decode + URL).
+- Live-hub proof: two scratch-hub postures → two shell screenshots; the web chip
+  audited against the same hubs.

--- a/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-05-docs-and-walk-rider.md
+++ b/pm/roadmap/holdspeak-mobile/phase-21-honest-everywhere/story-05-docs-and-walk-rider.md
@@ -1,0 +1,35 @@
+# HSM-21-05 — Docs + the walk rider
+
+- **Project:** holdspeak-mobile
+- **Phase:** 21
+- **Status:** todo
+- **Depends on:** 21-01…21-04 (documents what shipped; the rider verifies it).
+- **Unblocks:** phase close (the honesty checks ride the owner's staged couch session).
+- **Owner:** unassigned
+
+## Problem
+
+Every phase gets its own documentation story, and this phase's device verification
+should not cost a separate session — the couch session (18-06 + 19-07 walks) is already
+staged.
+
+## The design
+
+1. **Entry points current:** README / ARCHITECTURE / SECURITY where the egress story is
+   told — the one `EgressScope` grammar across surfaces, the Swift guard joining the
+   voice guard, the GitHub readiness truth.
+2. **`HSM-21-WALK-RIDER.md`**: three honesty checks appended to the couch session —
+   H1 a connector primitive's pullout wears Cloud (and a plain note wears On device);
+   H2 the shell dictate receipt wears the amber `Local + <host>`; H3 the trust chip
+   states the hub's real posture (flip actuators and watch it change).
+3. **Screenshots current** per story.
+
+## Scope
+
+- **In:** entry-point docs, the rider doc, screenshot inventory.
+- **Out:** running the rider (the owner's hands).
+
+## Test plan
+
+- Doc guards green (`uv run pytest -q tests/unit/test_doc_drift_guard.py`).
+- The rider validated press-play against a live local hub.


### PR DESCRIPTION
## What

Opens **Phase 21 — Honest everywhere**, the Equilibrium program's trust theme, the same evening its precondition cleared (the 18/19 iPad surfaces now exist for the badges to describe).

Survey-corrected against what already shipped: Wave 1 landed the web banned-copy scan and all-three connector configs, so the five re-grounded stories are the iPad half of honesty:

1. **HSM-21-01 (leads)** — the ONE `EgressScope` contract: `local / mixed(target) / cloud(target)` in Contracts, `DeskPrimitive.egress`, and every surface consuming it. Kills the hard-coded "On device" capsule that cloud connectors currently wear, and the fresh mixed-as-local drift the survey caught in the shell chips added tonight.
2. **HSM-21-02** — the Swift banned-copy + reassurance-prose guard (+ fixing the ~6 "nothing leaves" label sites; the badge is the privacy statement, per canon).
3. **HSM-21-03** — GitHub readiness truth: the host `companion_github_repo` fallback ratified as the path; the tile must not present ready when a send would 400.
4. **HSM-21-04** — the ambient trust chip on the iPad over the existing `/api/setup/status`, plus the web-chip posture audit.
5. **HSM-21-05** — docs + a walk rider (honesty checks join the staged 18/19 couch session).

Docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ