### PR TITLE
HSM-16-07: the entry points catch up — the desk across surfaces (8/9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ comes back as typed, reviewable artifacts:
 
 Launch `holdspeak` and the browser opens on the Desk: everything the two
 modes produce, living as objects in one spatial world. Meetings, notes,
-knowledge bases, agents, and their artifacts float on the stage; zones are
+knowledge bases, recipes, and their artifacts float on the stage; zones are
 shelves you drag things onto; tap anything and it opens in place.
 
 <p align="center">
@@ -52,10 +52,13 @@ shelves you drag things onto; tap anything and it opens in place.
 <p align="center"><em>The front door: the world your voice work lives in. The orb records, the rail asks, the tray files.</em></p>
 
 The Desk is where the loops close. Press the orb and the hub records a
-meeting; when it ends, the meeting lands on the stage as an object. Ask an
-agent from the rail and its answer persists as an artifact you can open,
-trace (the lineage chip names the agent that made it), and file into a
-zone. The egress badge in the corner is the one trust answer: local, or
+meeting; when it ends, the meeting lands on the stage as an object. Ask a
+recipe from the rail and its answer persists as an artifact you can open,
+trace (the lineage chip names the recipe that made it), and file into a
+zone. Or rope a few objects together with the lasso and **Ask AI** about
+exactly that pile: the answer prints as a card you keep or bin, and a kept
+card records every object it read plus your instruction. The egress badge
+in the corner is the one trust answer: local, or
 exactly which endpoint. See [The Desk](https://github.com/karolswdev/HoldSpeak/blob/main/docs/WEB_DESK.md).
 
 ## Why it's different

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,6 +306,60 @@ The composer's draft runs on the engine you configured, on device or on your
 endpoint, and shows that as its own badge; where the draft runs is not where
 the answer goes. A failed delivery keeps the question on the desk.
 
+## The desk across surfaces
+
+The desk is one convention rendered three times. Every desk concept
+(meeting, artifact, note, recipe, knowledge base, directory, chain,
+workflow, profile) is a primitive under a single documented contract
+([the Primitive Framework](../pm/roadmap/holdspeak-mobile/contracts/THE_PRIMITIVE_FRAMEWORK.md):
+one canonical table of kinds, wire shapes, and per-surface parity), and
+each surface derives its rendering from that contract rather than keeping
+its own model. The desktop hub owns the canonical store; the iPad and the
+web desk are authoring ports onto it.
+
+Not everything on a desk is the same kind of data, and the sync model
+keeps four classes apart:
+
+- **Content** (meetings, artifacts): the canonical record; syncs.
+- **Organization** (directories, knowledge bases, membership): which
+  object lives in which container is shared truth; it syncs, and the hub
+  is canonical.
+- **Capability** (recipes, chains, workflows, runtime profiles): the
+  definitions are portable and sync, so a workflow authored on the iPad
+  runs on the hub. Models are the exception: only a small **manifest**
+  syncs per node (its id, node, name, capabilities), so every surface can
+  say which model "run it on your desktop" would actually use. The model
+  binary never rides the wire, and the schema, the Swift wire test, and a
+  hub route test each assert that independently.
+- **Layout** (where a card sits, how it is arranged): per-device
+  ergonomics; never syncs.
+
+```mermaid
+flowchart LR
+  subgraph hub["Desktop hub (canonical store)"]
+    DB[("SQLite<br/>(db/*)")]
+    SY["Sync routes<br/>(web/routes/sync.py)"]
+  end
+  IPAD["iPad desk<br/>(DeskDioramaStage)"]
+  WEBD["Web desk<br/>(web/src/desk/)"]
+  IPAD <-->|"content, organization, capability,<br/>model manifests (never binaries)"| SY
+  WEBD <-->|"the same primitive routes"| SY
+  SY <--> DB
+  IPAD -. "layout stays on the iPad" .- IPAD
+  WEBD -. "layout stays in the browser" .- WEBD
+```
+
+The simplest capability needs no authoring at all. On any desk you can
+rope a few objects together and ask the AI one thing about exactly that
+pile: the run is grounded in the canonical record (the hub or the device
+reads each roped object's real content), nothing is stored unless you
+keep the answer, and a kept answer becomes an artifact whose lineage
+names every object it read plus the exact instruction. Both surfaces
+mint and read one provenance shape, so a card kept on the iPad shows the
+same lineage on the web and the other way round. The printed card's
+badge states where that run went (the model, and the host for an
+endpoint run), resolved per run rather than from the app default.
+
 ## The trust boundary
 
 Everything inside the box runs on your machine. Every arrow leaving it is a

--- a/docs/WEB_DESK.md
+++ b/docs/WEB_DESK.md
@@ -22,7 +22,8 @@ Every primitive is a pixel-art object with a soft shadow and a gentle bob:
 - **meetings** are cassette tapes,
 - **notes** are notepads,
 - **knowledge bases** are crystals,
-- **agents** and **coder sessions** are little characters,
+- **recipes** (your saved AI personas) and **coder sessions** are little
+  characters,
 - **chains** and **workflows** are cartridges,
 - **artifacts** are typed pages, each carrying its lineage.
 
@@ -37,9 +38,9 @@ No header, no sidebar. A compact cluster floats in each corner:
   (Dictation, Meetings, Studio, Settings); beside it, the hub dot (green
   when connected) and the **egress badge**, the one trust answer: local,
   or exactly which endpoint can be reached.
-- **Top right**: the create chips (**+ Note**, **+ KB**, **+ Agent**,
-  **+ Zone**), **Tidy** (only when you have arranged things), and
-  refresh.
+- **Top right**: the create chips (**+ Note**, **+ KB**, **+ Recipe**,
+  **+ Zone**, **+ Workflow**), **Tidy** (only when you have arranged
+  things), and refresh.
 - **Bottom center**: the **Record orb**.
 - **Right edge**: the **agent rail**.
 
@@ -47,10 +48,12 @@ No header, no sidebar. A compact cluster floats in each corner:
 
 A create chip makes the thing immediately; the object materializes at
 center and its editor opens beside it on the stage, with the world dimmed
-around it. Notes take a title, markdown body, and tags; agents show the
-essentials with **More** expanding the advanced fields in the same card.
-Everything autosaves as you type; Escape or a click outside settles the
-object back. There are no dialog windows on the desk.
+around it. Notes take a title, markdown body, and tags; recipes show the
+essentials (avatar, name, role, system prompt) with **More** expanding
+the advanced fields (template, tools, knowledge base, and which runtime
+profile it runs on) in the same card. Everything autosaves as you type;
+Escape or a click outside settles the object back. There are no dialog
+windows on the desk.
 
 ## Open, in place
 
@@ -85,12 +88,38 @@ stage as an object.
 
 ## Ask from the rail
 
-The right-edge rail holds your agent personas, each wearing a dot for
-where it runs (green on device, blue endpoint). Tap one, type an ask, and
-run it. The answer comes back in place with a copy button, and it also
+The right-edge rail holds your recipes, each wearing a dot for where it
+runs (green on device, blue endpoint). Tap one, type an ask, and run it.
+The answer comes back in place with a copy button, and it also
 **persists as an artifact on the stage**, wearing the NEW mark, with a
-lineage chip naming the agent. File it, reopen it, or copy it like
+lineage chip naming the recipe. File it, reopen it, or copy it like
 anything else.
+
+## Rope things together and Ask AI
+
+The desk's signature move needs no saved recipe at all. Drag on the
+empty desk and a rope follows your pointer; everything inside it is
+selected (shift-click or cmd-click ropes objects one at a time). A bar
+rises with the count and one action: **Ask AI**.
+
+The composer docks at the edge with the desk still alive behind it. Pick
+a lens (Summarize, Action items, Risks, Decisions, Draft email) or speak
+your own instruction with the mic, choose where it runs (the hub's
+default, or any runtime profile), and Ask. The hub reads the roped
+objects from its own store (a note's body, an artifact's text, a
+meeting's summary and actions) and runs your instruction over exactly
+that pile.
+
+The answer prints as a card wearing an honest badge: which model ran it
+and, for an endpoint run, which host it went to. This run, not the app
+default. Then you judge it:
+
+- **Keep** makes it a real artifact on the stage, and its lineage names
+  every object it read plus the exact instruction you gave.
+- **Bin** closes it. Nothing is stored.
+
+A kept ask syncs like any other artifact, so the card you keep here
+shows the same lineage on the iPad, and one kept there lands here.
 
 ## Talk, don't type
 

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -13,7 +13,16 @@
 > the build workaround args). Older loop/gotcha background: [`HANDOVER.md`](./HANDOVER.md).
 
 **Current phase:** [Phase 16 — The Desk, Everywhere](./phase-16-the-desk-everywhere/current-phase-status.md)
-— **7/9: HSM-16-04 DONE — the desk runs on the web too.** The survey-corrected remaining
+— **8/9: HSM-16-07 DONE — the entry points caught up; ONLY the 16-06 owner walk remains**
+(staged as [`HSM-16-06-WALK.md`](./phase-16-the-desk-everywhere/HSM-16-06-WALK.md): four
+checks ~15 min on the couch queue — the Ask atom on glass, the manifest naming the hub's
+real model, the org loop both ways, one kept Ask on every surface; PASS × 4 closes the
+phase). The docs: ARCHITECTURE's new "The desk across surfaces" (the four-class sync
+taxonomy, canonical hub + layout-is-local, no-binary manifests, the atom's cross-surface
+arc, one new rendered diagram), WEB_DESK's recipe-rename catch-up + the "Rope things
+together and Ask AI" walkthrough, README's tour sentence; doc guard 18/18, mermaid 2/2.
+Earlier the same day:
+**7/9: HSM-16-04 DONE — the desk runs on the web too.** The survey-corrected remaining
 slice shipped with its own truth-up: the "pre-paid" recipe layer was DEAD on the web (the
 Phase-17 rename half-landed — wrong loader keys, four stale kind checks, a crashing
 "+ Agent" chip, a red desk vitest suite no gate watched); resurrected, regression-locked,
@@ -120,7 +129,9 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-07-05 (**HSM-16-04 DONE — the desk runs on the web too.** The web
+**Last updated:** 2026-07-05 (**HSM-16-07 DONE — docs caught up; Phase 16 is 8/9 with only
+the 16-06 owner walk left**, runbook staged the same day. Earlier:
+**HSM-16-04 DONE — the desk runs on the web too.** The web
 recipe layer resurrected from its half-landed rename (a loud truth-up: the survey's
 "pre-paid" credit was false in practice) + in-world authoring parity; the Ask atom's full
 web arc over new hub `/api/ask` + `/api/ask/keep`, keep byte-identical to the iPad's kept

--- a/pm/roadmap/holdspeak-mobile/phase-16-the-desk-everywhere/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-16-the-desk-everywhere/current-phase-status.md
@@ -6,7 +6,15 @@ delivered and look for parity with the web client in Astro… and design for syn
 desktop. This is all a mesh system, so everything has to flow back and forth. Knowledge bases, stuff
 like that."*)
 
-**Last updated:** 2026-07-05 (**HSM-16-04 DONE — the desk runs on the web too (7/9).**
+**Last updated:** 2026-07-05 (**HSM-16-07 DONE — the entry points caught up (8/9).**
+`docs/ARCHITECTURE.md` gained "The desk across surfaces" (one primitive convention,
+three surfaces; the four-class sync taxonomy with canonical-hub + layout-is-local; the
+manifest's no-binary rule; the Ask atom's cross-surface story; one new mermaid diagram),
+`docs/WEB_DESK.md` caught up to the recipe rename and gained the "Rope things together
+and Ask AI" walkthrough, README's Desk tour names the lasso arc. Doc drift guard 18/18,
+mermaid guard 2/2, voice rules clean. **Only 16-06 remains — the owner's walk**
+([`HSM-16-06-WALK.md`](./HSM-16-06-WALK.md), staged earlier today, couch queue). Earlier
+the same day: **HSM-16-04 DONE — the desk runs on the web too (7/9).**
 The survey-corrected remaining slice shipped: the recipe layer RESURRECTED (the Phase-17
 rename had left it dead on web — loader keys, world/lineage/editor/pull-out kind checks,
 a crashing "+ Agent" chip, a red vitest suite nobody saw) with in-world authoring at
@@ -120,14 +128,24 @@ the user. It is the spine of the whole phase.
 | HSM-16-09 | **The Ask AI atom** — lasso → ask → speak → print → keep/bin (on-device, no mesh needed) | **done** (2026-07-04, sim-proven; device beat rides 16-06. TRUTH-UP: the survey's "zero code exists" was wrong — the skeleton had shipped; this story built the missing substance: full Ask lineage on the wire, two egress-honesty fixes, composer + printed card off the scrim) | capability (the atom) |
 | HSM-16-08 | Capability objects — the model manifest | **done** (2026-07-04: the `model` manifest is the sync wire's ELEVENTH kind — devices advertise installed models, the hub stores + advertises its own live row, and the run-target sheet NAMES what "your desktop" would run; no-binary invariant asserted on schema/Swift/hub layers. Truth-ups: combine-to-run + cross-node runs were pre-paid (desk era + P22); drop-model-sets-RUNS-ON superseded by P24 profiles; manifest informs the user's pick, never silent auto-routing (the approval+egress contract)) | capability (combine/execute) |
 | HSM-16-06 | The cross-surface proof (author on one surface → felt on the other two, real metal) | todo, **walk staged** ([`HSM-16-06-WALK.md`](./HSM-16-06-WALK.md): C1 the Ask on glass, C2 the manifest names the hub's real model, C3 the org loop both directions, C4 one Ask on every surface; ~15 min, couch queue) | proof (real metal) |
-| HSM-16-07 | Docs catch-up (mesh + DeskObject across surfaces) | todo | docs |
+| HSM-16-07 | Docs catch-up (mesh + DeskObject across surfaces) | **done** (2026-07-05 — ARCHITECTURE "The desk across surfaces" section + diagram, WEB_DESK recipe-rename catch-up + the Ask walkthrough, README tour sentence; guards 18/18 + mermaid 2/2) | docs |
 
 *(The build order after the survey: **16-09 → 16-08 → 16-04's remaining slice → 16-06 → 16-07.**
 09 is the atom 08 generalizes; 09 needs no sync and leads.)*
 
 ## Where we are
 
-**16-04 DONE (7/9) — the desk runs on the web too.** The story opened with its own
+**16-07 DONE (8/9) — the entry points caught up; the phase is one owner walk from
+closing.** ARCHITECTURE.md now tells the phase's whole story in product tense ("The desk
+across surfaces": the one primitive convention linked as the contract, the four-class
+sync taxonomy, canonical-hub + layout-is-local, the manifest's no-binary rule, the Ask
+atom's cross-surface arc, one new rendered diagram); WEB_DESK.md speaks the recipe
+rename everywhere a user reads it and walks the lasso → Ask AI → keep/bin move;
+README's tour names it in one sentence. Guards: doc drift 18/18, mermaid 2/2. What
+remains is exactly one thing: **the 16-06 walk** ([`HSM-16-06-WALK.md`](./HSM-16-06-WALK.md),
+four checks, ~15 min on the couch queue) — PASS on all four closes the story and the phase.
+
+Earlier — **16-04 DONE (7/9) — the desk runs on the web too.** The story opened with its own
 truth-up: the "substantially pre-paid" recipe layer was dead on the web (the Phase-17
 rename half-landed — the loader read the pre-rename wire key into a nonexistent items
 lane, four components still checked a kind that no longer exists, the create chip was a

--- a/pm/roadmap/holdspeak-mobile/phase-16-the-desk-everywhere/evidence-story-07.md
+++ b/pm/roadmap/holdspeak-mobile/phase-16-the-desk-everywhere/evidence-story-07.md
@@ -1,0 +1,36 @@
+# Evidence — HSM-16-07 (docs catch-up: the desk across surfaces)
+
+**Done 2026-07-05.** The entry points now say what the phase built — the Phase-64 lesson
+applied up front, not as a closeout footnote.
+
+## What changed
+
+- **`docs/ARCHITECTURE.md`** — new section "The desk across surfaces": one primitive
+  convention rendered three times (links `THE_PRIMITIVE_FRAMEWORK.md` as the contract),
+  the four-class sync taxonomy (content / organization / capability / layout) with the
+  canonical-hub and layout-never-syncs rules, the model MANIFEST's availability-only
+  no-binary rule (naming the three independent assertions), and the Ask atom's
+  cross-surface story (grounded runs, keep/bin, one provenance shape, per-run egress).
+  Plus one new mermaid diagram (hub ↔ iPad ↔ web: what flows, what stays local).
+- **`docs/WEB_DESK.md`** — caught up to the recipe rename (sprites list, create chips
+  now five incl. + Recipe / + Workflow, the rail and editor speak "recipes", the editor's
+  advanced fields listed) and gained **"Rope things together and Ask AI"**: the lasso,
+  the bundle bar, the lens grid, the mic, the runs-on pick, the honest printed badge,
+  Keep/Bin semantics, and the cross-surface lineage promise.
+- **`README.md`** — the Desk section speaks "recipes" and names the lasso → Ask AI →
+  keep/bin arc in one sentence (the entry-point tour stays a tour).
+
+## Verification
+
+- Doc drift guard: `uv run pytest tests/unit/test_doc_drift_guard.py` → **18 passed**
+  (dash rule, roadmap-vocabulary rule, AI-vocabulary rule, canonical names, link + image
+  resolution all green over the edited files).
+- Mermaid render guard: `uv run pytest tests/e2e/test_mermaid_renders.py` → **2 passed**
+  (the new diagram renders).
+
+## Deviations
+
+- Written before the 16-06 walk (the story's dependency note says the proof informs the
+  docs): everything documented is code-true and test-locked today — the walk verifies
+  feel on glass, not the shapes described here. If the walk falsifies a sentence, the fix
+  rides the walk's bug list.

--- a/pm/roadmap/holdspeak-mobile/phase-16-the-desk-everywhere/story-07-docs.md
+++ b/pm/roadmap/holdspeak-mobile/phase-16-the-desk-everywhere/story-07-docs.md
@@ -2,9 +2,11 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 16
-- **Status:** todo
+- **Status:** done (2026-07-05 — entry points caught up to the shipped phase; see
+  `evidence-story-07.md`. Written before the 16-06 walk by design: the docs describe what
+  is code-true and test-locked today; the walk verifies feel, not shape)
 - **Depends on:** HSM-16-01..06 (documents what shipped).
-- **Owner:** unassigned
+- **Owner:** agent (Fable)
 
 ## Problem
 
@@ -25,9 +27,17 @@ citizen — the architecture docs and the DeskObject convention must say so.
 
 ## Acceptance criteria
 
-- [ ] `docs/ARCHITECTURE.md` reflects organization sync across the three surfaces.
-- [ ] The DeskObject convention is linked from at least one entry-point doc.
-- [ ] The taxonomy + canonical-hub rule are documented where they belong; doc/voice guards pass.
+- [x] `docs/ARCHITECTURE.md` reflects organization sync across the three surfaces (new
+      "The desk across surfaces" section + a mermaid diagram of what flows vs what stays;
+      the model manifest's no-binary rule stated).
+- [x] The DeskObject convention is linked from at least one entry-point doc
+      (ARCHITECTURE.md links `THE_PRIMITIVE_FRAMEWORK.md` as the one contract).
+- [x] The taxonomy (content / organization / capability / layout) + the canonical-hub +
+      layout-is-local rules documented in the same section; `WEB_DESK.md` gained the
+      "Rope things together and Ask AI" walkthrough and caught up to the recipe rename
+      (chips, rail, editor); README's Desk section names the lasso arc. Doc drift guard
+      18/18, mermaid render guard 2/2, voice rules honoured (no dashes, no roadmap
+      vocabulary, canonical names).
 
 ## Test plan
 


### PR DESCRIPTION
Phase 16's docs story. Written before the 16-06 walk by design (everything documented is code-true and test-locked today; the walk verifies feel on glass).

- **`docs/ARCHITECTURE.md`** — new "The desk across surfaces" section: one primitive convention (links `THE_PRIMITIVE_FRAMEWORK.md` as the contract), the four-class sync taxonomy with canonical-hub + layout-is-local rules, the model manifest's no-binary rule, the Ask atom's cross-surface story, and one new mermaid diagram.
- **`docs/WEB_DESK.md`** — recipe-rename catch-up (chips/rail/editor) + the "Rope things together and Ask AI" walkthrough (lasso → lenses → honest badge → keep/bin → cross-surface lineage).
- **`README.md`** — the Desk tour names the lasso arc in one sentence.

Guards: doc drift **18/18**, mermaid render **2/2**, voice rules clean.

Phase 16 is **8/9** — only the 16-06 owner walk remains (runbook staged in #259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ