### PR TITLE
TestFlight build 7: 15-11 desktop-model agents on the phone

### DIFF
--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -119,7 +119,7 @@ target.build_configurations.each do |config|
   s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
   s['PRODUCT_NAME'] = 'HoldSpeakMobile'
   s['MARKETING_VERSION'] = '0.1.0'
-  s['CURRENT_PROJECT_VERSION'] = '6'   # TestFlight build number — bump per upload
+  s['CURRENT_PROJECT_VERSION'] = '7'   # TestFlight build number — bump per upload (b7 = 15-11 desktop-model agents + token fix)
   s['GENERATE_INFOPLIST_FILE'] = 'NO'
   s['INFOPLIST_FILE'] = info_plist
   s['TARGETED_DEVICE_FAMILY'] = '1,2'


### PR DESCRIPTION
One-line `CURRENT_PROJECT_VERSION` bump (6 → 7). Build 7 was archived from merged main (74b2a60), uploaded, processed **VALID**, and attached to "Owner (internal)" — receipts in the commit message. It carries HSM-15-11 (desktop-model agents + the `desktopClient` token fix) and the #272 debt fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ