### PR TITLE
On-device tuning: extraction-faithful sampling + 32K context ceiling

### DIFF
--- a/apple/App/MeetingCapture/ReviewUI.swift
+++ b/apple/App/MeetingCapture/ReviewUI.swift
@@ -47,11 +47,13 @@ final class MeetingReviewState: ObservableObject {
 
     /// Generate the meeting's artifacts ON-DEVICE (Mode A): the MIR profile picks the
     /// types, the local GGUF model drafts each, and they persist as proposals.
-    /// The on-device context CEILING — what we'd *like* (16K ≈ ~80 min of speech).
-    /// HSM-8-08 lowers it to what THIS device can actually afford (the KV-cache is RAM),
-    /// and HSM-8-07 chunks anything that still won't fit — so we never gamble on memory
-    /// regardless of meeting length.
-    private static let contextCeiling = 16_384
+    /// The on-device context CEILING — what we'd *like*. Raised to 32K for the
+    /// 12GB tier (iPhone 17 Pro/Air, recent iPads) now that the increased-memory
+    /// entitlement is live: ~2h of speech in one pass. HSM-8-08's budget still
+    /// LOWERS this to what THIS device can actually afford (the KV-cache is RAM,
+    /// clamped by `os_proc_available_memory()`), so a smaller device simply lands
+    /// below 32K — the ceiling never gambles, and HSM-8-07 chunks the rest.
+    private static let contextCeiling = 32_768
 
     /// Memory headroom before the iOS jetsam limit, with a conservative fallback.
     private static func availableMemoryBytes() -> Int {

--- a/apple/Sources/InferenceLlama/LlamaProvider.swift
+++ b/apple/Sources/InferenceLlama/LlamaProvider.swift
@@ -6,6 +6,29 @@ public enum LlamaProviderError: Error, Equatable {
     case modelLoadFailed(path: String)
 }
 
+/// On-device sampling for HoldSpeak's actual workload. Every local run here is
+/// extraction / summarization / dictation-rewriting — factual, structured,
+/// faithfulness-first — **not** open-ended chat. LLM.swift's stock temp 0.8 /
+/// topK 40 is tuned for chat and runs too hot for that: it invents, drifts, and
+/// reformats. These follow Qwen3's non-thinking guidance (topP 0.8, topK 20)
+/// with a low temperature for faithful extraction, and a gentle repeat penalty
+/// so a transcript's legitimately-repeated terms aren't punished. One preset,
+/// applied to every local provider — the single highest-leverage on-device
+/// quality knob, independent of which model is loaded.
+public struct LlamaSampling: Sendable, Equatable {
+    public var temp: Float
+    public var topP: Float
+    public var topK: Int32
+    public var repeatPenalty: Float
+
+    public init(temp: Float, topP: Float, topK: Int32, repeatPenalty: Float) {
+        self.temp = temp; self.topP = topP; self.topK = topK; self.repeatPenalty = repeatPenalty
+    }
+
+    /// HoldSpeak's on-device default: low-temperature, faithful extraction.
+    public static let extraction = LlamaSampling(temp: 0.4, topP: 0.8, topK: 20, repeatPenalty: 1.1)
+}
+
 /// HSM-5-02 — the on-device (charter Mode A) `ILLMProvider`, backed by llama.cpp
 /// through LLM.swift (the HSM-5-01 engine pick). Loads a GGUF by path and returns a
 /// completion with **no network** — the fully-local path.
@@ -28,23 +51,34 @@ public final class LlamaProvider: ILLMProvider, @unchecked Sendable {
     ///   - maxTokenCount: context budget (clamped to the model's trained context).
     public init(modelPath: String,
                 template: Template = .chatML(),
-                maxTokenCount: Int32 = 2048) throws {
+                maxTokenCount: Int32 = 2048,
+                sampling: LlamaSampling = .extraction) throws {
         guard let llm = LLM(from: URL(fileURLWithPath: modelPath),
                             template: template,
                             maxTokenCount: maxTokenCount) else {
             throw LlamaProviderError.modelLoadFailed(path: modelPath)
         }
+        // Apply the extraction-tuned sampling (LLM.swift's public setters push it
+        // to the sampler). Serial single-owner use means it lands before the
+        // first `getCompletion`, which is itself async and happens later.
+        llm.temp = sampling.temp
+        llm.topP = sampling.topP
+        llm.topK = sampling.topK
+        llm.repeatPenalty = sampling.repeatPenalty
         self.llm = llm
     }
 
     /// Build a provider that picks the model's chat template from its filename — so a
     /// downloaded/imported Gemma, Llama-3, Mistral or Qwen is prompted in its OWN format
     /// instead of a one-size-fits-all ChatML (wrong markers = degraded output). Prefer this
-    /// over the raw init at every call site that loads a user-chosen model.
-    public static func make(modelPath: String, maxTokenCount: Int32 = 2048) throws -> LlamaProvider {
+    /// over the raw init at every call site that loads a user-chosen model. Sampling
+    /// defaults to the on-device extraction preset.
+    public static func make(modelPath: String, maxTokenCount: Int32 = 2048,
+                            sampling: LlamaSampling = .extraction) throws -> LlamaProvider {
         try LlamaProvider(modelPath: modelPath,
                           template: autoTemplate(for: modelPath),
-                          maxTokenCount: maxTokenCount)
+                          maxTokenCount: maxTokenCount,
+                          sampling: sampling)
     }
 
     /// Map a GGUF filename to its chat template. Families are detected by the conventional

--- a/apple/Tests/InferenceLlamaTests/LlamaProviderTests.swift
+++ b/apple/Tests/InferenceLlamaTests/LlamaProviderTests.swift
@@ -52,4 +52,32 @@ final class LlamaProviderTests: XCTestCase {
         XCTAssertGreaterThan(artifacts.count, 0, "expected at least one artifact from the local model")
         XCTAssertTrue(artifacts.allSatisfy { $0.status == .draft })   // propose-only
     }
+
+    // MARK: - model-free locks (no GGUF needed)
+
+    /// The on-device sampling default is the faithful-extraction preset, not
+    /// LLM.swift's hot chat default (temp 0.8 / topK 40). This is the single
+    /// highest-leverage on-device quality knob — lock its values.
+    func testExtractionSamplingPresetValues() {
+        let s = LlamaSampling.extraction
+        XCTAssertEqual(s.temp, 0.4, "extraction runs faithful, not hot (LLM.swift default is 0.8)")
+        XCTAssertEqual(s.topP, 0.8)
+        XCTAssertEqual(s.topK, 20, "Qwen3 non-thinking guidance")
+        XCTAssertEqual(s.repeatPenalty, 1.1, "gentle — transcripts legitimately repeat terms")
+    }
+
+    /// A downloaded/imported model is prompted in ITS family's template, not a
+    /// one-size ChatML — verified by filename, no model load.
+    func testAutoTemplatePicksTheModelFamily() {
+        // Just assert distinct templates resolve per family (Template isn't
+        // Equatable, so compare stop sequences / identity via a smoke check that
+        // the picker doesn't collapse everyone to ChatML).
+        let qwen = LlamaProvider.autoTemplate(for: "Qwen3-4B-Instruct-2507-Q5_K_M.gguf")
+        let llama = LlamaProvider.autoTemplate(for: "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")
+        let gemma = LlamaProvider.autoTemplate(for: "gemma-3n-E4B-it-Q4_K_M.gguf")
+        // Llama-3 uses the eot header format; Qwen/Gemma do not.
+        XCTAssertEqual(llama.stopSequence, "<|eot_id|>", "Llama-3 gets its header template")
+        XCTAssertNotEqual(qwen.stopSequence, "<|eot_id|>", "Qwen is ChatML, not Llama-3")
+        XCTAssertNotEqual(gemma.stopSequence, "<|eot_id|>", "Gemma is its own template")
+    }
 }

--- a/pm/roadmap/holdspeak-mobile/ONDEVICE-MODEL-GUIDANCE.md
+++ b/pm/roadmap/holdspeak-mobile/ONDEVICE-MODEL-GUIDANCE.md
@@ -1,0 +1,98 @@
+# On-device model guidance — iPhone 17 Pro Max (and the 12GB tier)
+
+**Researched 2026-07-05.** Three parallel investigations (hardware limits, the model
+landscape, quant + KV-cache math) cross-checked against the app's own inference code
+(`OnDeviceBudget.swift`, `LlamaProvider.swift`, the vendored `LLM.swift` v2.1.0 +
+llama.cpp xcframework). This is the standing answer to "what model, quant, context, and
+config should we run on the phone."
+
+## The verdict (one line)
+
+**Qwen3-4B-Instruct-2507, Q5_K_M (imatrix), 16K context** — on Metal, non-thinking. It is
+the convergent winner for HoldSpeak's workload (meeting summarize/extract + dictation
+rewrite) on a thermally-constrained 12GB phone, and it is already the model witnessed
+running on the iPad.
+
+## Why the 4B, not the 8B (the counter-intuitive part)
+
+A phone is **heat-bound, not RAM-bound**, for multi-minute work. Measured A18/A19-class
+behavior: sustained inference throttles **~40% within a couple of minutes**; peak is
+~10–14 tok/s for an 8B Q4 vs ~20–30 tok/s for a 4B Q4. Generation is memory-bandwidth
+bound (~77 GB/s on A19), so a smaller model that **finishes before it cooks** beats a
+bigger one that throttles mid-summary. The 8B's marginal quality edge does not survive
+the thermal tax on a phone.
+
+And the decisive feature for *meetings*: **Qwen3-4B-Instruct-2507 has a 256K native
+context** (no YaRN/RoPE surgery) — so the model is never the context bottleneck; the app
+is. It is an explicit **non-thinking instruct** model (no `<think>` blocks), so no latency
+is wasted on hidden reasoning for straightforward extract/summarize calls. Top-of-class
+instruction-following for its size (IFEval 83.4, MMLU-Pro 69.6), and ~2.5–3 GB of weights
+leaves generous room for the KV cache.
+
+The 8B (Qwen3-8B) stays the **A/B fallback** if we ever want more raw capacity and don't
+mind the throttle: it beats Llama-3.1-8B across the board but only has 32K native context
+(needs YaRN for long meetings) and must be pinned to non-thinking mode. **Gemma 3 12B-it
+(QAT)** is the quality ceiling (IFEval 88.9, superb clean summaries) but at ~7–8 GB Q4 it
+is tight on a phone once the KV cache grows — a desktop-hub model, not a phone model.
+
+## Quant: Q5_K_M imatrix (with the trade spelled out)
+
+At 4B the weights are cheap, so quant quality matters more per byte and we can afford to
+spend it:
+
+| Quant | 4B weights | Quality (vs Q8) | Gen speed | Use when |
+|---|---|---|---|---|
+| Q4_K_M (imatrix) | ~2.5 GB | sweet spot; small PPL bump | fastest | max speed/battery/headroom |
+| **Q5_K_M (imatrix)** | **~2.9 GB** | **~60% of the way back to Q8** | ~10% slower | **the pick — near-top quality, still fast** |
+| Q6_K (imatrix) | ~3.3 GB | within ~0.02 PPL of Q8 (near-lossless) | ~25% slower | quality-first, don't mind slower gen |
+| Q8_0 | ~4.3 GB | lossless | slowest | overkill on a phone |
+
+Always prefer an **imatrix** build (unsloth / bartowski) over a plain quant — same size,
+measurably better, biggest effect at Q4–Q5. Never go below Q4 for extraction accuracy.
+
+## Context: 16K is the shipped ceiling (and it's fine)
+
+The app computes a safe context from live free memory and **clamps it to 16,384 tokens**
+(`OnDeviceBudget.contextTokens(... ceiling: 16_384)`, `ReviewUI.contextCeiling`). 16K
+(~12K words) covers most meetings in one pass; longer ones fall to the chunked map-reduce
+(HSM-8-07). fp16 KV at 16K for a 4B ≈ 2.25 GB — comfortable inside the ~9–10 GB app budget
+the increased-memory entitlement affords on a 12GB device.
+
+**Optional tune:** because Qwen3-4B-2507 natively supports 256K and the 12GB phone has
+headroom, we could raise `contextCeiling` to **32K** (fp16 KV ≈ 4.5 GB; 2.9 GB weights +
+1 GB overhead ≈ 8.4 GB, still inside budget) so a two-hour transcript fits one pass. Safe
+on this device; keep 16K as the cross-device default.
+
+## Engine findings that matter as much as the model
+
+1. **Sampling isn't tuned for extraction.** LLM.swift defaults to temp 0.8 / topK 40 /
+   topP 0.95 / repeatPenalty 1.2. Qwen3 non-thinking's own recommended settings are
+   **temp 0.7, topP 0.8, topK 20, minP 0** — and for *factual* extraction/summarization
+   a lower temp (~0.3–0.5) is better still. This is a cheap, high-leverage quality win and
+   is model-choice-independent.
+2. **Verify Metal offload on the A19.** Metal is compiled into the xcframework and the
+   code only forces CPU on the simulator (implying device offloads by default), but
+   `n_gpu_layers` isn't explicitly pinned. Worth a one-line os_log on the real device to
+   confirm all layers land on the GPU — the difference between seconds and minutes.
+3. **KV-cache quantization + flash attention are NOT exposed by LLM.swift v2.1.0**
+   (`contextParams` only sets `n_ctx`/`n_batch`). So the "q8_0 KV → 32K in 8 GB" lever
+   from the quant research is unavailable without patching the engine. Not needed for the
+   4B at 16K; relevant only if we ever chase 64K+ context on-device.
+4. **Templates are handled per family now** (Gemma/Qwen/Llama-3/Phi/Mistral auto-picked in
+   `LlamaProvider.autoTemplate`) — the old "ChatML for everything" caveat is dead. Model
+   choice is unconstrained by templating.
+
+## The download
+
+In-app: **Settings → Models**. `Qwen3 4B Instruct 2507` is already in the curated list at
+Q4_K_M; for this device prefer a **Q5_K_M imatrix** build via the HF search
+(`unsloth/Qwen3-4B-Instruct-2507-GGUF` → `Qwen3-4B-Instruct-2507-Q5_K_M.gguf`, or the
+bartowski equivalent). Q4_K_M is the safe cross-device default the list already ships.
+
+## If we do engine work next (ranked)
+
+1. Tune the on-device sampling for extraction (temp/topP/topK per Qwen3 non-thinking).
+2. Confirm +, if needed, pin Metal `n_gpu_layers` on device.
+3. (Optional) raise `contextCeiling` to 32K for the 12GB tier.
+4. (Later) patch LLM.swift for `--flash-attn` + q8_0 KV if 64K+ on-device context is ever
+   wanted.

--- a/pm/roadmap/holdspeak-mobile/ONDEVICE-MODEL-GUIDANCE.md
+++ b/pm/roadmap/holdspeak-mobile/ONDEVICE-MODEL-GUIDANCE.md
@@ -8,10 +8,49 @@ config should we run on the phone."
 
 ## The verdict (one line)
 
-**Qwen3-4B-Instruct-2507, Q5_K_M (imatrix), 16K context** — on Metal, non-thinking. It is
-the convergent winner for HoldSpeak's workload (meeting summarize/extract + dictation
-rewrite) on a thermally-constrained 12GB phone, and it is already the model witnessed
-running on the iPad.
+**On-device today: Qwen3-4B-Instruct-2507, Q5_K_M (imatrix), 16K context, non-thinking —
+the best model the SHIPPED engine can load. Power lane: route a profile over Tailscale to
+your own Mac/`.43` hub (Qwen3.5-9B or a Qwen3.5 MoE) — private, powerful, already built.**
+The full answer is HYBRID, not one model.
+
+## The engine reality (this overrides generic model advice) — verified 2026-07-05
+
+The bundled llama.cpp (LLM.swift 2.1.0 xcframework) recognizes exactly these architectures
+(pulled from the framework binary): `gemma, gemma2, gemma3, gemma3n, qwen2, qwen2moe,
+qwen3, qwen3moe, llama, llama4, phi2, phi3, phimoe, mistral (all variants), deepseek2,
+granite`. It is a **pre-April-2026 build**. Consequences that override any generic
+"best model" list:
+
+- **Gemma 4 (April 2026) will NOT load** — no `gemma4` arch in the bundle, even though
+  upstream llama.cpp added it at launch. Any recommendation to run Gemma 4 E4B on-device
+  is blocked until the engine is upgraded.
+- **Qwen3.5 / Qwen3.6 (2026) likely will NOT load on-device** in the shipped build either
+  (new family, post-dating this xcframework) — verify the arch before assuming.
+- **Qwen3 (dense) + Qwen3-MoE DO load** — so `qwen3moe` means a Qwen3/3.5-class **MoE**
+  (e.g. 30B-A3B / 35B-A3B) is viable as the HUB model on a beefier machine, reachable from
+  the phone over the mesh.
+- **The frontier has moved a generation** (Gemma 4, Qwen3.5/3.6, Claude Sonnet 5 — all
+  real, all verified). The shipped on-device engine is a generation behind them. So the
+  best *installable-today* model is still Qwen3-4B-Instruct-2507; the best *achievable*
+  on-device model needs an **engine upgrade** (bump the LLM.swift / llama.cpp xcframework
+  to a current build → unlocks Gemma 4 E4B + Qwen3.5-4B locally).
+
+## The hybrid is the real answer (and HoldSpeak already ships it)
+
+A phone should NOT try to be the whole brain. HoldSpeak's profile system + the Phase-15
+mesh already implement the right split:
+
+- **On-device fast/private/offline path** — Qwen3-4B-2507 for routing, rewriting, live
+  meeting state, offline fallback. Data never leaves the phone.
+- **Power lane over Tailscale to YOUR hardware** — the highest-leverage move for this
+  owner: an endpoint profile pointed at the CO Mac / `.43` box (already running
+  Qwen3.5-9B-Q6) or a Qwen3.5-MoE on a bigger host. Big-model quality, on hardware you own,
+  private, reachable NYC→CO over the tailnet via the dispatch seam (HSM-15-02) + the mesh
+  queue (HSM-15-03) shipped today. This is the "amazingness" lane, and it's cloud-free.
+- **Cloud premium lane (only if egress is acceptable)** — Claude Sonnet 5 (verified real,
+  near-Opus at $2/$10 intro) for the hardest agentic/coding traces; GPT-4.1 mini as a cheap
+  high-volume default. Given the owner's local-first / air-gapped posture, the Tailscale
+  lane is the better power answer than cloud.
 
 ## Why the 4B, not the 8B (the counter-intuitive part)
 
@@ -93,6 +132,27 @@ bartowski equivalent). Q4_K_M is the safe cross-device default the list already 
 
 1. Tune the on-device sampling for extraction (temp/topP/topK per Qwen3 non-thinking).
 2. Confirm +, if needed, pin Metal `n_gpu_layers` on device.
-3. (Optional) raise `contextCeiling` to 32K for the 12GB tier.
-4. (Later) patch LLM.swift for `--flash-attn` + q8_0 KV if 64K+ on-device context is ever
+3. **Upgrade the bundled llama.cpp / LLM.swift to a current (post-April-2026) build** —
+   unlocks Gemma 4 E4B and Qwen3.5-4B on-device (the frontier small models), and newer
+   quant/attention features. This is the single biggest capability jump for local
+   inference; the shipped engine is a generation behind.
+4. (Optional) raise `contextCeiling` to 32K for the 12GB tier.
+5. (Later) patch LLM.swift for `--flash-attn` + q8_0 KV if 64K+ on-device context is ever
    wanted.
+
+## Corrections to an external study (2026-07-05) — verify, don't assume
+
+A thorough external study recommended a hybrid architecture with Gemma 4 E4B as the
+primary on-device model and Claude Sonnet 5 as the premium lane. Adjudicated against
+live verification + the app's engine:
+
+- **Right (I was stale):** Claude Sonnet 5 IS real (2026-06-30, near-Opus, $2/$10 intro);
+  Gemma 4 and Qwen3.5/3.6 ARE real with upstream llama.cpp support; the HYBRID thesis is
+  correct and matches HoldSpeak's profile + mesh design.
+- **Wrong for this app:** Gemma 4 E4B (and Qwen3.5-4B) **cannot load in the shipped
+  engine** — the bundled xcframework predates them (arch list above). Generic model
+  research without checking the app's engine version is the trap. On-device TODAY =
+  Qwen3-4B-2507; Gemma 4 on-device = after an engine upgrade.
+- **Under-weighted:** the study's cloud-default framing under-serves this owner's
+  local-first / air-gapped posture. The Tailscale-to-your-own-Mac power lane (already
+  built) is the better "power" answer than cloud egress.


### PR DESCRIPTION
Two on-device wins from the model-guidance research (PR #267), in the app's own code — no vendored-engine patch:

- **Sampling:** every local run now uses `LlamaSampling.extraction` (temp 0.4 / topP 0.8 / topK 20 / repeatPenalty 1.1) instead of LLM.swift's stock chat default (temp 0.8 / topK 40). Every HoldSpeak on-device job is faithful extraction/summarization/rewriting — the hot default made it invent and drift. Highest-leverage on-device quality knob, model-independent.
- **Context:** `ReviewUI.contextCeiling` 16K → 32K. HSM-8-08's budget still clamps down per device (KV = RAM, bounded by `os_proc_available_memory`), so smaller devices land below 32K and never gamble — but a 12GB iPhone / recent iPad can hold ~2h of speech in one pass.

Locks: two model-free tests (preset values; `autoTemplate` picks the family, not one-size ChatML). `swift test` 481/9/0; app sim build green.

Implements items 1 + 4 of the guidance doc's engine-work list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ