### PR TITLE
Phase 23 (HSM-23-05, docs half): entry points current + the storage rider staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,11 @@ posture in the web chip's own four words, and a guard holds Apple product
 copy to the same canonical names and no-privacy-prose rule as the docs and
 the web. Its on-device storage is schema safe the same
 way the desktop is: it backs an older database up before migrating, and
-refuses to open one written by a newer build. The app itself is not released
+refuses to open one written by a newer build. A readiness section in its
+Settings states that store's health (schema version, integrity, a refused
+newer database named as exactly that) beside your desktop's own doctor
+readout, section by section, so the iPad can tell you it is healthy without
+a trip to the Mac. The app itself is not released
 yet; the screens and the typed client layer they ride on are built and tested.
 
 ### AIPI-Lite

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -231,7 +231,11 @@ before it touches anything: a database newer than the build is refused (it
 throws rather than rewrite your data), an older one is backed up to a
 timestamped sibling and then migrated forward, and a current one is a no-op.
 That mirrors the desktop store's safe-by-default posture on the mobile side,
-the same four-way schema matrix described below.
+the same four-way schema matrix described below. A readiness section in the
+iPad's Settings surfaces the matrix as a health readout: a probe on the same
+open path reports the stamped schema version, the integrity check, the count
+of backup siblings, and a refused newer database named with both versions,
+beside the hub's own doctor sections read from the setup-status route.
 
 The desktop schema matrix:
 

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -19,7 +19,10 @@ day** — Settings now states store health (`StoreHealthProbe`: ok / not created
 refused-newer / failed + backups), mic, models, app version, AND the paired hub's full
 doctor (`SetupStatus.sections`, previously dropped), proven live against a real scratch
 hub and a real seeded newer-version store (refused, rendered amber, left byte-intact).
-Only 23-05 (docs + the ~2-minute walk rider) remains.
+23-05's docs half is done (README, ARCHITECTURE, the web companion page) and
+[`HSM-23-WALK-RIDER.md`](./phase-23-mesh-safe-storage/HSM-23-WALK-RIDER.md) is staged
+(R1 + optional R2, ~2 min) — **the one owner couch session now closes Phases 18, 19,
+21, and 23.**
 [Phase 21 — Honest everywhere](./phase-21-honest-everywhere/current-phase-status.md)
 stands at **4/5, gate staged**: the iPad half
 of honesty, shipped: the ONE `EgressScope` contract (`DeskPrimitive.egress`; connectors
@@ -48,7 +51,11 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-07-04 (**PHASE 23 BUILT TO 4/5 THE DAY IT OPENED.** 23-03: the
+**Last updated:** 2026-07-04 (**PHASE 23 FULLY BUILT AND GATE-STAGED THE DAY IT
+OPENED.** 23-05's docs landed (README iPad section, ARCHITECTURE device path, the web
+companion page) and [`HSM-23-WALK-RIDER.md`](./phase-23-mesh-safe-storage/HSM-23-WALK-RIDER.md)
+is staged (R1 + optional R2, ~2 min) — the couch session now closes FOUR phases
+(18/19/21/23). Earlier the same day: 23-03: the
 readiness/doctor panel — `StoreHealthProbe` (the Wave-4 safety gets a face; refused-newer
 renders amber and the probe never stamps), `SetupStatus.sections` decoded (the hub's
 doctor block was dropped; the old test stub had drifted from the real wire), the

--- a/pm/roadmap/holdspeak-mobile/phase-23-mesh-safe-storage/HSM-23-WALK-RIDER.md
+++ b/pm/roadmap/holdspeak-mobile/phase-23-mesh-safe-storage/HSM-23-WALK-RIDER.md
@@ -1,0 +1,32 @@
+# HSM-23 — the storage rider (two checks for the staged couch session)
+
+Ride-alongs for the session that runs
+[`HSM-18-06-WALK.md`](../phase-18-ipad-dictation-contracts/HSM-18-06-WALK.md),
+[`HSM-19-07-WALK.md`](../phase-19-ipad-meeting-contracts/HSM-19-07-WALK.md) and
+[`HSM-21-WALK-RIDER.md`](../phase-21-honest-everywhere/HSM-21-WALK-RIDER.md) — same hub,
+same pairing, ~2 extra minutes. Both checks were already proven live from the connected
+simulator (see [`evidence-story-03.md`](./evidence-story-03.md)); the rider verifies the
+same truths on glass.
+
+**R1 — the iPad states its own health (23-03).** Open Settings → READINESS. EXPECT:
+**This iPad** shows the Store chip green (**ok · schema v2**), mic and models stated
+plainly, the app version under the header. Below it, the paired desktop card carries the
+hub's overall chip (**Ready** or **Needs attention**, matching what `holdspeak doctor`
+says on the Mac at that moment) and the doctor's own sections row by row, warn rows
+amber.
+
+**R2 (optional, the refusal on glass) — a newer store is named, never eaten.** Only if
+the session has a minute to spare: with a future-version `meetings.sqlite` seeded into
+the app container (the evidence file's sqlite3 one-liner), relaunch. EXPECT: the home
+banner reads **Store written by a newer HoldSpeak (v7 > v2), left unread**, and the
+Settings Store chip reads **newer than this app · v7 > v2** in amber. Delete the seeded
+file afterwards; the store recreates on the next launch.
+
+## The trace
+
+```
+R1 readiness panel:   PASS/FAIL — <store chip / hub overall seen, vs doctor on the Mac>
+R2 refusal (optional): PASS/FAIL/SKIPPED — <banner + chip wording seen>
+```
+
+PASS on R1 closes HSM-23-05 and the phase (R2 is a bonus, already machine-proven).

--- a/pm/roadmap/holdspeak-mobile/phase-23-mesh-safe-storage/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-23-mesh-safe-storage/current-phase-status.md
@@ -3,8 +3,12 @@
 **Status:** in-progress (opened 2026-07-04) — audit theme 6, the safety net for everything
 sync touches, opened before the mesh grows more newer-DB peers.
 
-**Last updated:** 2026-07-04 (**4/5 — 23-03 landed the same day, and the standing
-docs-story rule added 23-05.** The readiness panel is live: `StoreHealthProbe`
+**Last updated:** 2026-07-04 (**4/5 with the gate STAGED — the whole phase built the
+day it opened.** 23-05's docs half is done (README iPad section, ARCHITECTURE device
+path, the web companion page) and [`HSM-23-WALK-RIDER.md`](./HSM-23-WALK-RIDER.md) is
+staged: R1 + optional R2, ~2 minutes riding the 18/19/21 couch session — **that one
+owner sitting now closes Phases 18, 19, 21, AND 23.** Earlier: **23-03 landed the same
+day, and the standing docs-story rule added 23-05.** The readiness panel is live: `StoreHealthProbe`
 (ok/missing/refused-newer/failed + backup count, same open path as the app),
 `SetupStatus.sections` decoded (the hub's doctor block was being dropped; the old test
 stub had even drifted from the real wire), the two-card READINESS section in Settings,
@@ -70,7 +74,7 @@ that actually ships (§11 current, the stale lossy-finding corrected).
 | HSM-23-02 | Backup-then-apply (timestamped) before migration | done (pre-paid, Wave 4) — [`evidence-story-02.md`](./evidence-story-02.md) |
 | HSM-23-03 | The readiness / doctor panel in Settings | done — [`evidence-story-03.md`](./evidence-story-03.md) |
 | HSM-23-04 | Sync integrity: the per-primitive round-trip matrix + the serialization-contract pin | done — [`evidence-story-04.md`](./evidence-story-04.md) |
-| HSM-23-05 | Docs + the walk rider (schema safety joins the entry points) | todo |
+| HSM-23-05 | Docs + the walk rider (schema safety joins the entry points) | in-progress — docs done; [`HSM-23-WALK-RIDER.md`](./HSM-23-WALK-RIDER.md) staged (R1 + optional R2, ~2 min); the rider is the owner's |
 
 ## Where we are
 
@@ -88,5 +92,6 @@ the golden fixture, which now pins the Phase-77 fields on BOTH sides of the wire
 **23-03 followed the same day (4/5)** — the readiness/doctor panel in Settings (see
 "Last updated" above for the full account; per-story evidence + 3 screenshots). The
 standing docs-story rule ([[feedback_dedicated_docs_story]]) added **HSM-23-05** on
-this pass: entry-point docs + a ~2-minute walk rider joining the staged couch session.
-That rider is now the phase's only open item.
+this pass; its docs half landed the same day and the rider is staged. **The owner's
+couch session is the phase's only open item** — it now closes four phases in one
+sitting (18, 19, 21, 23).

--- a/pm/roadmap/holdspeak-mobile/phase-23-mesh-safe-storage/story-05-docs-and-walk-rider.md
+++ b/pm/roadmap/holdspeak-mobile/phase-23-mesh-safe-storage/story-05-docs-and-walk-rider.md
@@ -2,7 +2,12 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 23
-- **Status:** todo
+- **Status:** in-progress — docs done, rider staged (evidence ships with the done
+  flip when the rider passes, the 21-05 pattern). README's iPad section,
+  ARCHITECTURE's device path, and the web companion page carry the readiness story
+  (drift guard 18 passed, web build green);
+  [`HSM-23-WALK-RIDER.md`](./HSM-23-WALK-RIDER.md) (R1 + optional R2, ~2 min) rides
+  the staged couch session — the rider is the owner's.
 - **Depends on:** 23-01..04 (the features it documents).
 - **Unblocks:** phase closeout; the standing rule that every phase carries its own
   documentation story ([[feedback_dedicated_docs_story]]), entry points included

--- a/web/src/pages/companion.astro
+++ b/web/src/pages/companion.astro
@@ -10,6 +10,7 @@ const pairingSteps = [
   { n: "1", title: "Point at your hub", body: "Host, port, an optional token, and a scheme — over your own network." },
   { n: "2", title: "Probe, never assume", body: "The device probes /health, then reads /api/runtime/status for readiness." },
   { n: "3", title: "Drive both modes", body: "The dictation teleprompter and the meeting afterlife, from the iPad." },
+  { n: "4", title: "States its own health", body: "Settings on the iPad reports its store's schema safety and your hub's doctor, section by section." },
 ];
 ---
 


### PR DESCRIPTION
## What

The last Phase-23 story's docs half. The readiness/schema-safety story reaches the entry points:

- **README (iPad app section):** the readiness clause — Settings states the store's health beside the desktop's own doctor readout, so the iPad can tell you it is healthy without a trip to the Mac.
- **docs/ARCHITECTURE.md (device data path):** how the four-way matrix is *surfaced* — the probe on the same open path (schema version, integrity, backup count, a refused newer DB named with both versions) beside the hub's doctor sections.
- **web /companion:** a fourth "States its own health" pairing step.
- **`HSM-23-WALK-RIDER.md` staged:** R1 (the panel on glass, cross-checked against `holdspeak doctor` on the Mac) + optional R2 (the refusal on glass, already machine-proven), ~2 minutes riding the staged couch session.

## Phase state

Phase 23 → **4/5 with the gate staged** (23-05 evidence ships with the done flip after the owner's walk, the 21-05 pattern). **The one owner couch session now closes Phases 18, 19, 21, and 23.**

## Guards

- doc drift guard: **18 passed** (voice + banned-copy green over the new prose)
- web build: **17 pages, Complete** (source only; bundle stays gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ