### PR TITLE
HSM-25: scaffold Serve the Mesh — the phone becomes an edge

### DIFF
--- a/pm/roadmap/holdspeak-mobile/README.md
+++ b/pm/roadmap/holdspeak-mobile/README.md
@@ -12,7 +12,15 @@
 > web slice leads), and this session's traps (the kind-add checklist, the desk demo env vars,
 > the build workaround args). Older loop/gotcha background: [`HANDOVER.md`](./HANDOVER.md).
 
-**Current phase:** [Phase 16 — The Desk, Everywhere](./phase-16-the-desk-everywhere/current-phase-status.md)
+**Current phase:** [Phase 25 — Serve the Mesh](./phase-25-serve-the-mesh/current-phase-status.md)
+— **OPEN (0/3, scaffolded 2026-07-07)**: the phone becomes an edge. The recorded handoff from
+desktop [phase-85 — The Mesh Edge (CLOSED 5/5)](../holdspeak/phase-85-the-mesh-edge/final-summary.md):
+the Swift pull worker on the `ILLMProvider` seam + the off-by-default "Serve my models to the
+mesh" consent toggle, foreground-only, polling-is-liveness — flip one switch and a desk ask on
+the Mac executes on the phone's own model. Stories: 25-01 the worker, 25-02 consent + the
+serving surface, 25-03 the live proof + docs.
+
+**Also staged (owner-gated):** [Phase 16 — The Desk, Everywhere](./phase-16-the-desk-everywhere/current-phase-status.md)
 — **8/9: HSM-16-07 DONE — the entry points caught up; ONLY the 16-06 owner walk remains**
 (staged as [`HSM-16-06-WALK.md`](./phase-16-the-desk-everywhere/HSM-16-06-WALK.md): four
 checks ~15 min on the couch queue — the Ask atom on glass, the manifest naming the hub's

--- a/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/current-phase-status.md
@@ -1,0 +1,119 @@
+# Phase 25 — Serve the Mesh (the phone becomes an edge)
+
+**Status:** OPEN (0/3, scaffolded 2026-07-07).
+
+**Last updated:** 2026-07-07 (scaffolded — the recorded handoff from desktop
+[phase-85 — The Mesh Edge](../../holdspeak/phase-85-the-mesh-edge/final-summary.md),
+CLOSED the same day: the relay wire is proven live with the reference
+`holdspeak mesh serve` worker; this phase puts the SAME worker on the
+Apple devices, behind an explicit consent toggle).
+
+## Why this phase exists
+
+Phase 85 shipped the generalization: a `meshNode` profile relays a run
+through the hub to the node hosting the provider — the model and the key
+never move; the request does. Any Mac/Linux box already serves with one
+command. The devices the owner actually carries — the iPhone with its
+on-device GGUF, the iPad — cannot serve yet, and they are the whole point
+("use powerful models without any friction on synchronizing", the owner's
+post-84 direction). The Swift side already has every seam: the
+`ILLMProvider` protocol (`Providers.swift:22`), the `meshNode` contract
+mirror (`Primitives.swift:257`, HS-85-02), the Bearer-token hub client
+(`HTTPDesktopClient.swift:68`), and the foregrounded polling-loop
+precedent (`QueuePresence.swift:104`). There is NO Swift worker today
+(surveyed 2026-07-07) — a green field on proven seams.
+
+**One thesis:** flip one toggle on the phone, and a desk ask on the Mac
+executes on the phone's own model — badged honestly, refused fast and by
+name the moment the phone stops serving.
+
+## The design (pinned)
+
+- **The HS-85 posture, verbatim.** Pull-only (the worker claims from the
+  hub; nothing dials into the phone); polling IS liveness (the hub's
+  15s window over the ~3s claim cadence); serving IS consent — the toggle
+  is off by default, and stopping (toggle off, app backgrounded, app
+  killed) reads offline hub-side within seconds, refusals named.
+- **Foreground-only in v1.** The worker runs while the app is open —
+  the `QueuePresence` task-loop pattern, cancelled on scenePhase leaving
+  active. iOS background execution is a deliberate NON-goal (the honest
+  posture: a phone that OS-suspends mid-job must not look live); the
+  claim deadline (120s) already fails an interrupted job by name.
+- **The device's OWN provider, resolved the Phase-24 way.** The worker
+  executes through `InferenceConfigStore`'s active profile →
+  `InferenceProviderFactory` → `ILLMProvider` — its model file, its
+  Keychain key. No credential ever rides the relay (the HS-85 key rule).
+- **The fold is explicit.** `ILLMProvider.complete(prompt:)` takes one
+  string; the relay job carries system/user/temperature/max_tokens. The
+  worker folds system + user deterministically (the mirror of the
+  desktop's `_chat_completion_text` adapter) and ignores what the seam
+  cannot express in v1 — recorded, not smuggled.
+- **The recursion guard travels.** A device whose active profile is
+  itself `meshNode` (or `desktop`) refuses to serve — by name, at
+  toggle-time AND per-job, exactly like the Python worker's guard.
+- **The node name is the device's mesh name** — the same name the
+  device's model manifest pushes on sync, so pickers, doctor, and badges
+  all agree on one string.
+- **Serving is visible, not silent.** While the toggle is on, the
+  Settings surface states it plainly: node name, live state, jobs served
+  this session, last claim age. No prose beyond that (the no-prose rule).
+
+## Exit criteria (evidence required)
+
+- [ ] `swift test` covers the worker loop against a stubbed hub
+  (URLProtocol): claim→execute→complete verbatim; node-side failure →
+  fail verbatim; hub outage → backoff without crash; cancel stops
+  cleanly; the recursion guard refuses by name; the token rides as
+  Bearer and never appears in any label.
+- [ ] The consent toggle (off by default) starts/stops the worker; app
+  background/kill stops it; the serving state renders on Settings.
+- [ ] The live proof on real metal: a desk ask on the Mac (or web desk)
+  runs against a meshNode profile naming the DEVICE and executes on the
+  device's own provider — the hub-side badge names the device node, the
+  device's serving counter increments, and doctor's "Mesh edges" line
+  lists the device. Kill the app: pickers read offline, a forced run
+  refuses fast and named. Screenshots + outputs committed.
+- [ ] Docs teach it at the entry points (apple/README + the mobile
+  ARCHITECTURE note + desktop MODELS.md gains the "your phone can serve
+  too" sentence); guards green.
+
+## Story status
+
+| ID | Story | Status | Story file |
+|----|-------|--------|------------|
+| HSM-25-01 | The Swift relay worker on the provider seam | backlog | [story-01](./story-01-swift-relay-worker.md) |
+| HSM-25-02 | Consent + the serving surface | backlog | [story-02](./story-02-consent-and-serving-surface.md) |
+| HSM-25-03 | The live proof + docs | backlog | [story-03](./story-03-live-proof-and-docs.md) |
+
+## Where we are
+
+**2026-07-07 — scaffolded.** The desktop wire closed the same day
+(phase-85, PR #297) with the walk-find lessons recorded in its final
+summary; the Swift seam survey (receipts above) confirmed a green field.
+Next: HSM-25-01.
+
+## Active risks
+
+| Risk | Likelihood | Mitigation | Stop signal |
+|---|---|---|---|
+| iOS suspends the app mid-job and the hub waits the full deadline | medium | foreground-only posture + the 120s deadline fails the job by name; scenePhase cancel stamps nothing false | a hub-side job hanging past its deadline with the phone asleep |
+| The on-device model is too slow for the 120s deadline on big prompts | medium | the deadline error is named and honest; the picker shows the device model's name so the caller chose it knowingly | walk runs that routinely expire |
+| The fold loses sampling params silently | low | recorded v1 limit here + in the story; the job's temperature/max_tokens are honored where the provider grows them later | reviewer surprise at the fold |
+| Serving drains battery unnoticed | low | the toggle is loud on Settings while on; foreground-only bounds it | owner complaint |
+
+## Decisions made (this phase)
+
+- 2026-07-07 — Foreground-only serving in v1; background modes are a
+  deliberate non-goal. — honesty over reach: a suspended worker must not
+  look live. Authority: the HS-85 liveness posture.
+- 2026-07-07 — The worker folds system+user onto `complete(prompt:)`
+  rather than growing the provider protocol in this phase. — smallest
+  honest change; the protocol grows params when a real need lands.
+
+## Decisions deferred
+
+- **Background serving** (BGProcessingTask / push-to-claim). Trigger: the
+  owner actually wanting the phone to serve pocketed. Default: no.
+- **Serving the iPad and iPhone simultaneously under distinct node
+  names.** Already works by construction (per-device names); a walk rider
+  only if the owner asks.

--- a/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/story-01-swift-relay-worker.md
+++ b/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/story-01-swift-relay-worker.md
@@ -1,0 +1,66 @@
+# HSM-25-01 — The Swift relay worker on the provider seam
+
+- **Status:** backlog
+- **Depends on:** desktop phase-85 (shipped)
+- **Unblocks:** HSM-25-02, HSM-25-03
+
+## Problem
+
+The hub's relay wire (claim / complete / fail, HS-85-01) has one worker
+implementation: the Python `holdspeak mesh serve`. The devices need the
+same loop in Swift, executing on the device's OWN provider through the
+existing `ILLMProvider` seam — no new provider concepts, no key movement.
+
+## The design
+
+- `MeshRelayClient` (Sources/Providers/Desktop, beside
+  `HTTPDesktopClient`): three calls mirroring the wire —
+  `claim(node:) -> MeshRelayJob?`, `complete(jobID:result:)`,
+  `fail(jobID:error:)`. Bearer token discipline identical to the existing
+  client (never logged, never in a label). `MeshRelayJob` decodes
+  `{id, node, task_kind, system_prompt, user_prompt, temperature,
+  max_tokens, model_hint}` tolerantly.
+- `MeshServeWorker` (the loop, translated from
+  `holdspeak/commands/mesh_serve.py`): claim on a ~3s jittered cadence →
+  execute → post the outcome verbatim → immediately claim again while
+  work exists; hub outage backs off exponentially (1s→30s, reset on
+  success) without dying; cancellation stops cleanly with the in-flight
+  job finishing. Injectable client + provider factory + sleep for tests.
+- **Execution folds onto the seam:** system + "\n\n" + user →
+  `ILLMProvider.complete(prompt:)` (the provider protocol takes one
+  string in v1; recorded limit — temperature/max_tokens ride the job but
+  the seam cannot express them yet). A provider throw posts `fail` with
+  the error text verbatim.
+- **The recursion guard:** the worker's provider factory resolves the
+  active profile the Phase-24 way; a `meshNode` or `desktop` active
+  profile refuses to serve by name (`this device's profile runs
+  elsewhere — serving needs an on-device model or an endpoint`) — the
+  job fails honestly, mirroring the Python guard.
+- One honest log line per claim/outcome (the walk's evidence shape).
+
+## Scope
+
+- In: `MeshRelayJob` + `MeshRelayClient` + `MeshServeWorker`; unit tests.
+- Out: any UI (25-02), any background mode, protocol changes to
+  `ILLMProvider`.
+
+## Test plan
+
+`swift test` (ProvidersTests, URLProtocol stubbing per
+`DesktopClientTests.swift`):
+
+- claim returns a job → provider runs → complete posts the result
+  verbatim (body captured and asserted).
+- provider throws → fail posts the error verbatim.
+- hub unreachable → backoff sequence (1, 2, 4 …) via injected sleep; no
+  crash; recovery resets.
+- claim returns `{job: null}` → idle cadence, nothing posted.
+- cancel mid-loop → loop exits; no further requests.
+- recursion guard: a meshNode active profile → the job fails with the
+  named reason; nothing executes.
+- the token rides `Authorization: Bearer` (asserted via `lastAuth`).
+
+## Done when
+
+The worker round-trips a real job shape against the stubbed hub in tests,
+with the guard, backoff, and verbatim outcomes proven. No UI yet.

--- a/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/story-02-consent-and-serving-surface.md
+++ b/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/story-02-consent-and-serving-surface.md
@@ -1,0 +1,53 @@
+# HSM-25-02 — Consent + the serving surface
+
+- **Status:** backlog
+- **Depends on:** HSM-25-01
+- **Unblocks:** HSM-25-03
+
+## Problem
+
+No node serves the mesh implicitly (the HS-85 consent rule). The worker
+from 25-01 needs its one honest switch — off by default — and serving
+must be visible while it happens, not a silent battery drain.
+
+## The design
+
+- **The toggle**: a Settings card in the "WHERE INTELLIGENCE RUNS"
+  section, the `diarizeCard` pattern (`AppSettings.swift:451`): glyph +
+  "Serve my models to the mesh" + a `Toggle` bound to a new persisted
+  `InferenceConfigStore.meshServeOn` (UserDefaults, **default false**).
+- **Start/stop**: toggle on → `MeshServeWorker` starts (the
+  `QueuePresence.startMeshPolling` task-loop pattern), serving as the
+  device's mesh name — the SAME name the model manifest pushes on sync.
+  Toggle off, scenePhase leaving `.active`, or app kill → the worker
+  cancels; the hub's liveness window reads the node offline within
+  seconds (nothing to clean up hub-side — polling IS liveness).
+- **The recursion guard at the door**: with a meshNode/desktop active
+  profile the toggle refuses to arm and says why in the card's subline —
+  the same named reason as the per-job guard.
+- **The serving state, no prose**: while on, the card's subline states
+  `serving as <node> · <n> runs` and the last-claim age; while off, the
+  single label. The egress grammar for a served run is the hub's concern
+  (the caller's badge names this node); the device shows only its own
+  serving state.
+
+## Scope
+
+- In: the toggle + persisted flag, worker lifecycle wiring
+  (MeetingCaptureApp scenePhase), the serving state line, the at-the-door
+  guard.
+- Out: notifications, background serving, any hub-side change.
+
+## Test plan
+
+- `swift test`: the store persists `meshServeOn` (default false); the
+  guard refuses arming for meshNode/desktop actives; worker start/stop
+  follows the flag (injected worker spy).
+- Sim: toggle renders in Settings; on → serving line appears; off →
+  gone. Screenshot committed.
+
+## Done when
+
+Flipping one switch starts serving under the device's mesh name and
+stopping is instant and honest — verified in the simulator, wired for
+25-03's live proof.

--- a/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/story-03-live-proof-and-docs.md
+++ b/pm/roadmap/holdspeak-mobile/phase-25-serve-the-mesh/story-03-live-proof-and-docs.md
@@ -1,0 +1,48 @@
+# HSM-25-03 — The live proof + docs
+
+- **Status:** backlog
+- **Depends on:** HSM-25-01, HSM-25-02
+- **Unblocks:** none (closes the phase)
+
+## Problem
+
+The phase's claim — flip one toggle and the desk runs on the phone — has
+to be walked on real metal (the standing rule: seeded sim demos aren't
+proof), then taught at the entry points.
+
+## Scope
+
+- In: the live walk, on the real hub with the real device (or the
+  simulator against the live hub for the wire beats + the device for the
+  felt beats, per the HSM proof pattern):
+  1. Toggle ON in Settings — the device appears in `holdspeak doctor`'s
+     "Mesh edges" line and the hub's models door, live, under its mesh
+     name.
+  2. A meshNode profile naming the device (authored once, hub-side) runs
+     a desk ask on the Mac/web — the badge names the device; the device's
+     serving counter increments; the run's answer came from the DEVICE's
+     model.
+  3. Toggle OFF (and separately: kill the app) — pickers/doctor read
+     offline within the window; a forced run refuses fast (< 5s), naming
+     the device.
+  Screenshots (device Settings serving state; hub badge; offline picker)
+  + outputs committed to `screenshots/`.
+- In: docs at the entry points — `apple/README.md` (the serving toggle),
+  the mobile ARCHITECTURE note, desktop `docs/MODELS.md` ("your phone can
+  serve too" sentence in the mesh-edge section); voice/drift guards
+  green.
+- In: phase close — exit criteria re-run, `final-summary.md`, mobile
+  roadmap README pointer + "Last updated".
+- Out: background serving, multi-device simultaneous-serve walk (works by
+  construction; a rider only on owner ask).
+
+## Test plan
+
+- The walk IS the proof (outside the sandbox; hub restarted on merged
+  code with `HOLDSPEAK_WEB_PORT=8765` pinned).
+- Full `swift test` + desktop guards green at close.
+
+## Done when
+
+The walk's three beats pass with artifacts committed, the docs teach the
+toggle honestly, and the phase closes with the cadence complete.


### PR DESCRIPTION
The recorded handoff from desktop phase-85 (The Mesh Edge, CLOSED 5/5, PR #297): the relay wire is proven live with the reference `holdspeak mesh serve` worker — this phase puts the same worker on the Apple devices, behind an explicit consent toggle.

**Grounded** in a same-day Swift seam survey (file:line receipts in `current-phase-status.md`): `ILLMProvider` (Providers.swift:22) is the one provider seam; the `meshNode` contract mirror already landed (Primitives.swift:257, HS-85-02); `QueuePresence`'s task-loop is the polling precedent; no existing Swift worker — green field.

**Pinned design:** the HS-85 posture verbatim — pull-only, polling IS liveness, serving IS consent (off by default); foreground-only in v1; execution through the device's own Phase-24 profile resolution, key never leaves the Keychain; the system+user fold onto `complete(prompt:)` recorded as an explicit v1 limit; the recursion guard travels.

**Stories:**
- HSM-25-01 — the Swift relay worker on the provider seam (URLProtocol-tested loop)
- HSM-25-02 — consent + the serving surface (the diarizeCard pattern, scenePhase stop)
- HSM-25-03 — the live proof on real metal + entry-point docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ