### PR TITLE
TestFlight build 9: ground-this-ask + model chat on the phone

### DIFF
--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -119,7 +119,7 @@ target.build_configurations.each do |config|
   s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
   s['PRODUCT_NAME'] = 'HoldSpeakMobile'
   s['MARKETING_VERSION'] = '0.1.0'
-  s['CURRENT_PROJECT_VERSION'] = '8'   # TestFlight build number — bump per upload (b8 = keyboard dismissal everywhere)
+  s['CURRENT_PROJECT_VERSION'] = '9'   # TestFlight build number — bump per upload (b9 = ground-this-ask + model chat)
   s['GENERATE_INFOPLIST_FILE'] = 'NO'
   s['INFOPLIST_FILE'] = info_plist
   s['TARGETED_DEVICE_FAMILY'] = '1,2'

--- a/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-15-the-mesh/current-phase-status.md
@@ -238,6 +238,10 @@ grounding picker rides free on its composer. Live proof: a sim paired to the liv
 opened a chat that titled ITSELF with the real pull's manifest name
 (`Qwen3.5-9B-UD-Q6_K_XL.gguf`) and answered `MODEL CHAT OK` through
 127.0.0.1:8765 → the .43 llama.cpp (`screenshots/15-13-live-run.png`). Swift **493**.
+**TestFlight build 9** (b9 = merged main at #278: ground-this-ask + model chat)
+uploaded, VALID, attached to "Owner (internal)". Ops: the stale `tailscale serve`
+fronts :8443/:34999 are REMOVED (the daemon socket lives at
+`/opt/homebrew/var/run/tailscaled.sock` — pass `--socket`); :443 → 8765 kept.
 
 Earlier — **2026-07-06 (night) — THE ASK KNOWS YOUR RECORDS (15-12 built + real-metal hydration proven).**
 The second owner ask of the day shipped the same day. One assembler:


### PR DESCRIPTION
b9 = merged main at #278 (HSM-15-12 the context envelope + HSM-15-13 chat with the desktop's model). Archived Release headless (release Xcode + the ASC key), uploaded, processed **VALID**, attached to "Owner (internal)" — no beta review, testable now.

Ops receipt riding along: the stale `tailscale serve` fronts :8443/:34999 are removed (the brew daemon answers at `/opt/homebrew/var/run/tailscaled.sock` — pass `--socket`); the :443 TLS door to 8765 is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ