### PR TITLE
Phase 15 resumed, survey-corrected: 15-05 done pre-paid; 15-02 re-scoped to the per-step dispatch

### DIFF
--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -129,7 +129,13 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-07-05 (**HSM-16-07 DONE — docs caught up; Phase 16 is 8/9 with only
+**Last updated:** 2026-07-05 (**Phase 15 RESUMED, survey-corrected** — 15-05 recorded done
+pre-paid (one-spine proposal origin + P21 EgressScope, receipts in evidence); 15-02
+re-scoped to the per-step dispatch (the runner's `dispatchToMac` still throws; per-node
+pins ignored at run time; the HUD target label reads the app default) with `POST /api/ask`
+(16-04) as the ready-made RPC; filed: no aggregated mesh inbox yet (15-03 real),
+`PresenceStore.startPolling` never called (15-08/09 wiring). Earlier the same day:
+**HSM-16-07 DONE — docs caught up; Phase 16 is 8/9 with only
 the 16-06 owner walk left**, runbook staged the same day. Earlier:
 **HSM-16-04 DONE — the desk runs on the web too.** The web
 recipe layer resurrected from its half-landed rename (a loud truth-up: the survey's

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/current-phase-status.md
@@ -8,7 +8,26 @@ a senior software architect increasing his efficiency with tools + memory he pai
 running local inference on a machine he owns that is **completely air-gapped**, and still
 extracting enormous value.)
 
-**Last updated:** 2026-06-22 (**opened.** Authored from the owner's ratified vision. The
+**Last updated:** 2026-07-05 (**RESUMED, SURVEY-CORRECTED — the deltas kept getting pre-paid.**
+The phase's four genuinely-new deltas (named in the 2026-06-22 grounding) were re-read against
+the shipped code: **15-05 is done pre-paid** (the `meeting_id` decoupling shipped as the
+one-spine owner-typed proposal `origin`; the shared egress model is Phase 21's ONE
+`EgressScope` grammar + two-surface trust chip; approval parity is Qlippy≡dashboard + the
+iPad's `decided_by` decisions — receipts in `evidence-story-05.md`); the **"run a capability
+on your Mac" RPC now exists as `POST /api/ask`** (HSM-16-04 — prompt + context in, output +
+honest per-run egress out, persists nothing); the graph already **travels and runs on the hub
+whole** (Phase 22) with per-node `runs_on`/`failure_policy` on the wire (22-01) and the target
+pick informed by real model manifests (16-08). What is genuinely open: **the per-STEP
+dispatch** — `WorkflowRunner.dispatchToMac` still THROWS `dispatchUnimplemented`, `run()`
+hard-codes `.onDevice`, per-node `modelPref` is ignored at run time, and the Queue HUD's job
+target label reads the app-wide `isLocal` (the 16-09 class of egress lie) — now HSM-15-02's
+active build; the aggregated **mesh inbox** (15-03, still real: the hub has no single
+in-flight + pending-approvals endpoint and the HUD shows no desktop lane); the **connector
+sinks from a canvas run**, the **mesh source**, and the workflow-level policy (15-02's
+remaining rows); and one wiring find: **`PresenceStore.startPolling` has no call site** — the
+15-08/09 live-poll wiring is genuinely unwired. 15-06 (the air-gapped Proof) stays the
+owner's; 15-07 docs after the builds. Earlier:
+**2026-06-22 — opened.** Authored from the owner's ratified vision. The
 connective tissue already exists in code — the iPad pairs to the desktop over
 `HTTPDesktopClient` (host + port + token), `POST /api/dictation/remote` already runs an iPad
 dictation through the desktop's full pipeline into any focused app, `/api/companion/*` is the
@@ -194,11 +213,11 @@ contract, the LLM endpoints) is **reuse**, not new.
 | ID | Story | Status | Story file | Evidence |
 |----|-------|--------|------------|----------|
 | HSM-15-01 | Dictation, into your Mac (first-class flagship mode) | in-progress (**01a desktop delta + 01b iPad SURFACE both BUILT + Simulator-proven**; live LAN trace owner-gated) | [story-01](./story-01-dictation-into-your-mac.md) | `DictateView` (reactive waveform + push-to-talk/hands-free + read-back ticks + pairing-aware reach chip + egress badge); `sendRemoteDictation(target:.focused)`; suite **250/6/0**; `dictate-surface.png` |
-| HSM-15-02 | The Workbench targets the mesh (RUNS ON: Your Mac + real connectors) | backlog | [story-02](./story-02-workbench-mesh-targets.md) | — |
+| HSM-15-02 | The Workbench targets the mesh (RUNS ON: Your Mac + real connectors) | **in-progress, survey-corrected** (pre-paid: whole-graph travel + hub runs (P22), `runs_on` on the wire (22-01), manifest-informed target naming (16-08), the desk actuator relay, and the generic RPC itself — `POST /api/ask` (16-04). **Open: the per-step dispatch** — the runner's stubbed `dispatchToMac`, per-node pins ignored at run time, the HUD's app-default target label — plus connector sinks from a run, the mesh source, workflow-level policy) | [story-02](./story-02-workbench-mesh-targets.md) | rescope in the story |
 | HSM-15-03 | The mesh queue (desktop jobs + approvals in the QueueHUD) | backlog | [story-03](./story-03-the-mesh-queue.md) | — |
-| HSM-15-04 | One runner for the mesh (local or dispatched, policy-enforcing) | in-progress (pure runner BUILT + host-proven; **CANVAS NOW EXECUTES through it** — `PatchModel.lowerToWorkflow()` → `WorkflowRunner` on-device; nodes light + Queue HUD shows live `StepOutcome` jobs; Simulator-proven) | [story-04](./story-04-one-mesh-runner.md) | suite 250/6/0 · `scratchpad/wb-exec.png` (the Workbench running) |
-| HSM-15-05 | One approval + egress contract (across surfaces) | backlog | [story-05](./story-05-one-approval-egress-contract.md) | — |
-| HSM-15-08 | The Agent Desk — your live agents + the question each is asking | **built + Simulator-proven** (`AgentDeskView`/`AgentDeskCard`; waiting sorts first + pulses, tight question quote, Answer/pin/dismiss; `HS_DEMO_AGENTDESK` seed) — live `companionStatus()` poll + voice-answer are the wiring follow-up | [story-08](./story-08-the-agent-desk.md) | `apple/build/agentdesk.png`; iPad build green (runner+desk; FailurePolicy unified into RuntimeCore) |
+| HSM-15-04 | One runner for the mesh (local or dispatched, policy-enforcing) | in-progress (pure runner BUILT + host-proven; **CANVAS NOW EXECUTES through it** — `PatchModel.lowerToWorkflow()` → `WorkflowRunner` on-device; nodes light + Queue HUD shows live `StepOutcome` jobs; Simulator-proven. **2026-07-05 survey: closes with the 15-02 dispatch** — `run()` hard-codes `.onDevice`; the dispatch seam still throws) | [story-04](./story-04-one-mesh-runner.md) | suite 250/6/0 · `scratchpad/wb-exec.png` (the Workbench running) |
+| HSM-15-05 | One approval + egress contract (across surfaces) | **done** (2026-07-05, PRE-PAID: the `meeting_id` decoupling = the one-spine owner-typed proposal `origin` (locked by `test_db_actuator_origin.py`); one egress grammar = P21 `EgressScope` + two-surface trust chip; approval parity = Qlippy≡dashboard (P56) + iPad decisions (P19); air-gapped draft+badge = 17-05/16-09. Approve-from-the-HUD stays 15-03's) | [story-05](./story-05-one-approval-egress-contract.md) | [evidence](./evidence-story-05.md) |
+| HSM-15-08 | The Agent Desk — your live agents + the question each is asking | **built + Simulator-proven** (`AgentDeskView`/`AgentDeskCard`; waiting sorts first + pulses, tight question quote, Answer/pin/dismiss; `HS_DEMO_AGENTDESK` seed) — live `companionStatus()` poll + voice-answer are the wiring follow-up (**2026-07-05 survey: `PresenceStore.startPolling` exists but has NO call site — the live wiring is genuinely unwired**) | [story-08](./story-08-the-agent-desk.md) | `apple/build/agentdesk.png`; iPad build green (runner+desk; FailurePolicy unified into RuntimeCore) |
 | HSM-15-09 | Proactive agent presence — surface a waiting agent the moment it asks | **built + Simulator-proven** (`PresenceWatcher` pure rising-edge/debounce/quiet-mode, 7 host tests; HUD waiting-lane + the nudge card w/ Answer-by-voice; non-autonomous) — voice delivery reuses the desk composer (LAN proof owner-gated) | [story-09](./story-09-proactive-agent-presence.md) | 83 ProvidersTests green; `presence-hud-lane.png` |
 | HSM-15-10 | The Connect surface ("Your Computer" — discovery-first pairing) | **built end-to-end + Simulator-proven** (desktop advertises `_holdspeak._tcp` + unauth `/api/mesh/info`; iPad `ConnectView` browses via `NWBrowser`, discovered list by name + reach, tap-to-pair w/ token step + manual fallback, `DictatePeerStore.adopt/forget`; `NSBonjourServices` in plist + gen assertion) — real LAN discover+pair is the owner-at-iPad proof | [story-10](./story-10-the-connect-surface.md) | 12 mesh + 2205 desktop · iPad build green · `connect-surface.png` |
 | HSM-15-06 | The Proof — air-gapped value + the launch narrative | backlog | [story-06](./story-06-the-proof-and-narrative.md) | — |
@@ -206,7 +225,22 @@ contract, the LLM endpoints) is **reuse**, not new.
 
 ## Where we are
 
-**2026-06-22 — opened.** Phase authored from the owner's ratified Mesh vision. The thesis:
+**2026-07-05 — resumed, survey-corrected.** Two weeks of other phases quietly paid this
+one's bills: the proposal ledger decoupling (one-spine), the one egress grammar (Phase 21),
+whole-graph travel + hub runs with `runs_on` on the wire (Phase 22), manifest-informed
+target naming (16-08), and — as of this morning — the generic "run a capability on your
+Mac" RPC itself (`POST /api/ask`, HSM-16-04). The survey records 15-05 done pre-paid with
+receipts and re-scopes 15-02 to its genuinely-open heart: **the per-step dispatch**. The
+runner's `dispatchToMac` seam still throws, `run()` hard-codes `.onDevice`, a node pinned
+in the inspector is honoured on the wire but ignored at run time, and the Queue HUD labels
+every job with the app-wide default instead of where the step actually ran — the same
+class of egress lie 16-09 killed on the desk. That slice builds next, wiring the runner to
+the paired peer over `/api/ask` with the IF-UNREACHABLE policy (retry → queue / fall back
+on-device / skip) doing exactly what its inspector hints promise. Also filed: the hub
+still has no aggregated in-flight + pending-approvals endpoint (15-03 stays real), and
+`PresenceStore.startPolling` has no call site (the 15-08/09 live wiring is unwired).
+
+Earlier — **2026-06-22 — opened.** Phase authored from the owner's ratified Mesh vision. The thesis:
 HoldSpeak is a **personal intelligence mesh** — a desktop hub + mobile companions, two modes on
 every surface, fluid compute, one queue, one approval contract, all private and air-gappable.
 The seam already exists (`HTTPDesktopClient` pairing, `/api/dictation/remote`, `/api/companion/*`,

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/evidence-story-05.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/evidence-story-05.md
@@ -1,0 +1,52 @@
+# Evidence — HSM-15-05 (one approval + egress contract) — done PRE-PAID
+
+**Recorded 2026-07-05 by the resume survey.** The story's own grounding (2026-06-22) said
+the contract already existed and named ONE genuine delta. That delta, and every acceptance
+row, shipped in other phases while this one slept. Receipts, per acceptance criterion:
+
+## 1. Shared egress scope — shipped (Phase 21, "honest everywhere")
+
+- The ONE egress grammar is a Contracts type: `apple/Sources/Contracts/EgressScope.swift`
+  (on device / local + named target / cloud + named target), consumed by every badge and
+  chip; the Swift prose guard refuses narrated privacy sentences (it caught its own 7th
+  site when it landed).
+- The web/desktop side is the canonical `egress:{scope,label}` badge (POSITIONING canon;
+  `web/src/scripts/egress-badge.js`, the desk chrome + pull-out chips).
+- The two-surface trust chip reads the same `/api/setup/status` posture on the app header
+  and the web header, mapped by the same four-state precedence (Phase 21).
+
+## 2. One approval act, same id, audit parity — shipped (Phases 56 / 19 / 72)
+
+- The delta this story named — **decouple `actuator_proposals` from `meeting_id`** —
+  shipped in the one-spine phase as the owner-typed proposal origin: `origin='meeting'`
+  requires a real meeting id; `origin='desk'` (the iPad desk relay) carries
+  `meeting_id=None`; the old hidden sentinel meeting is gone
+  (`holdspeak/db/actuators.py`, locked by `tests/unit/test_db_actuator_origin.py`).
+- Qlippy card Approve ≡ dashboard Approve (audit parity, Phase 56); the iPad decides real
+  proposals against the same ids with `decided_by: "ipad-companion"` verified on a live
+  hub (Phase 19, walk rider W5 staged).
+- Device-initiated actions ride the desk actuator relay (`api/desk/actuators/*`): the iPad
+  proposes and approves; the executor runs ONLY on the hub (one 5-gate stack:
+  status → policy → payload-parity → connector → audit).
+
+## 3. Air-gapped safety (draft + badge, never a fake send) — shipped (17-05 / 16-09)
+
+- The coder-answer draft seam (17-05) produces a LOCAL draft with the honest badge when
+  the run is on-device; where the draft runs is not where the answer goes, and nothing
+  sends without the explicit human act.
+- The desk Ask's printed card wears the resolved per-run scope (On-device vs the named
+  host) — the 16-09 egress-honesty fixes; a run with no reachable endpoint parks/falls
+  back under the runner's failure policy rather than pretending.
+
+## What did NOT move here
+
+- **Approve from the iPad QueueHUD** is HSM-15-03's acceptance (the HUD is where mobile
+  approval happens) — explicitly left with 15-03, not claimed by this record.
+- The Workbench **Slack sink → desktop connector** routing is HSM-15-02's remaining slice
+  (the sink currently never proposes through the hub from a canvas run) — left with 15-02.
+
+## Lesson (the standing one, again)
+
+The survey that opened this phase (2026-06-22) was right about the machinery and still
+under-credited how fast the deltas would be paid by other phases. Pre-paid credit is only
+real once the surface's code is read — this record cites files and locks, not memory.

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-02-workbench-mesh-targets.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-02-workbench-mesh-targets.md
@@ -2,10 +2,46 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 15
-- **Status:** backlog
+- **Status:** in-progress (2026-07-05 — **survey-corrected**; see "The 2026-07-05 rescope"
+  below. Much of the original design shipped elsewhere; the genuinely-open heart — the
+  per-step dispatch — is the active build.)
 - **Depends on:** the Workbench canvas + `ModelPref`/`NodeKind` (Phase 14 / HSM-14-15);
   `HTTPDesktopClient` (the desktop's capabilities); HSM-15-04 (the runner dispatches per target).
-- **Owner:** unassigned
+- **Owner:** agent (Fable)
+
+## The 2026-07-05 rescope (the resume survey, code-read)
+
+Pre-paid while the phase slept:
+
+- **The graph travels and runs on the hub whole** — Phase 22: `lowerToBlueprint()` →
+  `graph_json` sync → the hub's `workflow_graph.py` linearizer runs it (22-04 proved the
+  iPad-authored graph on the hub with real `.43` intel).
+- **Per-node `runs_on` + `failure_policy` ride the wire** — 22-01 (`BPRunsOn`, the exact
+  raw strings the hub's `_RUN_TARGETS` accepts; unset stays byte-identical "auto").
+- **The run-target pick is informed, not blind** — 16-08: the model MANIFEST syncs and the
+  "where should it run?" sheet names the hub's actual model.
+- **Device-initiated proposals through the desktop connectors** — the desk actuator relay
+  (`api/desk/actuators/*`, Phase 38/72): the iPad proposes, the hub's one 5-gate executor
+  acts after approval.
+- **The generic "run a capability on your Mac" RPC this story's grounding asked for now
+  exists** — `POST /api/ask` (HSM-16-04): prompt + optional context in, output + honest
+  per-run egress out, persists nothing. The dispatch seam consumes it as-is.
+
+Genuinely open (the story's remaining substance):
+
+1. **Per-STEP dispatch** (the heart, building now): `WorkflowRunner.dispatchToMac` is a
+   stubbed seam that THROWS `dispatchUnimplemented`; `run()` hard-codes `.onDevice` for
+   every step; per-node `modelPref` is honoured on the WIRE but ignored at RUN time; and
+   the Queue HUD's job "target" label reads the app-wide `isLocal`, not the node's pin —
+   the same class of egress lie 16-09 killed on the desk. The slice: a "Your Mac" per-node
+   target, the runner's injected dispatch handler (unreachable Mac rides the node's
+   IF-UNREACHABLE policy: retry → queue / fall back on-device / skip), honest per-step
+   `ranOn`, dispatch wired to the paired peer over `/api/ask`.
+2. **Connector sinks from a canvas run** — a Slack/GitHub sink node still never routes
+   through the desktop's propose→approve→execute from a run (reachable → propose via the
+   desk relay; air-gapped → honest local draft + badge).
+3. **Mesh source** — a desktop meeting selectable as a workflow source.
+4. **Workflow-level default target + failure policy** (nodes inherit/override).
 
 ## Grounding (2026-06-22)
 

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-04-one-mesh-runner.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-04-one-mesh-runner.md
@@ -2,15 +2,14 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 15
-- **Status:** in-progress — **the pure on-device/endpoint runner is BUILT + host-proven (2026-06-22).**
-  `apple/Sources/RuntimeCore/Workbench/WorkflowRunner.swift` walks the linear `Workflow` model,
-  threads input, substitutes `{input}`, runs model-backed steps through an injected `ILLMProvider`
-  (on-device by default), does `keepIf` as a pure filter, and enforces a new `FailurePolicy`
-  (retryThenQueue / fallbackOnDevice / skip) with an injectable backoff + resume-from-cache. The
-  `RunTarget.dispatchToMac` seam is **stubbed** (additive mesh dispatch, not built). `WorkflowRunnerTests`
-  (9) green; full suite **250 tests / 6 skipped / 0 failures** (orchestrator-verified). Remaining: the
-  App canvas → `Workflow` lowering + wiring `Run` to drive the real `RunQueueStore`/pulses + the Mac
-  dispatch (HSM-15-02).
+- **Status:** in-progress — **the pure on-device/endpoint runner is BUILT + host-proven (2026-06-22),
+  and the canvas EXECUTES through it (HSM-14-15: `lowerToWorkflow()` → stepped runs lighting nodes +
+  real `StepOutcome` jobs in the Queue HUD, Simulator-proven).** The
+  `RunTarget.dispatchToMac` seam is **stubbed** (throws `dispatchUnimplemented`). 2026-07-05
+  survey notes: `run()` currently hard-codes `.onDevice` for every step (per-node `modelPref`
+  is lowered to the wire but ignored at run time), and the Queue HUD job's "target" label reads
+  the app-wide `isLocal` rather than the node's pin — both land with the dispatch build
+  (HSM-15-02's active slice). This story closes when the runner dispatches per RUNS-ON.
 - **Depends on:** the existing RuntimeCore `Workflow` model (linear; the App graph→`Workflow` lowering
   is later); `InferenceConfigStore.makeProvider`; `HTTPDesktopClient` (for the dispatched-to-Mac seam);
   the `RunQueueStore`.

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-05-one-approval-egress-contract.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-05-one-approval-egress-contract.md
@@ -2,10 +2,21 @@
 
 - **Project:** holdspeak-mobile
 - **Phase:** 15
-- **Status:** backlog
+- **Status:** done (2026-07-05 — **pre-paid while the phase slept**; recorded by the resume
+  survey, receipts in `evidence-story-05.md`. The one genuinely-new delta this story named
+  in its own grounding — decouple the proposal ledger from `meeting_id` — shipped in the
+  one-spine phase as the owner-typed proposal `origin` (`meeting`|`desk`, the sentinel
+  meeting killed; `holdspeak/db/actuators.py`, locked by `test_db_actuator_origin.py`).
+  The shared egress model shipped in Phase 21 as the ONE `EgressScope` grammar
+  (`apple/Sources/Contracts/EgressScope.swift`) + the two-surface trust chip; approval
+  parity shipped across Qlippy card ≡ dashboard (Phase 56) and the iPad proposal decisions
+  (`decided_by: ipad-companion`, live-hub proven, Phase 19); air-gapped degradation to a
+  local draft + badge shipped with the coder-answer draft seam (17-05) and the desk ask's
+  honest On-device chip (16-09). The remaining approval surface — approve from the
+  QueueHUD — belongs to HSM-15-03 and stays there.)
 - **Depends on:** the desktop actuator path (propose→approve→execute, exists on the server);
   the mobile egress badge (POSITIONING canon); HSM-15-03 (approve-from-the-HUD).
-- **Owner:** unassigned
+- **Owner:** recorded by the resume survey (agent, Fable)
 
 ## Grounding (2026-06-22)
 


### PR DESCRIPTION
The mesh phase's table was last true on 2026-06-22. Re-read against the shipped code (the Phase-16 #254 pattern):

- **15-05 done PRE-PAID** — the `meeting_id` decoupling shipped as the one-spine owner-typed proposal `origin`; the shared egress model is P21's `EgressScope` grammar + two-surface trust chip; approval parity is Qlippy ≡ dashboard + the iPad's `decided_by` decisions; air-gapped degradation is the draft seam + honest badges. Receipts cited in `evidence-story-05.md`.
- **The generic "run a capability on your Mac" RPC now exists** — `POST /api/ask` (HSM-16-04, merged this morning).
- **15-02 re-scoped to the genuinely-open heart: the per-step dispatch.** `WorkflowRunner.dispatchToMac` still throws `dispatchUnimplemented`, `run()` hard-codes `.onDevice`, per-node pins are honoured on the wire but ignored at run time, and the Queue HUD's target label reads the app default (the 16-09 class of egress lie). This is the next build.
- Filed: no aggregated mesh inbox on the hub (15-03 stays real); `PresenceStore.startPolling` has no call site (15-08/09 wiring genuinely unwired).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ