### PR TITLE
HSM-27-02 follow-on: the terminal entry point + TestFlight build 10

### DIFF
--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -3504,11 +3504,18 @@ struct DioStage: View {
                 }
                 // a desk-native settings entry (no bouncing to an old screen)
                 if landed && selected == nil && summonSource == nil && !capturing && path.isEmpty {
-                    Button { haptic(.light); showSettings = true } label: {
-                        Image(systemName: "gearshape.fill").font(.system(size: 16, weight: .bold)).foregroundStyle(DioPal.text.opacity(0.85))
-                            .frame(width: 42, height: 42).background(Circle().fill(.white.opacity(0.08)).overlay(Circle().strokeBorder(.white.opacity(0.12), lineWidth: 1)))
-                    }.buttonStyle(.plain)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading).padding(.top, topInset + 8).padding(.leading, 18).zIndex(70)
+                    VStack(spacing: 10) {
+                        Button { haptic(.light); showSettings = true } label: {
+                            Image(systemName: "gearshape.fill").font(.system(size: 16, weight: .bold)).foregroundStyle(DioPal.text.opacity(0.85))
+                                .frame(width: 42, height: 42).background(Circle().fill(.white.opacity(0.08)).overlay(Circle().strokeBorder(.white.opacity(0.12), lineWidth: 1)))
+                        }.buttonStyle(.plain)
+                        // HSM-27-02 — the terminal entry: attach to a pane and steer it.
+                        Button { haptic(.medium); openSteerPicker() } label: {
+                            Image(systemName: "terminal.fill").font(.system(size: 15, weight: .bold)).foregroundStyle(DioPal.violet)
+                                .frame(width: 42, height: 42).background(Circle().fill(DioPal.violet.opacity(0.14)).overlay(Circle().strokeBorder(DioPal.violet.opacity(0.35), lineWidth: 1)))
+                        }.buttonStyle(.plain)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading).padding(.top, topInset + 8).padding(.leading, 18).zIndex(70)
                 }
                 // THE SYNC STATUS — port your primitives to/from the paired Mac (hub), FELT.
                 // A premium ambient pill that wears the live state (syncing / synced·"2m ago" /
@@ -4341,7 +4348,7 @@ struct DioStage: View {
                 onKill: { steerKill() },
                 onCycleNode: { steerCycleNode() },
                 onClose: { steerPoll?.cancel(); withAnimation { steerSheet = nil } },
-                startPanesOpen: ProcessInfo.processInfo.environment["HS_DESK_STEER"] == "panes")
+                startPanesOpen: ss.paneKey.isEmpty || ProcessInfo.processInfo.environment["HS_DESK_STEER"] == "panes")
                 .id(ss.paneKey).zIndex(151).transition(.opacity)
         }
         // Notes + KBs are edited IN-WORLD on the desk (see `level`), never in a dimmed modal.
@@ -5768,6 +5775,22 @@ struct DioStage: View {
     }
 
     // MARK: HSM-27-02 — the terminal surface handlers (drive HSM-27-01's client)
+
+    /// Open the terminal sheet with the pane PICKER first (no pane chosen yet):
+    /// list the paired Mac's panes + configured nodes, then attach or spawn.
+    private func openSteerPicker() {
+        steerSheet = SteerSheetState(paneKey: "", title: "Terminal", lines: [], question: nil,
+                                     armed: false, remaining: 0, node: "", nodes: [], panes: [],
+                                     fate: "", fateOK: true)
+        steerPoll?.cancel()
+        steerPoll = Task { @MainActor in
+            guard let client = desktopClient else {
+                steerSheet?.fate = "pair your desktop to attach"; steerSheet?.fateOK = false; return
+            }
+            if let panes = try? await client.steeringPanes() { steerSheet?.panes = panes }
+            if let nodes = try? await client.steeringNodes() { steerSheet?.nodes = nodes }
+        }
+    }
 
     /// Open the terminal sheet on a pane/session key, and start the peek poll.
     private func openSteer(_ key: String, title: String) {

--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -119,7 +119,7 @@ target.build_configurations.each do |config|
   s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
   s['PRODUCT_NAME'] = 'HoldSpeakMobile'
   s['MARKETING_VERSION'] = '0.1.0'
-  s['CURRENT_PROJECT_VERSION'] = '9'   # TestFlight build number — bump per upload (b9 = ground-this-ask + model chat)
+  s['CURRENT_PROJECT_VERSION'] = '10'  # TestFlight build number — bump per upload (b10 = the terminal surface: attach/arm/keys/steer/spawn/kill on glass)
   s['GENERATE_INFOPLIST_FILE'] = 'NO'
   s['INFOPLIST_FILE'] = info_plist
   s['TARGETED_DEVICE_FAMILY'] = '1,2'


### PR DESCRIPTION
The steer surface only opened under the `HS_DESK_STEER` sim seed, so a real build had no way to reach it. This adds a **reachable entry point** and ships it to TestFlight.

- A **terminal button** beside the top-left gear opens the pane picker (`openSteerPicker`) — it lists the paired Mac's panes + configured nodes, then you attach or `+ Spawn` into the full surface. Picker-first when no pane is chosen.
- Bumped `CURRENT_PROJECT_VERSION` to 10.

**Shipped to TestFlight:** archive (Release, ASC key) → export/upload → build 10 processed VALID → attached to the internal group "Owner (internal)". The terminal surface is now openable on the owner's iPhone/iPad — the device walk can happen on the phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ