### PR TITLE
Keyboard dismissal everywhere (owner feedback on build 7) + b8 bump

### DIFF
--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -1121,7 +1121,14 @@ struct DioConnectCard: View {
         )
         .shadow(color: tint.opacity(0.4), radius: 26, y: 10).shadow(color: .black.opacity(0.55), radius: 16, y: 12)
         .transition(.scale(scale: 0.92).combined(with: .opacity))
-        .onAppear { lanProbe.start() }
+        .onAppear {
+            lanProbe.start()
+            #if targetEnvironment(simulator)
+            // Screenshot rig: summon the keyboard so the hide-keyboard accessory
+            // bar (KeyboardDismiss.swift) is verifiable headlessly.
+            if ProcessInfo.processInfo.environment["HS_DESK_KEYFOCUS"] == "1" { hostFocused = true }
+            #endif
+        }
         .onDisappear { lanProbe.stop() }
     }
 

--- a/apple/App/MeetingCapture/KeyboardDismiss.swift
+++ b/apple/App/MeetingCapture/KeyboardDismiss.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import UIKit
+
+// Owner feedback (2026-07-06, build 7): "One thing I miss is the ability to hide
+// the keyboard when done typing." On iPhone the system keyboard has no dismiss
+// key, and none of the desk's fields offered one — once up, the keyboard stayed.
+//
+// One fix, three layers, ALL app-wide (no per-field wiring):
+//   1. `keyboardDone()` — an accessory bar above the keyboard with a visible
+//      hide-keyboard button (the affordance you can SEE). Attached at the app
+//      root; SwiftUI collects keyboard toolbar items from any ancestor.
+//   2. `.scrollDismissesKeyboard(.interactively)` at the root — dragging any
+//      scrollable pulls the keyboard down, the platform-native way.
+//   3. `KeyboardDismissInstaller` — a window-level swipe-down that ends editing.
+//      The window is shared by every presentation (sheets included), so this
+//      catches the surfaces toolbar propagation can't reach.
+
+/// End editing everywhere — the first responder resigns, whatever it is.
+@MainActor func hideKeyboard() {
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                    to: nil, from: nil, for: nil)
+}
+
+extension View {
+    /// The visible hide-keyboard affordance: an accessory bar with one button.
+    func keyboardDone() -> some View {
+        toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button { hideKeyboard() } label: {
+                    Image(systemName: "keyboard.chevron.compact.down")
+                        .font(.system(size: 15, weight: .bold))
+                }
+                .accessibilityLabel("Hide keyboard")
+            }
+        }
+    }
+}
+
+/// Installs ONE swipe-down recognizer on the app's window: swiping down while
+/// typing puts the keyboard away, anywhere — desk cards, composers, sheets.
+/// `cancelsTouchesInView = false` + simultaneous recognition: it never steals
+/// a tap, a drag, or a scroll; it only ends editing alongside them.
+struct KeyboardDismissInstaller: UIViewRepresentable {
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeUIView(context: Context) -> UIView {
+        let v = UIView(frame: .zero)
+        v.isUserInteractionEnabled = false
+        return v
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // The window exists only after attachment — install (once) from here.
+        DispatchQueue.main.async {
+            guard !context.coordinator.installed, let window = uiView.window else { return }
+            let swipe = UISwipeGestureRecognizer(target: context.coordinator,
+                                                 action: #selector(Coordinator.swiped))
+            swipe.direction = .down
+            swipe.cancelsTouchesInView = false
+            swipe.delegate = context.coordinator
+            window.addGestureRecognizer(swipe)
+            context.coordinator.installed = true
+        }
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var installed = false
+        @objc func swiped() { Task { @MainActor in hideKeyboard() } }
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+}

--- a/apple/App/MeetingCaptureApp.swift
+++ b/apple/App/MeetingCaptureApp.swift
@@ -83,6 +83,12 @@ struct MeetingCaptureApp: App {
                 PresenceNudgeOverlay()
             }
             .preferredColorScheme(.dark)
+            // Owner feedback (build 7): the keyboard had no way DOWN. Three app-wide
+            // layers (KeyboardDismiss.swift): a visible hide button above the keyboard,
+            // interactive scroll-to-dismiss, and a window-level swipe-down (covers sheets).
+            .keyboardDone()
+            .scrollDismissesKeyboard(.interactively)
+            .background(KeyboardDismissInstaller())
             .onAppear {
                 ModelDownloadManager.shared.ensureSession()   // reattach any in-flight model download
                 #if targetEnvironment(simulator)

--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -119,7 +119,7 @@ target.build_configurations.each do |config|
   s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
   s['PRODUCT_NAME'] = 'HoldSpeakMobile'
   s['MARKETING_VERSION'] = '0.1.0'
-  s['CURRENT_PROJECT_VERSION'] = '7'   # TestFlight build number — bump per upload (b7 = 15-11 desktop-model agents + token fix)
+  s['CURRENT_PROJECT_VERSION'] = '8'   # TestFlight build number — bump per upload (b8 = keyboard dismissal everywhere)
   s['GENERATE_INFOPLIST_FILE'] = 'NO'
   s['INFOPLIST_FILE'] = info_plist
   s['TARGETED_DEVICE_FAMILY'] = '1,2'


### PR DESCRIPTION
Owner feedback on build 7: *"One thing I miss is the ability to hide the keyboard when done typing."*

Three app-wide layers, wired once at the app root (`KeyboardDismiss.swift`):
1. A visible **hide-keyboard button** on the keyboard accessory bar — toolbar `placement: .keyboard` propagates from the root to every field.
2. **`.scrollDismissesKeyboard(.interactively)`** — dragging any scrollable pulls the keyboard down.
3. A **window-level swipe-down** that ends editing — the window is shared by sheets too, so this reaches what toolbar propagation can't. `cancelsTouchesInView = false` + simultaneous recognition: it never steals a tap, drag, or scroll.

Verified on the iPhone 17 Pro sim with the software keyboard forced on: the hide button renders above the keyboard (focused via the new `HS_DESK_KEYFOCUS=1` rig). Includes the b8 build-number bump; build 8 ships to TestFlight once this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ