### PR TITLE
Engine upgrade PROVEN: reproducible llama.cpp swap unlocks Gemma 4 + Qwen3.5 on-device

### DIFF
--- a/apple/scripts/upgrade-llama-xcframework.sh
+++ b/apple/scripts/upgrade-llama-xcframework.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Upgrade the on-device engine: swap LLM.swift's stale (2025-12) vendored
+# llama.cpp xcframework for a CURRENT build that supports the frontier
+# on-device archs — Gemma 4 (`gemma4`) and Qwen3.5 (`qwen35`) — which the
+# shipped LLM.swift 2.1.0 binary lacks.
+#
+# Proven 2026-07-05: after this swap the app builds + links, and the framework
+# binary carries gemma4/gemma4-assistant/qwen35 (verified via `strings`).
+#
+# Usage:  scripts/upgrade-llama-xcframework.sh <derived-data-path>
+#   e.g.  scripts/upgrade-llama-xcframework.sh build/dd-device
+#
+# Runs AFTER package resolution (i.e. after patch-llm-macro.sh has cloned
+# LLM.swift into <derived-data>/SourcePackages/checkouts). Idempotent: if the
+# checkout's framework already has `gemma4`, it no-ops.
+#
+# Reproducible: pinned to the llama.cpp commit below. Uses a per-commit cache
+# in ~/.holdspeak-build-cache so only the FIRST run pays the ~15-min build;
+# later runs (and other derived-data dirs) copy from cache instantly.
+set -euo pipefail
+
+LLAMA_COMMIT="2da6686"                       # ggml-org/llama.cpp, 2026-07-05 (has gemma4 + qwen35)
+DD="${1:?usage: upgrade-llama-xcframework.sh <derived-data-path>}"
+CHECKOUT="$DD/SourcePackages/checkouts/LLM.swift/llama.cpp/llama.xcframework"
+CACHE="$HOME/.holdspeak-build-cache/llama-xcframework-$LLAMA_COMMIT"
+DEV="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+
+if [[ ! -d "$CHECKOUT" ]]; then
+  echo "== no LLM.swift checkout at $CHECKOUT — run patch-llm-macro.sh first" >&2
+  exit 1
+fi
+
+# Whether the checkout's device framework already carries the frontier arch.
+# NOTE: use `grep -c` (reads all input), not `grep -q` — with `set -o pipefail`,
+# grep -q closes the pipe early and SIGPIPEs `strings`, which pipefail then
+# reports as a failure even on a match (a false negative).
+has_gemma4() {
+  [[ "$(strings "$1" 2>/dev/null | grep -cw gemma4 || true)" -gt 0 ]]
+}
+DEV_FW="$CHECKOUT/ios-arm64/llama.framework/llama"
+
+# Already upgraded? (the frontier arch is the tell)
+if has_gemma4 "$DEV_FW"; then
+  echo "== engine already current (gemma4 present) — nothing to do"
+  exit 0
+fi
+
+# Build the xcframework once, cache it per commit.
+if [[ ! -d "$CACHE" ]]; then
+  echo "== building llama.cpp xcframework @ $LLAMA_COMMIT (first run, ~15 min) =="
+  WORK="$(mktemp -d)"
+  git clone --filter=blob:none "https://github.com/ggml-org/llama.cpp.git" "$WORK/llama.cpp"
+  git -C "$WORK/llama.cpp" checkout "$LLAMA_COMMIT"
+  ( cd "$WORK/llama.cpp" && DEVELOPER_DIR="$DEV" ./build-xcframework.sh )
+  mkdir -p "$(dirname "$CACHE")"
+  cp -R "$WORK/llama.cpp/build-apple/llama.xcframework" "$CACHE"
+  rm -rf "$WORK"
+else
+  echo "== using cached xcframework at $CACHE"
+fi
+
+# Swap it in (keep a one-shot backup of the stale one).
+rm -rf "$CHECKOUT.stale"
+mv "$CHECKOUT" "$CHECKOUT.stale"
+cp -R "$CACHE" "$CHECKOUT"
+
+if has_gemma4 "$DEV_FW"; then
+  echo "== engine upgraded: gemma4 + qwen35 now available on-device"
+else
+  echo "== WARNING: swap done but gemma4 not found — check the build" >&2
+  exit 1
+fi

--- a/pm/roadmap/holdspeak-mobile/ONDEVICE-MODEL-GUIDANCE.md
+++ b/pm/roadmap/holdspeak-mobile/ONDEVICE-MODEL-GUIDANCE.md
@@ -8,10 +8,27 @@ config should we run on the phone."
 
 ## The verdict (one line)
 
-**On-device today: Qwen3-4B-Instruct-2507, Q5_K_M (imatrix), 16K context, non-thinking —
-the best model the SHIPPED engine can load. Power lane: route a profile over Tailscale to
-your own Mac/`.43` hub (Qwen3.5-9B or a Qwen3.5 MoE) — private, powerful, already built.**
+**On-device today: Qwen3-4B-Instruct-2507, Q5_K_M (imatrix), 16K→32K context,
+non-thinking, extraction-tuned sampling. Power lane: a profile over Tailscale to your own
+Mac/`.43` hub. Engine upgrade to Gemma 4 / Qwen3.5 on-device is PROVEN and reproducible.**
 The full answer is HYBRID, not one model.
+
+## Status of the engine-work items (2026-07-05)
+
+- **DONE (shipped):** extraction-tuned sampling (`LlamaSampling.extraction`) + the 32K
+  context ceiling for the 12GB tier (PR #268).
+- **PROVEN + reproducible:** the engine ARCH upgrade. The bundled LLM.swift 2.1.0 carries a
+  2025-12 llama.cpp (no `gemma4`/`qwen35`). Building a current llama.cpp xcframework
+  (ggml-org @ `2da6686`, 2026-07-05) and swapping it in makes the app **build + link with
+  `gemma4`, `gemma4-assistant`, and `qwen35` present** (verified via `strings` on the
+  device slice). `apple/scripts/upgrade-llama-xcframework.sh <derived-data>` does this
+  reproducibly, pinned + cached (first run ~15 min, then instant). **Open decision:** how
+  to vendor the ~210MB iOS binary for CI/TestFlight (build-from-script vs git-lfs vs a
+  GitHub release asset). **Open verification:** load a Gemma-4-E4B / Qwen3.5-4B GGUF on the
+  real iPhone (device-gated).
+- After the upgrade lands durably: add Gemma 4 E4B + Qwen3.5-4B to the curated download
+  list (Settings → Models) — do NOT add them before, or a user downloads a model the
+  shipped binary can't load.
 
 ## The engine reality (this overrides generic model advice) — verified 2026-07-05
 


### PR DESCRIPTION
"Kicked off" and proven. The bundled LLM.swift 2.1.0 ships a **2025-12** llama.cpp (no `gemma4`/`qwen35`), and LLM.swift's own `main` hasn't bumped its xcframework since then — so this is **not a version bump**, it needs a current llama.cpp xcframework from source.

**Proven:** built one (ggml-org @ `2da6686`), swapped it into the checkout, and the app **builds + links with `gemma4`, `gemma4-assistant`, and `qwen35` in the device-slice binary** (verified via `strings`). Gemma 4 E4B and Qwen3.5-4B are now reachable on-device.

`apple/scripts/upgrade-llama-xcframework.sh <derived-data>` makes it reproducible — pinned to the commit, per-commit cached (~15 min first run, then instant), idempotent, run after `patch-llm-macro.sh`. (Fixed a `pipefail`+`grep -q` SIGPIPE false-negative in the verify.)

The ~210MB iOS binary is **deliberately not committed** — reproducible-from-script keeps the repo clean.

**Two things left, both need a decision/device:**
1. **Owner call — durable vendoring** for CI/TestFlight: build-from-script (clean repo, slower first build) vs git-lfs vs a GitHub release asset.
2. **Device verification** — load a Gemma-4-E4B / Qwen3.5-4B GGUF on the real iPhone (device-gated).

Only after that lands durably do we add those models to the curated download list (so a user never downloads a model the shipped binary can't load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ