### PR TITLE
The saga's repo debt paid: schema v9 + tolerant ChangeSet wire + honest sync-pill states (HSM-15-10)

### DIFF
--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -5363,7 +5363,10 @@ struct DioStage: View {
                 // everything we just pushed/round-tripped is now canonical on the hub → mark it
                 // confirmed so the per-primitive cue can honestly read "synced".
                 syncConfirmed.formUnion(deskPrimitiveIds(merged))
-                lastSyncSummary = "Synced · \(outcome.pushed) sent · \(outcome.applied) in"
+                // A skipped row (a record this build couldn't decode) is admitted,
+                // never hidden — completeness claims are earned.
+                let skipped = outcome.skippedRecords > 0 ? " · \(outcome.skippedRecords) skipped" : ""
+                lastSyncSummary = "Synced · \(outcome.pushed) sent · \(outcome.applied) in\(skipped)"
                 // PULL-APPLIED FEEDBACK: a remote primitive (a note authored on the web, an agent
                 // from the desktop) lands on the desk with the NEW-arrival treatment — cross-surface
                 // sync is visible + delightful, reusing the same `arrivedIds` halo as a fresh weave.
@@ -5375,12 +5378,29 @@ struct DioStage: View {
                     withAnimation(.easeOut(duration: 0.9)) { flash = 0 }
                     DispatchQueue.main.asyncAfter(deadline: .now() + 6) { withAnimation { arrivedIds.subtract(fresh) } }
                 }
-            } else if outcome.pendingAfter > 0 {
-                syncState = .offline
-                lastSyncSummary = "Offline · queued for your desktop"
             } else {
-                syncState = .error("Couldn’t reach your desktop")
-                lastSyncSummary = nil
+                // The honest failure states (the 2026-07-06 saga's lesson): a hub
+                // 500, a rejected token, and a wire mismatch are NOT "offline" —
+                // only a dead network path is, and only that state may say "queued".
+                switch outcome.failure {
+                case .unauthorized:
+                    syncState = .error("Token rejected")
+                    lastSyncSummary = "Token rejected · fix it in Connect"
+                case .hubError(let code):
+                    syncState = .error("Hub error \(code)")
+                    lastSyncSummary = "Hub error \(code) · check the desktop"
+                case .contractMismatch:
+                    syncState = .error("Hub reply unreadable")
+                    lastSyncSummary = "Hub reply unreadable · update app or desktop"
+                case .unreachable, .none:
+                    if outcome.pendingAfter > 0 {
+                        syncState = .offline
+                        lastSyncSummary = "Offline · queued for your desktop"
+                    } else {
+                        syncState = .error("Couldn’t reach your desktop")
+                        lastSyncSummary = nil
+                    }
+                }
             }
             if let s = lastSyncSummary { toast(s) }
         }

--- a/apple/App/MeetingCapture/DeskSync.swift
+++ b/apple/App/MeetingCapture/DeskSync.swift
@@ -354,6 +354,17 @@ struct DeskSyncDriver {
     var localModels: [Synced<ModelManifest>] = []
     let store = DeskSyncStore()
 
+    /// WHY a pass failed. The 2026-07-06 saga's five defects all wore ONE state
+    /// ("Offline · queued") because this distinction didn't exist — a hub 500, a
+    /// rejected token, an undecodable reply, and a dead network demand different
+    /// fixes from the owner, so they wear different states.
+    enum SyncFailure: Equatable {
+        case unauthorized            // 401/403 — the token is wrong or missing
+        case hubError(Int)           // any other non-2xx — the hub itself broke (e.g. the v8 pull 500)
+        case contractMismatch        // the reply didn't decode — app and hub disagree on the wire
+        case unreachable             // no network path — the only case that is honestly "offline"
+    }
+
     struct Outcome: Equatable {
         var pushed = 0
         var pendingAfter = 0
@@ -362,6 +373,11 @@ struct DeskSyncDriver {
         /// The mesh's model availability as pulled from the hub (its own model + every
         /// node's pushed manifests) — what "run it on your desktop" would actually run.
         var meshModels: [ModelManifest] = []
+        /// nil on success; on failure, the honest reason (drives the sync pill).
+        var failure: SyncFailure? = nil
+        /// Records the tolerant ChangeSet decode skipped (novel/malformed rows) —
+        /// surfaced so "Synced" can admit "· n skipped" instead of feigning completeness.
+        var skippedRecords = 0
     }
 
     /// Build a driver pointed at the paired hub. Returns nil when no peer is paired.
@@ -395,10 +411,25 @@ struct DeskSyncDriver {
             let (merged, report) = store.apply(incoming, to: records)
             return (merged, Outcome(pushed: pushed, pendingAfter: pendingAfter,
                                     applied: report.applied, reachedPeer: true,
-                                    meshModels: incoming.models.compactMap(\.value)))
+                                    meshModels: incoming.models.compactMap(\.value),
+                                    skippedRecords: incoming.undecodedRecords))
         } catch {
             return (records, Outcome(pushed: pushed, pendingAfter: pendingAfter,
-                                     applied: 0, reachedPeer: false))
+                                     applied: 0, reachedPeer: false,
+                                     failure: Self.classify(error)))
         }
+    }
+
+    /// Map a pull error to its honest failure. Anything unrecognized is treated as
+    /// unreachable — the queue holds the snapshot either way.
+    static func classify(_ error: Error) -> SyncFailure {
+        if let e = error as? HTTPSyncProvider.SyncTransportError {
+            switch e {
+            case .http(401), .http(403): return .unauthorized
+            case .http(let code): return .hubError(code)
+            case .malformedResponse: return .contractMismatch
+            }
+        }
+        return .unreachable
     }
 }

--- a/apple/Sources/Contracts/Enums.swift
+++ b/apple/Sources/Contracts/Enums.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-/// The 15 shipped artifact types (+ the plugin_output fallback), from the desktop
-/// `plugins/synthesis.py` `_ARTIFACT_TYPE_BY_PLUGIN` map. Raw values are the wire
-/// strings (key-conversion does not touch enum values).
+/// The 15 shipped artifact types (+ the plugin_output fallback + the v6 run-born
+/// run_output), from the desktop `plugins/synthesis.py` `_ARTIFACT_TYPE_BY_PLUGIN`
+/// map and `_persist_run_artifact`. Raw values are the wire strings
+/// (key-conversion does not touch enum values).
 public enum ArtifactType: String, Codable, Sendable, CaseIterable {
     case requirements
     case actionItems = "action_items"
@@ -20,6 +21,7 @@ public enum ArtifactType: String, Codable, Sendable, CaseIterable {
     case decisionAnnouncement = "decision_announcement"
     case projectAssociation = "project_association"
     case pluginOutput = "plugin_output"
+    case runOutput = "run_output"   // missing here failed whole ChangeSets (the 2026-07-06 saga, defect #3)
 }
 
 public enum ArtifactStatus: String, Codable, Sendable {

--- a/apple/Sources/Contracts/Sync.swift
+++ b/apple/Sources/Contracts/Sync.swift
@@ -105,25 +105,54 @@ public struct ChangeSet: Codable, Equatable, Sendable {
         self.models = models
     }
 
-    // Decode tolerantly: any array absent from the payload defaults to []. A surface that doesn't yet
-    // know a kind (e.g. the hub before it learns `profiles`) sends a subset, and the others must still
-    // decode — the whole point of cross-surface equilibrium. (Encoding stays synthesized: all keys out.)
+    /// Records the tolerant decode below could not read (a novel enum value, a
+    /// malformed payload). Never encoded; surfaced so a sync pass can report
+    /// "n skipped" instead of silently pretending completeness. One bad record
+    /// must never fail the whole ChangeSet again (the 2026-07-06 saga: a single
+    /// `run_output` artifact took down every pull for four builds).
+    public var undecodedRecords: Int = 0
+
+    // Decode tolerantly, on two axes:
+    // - any array absent from the payload defaults to [] (a surface that doesn't yet
+    //   know a kind sends a subset, and the others must still decode);
+    // - within an array, a record that fails to decode is skipped and COUNTED
+    //   (`undecodedRecords`), never allowed to fail the set.
+    // (Encoding stays synthesized: all keys out; the counter is not a CodingKey.)
     private enum CodingKeys: String, CodingKey {
         case meetings, artifacts, notes, kbs, directories, directoryMemberships, recipes, chains, workflows, profiles, models
     }
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        meetings = try c.decodeIfPresent([Synced<Meeting>].self, forKey: .meetings) ?? []
-        artifacts = try c.decodeIfPresent([Synced<Artifact>].self, forKey: .artifacts) ?? []
-        notes = try c.decodeIfPresent([Synced<Note>].self, forKey: .notes) ?? []
-        kbs = try c.decodeIfPresent([Synced<KB>].self, forKey: .kbs) ?? []
-        directories = try c.decodeIfPresent([Synced<Directory>].self, forKey: .directories) ?? []
-        directoryMemberships = try c.decodeIfPresent([Synced<Membership>].self, forKey: .directoryMemberships) ?? []
-        recipes = try c.decodeIfPresent([Synced<Recipe>].self, forKey: .recipes) ?? []
-        chains = try c.decodeIfPresent([Synced<Chain>].self, forKey: .chains) ?? []
-        workflows = try c.decodeIfPresent([Synced<WorkflowDefinition>].self, forKey: .workflows) ?? []
-        profiles = try c.decodeIfPresent([Synced<RuntimeProfile>].self, forKey: .profiles) ?? []
-        models = try c.decodeIfPresent([Synced<ModelManifest>].self, forKey: .models) ?? []
+        var dropped = 0
+        func lossy<V: Codable & Equatable & Sendable>(
+            _ type: V.Type, _ key: CodingKeys
+        ) -> [Synced<V>] {
+            guard var arr = try? c.nestedUnkeyedContainer(forKey: key) else { return [] }
+            var out: [Synced<V>] = []
+            while !arr.isAtEnd {
+                if let rec = try? arr.decode(Synced<V>.self) {
+                    out.append(rec)
+                } else {
+                    // A failed decode does not advance the container — consume the
+                    // element as an opaque JSONValue to move past it.
+                    _ = try? arr.decode(JSONValue.self)
+                    dropped += 1
+                }
+            }
+            return out
+        }
+        meetings = lossy(Meeting.self, .meetings)
+        artifacts = lossy(Artifact.self, .artifacts)
+        notes = lossy(Note.self, .notes)
+        kbs = lossy(KB.self, .kbs)
+        directories = lossy(Directory.self, .directories)
+        directoryMemberships = lossy(Membership.self, .directoryMemberships)
+        recipes = lossy(Recipe.self, .recipes)
+        chains = lossy(Chain.self, .chains)
+        workflows = lossy(WorkflowDefinition.self, .workflows)
+        profiles = lossy(RuntimeProfile.self, .profiles)
+        models = lossy(ModelManifest.self, .models)
+        undecodedRecords = dropped
     }
 
     public var isEmpty: Bool {

--- a/apple/Tests/ContractsTests/ChangeSetToleranceTests.swift
+++ b/apple/Tests/ContractsTests/ChangeSetToleranceTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Contracts
+
+/// The 2026-07-06 connect-saga regression pins (defect #3): a single novel
+/// artifact type on the wire (`run_output`) made the whole `/api/sync/pull`
+/// ChangeSet undecodable, so every build since 1 showed "Offline · queued".
+/// Two guarantees, tested separately:
+/// 1. `run_output` is a KNOWN type now — those records decode whole.
+/// 2. A type the app has never heard of drops THAT record, counted in
+///    `undecodedRecords`, and the rest of the set survives.
+final class ChangeSetToleranceTests: XCTestCase {
+
+    private func changeSetJSON(artifactType: String) -> Data {
+        """
+        {
+          "artifacts": [
+            {
+              "meta": {"id": "art_bad", "kind": "artifact",
+                       "last_modified": "2026-07-06T12:00:00Z", "deleted": false},
+              "value": {
+                "id": "art_bad", "meeting_id": "", "artifact_type": "\(artifactType)",
+                "title": "Recipe run", "body_markdown": "output text",
+                "structured_json": {}, "confidence": 1.0, "status": "draft",
+                "plugin_id": "recipe_run", "plugin_version": "1", "sources": [],
+                "origin": "run"
+              }
+            },
+            {
+              "meta": {"id": "art_good", "kind": "artifact",
+                       "last_modified": "2026-07-06T12:00:00Z", "deleted": false},
+              "value": {
+                "id": "art_good", "meeting_id": "mtg_001", "artifact_type": "decisions",
+                "title": "Decisions", "body_markdown": "- ship it",
+                "structured_json": {}, "confidence": 0.9, "status": "draft",
+                "plugin_id": "core", "plugin_version": "1", "sources": []
+              }
+            }
+          ],
+          "notes": [
+            {
+              "meta": {"id": "n1", "kind": "note",
+                       "last_modified": "2026-07-06T12:00:00Z", "deleted": false},
+              "value": {"id": "n1", "title": "Survives", "body_markdown": "",
+                        "tags": [], "created_at": "2026-07-06T12:00:00Z",
+                        "updated_at": "2026-07-06T12:00:00Z"}
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+    }
+
+    func testRunOutputIsAKnownArtifactType() throws {
+        let set = try HoldSpeakContracts.decoder().decode(
+            ChangeSet.self, from: changeSetJSON(artifactType: "run_output"))
+        XCTAssertEqual(set.artifacts.count, 2)
+        XCTAssertEqual(set.artifacts.first?.value?.artifactType, .runOutput)
+        XCTAssertTrue(set.artifacts.first?.value?.isRunBorn ?? false)
+        XCTAssertEqual(set.undecodedRecords, 0)
+    }
+
+    func testANovelTypeDropsOneRecordNotTheWholeSet() throws {
+        let set = try HoldSpeakContracts.decoder().decode(
+            ChangeSet.self, from: changeSetJSON(artifactType: "time_travel_log"))
+        // The bad record is skipped and COUNTED; its siblings all land.
+        XCTAssertEqual(set.artifacts.count, 1)
+        XCTAssertEqual(set.artifacts.first?.value?.id, "art_good")
+        XCTAssertEqual(set.notes.count, 1)
+        XCTAssertEqual(set.undecodedRecords, 1)
+    }
+
+    func testCleanSetsReportZeroUndecoded() throws {
+        let set = try HoldSpeakContracts.decoder().decode(
+            ChangeSet.self, from: Data("{}".utf8))
+        XCTAssertTrue(set.isEmpty)
+        XCTAssertEqual(set.undecodedRecords, 0)
+    }
+}

--- a/apple/Tests/RuntimeCoreTests/SyncEngineTests.swift
+++ b/apple/Tests/RuntimeCoreTests/SyncEngineTests.swift
@@ -114,15 +114,19 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(try b.loadArtifacts(meetingId: s.artifact.meetingId), [s.artifact])
     }
 
-    func testMalformedChangeSetRejectedAtWire() {
-        // A live meeting record missing the required `id` — schema-invalid; the
-        // contract decoder must reject it before it could ever reach the store.
+    func testMalformedRecordSkippedAtWire() throws {
+        // A live meeting record missing the required `id` — schema-invalid. The
+        // safety property is unchanged: it must never reach the store. The
+        // MECHANISM changed with the tolerant ChangeSet decode (the 2026-07-06
+        // saga): the bad record is skipped and counted, not allowed to fail the
+        // whole set (which is what turned one bad row into "Offline · queued").
         let bad = #"""
         {"meetings":[{"meta":{"id":"m1","kind":"meeting","last_modified":"2026-01-01T00:00:00Z","deleted":false},
          "value":{"started_at":"2026-01-01T00:00:00Z","tags":[],"segments":[],"bookmarks":[],
                   "intel_status":"none","mic_label":"m","remote_label":"r","devices":[]}}],"artifacts":[]}
         """#
-        XCTAssertThrowsError(
-            try HoldSpeakContracts.decoder().decode(ChangeSet.self, from: Data(bad.utf8)))
+        let set = try HoldSpeakContracts.decoder().decode(ChangeSet.self, from: Data(bad.utf8))
+        XCTAssertEqual(set.meetings.count, 0)      // never reaches the store
+        XCTAssertEqual(set.undecodedRecords, 1)    // and the skip is visible, not silent
     }
 }

--- a/holdspeak/db/core.py
+++ b/holdspeak/db/core.py
@@ -39,7 +39,7 @@ log = get_logger("db")
 
 # Default database location
 DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "holdspeak" / "holdspeak.db"
-SCHEMA_VERSION = 8   # v8: the persona subsystem is named Recipe (agents table -> recipes; owner-ratified rename)
+SCHEMA_VERSION = 9   # v9: model_manifests (HSM-16-08) — shipped additively without a bump, so v8-stamped DBs never ran the DDL and /api/sync/pull 500'd; the bump routes them through backup-then-apply
 
 
 class SchemaVersionError(RuntimeError):

--- a/pm/roadmap/holdspeak-mobile/HANDOVER-2026-07-06-connect-saga.md
+++ b/pm/roadmap/holdspeak-mobile/HANDOVER-2026-07-06-connect-saga.md
@@ -46,17 +46,18 @@ from NYC. The phone pairs and syncs.
 
 ## Repo debt (owed, ordered)
 
-1. **Schema v9 bump** (`holdspeak/db/core.py SCHEMA_VERSION`): `model_manifests` shipped
-   additively without a bump, so every v8-stamped DB no-ops the DDL and pull 500s. The
-   owner's live DB was hand-fixed (backups at
-   `~/.local/share/holdspeak/holdspeak.db.backup-*`); every OTHER v8 DB is still broken.
-2. **`ArtifactType` tolerance** (`apple/Sources/Contracts/Enums.swift`): add
-   `case runOutput = "run_output"` AND make decoding unknown-tolerant — one novel type
-   must never fail the whole ChangeSet again. (The live row was retyped to
-   `plugin_output` as the unblock.)
-3. **Honest sync-pill states** (`DeskSyncDriver.syncNow` catch + `DioSyncStatus`):
-   500 / 401 / decode-fail / no-network all wear "Offline · queued" today — that mask
-   is what made this saga cost two days.
+1. ~~**Schema v9 bump**~~ **PAID 2026-07-06** (mesh-repo-debt PR): `SCHEMA_VERSION = 9`
+   routes v8 DBs through backup-then-apply; pinned by
+   `test_v8_db_gains_model_manifests_via_the_bump`. The owner's hand-fixed live DB reads
+   as v8-with-the-table and upgrades cleanly (the DDL is `IF NOT EXISTS`).
+2. ~~**`ArtifactType` tolerance**~~ **PAID 2026-07-06**: `case runOutput = "run_output"`
+   added (enum + wire schema), and `ChangeSet.init(from:)` is per-record tolerant — a
+   novel type drops that record into a visible `undecodedRecords` count, never the set
+   (`ChangeSetToleranceTests`).
+3. ~~**Honest sync-pill states**~~ **PAID 2026-07-06**: `DeskSyncDriver.Outcome.failure`
+   classifies unauthorized / hubError(code) / contractMismatch / unreachable; the desk
+   pill wears each ("Token rejected", "Hub error 500", "Hub reply unreadable") — only a
+   dead network path says "Offline · queued", and "Synced" admits "· n skipped".
 4. **Classic-home cleanup:** build 3's diagnostics went to `PairMacSheet` on the
    unreachable classic home; the desk card now has better ones. Consider retiring the
    classic-home connect path entirely.

--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -129,16 +129,16 @@ dictation contracts); the rest open in sequence.
 Its design layer: [`EXPERIENCE-VISION-2026-06-27.md`](./EXPERIENCE-VISION-2026-06-27.md) — the
 masterful interface direction (web + iOS, iPad=iPhone), one per experience, build against it.
 
-**Last updated:** 2026-07-06 (**THE REMOTE-PAIRING SAGA CLOSED (HSM-15-10) — the mesh
-connects from another city.** Phone in NYC vs hub in Denver over Tailscale: five stacked
-defects unmasked and fixed across TestFlight builds 3–4 — the silent classic-home sheet,
-the un-bumped schema (missing `model_manifests` → pull 500s), a Swift-undecodable sync
-wire (`run_output` + naive timestamps; `_iso` fixed, proven via a compiled-Contracts
-decode harness), and a leftover `tailscale serve` TLS interceptor eating the app's
-cleartext while Safari's auto-HTTPS looked like proof of health. Build 4 (VALID, attached):
-`WILL DIAL` + exact probe reason on the desk card, ONE `PeerAddress` host rule with
-`https://` support, browse-on-open forces the LN prompt. Full autopsy:
-phase-15 story-10. Riders: schema v9, tolerant `ArtifactType`, honest sync-error states.)
+**Last updated:** 2026-07-06 (**THE SAGA'S REPO DEBT IS PAID (HSM-15-10 riders 1–3).**
+Schema v9 routes every v8-stamped DB through backup-then-apply so `model_manifests`
+lands (regression-pinned); the `ChangeSet` wire decode is per-record tolerant with
+`ArtifactType.runOutput` known and a visible `undecodedRecords` count — one novel type
+can never fail a whole pull again; and the desk sync pill wears honest failure states
+("Token rejected" / "Hub error 500" / "Hub reply unreadable") — only a dead network path
+may say "Offline · queued". Hub 3199 / Swift 484 / validator + sim build green. Earlier
+same day: the remote-pairing saga closed — five stacked defects unmasked, full autopsy in
+phase-15 story-10; the phone pairs and syncs from NYC. Next: 15-11 agents on your
+desktop's models, then 15-12 the context envelope.)
 Earlier — 2026-07-05 (**THE MESH QUEUE IS REAL — the hub's work + asks ride the
 pill in your hand; approving there IS approving on the desktop.** HSM-15-03 CLOSED: hub
 `GET /api/mesh/inbox` (both queues in flight + pending proposals across meeting/desk

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/artifact.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/artifact.schema.json
@@ -27,7 +27,7 @@
       "type": "string"
     },
     "artifact_type": {
-      "description": "Discriminator. The 15 shipped types from plugins/synthesis.py _ARTIFACT_TYPE_BY_PLUGIN, plus the plugin_output fallback.",
+      "description": "Discriminator. The 15 shipped types from plugins/synthesis.py _ARTIFACT_TYPE_BY_PLUGIN, plus the plugin_output fallback and the v6 run-born run_output (_persist_run_artifact).",
       "enum": [
         "requirements",
         "action_items",
@@ -44,7 +44,8 @@
         "runbook_delta",
         "decision_announcement",
         "project_association",
-        "plugin_output"
+        "plugin_output",
+        "run_output"
       ]
     },
     "title": {

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/current-phase-status.md
@@ -219,7 +219,7 @@ contract, the LLM endpoints) is **reuse**, not new.
 | HSM-15-05 | One approval + egress contract (across surfaces) | **done** (2026-07-05, PRE-PAID: the `meeting_id` decoupling = the one-spine owner-typed proposal `origin` (locked by `test_db_actuator_origin.py`); one egress grammar = P21 `EgressScope` + two-surface trust chip; approval parity = Qlippy≡dashboard (P56) + iPad decisions (P19); air-gapped draft+badge = 17-05/16-09. Approve-from-the-HUD stays 15-03's) | [story-05](./story-05-one-approval-egress-contract.md) | [evidence](./evidence-story-05.md) |
 | HSM-15-08 | The Agent Desk — your live agents + the question each is asking | **built + Simulator-proven** (`AgentDeskView`/`AgentDeskCard`; waiting sorts first + pulses, tight question quote, Answer/pin/dismiss; `HS_DEMO_AGENTDESK` seed) — **the live `companionStatus()` poll is WIRED as of the 15-03 build** (`startPolling` now called at the paired-peer call site in the app root; the survey had found it call-site-less); the device walk beat joins the owner queue | [story-08](./story-08-the-agent-desk.md) | `apple/build/agentdesk.png`; iPad build green (runner+desk; FailurePolicy unified into RuntimeCore) |
 | HSM-15-09 | Proactive agent presence — surface a waiting agent the moment it asks | **built + Simulator-proven** (`PresenceWatcher` pure rising-edge/debounce/quiet-mode, 7 host tests; HUD waiting-lane + the nudge card w/ Answer-by-voice; non-autonomous) — voice delivery reuses the desk composer (LAN proof owner-gated) | [story-09](./story-09-proactive-agent-presence.md) | 83 ProvidersTests green; `presence-hud-lane.png` |
-| HSM-15-10 | The Connect surface ("Your Computer" — discovery-first pairing) | **built end-to-end + Simulator-proven; 2026-07-06: the remote-pairing saga closed** (five stacked defects across TestFlight builds 3–4: the silent manual sheet, the un-bumped schema's missing `model_manifests`, two sync-wire poisons the Swift contract can't decode (`run_output` + naive `isoformat()`), and a leftover `tailscale serve` TLS interceptor on the hub port eating the app's cleartext while Safari's auto-HTTPS "proved" the network fine; build 4 = `WILL DIAL` + exact probe reason on `DioConnectCard`, ONE `PeerAddress` host rule w/ `https://` support, browse-on-open forces the LN prompt) — owner's on-device green run is the remaining proof | [story-10](./story-10-the-connect-surface.md) | 12 mesh + 2205 desktop · iPad build green · sim "Synced · just now" vs the live hub · b4 VALID+attached |
+| HSM-15-10 | The Connect surface ("Your Computer" — discovery-first pairing) | **built end-to-end + Simulator-proven; 2026-07-06: the remote-pairing saga closed** (five stacked defects across TestFlight builds 3–4: the silent manual sheet, the un-bumped schema's missing `model_manifests`, two sync-wire poisons the Swift contract can't decode (`run_output` + naive `isoformat()`), and a leftover `tailscale serve` TLS interceptor on the hub port eating the app's cleartext while Safari's auto-HTTPS "proved" the network fine; build 4 = `WILL DIAL` + exact probe reason on `DioConnectCard`, ONE `PeerAddress` host rule w/ `https://` support, browse-on-open forces the LN prompt); **repo debt 1–3 paid** (schema v9 + tolerant ChangeSet/`runOutput` + honest sync-pill states) — owner's on-device green run is the remaining proof | [story-10](./story-10-the-connect-surface.md) | 12 mesh + 2205 desktop · iPad build green · sim "Synced · just now" vs the live hub · b4 VALID+attached · debt PR: hub 3199 / Swift 484 / sim build green |
 | HSM-15-11 | Agents on your desktop's models (pick the Mac's model, run through it) | **scaffolded** (owner ask 2026-07-06 minutes after the first NYC→Denver pair; agent-definition sync already ships via Phase 17 — the delta is a `desktop` profile kind dispatching recipe/chat/chain turns over `/api/ask`, picker fed by the synced model manifests, egress from the hub's per-run report) | [story-11](./story-11-agents-on-your-desktops-models.md) | — |
 | HSM-15-12 | The context envelope (select meetings, expand their artifacts, into the ask) | **scaffolded** (owner ask 2026-07-06 with 15-11; today context = manualContext + all-zone-meetings-truncated + a KB *hint string* — the story adds a per-ask picker w/ artifact expansion + ONE provenance-headed envelope across run targets + hub-side hydration via `/api/ask` grounding refs + the KB-honesty rider) | [story-12](./story-12-the-context-envelope.md) | — |
 | HSM-15-06 | The Proof — air-gapped value + the launch narrative | backlog | [story-06](./story-06-the-proof-and-narrative.md) | — |
@@ -227,7 +227,24 @@ contract, the LLM endpoints) is **reuse**, not new.
 
 ## Where we are
 
-**2026-07-06 — THE REMOTE-PAIRING SAGA CLOSED (15-10): the mesh works from another city.**
+**2026-07-06 (later) — THE SAGA'S REPO DEBT IS PAID (15-10 riders 1–3, the mesh-repo-debt PR).**
+The three code riders the saga left behind shipped together: **schema v9**
+(`SCHEMA_VERSION = 9` routes every v8-stamped DB through backup-then-apply so
+`model_manifests` lands; regression pin `test_v8_db_gains_model_manifests_via_the_bump` —
+no other v8 install can hit the pull-500 again), **a tolerant ChangeSet wire**
+(`ArtifactType.runOutput` known in enum + wire schema, and `ChangeSet.init(from:)` decodes
+per-record: a novel type drops that one record into a visible `undecodedRecords` count
+instead of failing the whole set — `ChangeSetToleranceTests`, plus the SyncEngine wire test
+re-pinned to skip-and-count), and **honest sync-pill states**
+(`DeskSyncDriver.Outcome.failure` distinguishes unauthorized / hubError(code) /
+contractMismatch / unreachable; the pill says "Token rejected" / "Hub error 500" /
+"Hub reply unreadable" — only a dead network path may say "Offline · queued", and "Synced"
+admits "· n skipped"). Suites: hub **3199 passed**, Swift package **484/9/0**, contract
+validator ALL PASS, iPad sim build green. Debt row 4 (classic-home connect cleanup) stays
+open; next builds are 15-11 (agents on your desktop's models) then 15-12 (the context
+envelope).
+
+Earlier — **2026-07-06 — THE REMOTE-PAIRING SAGA CLOSED (15-10): the mesh works from another city.**
 The owner, phone in NYC and hub in Denver, couldn't pair the TestFlight app while Safari on
 the same phone reached the identical hub — the desk pill lied "Offline · queued" through
 FIVE stacked, mutually-masking defects (full autopsy in story-10): the classic-home sheet
@@ -246,7 +263,8 @@ new `PeerAddress` helper is the ONE host rule at every dial site and speaks `htt
 (a `tailscale serve` TLS front is now a first-class door), and opening the card browses
 Bonjour so iOS surfaces the Local Network prompt. Riders queued: schema v9 bump, `runOutput`
 + unknown-tolerant enum decoding, honest sync-pill error states (500/401/decode/no-network
-currently all wear "Offline · queued"). Remaining beat: the owner's on-device green run.
+currently all wear "Offline · queued") — **all three paid later this day, see above**.
+Remaining beat: the owner's on-device green run.
 
 Earlier — **2026-07-05 (evening) — THE MESH QUEUE IS REAL: the hub's work and the hub's asks ride
 the pill in your hand, and approving there IS approving on the desktop.** 15-03 closed:

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-10-the-connect-surface.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/story-10-the-connect-surface.md
@@ -117,6 +117,18 @@ the card itself is screenshot-verified BEFORE upload (the build-4 lesson: `strin
 verification lies twice — short literals are register-packed and em-dashes split ASCII
 runs; verify with pure-ASCII substrings + eyes on the rendered surface).
 
+**Repo debt paid (2026-07-06, the mesh-repo-debt PR):** the saga's three code riders shipped
+together: (1) `SCHEMA_VERSION` → 9, so every v8-stamped DB takes the backup-then-apply path and
+gains `model_manifests` (regression pin: `test_v8_db_gains_model_manifests_via_the_bump`);
+(2) `ArtifactType` knows `runOutput` AND the `ChangeSet` decode is per-record tolerant — a novel
+type drops that one record into a visible `undecodedRecords` count instead of failing the set
+(`ChangeSetToleranceTests`; the wire schema's `artifact_type` enum gained `run_output`);
+(3) `DeskSyncDriver` classifies failure (`unauthorized` / `hubError(code)` / `contractMismatch` /
+`unreachable`) and the desk pill wears each honestly — only a dead network path may say
+"Offline · queued", and "Synced" admits "· n skipped" when the tolerant decode dropped rows.
+Still owed from the saga: the classic-home connect cleanup (debt row 4) and the hub-side
+hublog/serve teardown (ops, not repo).
+
 **Debug rig (reusable):** the logging proxy (`/tmp/hublog.py`, 8765→hub) shows arrivals per
 TCP connection (keep-alive hides follow-up requests — a "missing" pull can be an unlogged
 same-connection ride); `xcrun simctl spawn <sim> defaults write dev.holdspeak.mobile

--- a/tests/unit/test_db_schema_policy.py
+++ b/tests/unit/test_db_schema_policy.py
@@ -116,6 +116,30 @@ def test_newer_db_is_refused_and_left_untouched(db_path: Path) -> None:
     assert list(db_path.parent.glob("*.bak")) == []
 
 
+def test_v8_db_gains_model_manifests_via_the_bump(db_path: Path) -> None:
+    """The v9 regression pin (the 2026-07-06 connect saga, defect #2).
+
+    model_manifests shipped additively WITHOUT a version bump, so a v8-stamped
+    database read `stored == SCHEMA_VERSION`, never re-ran SCHEMA_SQL, and
+    /api/sync/pull 500'd on the missing table. A v8 DB missing the table must
+    now take the backup-then-apply path and land it.
+    """
+    Database(db_path)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("DROP TABLE model_manifests")  # what a real v8 install looks like
+    conn.execute("DELETE FROM schema_version")  # the reader takes MAX(version); clear the v9 stamp
+    conn.commit()
+    conn.close()
+    _stamp_version(db_path, 8)
+
+    db = Database(db_path)
+
+    assert _stored_version(db_path) == SCHEMA_VERSION
+    assert db.model_manifests.list() == []  # the table exists and reads clean
+    backups = list(db_path.parent.glob("*.bak"))
+    assert len(backups) == 1  # safe-by-default: backed up before the apply
+
+
 def test_backup_database_copies_to_timestamped_sibling(db_path: Path) -> None:
     Database(db_path)
     conn = sqlite3.connect(str(db_path))


### PR DESCRIPTION
The three code riders from the 2026-07-06 connect saga (`HANDOVER-2026-07-06-connect-saga.md` §Repo debt, rows 1–3), shipped as one atomic debt payment — each alone leaves the saga's failure mode reproducible.

## What

1. **Schema v9** (`holdspeak/db/core.py`): `model_manifests` shipped additively without a version bump, so every v8-stamped DB no-op'd the DDL and `/api/sync/pull` 500'd forever. The bump routes v8 DBs through the existing backup-then-apply path. Regression pin: `test_v8_db_gains_model_manifests_via_the_bump`.
2. **Tolerant ChangeSet wire** (Contracts): `ArtifactType` knows `runOutput = "run_output"` (enum + wire schema), and `ChangeSet.init(from:)` decodes per-record — a novel or malformed record is skipped into a visible `undecodedRecords` count instead of failing the whole set. One `run_output` row took down every pull for four TestFlight builds; that class of failure is now structurally impossible. Tests: `ChangeSetToleranceTests` (new) + the SyncEngine malformed-wire test re-pinned to skip-and-count.
3. **Honest sync-pill states** (`DeskSync.swift` + `DeskDioramaStage.swift`): `DeskSyncDriver.Outcome.failure` classifies `unauthorized` / `hubError(code)` / `contractMismatch` / `unreachable`. The pill wears "Token rejected" / "Hub error N" / "Hub reply unreadable"; only a dead network path may say "Offline · queued"; "Synced" admits "· n skipped". The one-mask-for-everything pill is what made five defects read as one symptom for two days.

Debt row 4 (classic-home connect cleanup) intentionally stays open.

## Evidence read

- `uv run pytest -q` → **3199 passed**, 37 skipped
- `swift test` → **484 passed**, 9 skipped, 0 failures
- `contracts/validate.py` → ALL CHECKS PASSED
- iPad simulator `xcodebuild` → **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ