### PR TITLE
HSM-27-01 — The iPad steering client catches up to Phase 89/90

### DIFF
--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Steering.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Steering.swift
@@ -34,13 +34,83 @@ public struct CoderDisarmResult: Codable, Equatable, Sendable {
     public var wasArmed: Bool
 }
 
+// --- Phase-89/90 parity (the iPad catches up to the web desk) ---------------
+
+/// A key in a `/keys` sequence: a NAMED tmux key (`C-c`, `Up`, `Escape`) or a
+/// LITERAL run. Matches the hub's body — a bare string for a named key, a
+/// `{ "literal": "…" }` object for a literal.
+public enum SteerKey: Equatable, Sendable {
+    case named(String)
+    case literal(String)
+    var wire: Any {
+        switch self {
+        case .named(let k): return k
+        case .literal(let t): return ["literal": t]
+        }
+    }
+    public static let interrupt = SteerKey.named("C-c")
+    public static let escape = SteerKey.named("Escape")
+    public static let enter = SteerKey.named("Enter")
+    public static let up = SteerKey.named("Up")
+    public static let down = SteerKey.named("Down")
+    public static let left = SteerKey.named("Left")
+    public static let right = SteerKey.named("Right")
+}
+
+/// A tmux pane from `GET /api/coders/steering/panes` — attach to ANY of them.
+public struct PaneInfo: Codable, Equatable, Sendable {
+    // No explicit CodingKeys: the shared decoder converts snake_case
+    // (pane_id → paneId), matching the CoderArmResult precedent.
+    public var paneId: String
+    public var session: String
+    public var window: String?
+    public var command: String?
+    public var title: String?
+    public var active: Bool?
+    public init(paneId: String, session: String, window: String? = nil,
+                command: String? = nil, title: String? = nil, active: Bool? = nil) {
+        self.paneId = paneId; self.session = session; self.window = window
+        self.command = command; self.title = title; self.active = active
+    }
+}
+
+/// The outcome of ending a pane/session (`POST /{key}/kill`). A refusal is
+/// DATA (a 409 body): an unarmed or recycled-pane kill decodes here, and a
+/// revoking refusal sets `revoked` so the surface re-offers ARM.
+public struct CoderKillResult: Codable, Equatable, Sendable {
+    public var status: String            // "killed" | unarmed | pane_mismatch | pane_gone | ...
+    public var paneId: String?
+    public var scope: String?
+    public var revoked: Bool?
+    public var detail: String?
+    public var isKilled: Bool { status == "killed" }
+    public var didRevoke: Bool { revoked == true }
+}
+
+/// The outcome of a factory create/label act (`POST /factory/{spawn,rename}`).
+/// A bad name / duplicate is DATA (a 409 body).
+public struct FactoryResult: Codable, Equatable, Sendable {
+    public var status: String            // "spawned" | "renamed" | bad_name | exists | ...
+    public var session: String?
+    public var paneId: String?
+    public var detail: String?
+    public var isOk: Bool { status == "spawned" || status == "renamed" }
+    /// The `pane:%N` key of a just-spawned session, ready to attach to.
+    public var paneKey: String? { paneId.map { "pane:\($0)" } }
+}
+
 extension HTTPDesktopClient {
 
     /// `GET /api/coders/{key}/peek` — the read-only window into a session's pane.
     /// Watching is free: no grant, no keystroke. `lastHash` rides the content
     /// gate (an unchanged pane answers `not_modified`, no body).
-    public func coderPeek(key: String, lines: Int = 200, lastHash: String? = nil) async throws -> CoderSessionPeek {
-        var path = "api/coders/\(encoded(key))/peek?lines=\(lines)"
+    public func coderPeek(key: String, lines: Int = 200, lastHash: String? = nil, node: String? = nil) async throws -> CoderSessionPeek {
+        var path: String
+        if let n = node, !n.isEmpty {
+            path = "api/coders/relay/\(encoded(n))/peek?key=\(encoded(key))&lines=\(lines)"
+        } else {
+            path = "api/coders/\(encoded(key))/peek?lines=\(lines)"
+        }
         if let h = lastHash, !h.isEmpty { path += "&last_hash=\(encoded(h))" }
         let data = try await sendSteer(makeSteerRequest(path: path, method: "GET"))
         guard let peek = try? HoldSpeakContracts.decoder().decode(CoderSessionPeek.self, from: data) else {
@@ -52,9 +122,11 @@ extension HTTPDesktopClient {
     /// `POST /api/coders/{key}/arm` — earn the grant. 200 → armed; 409 → a typed
     /// refusal (both decode into CoderArmResult). Pins the pane's %N and starts
     /// the countdown.
-    public func armCoder(key: String, ttlSeconds: Int? = nil) async throws -> CoderArmResult {
-        let body: [String: Any] = ttlSeconds.map { ["ttl_seconds": $0] } ?? [:]
-        let data = try await sendSteerAllowing409(makeSteerRequest(path: "api/coders/\(encoded(key))/arm", method: "POST", jsonBody: body))
+    public func armCoder(key: String, ttlSeconds: Int? = nil, node: String? = nil) async throws -> CoderArmResult {
+        let (path, keyInBody) = steerVerb(node: node, key: key, verb: "arm")
+        var body: [String: Any] = ttlSeconds.map { ["ttl_seconds": $0] } ?? [:]
+        if keyInBody { body["key"] = key }
+        let data = try await sendSteerAllowing409(makeSteerRequest(path: path, method: "POST", jsonBody: body))
         guard let res = try? HoldSpeakContracts.decoder().decode(CoderArmResult.self, from: data) else {
             throw DesktopClientError.malformed
         }
@@ -75,12 +147,14 @@ extension HTTPDesktopClient {
     /// revoking refusal (recycled pane / expiry) sets `revoked` so the surface
     /// re-offers ARM.
     public func steerCoder(key: String, text: String, submit: Bool = true,
-                           grounding: [RailsGroundingRef]? = nil) async throws -> SteerResult {
+                           grounding: [RailsGroundingRef]? = nil, node: String? = nil) async throws -> SteerResult {
+        let (path, keyInBody) = steerVerb(node: node, key: key, verb: "steer")
         var body: [String: Any] = ["text": text, "submit": submit]
+        if keyInBody { body["key"] = key }
         if let g = grounding, !g.isEmpty {
             body["grounding"] = ["rails": g.map { ["repo": $0.repo, "project": $0.project, "kind": $0.kind, "id": $0.id] }]
         }
-        let data = try await sendSteerAllowing409(makeSteerRequest(path: "api/coders/\(encoded(key))/steer", method: "POST", jsonBody: body))
+        let data = try await sendSteerAllowing409(makeSteerRequest(path: path, method: "POST", jsonBody: body))
         guard let res = try? HoldSpeakContracts.decoder().decode(SteerResult.self, from: data) else {
             throw DesktopClientError.malformed
         }
@@ -100,7 +174,90 @@ extension HTTPDesktopClient {
 
     struct AuditDTO: Decodable { var audit: [SteeringAuditEntry]? }
 
+    // MARK: - Phase-89/90 parity
+
+    /// `POST /api/coders/{key}/keys` — full key control (HS-89-01). Send real
+    /// keys (`.interrupt`, arrows, `.escape`) through the chokepoint. 200 →
+    /// delivered; 409 → a typed refusal (a revoking one re-offers ARM). A
+    /// `node` routes through the relay (HS-89-03).
+    public func coderKeys(key: String, keys: [SteerKey], node: String? = nil) async throws -> SteerResult {
+        let (path, keyInBody) = steerVerb(node: node, key: key, verb: "keys")
+        var body: [String: Any] = ["keys": keys.map { $0.wire }]
+        if keyInBody { body["key"] = key }
+        let data = try await sendSteerAllowing409(makeSteerRequest(path: path, method: "POST", jsonBody: body))
+        guard let res = try? HoldSpeakContracts.decoder().decode(SteerResult.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return res
+    }
+
+    /// `GET /api/coders/steering/panes` — every tmux pane on the machine
+    /// (HS-89-02). Watch any free; arm one by its `pane:%N` key to steer it.
+    public func steeringPanes() async throws -> [PaneInfo] {
+        let data = try await sendSteer(makeSteerRequest(path: "api/coders/steering/panes", method: "GET"))
+        guard let dto = try? HoldSpeakContracts.decoder().decode(PanesDTO.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return dto.panes ?? []
+    }
+
+    /// `GET /api/coders/steering/nodes` — the configured steering nodes, NAMES
+    /// ONLY (HS-90-02). Empty means "this Mac only".
+    public func steeringNodes() async throws -> [String] {
+        let data = try await sendSteer(makeSteerRequest(path: "api/coders/steering/nodes", method: "GET"))
+        guard let dto = try? HoldSpeakContracts.decoder().decode(NodesDTO.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return dto.nodes ?? []
+    }
+
+    /// `POST /api/coders/{key}/kill` — end the armed pane (`scope: "pane"`) or
+    /// its session (`scope: "session"`) (HS-90-01). The ultimate manipulation,
+    /// gated like a steer; a refusal is DATA. Local only, like the web desk.
+    public func killCoder(key: String, scope: String = "pane") async throws -> CoderKillResult {
+        let data = try await sendSteerAllowing409(makeSteerRequest(path: "api/coders/\(encoded(key))/kill", method: "POST", jsonBody: ["scope": scope]))
+        guard let res = try? HoldSpeakContracts.decoder().decode(CoderKillResult.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return res
+    }
+
+    /// `POST /api/coders/factory/spawn` — create a detached session (HS-90-01).
+    /// The name is validated hub-side; a bad name is a 409 `bad_name`. On
+    /// success `paneKey` is the `pane:%N` to attach to.
+    public func spawnSession(name: String, command: String? = nil) async throws -> FactoryResult {
+        var body: [String: Any] = ["name": name]
+        if let c = command, !c.isEmpty { body["command"] = c }
+        let data = try await sendSteerAllowing409(makeSteerRequest(path: "api/coders/factory/spawn", method: "POST", jsonBody: body))
+        guard let res = try? HoldSpeakContracts.decoder().decode(FactoryResult.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return res
+    }
+
+    /// `POST /api/coders/factory/rename` — relabel a session (HS-90-01).
+    public func renameSession(target: String, name: String) async throws -> FactoryResult {
+        let data = try await sendSteerAllowing409(makeSteerRequest(path: "api/coders/factory/rename", method: "POST", jsonBody: ["target": target, "name": name]))
+        guard let res = try? HoldSpeakContracts.decoder().decode(FactoryResult.self, from: data) else {
+            throw DesktopClientError.malformed
+        }
+        return res
+    }
+
+    struct PanesDTO: Decodable { var panes: [PaneInfo]? }
+    struct NodesDTO: Decodable { var nodes: [String]? }
+
     // MARK: - internals
+
+    /// Node-aware path (HS-89-03 / HS-90-02): a targeted node routes through
+    /// the relay with the key in the BODY; "this Mac" hits the pane's own
+    /// route with the key in the PATH.
+    private func steerVerb(node: String?, key: String, verb: String) -> (path: String, keyInBody: Bool) {
+        if let n = node, !n.isEmpty {
+            return ("api/coders/relay/\(encoded(n))/\(verb)", true)
+        }
+        return ("api/coders/\(encoded(key))/\(verb)", false)
+    }
 
     private func encoded(_ s: String) -> String {
         s.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? s

--- a/apple/Tests/ProvidersTests/SteeringClientTests.swift
+++ b/apple/Tests/ProvidersTests/SteeringClientTests.swift
@@ -133,4 +133,91 @@ final class SteeringClientTests: XCTestCase {
         XCTAssertEqual(trail[0].outcome, "delivered")
         XCTAssertEqual(trail[0].grounding, ["rails:story:HS-88-05"])
     }
+
+    // MARK: - Phase-89/90 parity (the iPad catches up)
+
+    func testKeysDeliverNamedAndLiteral() async throws {
+        route("/api/coders/claude:s1/keys", 200,
+              #"{"status":"delivered","pane_id":"%5","keys":"C-c"}"#)
+        let res = try await client().coderKeys(key: "claude:s1", keys: [.interrupt, .literal("/find"), .down])
+        XCTAssertTrue(res.isDelivered)
+        let sent = String(decoding: StubProtocol.lastBody ?? Data(), as: UTF8.self)
+        XCTAssertTrue(sent.contains("\"C-c\""))       // a named key is a bare string
+        XCTAssertTrue(sent.contains("\"literal\""))   // a literal run is an object
+        XCTAssertTrue(sent.contains("/find"))
+    }
+
+    func testKeysRefusalIsData() async throws {
+        // A recycled-pane keys refusal comes back 409 → SteerResult, revoking.
+        route("/api/coders/claude:s1/keys", 409,
+              #"{"status":"pane_mismatch","revoked":true,"detail":"recycled"}"#)
+        let res = try await client().coderKeys(key: "claude:s1", keys: [.interrupt])
+        XCTAssertFalse(res.isDelivered)
+        XCTAssertTrue(res.didRevoke)
+    }
+
+    func testKeysToANodeRouteThroughTheRelayWithKeyInBody() async throws {
+        route("/api/coders/relay/beta/keys", 200, #"{"status":"delivered","node":"beta","pane_id":"%5"}"#)
+        let res = try await client().coderKeys(key: "pane:%5", keys: [.interrupt], node: "beta")
+        XCTAssertTrue(res.isDelivered)
+        let sent = String(decoding: StubProtocol.lastBody ?? Data(), as: UTF8.self)
+        XCTAssertTrue(sent.contains("\"key\""))        // the key rides the BODY on the relay
+        XCTAssertTrue(sent.contains("pane:%5"))
+    }
+
+    func testSteerToANodeRoutesThroughTheRelay() async throws {
+        route("/api/coders/relay/beta/steer", 200, #"{"status":"delivered","node":"beta","pane_id":"%5"}"#)
+        let res = try await client().steerCoder(key: "pane:%5", text: "hi", node: "beta")
+        XCTAssertTrue(res.isDelivered)
+        XCTAssertTrue(String(decoding: StubProtocol.lastBody ?? Data(), as: UTF8.self).contains("\"key\""))
+    }
+
+    func testPanesListDecodes() async throws {
+        route("/api/coders/steering/panes", 200, #"""
+        {"panes":[{"pane_id":"%3","session":"work","window":"0","command":"claude","title":"","active":true},
+                  {"pane_id":"%7","session":"build","window":"1","command":"npm","title":"","active":false}]}
+        """#)
+        let panes = try await client().steeringPanes()
+        XCTAssertEqual(panes.count, 2)
+        XCTAssertEqual(panes[0].paneId, "%3")
+        XCTAssertEqual(panes[0].command, "claude")
+        XCTAssertEqual(panes[0].active, true)
+    }
+
+    func testNodesListDecodes() async throws {
+        route("/api/coders/steering/nodes", 200, #"{"nodes":["beta","gamma"]}"#)
+        let nodes = try await client().steeringNodes()
+        XCTAssertEqual(nodes, ["beta", "gamma"])
+    }
+
+    func testKillDeliversAndRefusalIsData() async throws {
+        route("/api/coders/pane:%5/kill", 200, #"{"status":"killed","pane_id":"%5","scope":"session"}"#)
+        let killed = try await client().killCoder(key: "pane:%5", scope: "session")
+        XCTAssertTrue(killed.isKilled)
+        XCTAssertEqual(killed.scope, "session")
+
+        route("/api/coders/pane:%5/kill", 409, #"{"status":"unarmed"}"#)
+        let refused = try await client().killCoder(key: "pane:%5")
+        XCTAssertFalse(refused.isKilled)
+        XCTAssertEqual(refused.status, "unarmed")
+    }
+
+    func testSpawnReturnsThePaneKeyAndBadNameIsData() async throws {
+        route("/api/coders/factory/spawn", 200, #"{"status":"spawned","session":"work","pane_id":"%9"}"#)
+        let ok = try await client().spawnSession(name: "work", command: "bash")
+        XCTAssertTrue(ok.isOk)
+        XCTAssertEqual(ok.paneKey, "pane:%9")   // ready to attach
+
+        route("/api/coders/factory/spawn", 409, #"{"status":"bad_name","detail":"no"}"#)
+        let bad = try await client().spawnSession(name: "a b")
+        XCTAssertFalse(bad.isOk)
+        XCTAssertEqual(bad.status, "bad_name")
+    }
+
+    func testRenameRelabels() async throws {
+        route("/api/coders/factory/rename", 200, #"{"status":"renamed","session":"shipped"}"#)
+        let res = try await client().renameSession(target: "work", name: "shipped")
+        XCTAssertTrue(res.isOk)
+        XCTAssertEqual(res.session, "shipped")
+    }
 }

--- a/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/current-phase-status.md
+++ b/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/current-phase-status.md
@@ -1,0 +1,46 @@
+# HSM Phase 27 — The iPad Terminal (parity with Phase 89/90)
+
+**Status:** in progress (1/2). The iPad catches up to the web desk's
+first-class agent manipulation.
+
+**Last updated:** 2026-07-08.
+
+## Why
+
+Phases 89 and 90 gave the WEB desk first-class terminal manipulation —
+any key, any pane, any machine, plus the session lifecycle (spawn/
+rename/kill) — with a full on-glass surface. The iPad was left behind:
+its steering client had only the original five verbs (peek/arm/disarm/
+steer/audit) and no interactive UI at all. This phase closes that gap.
+
+## Scope
+
+- In: the Swift steering CLIENT parity (keys, panes, nodes, kill, spawn,
+  rename, and node routing on arm/steer/keys/peek) — verifiable now; the
+  interactive terminal SURFACE on the diorama (peek + hold-to-arm + key
+  palette + composer + pane picker + factory controls) — device-felt.
+- Out: a full PTY emulator (peek stays the hash-gated poll); cross-machine
+  factory (local, like the web); launching an agent into a spawned pane.
+
+## Story status
+
+| ID | Story | Status | Story file |
+|---|---|---|---|
+| HSM-27-01 | The steering client parity | **done** (2026-07-08, `swift test` 519/0, [evidence](./evidence-story-01.md)) | [story-01-client-parity](./story-01-client-parity.md) |
+| HSM-27-02 | The terminal surface on the diorama | backlog (device-gated — the couch) | [story-02-terminal-surface](./story-02-terminal-surface.md) |
+
+## Where we are
+
+HSM-27-01 done: `HTTPDesktopClient+Steering.swift` now speaks the full
+Phase-89/90 wire — `coderKeys` (named + literal, node-routable),
+`steeringPanes`, `steeringNodes`, `killCoder`, `spawnSession`,
+`renameSession`, and a `node` param on arm/steer/keys/peek that routes
+through the relay (the web's `verbEndpoint` mirrored). New loose result
+types (SteerKey, PaneInfo, CoderKillResult, FactoryResult). Every verb
+pinned over a URLProtocol stub (`SteeringClientTests`, 16), including the
+refusal-as-data paths and the relay key-in-body. `swift test` 519/0.
+
+HSM-27-02 (the interactive surface) is device-felt consent craft — the
+hold-to-arm gesture, the key palette taps, the composer, the spawn/kill
+controls — proven on the cabled iPad, not a sim screenshot (the owner's
+bar). Staged for the couch, mirroring the web desk's SessionPullout.

--- a/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/evidence-story-01.md
+++ b/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/evidence-story-01.md
@@ -1,0 +1,23 @@
+# Evidence - HSM-27-01
+
+- **Story:** HSM-27-01 - The steering client parity
+- **Status:** done
+- **Date:** 2026-07-08
+
+## Proof
+
+### Captured run — 2026-07-09T00:47:21Z
+
+- **Command:** `bash -c cd apple && swift test --filter SteeringClientTests 2>&1 | tail -6`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** a384aa4f2b2e92a0efcd3a2671db37279b82c4da
+
+```text
+Test Suite 'Selected tests' passed at 2026-07-08 18:47:22.112.
+	 Executed 16 tests, with 0 failures (0 unexpected) in 0.015 (0.017) seconds
+◇ Test run started.
+↳ Testing Library Version: 1743
+↳ Target Platform: arm64e-apple-macos14.0
+✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
+```

--- a/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/story-01-client-parity.md
+++ b/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/story-01-client-parity.md
@@ -1,0 +1,38 @@
+# HSM-27-01 — The steering client parity
+
+- **Status:** done
+- **Shipped:** 2026-07-08 — the Swift client speaks the full Phase-89/90 wire; `swift test` 519/0. Evidence: [evidence-story-01.md](./evidence-story-01.md).
+- **Depends on:** Phase 89/90 (the hub routes), HSM-26-03 (the client base)
+
+## Problem
+
+The iPad's steering client stopped at Phase 87's five verbs. The web
+desk gained keys, panes, nodes, kill, spawn, rename, and cross-machine
+routing. The client must reach all of it before any surface can.
+
+## What shipped
+
+`apple/Sources/Providers/Desktop/HTTPDesktopClient+Steering.swift`:
+
+- `coderKeys(key:keys:node:)` — full key control; `SteerKey.named` /
+  `.literal` (`.interrupt`, arrows, `.escape` shorthands); a named key is
+  a bare string, a literal is `{literal}`; refusal is DATA (a 409
+  SteerResult, revoking re-offers ARM).
+- `steeringPanes()` → `[PaneInfo]`; `steeringNodes()` → `[String]`.
+- `killCoder(key:scope:)` → `CoderKillResult` (killed or a typed refusal;
+  local only, like the web).
+- `spawnSession(name:command:)` / `renameSession(target:name:)` →
+  `FactoryResult` (spawned returns `paneKey`, ready to attach; bad_name
+  is DATA).
+- A `node` param on `coderPeek`/`armCoder`/`steerCoder`/`coderKeys` that
+  routes through the relay (`api/coders/relay/{node}/{verb}`, the key in
+  the BODY) — the web's `verbEndpoint` mirrored.
+
+## Acceptance criteria
+
+- [x] Every new verb round-trips over a URLProtocol stub, incl. the
+      refusal-as-data paths and the relay key-in-body
+      (`SteeringClientTests`, 16).
+- [x] `PaneInfo` decodes the `/panes` shape (snake_case via the shared
+      decoder, the `CoderArmResult` precedent — no clashing CodingKeys).
+- [x] `swift test` green (519/0); the package builds.

--- a/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/story-02-terminal-surface.md
+++ b/pm/roadmap/holdspeak-mobile/phase-27-the-ipad-terminal/story-02-terminal-surface.md
@@ -1,0 +1,39 @@
+# HSM-27-02 — The terminal surface on the diorama
+
+- **Status:** backlog
+- **Owner-gated:** device work — the hold-to-arm gesture, the key palette,
+  the composer, and the spawn/kill controls are motion-felt; a sim
+  screenshot is not the proof (the owner's bar). Proven on the cabled iPad.
+- **Depends on:** HSM-27-01
+
+## Problem
+
+The iPad can decode the whole terminal wire now, but there is no way to
+DO it on glass. This is the interactive surface, mirroring the web desk's
+SessionPullout.
+
+## Scope
+
+- In: on the diorama's session surface — the live peek, a hold-to-arm
+  chip → countdown, a KEY PALETTE (`^C`/arrows/`Escape`, armed-only), the
+  voice-first composer, a PANE PICKER (attach to any `pane:%N`), a NODE
+  chip, and the FACTORY controls (spawn in the picker; rename + a
+  confirm-gated kill in the armed surface).
+- Out: a PTY emulator; cross-machine factory; agent orchestration.
+
+## Acceptance criteria
+
+- [ ] The surface decodes and drives through HSM-27-01's client; the
+      consent spine holds on glass (watch free, manipulate armed, the
+      countdown visible, kill confirmed).
+- [ ] The couch walk: attach a pane → arm → `C-c` → steer → spawn →
+      rename → kill, live from the iPad; the audit reads it back.
+- [ ] `swift test` green; the layer rule holds (no SwiftUI in
+      Contracts/RuntimeCore/Providers).
+
+## Implementation direction
+
+- Mirror `web/src/desk/components/SessionPullout.tsx`: the key palette in
+  the armed footer, the pane picker as a launcher, the factory controls
+  as a SESSION row. Reuse the Phase-26 DioStage session grammar.
+- Device-felt: build on the cabled iPad, not a sim screenshot.


### PR DESCRIPTION
## HSM Phase 27 — The iPad Terminal (parity), story 1: the client

Fixing the iOS gap: Phases 89/90 gave the **web** desk first-class terminal manipulation (any key, any pane, any machine, plus the session lifecycle), but the iPad's steering client stopped at Phase 87's five verbs and had no interactive UI. This lands the client parity.

### `HTTPDesktopClient+Steering.swift`

- **`coderKeys(key:keys:node:)`** — full key control. `SteerKey.named` / `.literal` (`.interrupt`, arrows, `.escape` shorthands); a named key is a bare string, a literal is `{literal}`; a 409 refusal is DATA (a `SteerResult`, revoking re-offers ARM).
- **`steeringPanes()`** → `[PaneInfo]`; **`steeringNodes()`** → `[String]`.
- **`killCoder(key:scope:)`** → `CoderKillResult` (killed or a typed refusal; local only, like the web desk).
- **`spawnSession(name:command:)` / `renameSession(target:name:)`** → `FactoryResult` (spawned returns `paneKey`, ready to attach; `bad_name` is DATA).
- A **`node`** param on `coderPeek`/`armCoder`/`steerCoder`/`coderKeys` that routes through the relay (`api/coders/relay/{node}/{verb}`, key in the BODY) — the web's `verbEndpoint` mirrored.

### Proof

`SteeringClientTests` grew to 16, pinning every verb over a URLProtocol stub (fully offline), including the refusal-as-data paths and the relay key-in-body. `swift test` 519/0; the package builds.

### What's left (HSM-27-02, device-gated)

The interactive terminal surface on the diorama — hold-to-arm, key palette, composer, pane picker, factory controls — is motion-felt consent craft. Per the owner's bar a sim screenshot is not its proof, so it's built and reviewed on the cabled iPad, mirroring the web desk's `SessionPullout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ