### PR TITLE
Build 2: Qwen3.5-4B + Gemma 4 E4B join the curated models

### DIFF
--- a/apple/App/MeetingCapture/ModelDownloads.swift
+++ b/apple/App/MeetingCapture/ModelDownloads.swift
@@ -38,19 +38,29 @@ struct SuggestedModel: Identifiable {
 
 enum SuggestedModels {
     // Ordered small → large. Each fileName was verified against the repo's file list.
+    // Qwen3.5 + Gemma 4 need the upgraded engine (scripts/upgrade-llama-xcframework.sh,
+    // shipped from build 2) — the 2025-12 llama.cpp lacks their archs and cannot load them.
     static let all: [SuggestedModel] = [
         SuggestedModel(name: "Llama 3.2 3B Instruct",
                        detail: "~2.0 GB · fast, great on iPhone",
                        repo: "bartowski/Llama-3.2-3B-Instruct-GGUF",
                        fileName: "Llama-3.2-3B-Instruct-Q4_K_M.gguf"),
         SuggestedModel(name: "Qwen3 4B Instruct 2507",
-                       detail: "~2.5 GB · recommended",
+                       detail: "~2.5 GB · proven on-device",
                        repo: "unsloth/Qwen3-4B-Instruct-2507-GGUF",
                        fileName: "Qwen3-4B-Instruct-2507-Q4_K_M.gguf"),
+        SuggestedModel(name: "Qwen3.5 4B",
+                       detail: "~2.9 GB · recommended · 256K context",
+                       repo: "unsloth/Qwen3.5-4B-GGUF",
+                       fileName: "Qwen3.5-4B-Q5_K_M.gguf"),
         SuggestedModel(name: "Gemma 3n E4B",
                        detail: "~4.2 GB · Google, built for on-device",
                        repo: "unsloth/gemma-3n-E4B-it-GGUF",
                        fileName: "gemma-3n-E4B-it-Q4_K_M.gguf"),
+        SuggestedModel(name: "Gemma 4 E4B",
+                       detail: "~4.3 GB · Google's newest mobile-first",
+                       repo: "unsloth/gemma-4-E4B-it-GGUF",
+                       fileName: "gemma-4-E4B-it-Q4_K_M.gguf"),
         SuggestedModel(name: "Llama 3.1 8B Instruct",
                        detail: "~4.9 GB · best on iPad",
                        repo: "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",

--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -119,7 +119,7 @@ target.build_configurations.each do |config|
   s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
   s['PRODUCT_NAME'] = 'HoldSpeakMobile'
   s['MARKETING_VERSION'] = '0.1.0'
-  s['CURRENT_PROJECT_VERSION'] = '1'
+  s['CURRENT_PROJECT_VERSION'] = '2'   # TestFlight build number — bump per upload
   s['GENERATE_INFOPLIST_FILE'] = 'NO'
   s['INFOPLIST_FILE'] = info_plist
   s['TARGETED_DEVICE_FAMILY'] = '1,2'


### PR DESCRIPTION
The frontier small models land in Settings → Models, shipping in the **same build** as the engine that can load them (PR #269's llama.cpp upgrade, applied via `scripts/upgrade-llama-xcframework.sh` — vendoring decision: **build-from-script**, pinned + cached).

- **Qwen3.5 4B** (`unsloth/Qwen3.5-4B-GGUF`, Q5_K_M ~2.9GB) — the new recommended pick: 256K context, near-lossless quant for the 12GB tier.
- **Gemma 4 E4B** (`unsloth/gemma-4-E4B-it-GGUF`, Q4_K_M) — Google's mobile-first.

Both filenames verified against the live HF repo trees. Qwen3-4B-2507 stays listed as the proven-on-device option. `CURRENT_PROJECT_VERSION` → 2 for the TestFlight upload. Real-iPhone load proof joins the walk queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ