### PR TITLE
Increased Memory Limit is ON: the entitlement ships in both GGUF-hosting apps

### DIFF
--- a/apple/scripts/gen-local-harness.rb
+++ b/apple/scripts/gen-local-harness.rb
@@ -81,11 +81,11 @@ target.build_configurations.each do |config|
   s['DEVELOPMENT_TEAM'] = TEAM
   s['CODE_SIGN_IDENTITY'] = 'Apple Development'
   s['SDKROOT'] = 'iphoneos'
-  # NOTE: com.apple.developer.kernel.increased-memory-limit (App/Local.entitlements)
-  # would raise the per-app RAM ceiling, but automatic dev signing can't add it —
-  # the App ID needs the "Increased Memory Limit" capability enabled in the developer
-  # portal first. Until then we run within the default ceiling, so keep the model at
-  # ~4B Q4 on an 8GB iPad. Re-enable CODE_SIGN_ENTITLEMENTS once the capability is on.
+  # The Increased Memory Limit capability is ON the App ID (2026-07-05, registered
+  # by automatic signing over the App Store Connect auth key; verified in the
+  # embedded profile). The entitlement raises the per-app RAM ceiling toward
+  # physical RAM — 7B/8B GGUFs stop being jetsam-killed on the 8GB iPad.
+  s['CODE_SIGN_ENTITLEMENTS'] = File.join(ROOT, 'App', 'Local.entitlements')
 end
 
 project.save

--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -125,6 +125,12 @@ target.build_configurations.each do |config|
   s['DEVELOPMENT_TEAM'] = TEAM
   s['CODE_SIGN_IDENTITY'] = 'Apple Development'
   s['SDKROOT'] = 'iphoneos'
+  # HSM-5-02, enabled 2026-07-05: the increased-memory-limit entitlement raises the
+  # per-app RAM ceiling so bigger GGUFs aren't jetsam-killed. Automatic signing can
+  # register the capability on the App ID itself now that headless builds carry the
+  # App Store Connect auth key (the old blocker was Xcode having no account to talk
+  # to the portal with).
+  s['CODE_SIGN_ENTITLEMENTS'] = File.join(ROOT, 'App', 'Local.entitlements')
 end
 
 project.save


### PR DESCRIPTION
The capability the iPad's bigger models have been waiting for.

- The public ASC API's `capabilityType` enum doesn't include `INCREASED_MEMORY_LIMIT` (confirmed: 409 with the full enum) — but the old "enable it in the portal first" blocker was really *headless Xcode has no account*: with `-allowProvisioningUpdates` + the ASC auth key, **automatic signing registered the capability on `dev.holdspeak.mobile` itself**.
- Proven both layers on today's signed device build: the codesign entitlements AND the embedded provisioning profile carry `com.apple.developer.kernel.increased-memory-limit` (a profile only carries it when the App ID capability is live on Apple's side).
- `CODE_SIGN_ENTITLEMENTS` → `App/Local.entitlements` in `gen-meeting-capture.rb` and `gen-local-harness.rb` (whose stale portal-blocker note is replaced with the truth).
- Effect: per-app RAM ceiling rises toward physical RAM — 7B/8B GGUFs stop being jetsam-killed on the 8GB iPad Air.
- Device build + simulator build both green with the entitlement wired; no Sources change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ