### PR TITLE
Phase 22 (the graph travels) opened, survey-corrected: 22-02 pre-paid

### DIFF
--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -9,8 +9,19 @@
 > 🚀 **New agent (general):** [`HANDOVER.md`](./HANDOVER.md) — the build→deploy→show loop,
 > gotchas, and the exact remaining work to finish **Phase 8** and **Phase 14** (top priority).
 
-**Current phase:** [Phase 23 — Mesh-safe storage](./phase-23-mesh-safe-storage/current-phase-status.md)
-— **OPENED 2026-07-04, survey-corrected, and built to 4/5 the same day.** The Wave-4
+**Current phase:** [Phase 22 — The graph travels](./phase-22-the-graph-travels/current-phase-status.md)
+— **OPENED 2026-07-04, survey-corrected: 1/4 on open.** The hub half (22-02) was
+pre-paid by Equilibrium Wave 1 and is recorded done with a fresh 50-test green run;
+the survey also KILLED a false memory (the "web authors a linear graph" Wave-2 claim
+has no code behind it: 22-03 stays genuinely todo) and caught a producer hole the
+audit missed (`BPNode` carries no `runs_on`, so the iPad cannot emit the policy the
+hub reads — folded into 22-01). **22-01 leads:** the Blueprint→`graph_json` lowering +
+Save + `DeskSync`, pinned by a Swift-ENCODED golden fixture fed byte-for-byte into
+`linearize()` (the HS-72-01 pattern applied to graphs). Then 22-03 (web linear builder
++ the `primitives.ts` type fix + the dropped run `warning`) and 22-04 (the
+cross-surface proof + `runWorkflow` on the iPad hub path + docs/rider).
+[Phase 23 — Mesh-safe storage](./phase-23-mesh-safe-storage/current-phase-status.md)
+is **fully built and gate-staged, the same day it opened**: the Wave-4
 refuse-newer + backup-then-apply mechanism (23-01/02) is recorded done with fresh green
 runs; **23-04 (sync integrity) landed** (the 10-kind round-trip matrix complete, §11
 rewritten to the shipping wire, the stale "lossy manual_context" finding corrected +
@@ -51,7 +62,12 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-07-04 (**PHASE 23 FULLY BUILT AND GATE-STAGED THE DAY IT
+**Last updated:** 2026-07-04 (**PHASE 22 OPENED, survey-corrected — the LAST
+Equilibrium build phase.** 22-02 (the hub honors the graph) pre-paid by Wave 1,
+recorded done with a fresh 50-test run; the survey killed the false "web authors a
+graph" memory and caught the missing `BPNode.runs_on` producer hole; 22-01 (the
+Blueprint→`graph_json` lowering + the Swift-encoded golden pin against `linearize()`)
+leads. Earlier the same day: **PHASE 23 FULLY BUILT AND GATE-STAGED THE DAY IT
 OPENED.** 23-05's docs landed (README iPad section, ARCHITECTURE device path, the web
 companion page) and [`HSM-23-WALK-RIDER.md`](./phase-23-mesh-safe-storage/HSM-23-WALK-RIDER.md)
 is staged (R1 + optional R2, ~2 min) — the couch session now closes FOUR phases

--- a/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/current-phase-status.md
@@ -1,50 +1,64 @@
 # Phase 22 — The graph travels (the Workbench bridge)
 
-**Status:** planned — independent of the iPad-client work; can run in parallel with 18/19.
-Stories detailed on open.
+**Status:** in-progress (opened 2026-07-04) — audit theme 5, the keystone the
+cross-surface workflow story waits on. Independent of the walk-gated phases.
 
-**Last updated:** 2026-06-27 (**authored** from the parity audit, theme 5.)
+**Last updated:** 2026-07-04 (**OPENED, survey-corrected — the hub half was pre-paid,
+the authoring half was not.** The 2026-06-27 draft predates Equilibrium Wave 1 and
+Phase 23: **22-02 shipped in Wave 1** (`workflow_graph.py` linearizes the Swift
+tagged-union shape, carries AND applies per-node `failure_policy`, carries `runs_on`,
+refuses control flow honestly with a `warning`, and documents what it does not
+enforce — 50 tests re-run green on open), and 23-04 locked `graph_json` surviving sync
+byte-faithful. But the survey KILLED a false memory: the Wave-2 "web authors a linear
+graph" claim is **not backed by code** (no `exec_edges` anywhere in `web/src`; the
+workbench page is localStorage-only; `primitives.ts:153` still types `graphJson` as a
+string) — 22-03 stays genuinely todo. And the audit itself missed a producer hole:
+**`BPNode` carries no `runs_on` at all**, so the iPad cannot emit the policy the hub
+already reads; 22-01 absorbs that fix. Stories re-grounded below.)
 
 ## Why this phase exists
 
-Audit theme 5: *the Workbench graph is authored richly on iPad but cannot travel.* The full
-Blueprint interpreter (two wires, control flow, typed edges, event stream) runs on device, but:
+Audit theme 5: *the Workbench graph is authored richly on iPad but cannot travel.* The
+full Blueprint interpreter (two wires, control flow, typed edges, event stream) runs on
+device, but the graph never leaves the canvas:
 
-- **It never serializes.** `GraphCanvasView` is disconnected from `graph_json`: no Save
-  button, no serializer; `startRun()` runs against demo text and never persists. An authored
-  graph runs once and is lost.
-- **The hub runs linear-only.** `workflow_graph.py:linearize` parses one straight pipeline and
-  **refuses** branch/loop/fan-out; the linearizer also drops per-node `failure_policy` and
-  `runs_on` (`GraphNode` holds only id/kind/payload) though the Swift model carries them.
-- **Web cannot author a graph.** `submitWorkflow` hardcodes `graph_json: {}` yet
-  `primitives.ts` marks workflow `authorable: true`; `primitives.ts:153` even type-drifts
+- **It never serializes.** Nothing encodes a `Blueprint` into
+  `WorkflowDefinition.graphJson` (still commented "reserved",
+  `Contracts/Primitives.swift:346`); the canvas has no Save; `startRun()` is
+  demo-gated; `WorkbenchLibrary` persists the engine model to UserDefaults only.
+- **The iPad cannot even express `runs_on`.** `BPNode` (`Blueprint.swift:162`) carries
+  `failurePolicy` but no per-node runs-on — the hub parses a field no producer emits.
+- **Web cannot author a graph.** No surface emits `nodes`/`exec_edges`;
+  `useDesk.createPrimitive` has no workflow case; `primitives.ts` type-drifts
   (`graphJson?: string` vs the object wire).
-
-The graph bridge is the keystone the cross-surface workflow story waits on.
+- **The language boundary is unproven.** The hub's conformance test runs a
+  hand-written Python dict in the Swift shape; no test feeds real Swift-ENCODER bytes
+  into `linearize()`. (The 23-04 sync fixture survives the wire but would not
+  linearize — a placeholder shape, worth upgrading.)
 
 ## The load-bearing design call
 
-**One `graph_json` wire shape, authored anywhere, run honestly.** Lower the iPad Blueprint to
-the canonical snake_case `graph_json`, persist it as a `WorkflowRecord`, and sync it via
-`DeskSync` — so a graph authored on the iPad survives, travels, and round-trips against
-`workflow_graph.linearize`. The hub either *honors* control flow / `failure_policy` / `runs_on`
-or **documents the omission honestly** (the audit filed these as low-severity desktop
-footnotes; this phase promotes them to first-class contract findings per the EQUILIBRIUM rule
-that desktop is audited, not assumed). Web ships a minimal linear-chain builder emitting the
-same shape, or scopes its claim honestly with a "graphed on iPad" affordance.
+**One `graph_json` wire shape, authored anywhere, run honestly.** Lower the iPad
+Blueprint to the canonical snake_case `graph_json` through the shared coder, persist it
+as a `WorkflowRecord`, and sync it via `DeskSync` — and pin the language boundary the
+HS-72-01 way: a golden fixture ENCODED BY SWIFT, committed, and fed byte-for-byte into
+`workflow_graph.linearize()` by pytest, so the two parsers can never drift again. The
+hub already honors the faithful subset and warns on the rest (22-02, shipped). Web
+ships a minimal linear builder emitting the same shape, or scopes its claim honestly.
 
 ## Stories
 
 | ID | Title | Status |
 |----|-------|--------|
-| HSM-22-01 | The `graph_json` serializer on iPad (+ Save + `DeskSync`) — **leads** | todo |
-| HSM-22-02 | The hub honors the graph (control flow / `failure_policy` / `runs_on`, or honest omission) | todo |
-| HSM-22-03 | Web authors a linear graph (or honest scope) + the `primitives.ts` type fix | todo |
-| HSM-22-04 | The cross-surface proof + docs | todo |
+| HSM-22-01 | The `graph_json` serializer on iPad (+ `runs_on` on `BPNode`, Save, `DeskSync`, the Swift-encoded golden fixture → `linearize()` conformance) — **leads** | todo |
+| HSM-22-02 | The hub honors the graph (control flow / `failure_policy` / `runs_on`, or honest omission) | done (pre-paid, Wave 1) — [`evidence-story-02.md`](./evidence-story-02.md) |
+| HSM-22-03 | Web authors a linear graph (or honest scope) + the `primitives.ts` type fix + the run UI renders the hub's `warning` | todo |
+| HSM-22-04 | The cross-surface proof (authored → synced → run) + `runWorkflow` on the iPad hub path + docs | todo |
 
 ## Where we are
 
-Not started. **22-01 leads** (without serialization, nothing travels). 22-02 is the desktop
-contract re-audit the program promised — the linearizer dropping `failure_policy`/`runs_on` is
-a real cross-surface hole, not a footnote. Round-trip the serializer against
-`workflow_graph.linearize` as the conformance test.
+Opened 2026-07-04, survey-corrected: **1/4 on open** — 22-02 shipped in Equilibrium
+Wave 1 (evidence recorded from the shipped code + a fresh 50-test green run). **22-01
+leads**: without serialization nothing travels, and the golden-fixture conformance is
+the one lock that makes every later story safe. 22-04 upgrades the 23-04 sync fixture
+to a linearizable graph and closes the iPad's missing run-workflow-on-hub path.

--- a/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/evidence-story-02.md
+++ b/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/evidence-story-02.md
@@ -1,0 +1,48 @@
+# Evidence — HSM-22-02 — The hub honors the graph
+
+**Status:** done. Built in **Equilibrium Wave 1 (2026-06-27)** ("Graph node
+policy/target", the wave log in `EQUILIBRIUM.md`), before this phase opened; recorded
+here on phase open (2026-07-04) with a fresh green run.
+
+## The shipped mechanism (`holdspeak/web/routes/workflow_graph.py`)
+
+- `GraphNode` (`:99-112`) carries per-node `failure_policy` + `runs_on`, parsed from
+  the wire (`:168-174`) — the exact fields the audit said the linearizer dropped.
+- `linearize()` (`:205-283`) accepts the Swift tagged-union Codable shape — including
+  the `{"extract":{"_0":"action_items"}}` single-unlabeled-associated-value form
+  (`_extract_artifact_type`, `:289-303`, the god-review fix) — and REFUSES
+  branch/for-each/while/sequence (`_CONTROL_FLOW_KINDS`), fan-out, joins, cycles, and
+  disconnected chains with a stated reason (`LinearPlan.linearizable=False`).
+- The runner applies the faithful subset: `skip` / `fallbackOnDevice` carry the input
+  through and continue; `retryThenQueue` and unset fail fast (`on_node_error`,
+  `:381-402`).
+- The run route (`holdspeak/web/routes/primitives/workflows.py:97`,
+  `POST /api/workflows/{id}/run`) returns `output`, `provider`, per-step
+  `node_id`/`kind`/`failure_policy`/`runs_on`/`status`, `sources`, `artifact_id`, and
+  a `warning` when a graph was refused; its docstring (`:128-136`) documents what the
+  hub does NOT enforce (`runs_on` carried, not pinned to a provider; no real retry
+  queue) — the honest-omission clause this story demanded.
+
+## The lock
+
+- `tests/unit/test_workflow_graph.py` — tagged-union decode, every refusal class, the
+  `failure_policy`/`runs_on` carry (`:170-180`), the `extract` Codable shape
+  (`:150-157`).
+- `tests/unit/test_web_routes_primitives.py` — `_linear_graph()` (`:455`) is the
+  Swift-shape conformance dict; `test_run_workflow_linear_graph_runs_in_order`
+  (`:497`), the branch-refusal warning (`:536`), the 400 (`:555`).
+
+## Fresh run on phase open (2026-07-04)
+
+```
+uv run pytest -q tests/unit/test_workflow_graph.py tests/unit/test_web_routes_primitives.py
+50 passed
+```
+
+## Honest boundaries
+
+- The conformance dict is hand-written in the Swift shape; real Swift-ENCODER bytes
+  reach `linearize()` only with 22-01's golden fixture (deliberately that story's
+  lock, not claimed here).
+- Control flow is refused, not emulated; the omissions are documented, not fixed —
+  that is the design call, unchanged.

--- a/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-01-ipad-serializer.md
+++ b/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-01-ipad-serializer.md
@@ -1,0 +1,57 @@
+# HSM-22-01 — The `graph_json` serializer on iPad (Save, sync, and the golden pin)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 22
+- **Status:** todo
+- **Depends on:** the Blueprint model + interpreter (Phase 14, shipped); the hub
+  linearizer (HSM-22-02, shipped); `graph_json` sync survival (HSM-23-04, shipped).
+- **Unblocks:** 22-03 (the web consumes/authors the same shape), 22-04 (the
+  cross-surface proof needs an authored producer).
+- **Owner:** unassigned
+
+## Problem
+
+The iPad authors a rich Blueprint that never leaves the canvas:
+
+1. Nothing encodes a `Blueprint` into `WorkflowDefinition.graphJson` — the field is
+   still commented "reserved" (`Contracts/Primitives.swift:346`); the canvas has no
+   Save; `WorkbenchLibrary` (`WorkbenchUI.swift:11`) persists the engine model to
+   UserDefaults only.
+2. **`BPNode` carries no `runs_on`** (`Blueprint.swift:162`) — the hub parses a
+   per-node field (`workflow_graph.py:74`) that no producer can emit. The audit
+   missed this; the survey caught it.
+3. The language boundary is unproven: the hub's conformance test runs a hand-written
+   dict; Swift's Codable test round-trips Swift↔Swift with a plain coder (no
+   snake_case, no wire-shape assertion).
+
+## The design
+
+1. **`runs_on` joins `BPNode`** (optional; absent = the hub's default), rendered on
+   the node inspector with the existing `RunsOnPicker`.
+2. **The lowering:** `Blueprint` → `graph_json` through the canonical
+   `HoldSpeakContracts` coder (snake_case, the `{"extract":{"_0":…}}` tagged-union
+   shape), landing in `WorkflowDefinition.graphJson` / `WorkflowRecord`.
+3. **Save on the canvas:** an authored Blueprint persists as a real `WorkflowRecord`
+   and rides `DeskSync` like every other primitive (no parallel store).
+4. **The golden pin (the HS-72-01 pattern applied to graphs):** a fixture ENCODED BY
+   SWIFT (a real Blueprint exercising entry/llm/extract/keepIf + `failure_policy` +
+   `runs_on`) committed under `contracts/fixtures/`; a Swift test regenerates and
+   compares; a pytest feeds the exact bytes into `workflow_graph.linearize()` and
+   asserts the plan (order, policies, runs_on). A second fixture with a `branch`
+   asserts the honest refusal reason. The two parsers can never drift silently again.
+
+## Scope
+
+- **In:** the `BPNode.runs_on` field + inspector picker; the lowering + Save +
+  DeskSync wiring; both fixtures + the Swift regen test + the pytest conformance;
+  sim proof (author → Save → the record visible on the hub via sync).
+- **Out:** the hub executing control flow (22-02 refused it honestly; unchanged);
+  web authoring (22-03); the iPad run-on-hub path (22-04).
+
+## Test plan
+
+- `swift test` (the new serializer/regen tests; Blueprint suites green).
+- `uv run pytest -q tests/unit/test_workflow_graph.py` + the new fixture conformance
+  test (Swift bytes → `linearize()`).
+- Sim proof against a live scratch hub: Save on the canvas → `/api/sync/pull` shows
+  the workflow with the real `graph_json`.

--- a/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-02-hub-honors-graph.md
+++ b/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-02-hub-honors-graph.md
@@ -1,0 +1,40 @@
+# HSM-22-02 — The hub honors the graph
+
+- **Project:** holdspeak-mobile
+- **Phase:** 22
+- **Status:** done (pre-paid, Equilibrium Wave 1, 2026-06-27) — see
+  [`evidence-story-02.md`](./evidence-story-02.md). The linearizer runs the faithful
+  subset, applies `failure_policy`, carries `runs_on`, and refuses control flow with
+  an honest `warning`.
+- **Depends on:** the Swift Blueprint wire shape (the tagged-union Codable form).
+- **Unblocks:** 22-01's conformance target; 22-04's cross-surface run.
+- **Owner:** unassigned
+
+## Problem
+
+The audit filed the hub side as footnotes: `linearize` parsed one straight pipeline
+and dropped per-node `failure_policy`/`runs_on` entirely (`GraphNode` held only
+id/kind/payload), and nothing documented what the hub refused.
+
+## The design (as shipped)
+
+`holdspeak/web/routes/workflow_graph.py`: `GraphNode` carries `failure_policy` +
+`runs_on`; `linearize()` accepts the Swift tagged-union shape (incl. the
+`{"extract":{"_0":…}}` Codable form) and refuses branch/for-each/while/sequence,
+fan-out, joins, cycles, and disconnected chains with a stated reason. The runner
+applies the faithful subset (skip / fallback-on-device continue; retry-then-queue and
+unset fail fast) and surfaces per-step `failure_policy`/`runs_on`/`status` in the run
+route's `steps`, with a `warning` when a graph was refused. The route docstring
+documents what is NOT enforced (runs_on is carried, not pinned; no real retry queue).
+
+## Scope
+
+- **In (shipped):** the linearizer + policy carry/apply + honest refusals + run-route
+  steps/warning + docstring omissions.
+- **Out:** executing control flow on the hub (deliberately refused, not emulated);
+  Swift-encoder conformance bytes (22-01's golden pin).
+
+## Test plan
+
+- `uv run pytest -q tests/unit/test_workflow_graph.py tests/unit/test_web_routes_primitives.py`
+  — green (re-run on phase open, 50 passed).

--- a/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-03-web-authors-linear.md
+++ b/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-03-web-authors-linear.md
@@ -1,0 +1,45 @@
+# HSM-22-03 — Web authors a linear graph (or honest scope)
+
+- **Project:** holdspeak-mobile
+- **Phase:** 22
+- **Status:** todo
+- **Depends on:** HSM-22-01 (the canonical authored shape to match).
+- **Unblocks:** 22-04's any-surface leg.
+- **Owner:** unassigned
+
+## Problem
+
+Survey-corrected: the remembered Wave-2 "web authors a linear graph" claim is **not
+backed by code**. Today:
+
+- No web surface emits `nodes`/`exec_edges` (grep-clean across `web/src`);
+  `useDesk.createPrimitive` (`web/src/desk/store.ts:60`) has no workflow case.
+- `web/src/pages/workbench.astro` + `scripts/workbench/model.js` build the ENGINE
+  workflow shape and persist to localStorage only — never `/api/workflows`.
+- `web/src/lib/primitives.ts:153` still types `graphJson?: string` against the object
+  wire (the desk path routes around it via `fromWireWorkflow`).
+- The desk run UI renders `steps` but drops the hub's `warning` (a refused graph runs
+  linear silently for the web reader).
+
+## The design
+
+1. **The type fix:** `primitives.ts` `graphJson` becomes the object wire type.
+2. **A minimal linear builder on the web desk:** author an ordered chain of the
+   faithful-subset kinds (entry → llm/extract/summarize/rewrite/keepIf), emitted in
+   the exact tagged-union + `exec_edges`/`data_edges` shape `linearize()` and the
+   iPad speak, POSTed to the real `/api/workflows`. Linear only, honestly: control
+   flow stays "graphed on iPad".
+3. **The run UI renders the hub's `warning`** beside the steps trail.
+
+## Scope
+
+- **In:** the three items above + web build + a desk test locking the emitted shape
+  against the same golden expectations 22-01 pins.
+- **Out:** a full node-graph canvas on web (the iPad owns Blueprint authoring);
+  executing control flow.
+
+## Test plan
+
+- `cd web && npm run build` + the desk vitest suite.
+- `uv run pytest -q tests/unit/test_web_routes_primitives.py` (the web-emitted shape
+  runs through the real route in a test).

--- a/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-04-cross-surface-proof.md
+++ b/pm/roadmap/holdspeak-mobile/phase-22-the-graph-travels/story-04-cross-surface-proof.md
@@ -1,0 +1,44 @@
+# HSM-22-04 — The cross-surface proof + docs
+
+- **Project:** holdspeak-mobile
+- **Phase:** 22
+- **Status:** todo
+- **Depends on:** 22-01 (the producer), 22-02 (the runner, shipped), 22-03 (the web
+  leg).
+- **Unblocks:** phase closeout.
+- **Owner:** unassigned
+
+## Problem
+
+The travel is proven only in fragments: the hub runs a hand-written dict; sync
+round-trips a placeholder graph that would not linearize; the iPad cannot ask the hub
+to run a workflow at all (`runOnHub` switches only agent/chain,
+`DeskDioramaStage.swift:4934`; no `runWorkflow` on the desktop client); and no single
+trace shows one authored graph crossing surfaces.
+
+## The design
+
+1. **`runWorkflow` joins the iPad hub path** (`IDesktopClient` + `runOnHub` +
+   `PendingHubRun.kind`), surfacing the hub's `steps` + `warning` like agent/chain
+   runs — the printed card carries the run's real `artifact_id` (the 18-07 lesson).
+2. **The sync fixture upgrades** to a linearizable graph (the 23-04 placeholder shape
+   documented as a non-example), and an integration test runs a SYNCED graph: push a
+   real graph_json → run via `/api/workflows/{id}/run` → assert the threaded steps.
+3. **The live proof:** author on the iPad canvas → Save → sync to a scratch hub →
+   run from the iPad (and once from web) → the same steps/warning on both readers.
+4. **Docs + the rider:** ARCHITECTURE's pipeline section gains the graph bridge;
+   a short rider joins the staged couch session.
+
+## Scope
+
+- **In:** the client route + UI surface, the fixture upgrade + synced-run test, the
+  live proof, docs + rider.
+- **Out:** hub-side control-flow execution; retry/queue enforcement (documented
+  omissions stand).
+
+## Test plan
+
+- `swift test` (client + decode tests) + sim proof against a live scratch hub.
+- `uv run pytest -q tests/unit/test_web_routes_sync_primitives.py
+  tests/integration/test_primitive_framework_sync.py tests/unit/test_web_routes_primitives.py`.
+- Doc drift guard green; the rider staged.


### PR DESCRIPTION
## What

The last Equilibrium build phase opens, survey-corrected like 19/21/23 before it:

- **22-02 (the hub honors the graph) → done, pre-paid by Wave 1.** `workflow_graph.py` linearizes the Swift tagged-union shape, carries AND applies per-node `failure_policy` (skip / fallback continue; retry-or-unset fail fast), carries `runs_on`, refuses control flow honestly with a `warning`, and documents what it does not enforce. Evidence recorded with a fresh **50-test green run**.
- **A false memory killed:** the Wave-2 "web authors a linear graph" claim has no code behind it (no `exec_edges` anywhere in `web/src`; the workbench page is localStorage-only; `primitives.ts:153` still types `graphJson` as a string). 22-03 stays genuinely todo, re-grounded.
- **A producer hole the audit missed:** `BPNode` carries no `runs_on`, so the iPad cannot emit the policy the hub already parses — folded into 22-01's scope.
- **Stories re-grounded:** 22-01 leads (Blueprint→`graph_json` lowering + Save + `DeskSync`, pinned by a Swift-ENCODED golden fixture fed byte-for-byte into `linearize()` — the HS-72-01 pattern applied to graphs); 22-04 gains the iPad `runWorkflow` hub path + the sync-fixture upgrade (the 23-04 placeholder would never linearize).

## Suites

- `uv run pytest -q tests/unit/test_workflow_graph.py tests/unit/test_web_routes_primitives.py` — **50 passed**
- doc drift guard — **18 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ