### PR TITLE
holdspeak-uat: scaffold the project + Phase 1 (The Mechanics)

### DIFF
--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -9,7 +9,7 @@ and the clients that call it (extracted from the real call sites in
 `web/src` and `apple/`). "server only" means no in-repo client calls
 it today.
 
-Routes: 270 (plus static mounts). iOS-consumed: 64. Web-consumed: 198.
+Routes: 270 (plus static mounts). iOS-consumed: 76. Web-consumed: 198.
 
 ## device_audio_ws
 
@@ -446,22 +446,22 @@ Routes: 270 (plus static mounts). iOS-consumed: 64. Web-consumed: 198.
 
 | Method | Path | Consumers |
 |---|---|---|
-| POST | `/api/coders/factory/rename` | web |
-| POST | `/api/coders/factory/spawn` | web |
-| POST | `/api/coders/relay/{node}/arm` | web |
-| POST | `/api/coders/relay/{node}/disarm` | web |
-| POST | `/api/coders/relay/{node}/keys` | web |
-| GET | `/api/coders/relay/{node}/peek` | web |
-| POST | `/api/coders/relay/{node}/steer` | web |
+| POST | `/api/coders/factory/rename` | ios, web |
+| POST | `/api/coders/factory/spawn` | ios, web |
+| POST | `/api/coders/relay/{node}/arm` | ios, web |
+| POST | `/api/coders/relay/{node}/disarm` | ios, web |
+| POST | `/api/coders/relay/{node}/keys` | ios, web |
+| GET | `/api/coders/relay/{node}/peek` | ios, web |
+| POST | `/api/coders/relay/{node}/steer` | ios, web |
 | GET | `/api/coders/steering/audit` | ios, web |
 | GET | `/api/coders/steering/grants` | web |
-| GET | `/api/coders/steering/nodes` | web |
-| GET | `/api/coders/steering/panes` | web |
+| GET | `/api/coders/steering/nodes` | ios, web |
+| GET | `/api/coders/steering/panes` | ios, web |
 | POST | `/api/coders/{key}/arm` | ios, web |
 | POST | `/api/coders/{key}/disarm` | ios, web |
-| POST | `/api/coders/{key}/keep-note` | web |
-| POST | `/api/coders/{key}/keys` | web |
-| POST | `/api/coders/{key}/kill` | web |
+| POST | `/api/coders/{key}/keep-note` | ios, web |
+| POST | `/api/coders/{key}/keys` | ios, web |
+| POST | `/api/coders/{key}/kill` | ios, web |
 | GET | `/api/coders/{key}/peek` | ios, web |
 | POST | `/api/coders/{key}/steer` | ios, web |
 

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -662,6 +662,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -672,6 +673,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -692,6 +694,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -702,6 +705,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -712,6 +716,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -722,6 +727,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -732,6 +738,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -795,6 +802,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -805,6 +813,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -837,6 +846,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -847,6 +857,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },
@@ -857,6 +868,7 @@
       ],
       "module": "web.routes.system.coder_steering_routes",
       "consumers": [
+        "ios",
         "web"
       ]
     },

--- a/pm/roadmap/holdspeak-uat/README.md
+++ b/pm/roadmap/holdspeak-uat/README.md
@@ -1,0 +1,107 @@
+# HoldSpeak UAT — Roadmap
+
+**Last updated:** 2026-07-08 (project scaffolded; Phase 1 — The Mechanics — 0/6)
+**Current phase:** [Phase 1 — The Mechanics](./phase-1-the-mechanics/current-phase-status.md)
+**Status:** active
+
+## Vision
+
+Ninety-plus phases shipped features; almost every proof was an agent
+proving its own work. What the product has never had is a **forcing
+function for the human**: a rig that sits the owner down, walks them
+through the real product scenario by scenario, and captures what they
+actually saw — so the two of us (owner and agent) can look at the same
+record afterwards and decide what to fix, what to cut, and what was
+fine all along.
+
+This project builds that rig: the **conductor** (a standalone process
+that hosts HoldSpeak on this Mac — boots it with a chosen
+configuration, good or deliberately bad, seeds the desk, spawns mesh
+nodes, restarts it between scenarios) and the **guided UAT site** (a
+local website that runs the script: "do this, expect this", one
+verdict per step, notes and screenshots attached, everything landing
+in a run database). A run ends in a **debrief packet** the owner and
+the agent triage together; accepted findings feed
+`pm/roadmap/holdspeak/BACKLOG.md` with the run as the citation.
+
+Two principles anchor it:
+
+1. **The harness stands outside the product.** It must be able to
+   boot HoldSpeak broken, kill it, and boot it again differently — so
+   it can never live inside the process under test. It supersedes the
+   Phase-67 dogfood harness and absorbs its substrate (the isolated
+   `_home`, the mock repos, the `say`-rendered fixtures); the guided
+   site replaces the fillable `PROTOCOL.md` as how a human runs UAT.
+2. **Coverage is enumerated, not remembered.** The shipped surface is
+   derived from the record we already have — the 90-phase index and
+   git history — into a feature ledger every scenario cites, so a
+   debrief can honestly state what fraction of the product a sitting
+   touched and what has never been sat through.
+
+## Source canon
+
+Phase content must be grounded in these. If a phase disagrees with
+canon, canon wins.
+
+- `dogfood/PROTOCOL.md` + `dogfood/` — the Phase-67 substrate this
+  project absorbs (isolated HOME, fixtures, mock repos, `.43` wiring).
+- `docs/ARCHITECTURE.md` — the system map the scenarios exercise.
+- `docs/internal/POSITIONING.md` — the story the product must live up
+  to under a stranger's hands; scenario "expect" lines are written
+  against it.
+- `pm/roadmap/holdspeak/README.md` (phase index) — the coverage
+  ledger's source of truth for what shipped.
+- `CLAUDE.md` — the PMO gate every commit passes.
+
+## Phase index
+
+| Phase | Goal (one line) | Status | Folder |
+|---|---|---|---|
+| 1 | The Mechanics: the conductor (hosted runs, config decks, desk seeding, mesh nodes), the scenario contract + coverage ledger, the guided UAT site, the debrief + triage protocol, proven by one live smoke-pack sitting | in-progress (0/6) | [phase-1-the-mechanics](./phase-1-the-mechanics/) |
+
+(Status values: `planning`, `in-progress`, `done`, `paused`, `cancelled`.)
+
+Phase 2 (not yet scaffolded) is the first real coverage pack: scenario
+authorship across the whole feature ledger — dictation, meetings,
+desk, mesh, steering, the belt — sat through end to end.
+
+## Operating cadence
+
+Per `pm/roadmap/roadmap-builder.md` §3, every shipping commit updates,
+in the same commit:
+
+1. The story file header (status flip).
+2. The phase's `current-phase-status.md` story-status row + "Where we are".
+3. This README's "Last updated" line.
+4. Any project-canon doc touched by the story.
+
+Per `pm/roadmap/PMO-CONTRACT.md`: the pre-commit hook gates every
+commit on a fresh `.tmp/CONTRACT.md`.
+
+## Project metadata
+
+- **Slug:** `holdspeak-uat`
+- **Story ID prefix:** `HSU` (e.g. `HSU-1-01`)
+- **Code home:** `uat/` at the repo root (the conductor, decks,
+  scenarios, the site). Dev harness — never part of the published
+  `holdspeak` package.
+
+## Glossary
+
+- **Conductor** — the standalone harness process: hosts HoldSpeak as a
+  managed subprocess per run, applies decks, seeds the desk, serves
+  the guided site.
+- **Deck** — a named configuration permutation (good or deliberately
+  bad) written into the run's isolated HOME before boot.
+- **Seed manifest** — a declarative description of desk/context state
+  (notes, KB, recipes, meetings) injected before a scenario starts.
+- **Scenario** — a declarative script: deck + seeds + ordered steps,
+  each step an instruction, an expectation, and a verdict prompt.
+- **Pack** — a curated set of scenarios run as one sitting.
+- **Sitting** — one human UAT run of a pack, end to end, on real metal.
+- **Debrief packet** — the generated record of a sitting (verdicts,
+  notes, screenshots, coverage) that the owner and the agent triage
+  together.
+- **Feature ledger** — `uat/features.yaml`: the enumerated shipped
+  surface, derived from the holdspeak phase index; scenarios cite its
+  keys; debriefs compute coverage against it.

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/current-phase-status.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/current-phase-status.md
@@ -1,0 +1,103 @@
+# Phase 1 — The Mechanics
+
+**Last updated:** 2026-07-08 (scaffolded, 0/6)
+
+## Goal
+
+Build the UAT rig itself — the conductor that hosts HoldSpeak on this
+Mac under controlled conditions (isolated HOME per run, named config
+decks good and bad, desk seeding, mesh nodes), the scenario contract
+with an enumerated feature ledger, the guided website that walks a
+human through a pack and captures a verdict per step, and the debrief
++ triage protocol that turns a sitting into backlog-ready findings —
+proven by one real smoke-pack sitting run end to end by the owner.
+
+## Scope
+
+- **In:** the `uat/` harness (conductor process, run lifecycle, run
+  DB), config decks, seed manifests, mesh-node spawn/kill, the
+  scenario YAML contract + loader + validation, `uat/features.yaml`
+  (the coverage ledger derived from the holdspeak phase index), one
+  smoke pack (~6–8 scenarios incl. at least one deliberately-bad
+  deck), the React+Vite guided site, the debrief packet generator,
+  the joint triage protocol, harness docs, the live closing sitting.
+  Absorbing the dogfood substrate (isolated `_home` recipe, fixture
+  generators, mock repos, transcripts).
+- **Out:** full scenario coverage of the product (Phase 2); any change
+  to HoldSpeak product behavior (the harness drives the product
+  through its existing CLI/config/API surface only — a product bug
+  found here becomes a *finding*, not a fix in this phase); CI
+  automation of sittings (a sitting is human by definition);
+  packaging/publishing the harness.
+
+## Exit criteria
+
+- [ ] `uv run python -m uat.conductor` serves the guided site on a
+      pinned local port; a run boots an isolated HoldSpeak with a
+      chosen deck, health-checked, logs captured, torn down cleanly.
+- [ ] At least five decks exist including two deliberately bad ones,
+      and a scenario can assert the product *fails honestly* under
+      them.
+- [ ] A seed manifest materializes a described desk (notes, KB,
+      recipes, ≥1 imported meeting) before a scenario starts.
+- [ ] The scenario contract is validated by tests;
+      `uat/features.yaml` enumerates the shipped surface with every
+      holdspeak phase mapped; the smoke pack loads clean.
+- [ ] The guided site walks a pack step by step, captures
+      pass/fail/partial/skip + note + screenshot per step into the run
+      DB, and survives a mid-sitting product restart.
+- [ ] A finished sitting generates a debrief packet (markdown + JSON,
+      coverage % included); the triage protocol doc defines the joint
+      review and the BACKLOG feed format.
+- [ ] The closing sitting: the owner runs the smoke pack live on this
+      Mac end to end, the debrief is generated, and at least one
+      finding is triaged through the protocol.
+
+## Story status
+
+| ID | Story | Status | Story file | Evidence |
+|---|---|---|---|---|
+| HSU-1-01 | The conductor: hosted runs | backlog | [story-01](./story-01-the-conductor.md) | — |
+| HSU-1-02 | Decks, seeds, and the mesh | backlog | [story-02](./story-02-decks-and-seeding.md) | — |
+| HSU-1-03 | The scenario contract + the feature ledger | backlog | [story-03](./story-03-scenario-contract-and-coverage.md) | — |
+| HSU-1-04 | The guided site | backlog | [story-04](./story-04-the-guided-site.md) | — |
+| HSU-1-05 | The debrief + the triage protocol | backlog | [story-05](./story-05-the-debrief.md) | — |
+| HSU-1-06 | Docs + the first sitting | backlog | [story-06](./story-06-docs-and-first-sitting.md) | — |
+
+## Where we are
+
+Scaffolded 2026-07-08 from the owner's direct ask: a robust UAT
+harness that forces a real human sitting — a guided website with
+scenario scripts and per-step feedback capture, powerful enough to
+host the server, flip good/bad configurations, and seed the desk.
+Decisions locked at scaffold: standalone conductor (not an in-product
+route), absorb + supersede the Phase-67 dogfood harness, coverage
+enumerated from the git/phase record, mechanics + one smoke pack only
+(full coverage is Phase 2). Next: HSU-1-01.
+
+## Active risks
+
+| Risk | Likelihood | Mitigation | Stop signal |
+|---|---|---|---|
+| The conductor grows a second product (auth, users, deploy) instead of staying a dev rig | medium | Localhost-only, no auth, run DB is a local sqlite; scope "Out" list enforced at review | Any story adding harness features no scenario needs |
+| Seeding via product APIs couples the harness to route churn | medium | Seed through the same public routes the web UI uses; contract tests pin the few routes used | A product route rename silently breaking seeds with no failing harness test |
+| Bad decks bitrot as the config schema moves | medium | Decks are validated against `Config.load` round-trip in tests | A deck that no longer produces the failure its scenario asserts |
+| The human sitting never happens and the rig joins PROTOCOL.md on the shelf | medium | The closing story IS the sitting; the phase cannot close without it | Phase open >2 weeks with 5/6 done |
+
+## Decisions made
+
+| Date | Decision | Reason | Authority |
+|---|---|---|---|
+| 2026-07-08 | Standalone conductor process, never an in-product route | The harness must boot/kill/reboot the product under bad configs; it cannot live inside the process under test | owner + agent |
+| 2026-07-08 | Absorb and supersede dogfood (Phase 67) | One harness, no drift; the guided site replaces the fillable PROTOCOL.md | owner |
+| 2026-07-08 | Coverage ledger derived from the phase index + git history | "We have git" — the shipped surface is enumerated from the record, not from memory | owner |
+| 2026-07-08 | Phase 1 = mechanics + one smoke pack; full coverage is Phase 2 | Prove the rig on a thin vertical slice before authoring at scale | owner |
+| 2026-07-08 | Story prefix `HSU`, code home `uat/` | Consistent with HS/HSM siblings; harness never ships in the package | owner |
+
+## Decisions deferred
+
+| Decision | Trigger | Default |
+|---|---|---|
+| Whether dogfood's files physically move under `uat/` or are imported in place | HSU-1-01 implementation | Import/reuse in place; move only what the conductor must own |
+| Speak-to-fill mic on the site's note fields (needs a transcriber; the product under test may be down) | HSU-1-04 | Ship typed notes first; mic rides the host product's transcribe route when it is up, degrades honestly when not |
+| Whether a sitting can drive a remote mesh node on another machine | Phase 2 scenario needs | Phase 1 spawns local `mesh serve` processes only |

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-01-the-conductor.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-01-the-conductor.md
@@ -1,0 +1,84 @@
+# HSU-1-01 — The conductor: hosted runs
+
+- **Project:** holdspeak-uat
+- **Phase:** 1
+- **Status:** backlog
+- **Depends on:** none
+- **Owner:** unassigned
+
+## Problem
+
+Nothing today can hold HoldSpeak at arm's length: boot it with a
+chosen configuration, watch its health, capture its logs, kill it, and
+boot it again differently — all while an independent website stays up
+to guide the human. The dogfood harness (Phase 67) proved the
+substrate (isolated `_home`, `dogfood/setup.sh`, `dogfood/env.sh`) but
+it is shell scripts a human drives by hand. The conductor is that
+substrate turned into a process.
+
+## Scope
+
+- In:
+  - `uat/conductor/` — a small FastAPI app, launched with
+    `uv run python -m uat.conductor`, serving on a pinned local port
+    (default `8799`, `UAT_PORT` to override), localhost only.
+  - **Run lifecycle**: a *run* gets a fresh isolated HOME under
+    `uat/_runs/<run_id>/home/` (the dogfood `_home` recipe: config
+    dir, data dir, linked HF/model caches so nothing re-downloads),
+    boots `holdspeak web --no-open` as a managed subprocess with
+    `HOLDSPEAK_WEB_PORT` pinned (default `8788`) and `HOME` overridden,
+    polls a health route until up, and tears down (SIGTERM, then kill)
+    cleanly. Restart-with-a-different-deck is a first-class verb —
+    scenarios depend on it.
+  - **Run DB**: sqlite at `uat/_runs/uat.db` — runs, scenario
+    executions, step verdicts (schema lands here; verdict *writes*
+    land in HSU-1-04). `uat/_runs/` is gitignored.
+  - **Log capture**: the product's stdout/stderr per run to
+    `uat/_runs/<run_id>/logs/`, tail-able over the conductor's API
+    (a failing scenario's first question is "what did the server say").
+  - **Dogfood absorption, part 1**: the conductor reuses the dogfood
+    sandbox-building logic (setup, cache links) — imported or ported,
+    not duplicated. Physical file moves only where the conductor must
+    own the code.
+  - Conductor API: `POST /api/runs` (create + boot), `GET
+    /api/runs/{id}` (status/health), `POST /api/runs/{id}/restart`
+    (new deck), `DELETE /api/runs/{id}` (teardown), `GET
+    /api/runs/{id}/logs`.
+- Out: decks and seeding (HSU-1-02), scenarios (HSU-1-03), the site UI
+  (HSU-1-04), any change under `holdspeak/`.
+
+## Acceptance criteria
+
+- [ ] `uv run python -m uat.conductor` serves; `POST /api/runs` boots
+      an isolated HoldSpeak whose DB and config live under
+      `uat/_runs/<run_id>/home/`, never the real `~`.
+- [ ] Health is honest: a run reports `booting → up → down`, and a
+      product that fails to boot reports `failed` with the log tail —
+      never a hang.
+- [ ] Restart-with-teardown works: two boots in one run, second under
+      a different config file, no orphan processes (asserted by pid
+      checks in tests).
+- [ ] Product stdout/stderr captured per run and readable via the API.
+- [ ] The conductor never imports the `holdspeak` package into its own
+      process (subprocess boundary only) — enforced by a test grepping
+      `uat/conductor/` imports.
+- [ ] Unit/integration tests green under `uv run pytest -q tests/uat/`.
+
+## Test plan
+
+- Unit: run-ID/paths, HOME assembly, deck-file placement,
+  process-state machine (fake subprocess).
+- Integration: real `holdspeak web --no-open` boot on a free port,
+  health poll, teardown, restart (marked, skipped where the package
+  can't boot).
+- Manual / device: n/a — covered in HSU-1-06.
+
+## Notes / open questions
+
+- Port pair convention: conductor `8799`, product-under-test `8788` —
+  both distinct from the real hub's `8765` so a sitting can run beside
+  the owner's live desk.
+- The mesh hub auth token (`web_auth.py:ensure_web_token`) is per-HOME,
+  so the isolated run gets its own token for free; the conductor reads
+  it from the run HOME when it needs to call product APIs (seeding,
+  HSU-1-02).

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-02-decks-and-seeding.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-02-decks-and-seeding.md
@@ -1,0 +1,83 @@
+# HSU-1-02 — Decks, seeds, and the mesh
+
+- **Project:** holdspeak-uat
+- **Phase:** 1
+- **Status:** backlog
+- **Depends on:** HSU-1-01
+- **Owner:** unassigned
+
+## Problem
+
+A UAT scenario is only meaningful if it starts from a *described*
+world: a known configuration (sometimes deliberately broken — "does it
+fail honestly?" is half of trust) and a known desk (notes, KB,
+recipes, a meeting in history — not whatever was lying around). Today
+config permutation means hand-editing `config.json` and desk state
+means clicking. Both must become declarative inputs to a run.
+
+## Scope
+
+- In:
+  - **Decks** — named config permutations under `uat/decks/*.yaml`,
+    each a sparse overlay the conductor merges over defaults and
+    writes as the run HOME's `config.json` before boot
+    (`Config.load()` round-trip validated in tests so decks can't rot
+    silently). Ship at least five: `golden-local` (everything local,
+    the POSITIONING default), `golden-43` (intel on the
+    `192.168.1.43` llama.cpp, the dogfood tier-2 posture),
+    `bad-endpoint` (intel pointed at a dead port — features must
+    degrade honestly, never hang), `no-model` (no Whisper model
+    available — first-run/doctor surfaces must tell the truth), and
+    `mesh-node` (a runtime profile targeting a named mesh node the
+    conductor controls).
+  - **Seed manifests** — `uat/seeds/*.yaml` describing desk/context
+    state; the conductor applies one after boot **through the
+    product's own public routes** (the same `/api/desk/*` the web UI
+    calls: notes, KB, recipes; meetings via the transcript-import
+    route with dogfood's committed `.vtt`/`.txt` fixtures) so seeding
+    exercises real product surface and a seeded object is
+    indistinguishable from a user-made one. Auth via the run HOME's
+    own web token.
+  - **Mesh hands** — the conductor spawns/kills local
+    `holdspeak mesh serve` worker processes attached to a run (same
+    managed-subprocess machinery as HSU-1-01), so a scenario can stage
+    "the node is alive" and "the node just died" mid-sitting.
+  - Conductor API: `GET /api/decks`, `POST /api/runs/{id}/seed`,
+    `POST /api/runs/{id}/nodes` + `DELETE /api/runs/{id}/nodes/{name}`.
+  - **Dogfood absorption, part 2**: reuse the transcript/meeting
+    fixtures (and `make_fixtures.py` where audio is wanted); nothing
+    re-authored that dogfood already renders.
+- Out: scenario files referencing decks/seeds (HSU-1-03), UI
+  (HSU-1-04), remote-machine nodes (deferred, Phase 2), new fixture
+  *content* beyond what the smoke pack needs.
+
+## Acceptance criteria
+
+- [ ] Each shipped deck round-trips through `Config.load` in tests;
+      `bad-endpoint` and `no-model` boot a product that *runs* and
+      reports its condition (doctor/UI state), not a crash-loop.
+- [ ] A seed manifest materializes: ≥2 notes, ≥1 KB entry, ≥1 recipe,
+      ≥1 imported meeting — verified back through product `GET`
+      routes, not by poking the product DB directly.
+- [ ] Seeding a run twice is idempotent or refuses loudly (no silent
+      duplicate desks).
+- [ ] A run can spawn a named local mesh node, see it live from the
+      product side, kill it, and see the product report it offline.
+- [ ] Tests green under `uv run pytest -q tests/uat/`.
+
+## Test plan
+
+- Unit: deck overlay/merge, manifest parsing, idempotency keys.
+- Integration: boot `golden-local`, apply the smoke seed, read desk
+  state back via product routes; boot `bad-endpoint` and assert doctor
+  reports the dead intel endpoint (no `.43` needed — the bad deck
+  points at a local dead port).
+- Manual / device: mesh-node death observed live rides HSU-1-06.
+
+## Notes / open questions
+
+- Decks are *overlays*, not full configs — the product's defaults stay
+  the single source of truth and decks state only their delta.
+- Seeding through public routes is a deliberate coupling: if a route
+  rename breaks seeding, that is a real cross-surface break we want a
+  failing harness test to catch (risk table in the phase doc).

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-03-scenario-contract-and-coverage.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-03-scenario-contract-and-coverage.md
@@ -1,0 +1,83 @@
+# HSU-1-03 — The scenario contract + the feature ledger
+
+- **Project:** holdspeak-uat
+- **Phase:** 1
+- **Status:** backlog
+- **Depends on:** HSU-1-02
+- **Owner:** unassigned
+
+## Problem
+
+The scenario is the unit of UAT, and it needs a contract: what world
+to stage (deck + seeds + nodes), what to tell the human to do, what
+they should expect, and what verdict to collect. Just as important:
+scenarios must cite *which shipped feature they cover*, against an
+enumerated ledger of everything the 90 phases actually delivered — the
+owner's standing point: **we have git; coverage is derived from the
+record, not remembered.** Without the ledger, a green sitting proves
+only that we tested what we happened to think of.
+
+## Scope
+
+- In:
+  - **The scenario contract** — `uat/scenarios/<pack>/<nn>-<slug>.yaml`:
+    `id`, `title`, `features: [ledger keys]`, `deck`, `seeds`,
+    `nodes`, ordered `steps` (each: `do` — the instruction to the
+    human, `expect` — the honest pass bar, optional `where` — the
+    product route/surface to open), optional `mid_run` actions the
+    conductor performs between steps (restart with another deck, kill
+    a node — the HSU-1-01/02 verbs), and `teardown`. Loader +
+    validation with named, greppable errors.
+  - **The feature ledger** — `uat/features.yaml`: the shipped surface
+    enumerated as stable keys (e.g. `dictation.pipeline`,
+    `meetings.import.transcript`, `desk.steering.arm`,
+    `mesh.relay`, …), each entry naming the holdspeak phase(s) that
+    shipped it. Built by walking `pm/roadmap/holdspeak/README.md`'s
+    phase index (with git history as the tiebreaker for what survived
+    later phases), reviewed by hand — the derivation script
+    (`uat/tools/build_ledger.py`) proposes, the committed YAML is
+    canon. Retired features are marked `retired`, not deleted.
+  - **Coverage math** — given a pack (or a finished sitting), compute
+    features covered / total live features; exposed via the conductor
+    API for HSU-1-04/05 to render.
+  - **The smoke pack** — `uat/scenarios/smoke/`: 6–8 scenarios proving
+    the rig's whole vocabulary: a dictation-surface walk on
+    `golden-local`, a meeting round-trip on a seeded imported meeting,
+    a desk walk over seeded primitives, one `bad-endpoint` honest-
+    failure scenario, one `no-model` first-run-truth scenario, one
+    mesh-node scenario with a mid-run node kill.
+- Out: rendering (HSU-1-04), verdict storage semantics (HSU-1-04),
+  full-coverage pack authorship (Phase 2 — the ledger will make the
+  gap list explicit).
+
+## Acceptance criteria
+
+- [ ] The contract is schema-validated; a malformed scenario fails
+      load with a named error naming the file and field.
+- [ ] Every scenario must cite ≥1 ledger key that exists; an unknown
+      key fails validation.
+- [ ] `uat/features.yaml` exists with every holdspeak phase (0–90)
+      mapped to at least one ledger entry or an explicit
+      `internal/no-uat-surface` marker — no phase silently absent.
+- [ ] Coverage math is exact and tested (covered, uncovered, retired
+      excluded).
+- [ ] The smoke pack loads clean, cites real ledger keys, and
+      exercises: both golden decks' postures, both bad decks, seeding,
+      and one mid-run conductor action.
+- [ ] Tests green under `uv run pytest -q tests/uat/`.
+
+## Test plan
+
+- Unit: schema validation (positive + negative fixtures), ledger
+  integrity (keys unique, phases exhaustive), coverage math.
+- Integration: load the smoke pack end to end; dry-run a scenario's
+  staging (deck applied, seeds applied, nodes up) without a human.
+- Manual / device: the pack is *sat through* in HSU-1-06.
+
+## Notes / open questions
+
+- `expect` lines are written against POSITIONING canon voice: honest
+  pass bars ("the badge reads local", "doctor names the dead
+  endpoint"), never marketing.
+- The ledger doubles as the Phase-2 work generator: uncovered keys ARE
+  the scenario backlog.

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-04-the-guided-site.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-04-the-guided-site.md
@@ -1,0 +1,88 @@
+# HSU-1-04 — The guided site
+
+- **Project:** holdspeak-uat
+- **Phase:** 1
+- **Status:** backlog
+- **Depends on:** HSU-1-03
+- **Owner:** unassigned
+
+## Problem
+
+The whole point of this project is to force the human sitting — and a
+fillable markdown file does not force anything (Phase 67's
+`PROTOCOL.md` proved that by sitting on the shelf). The guided site is
+the front door: pick a pack, the rig stages the world, and the site
+walks you step by step — do this, expect this, verdict, next — until
+the sitting is done and the record exists.
+
+## Scope
+
+- In:
+  - **A React + Vite app** under `uat/web/`, built to static assets
+    the conductor serves (per the standing web-stack direction; no
+    Alpine, no Astro islands needed — this is one SPA). Signal-grade
+    visual bar: the desk's tokens reused, real affordances, overflow
+    checked — a test rig the owner *wants* to sit in, not a gray
+    checklist.
+  - **Home** — packs with coverage %, past sittings with scores, a
+    Resume affordance for an interrupted sitting.
+  - **Sitting setup** — pick pack (+ optional deck override), watch
+    the rig stage the world honestly: boot progress, deck applied,
+    seeds verified, nodes up; a staging failure is shown with the log
+    tail, never hidden.
+  - **The walkthrough** — one step at a time: the `do` instruction,
+    the `expect` bar, an "Open the product" affordance (the run's
+    product URL, deep-linked to `where` when the scenario names it),
+    the four verdict verbs (pass / fail / partial / skip), a note
+    field, screenshot attach (file drop; stored under
+    `uat/_runs/<run_id>/shots/`), elapsed time per step. Mid-run
+    conductor actions (restart, node kill) execute visibly between
+    steps with their own status line.
+  - **Verdict persistence** — every verdict written to the run DB the
+    moment it is cast (HSU-1-01 schema); a browser refresh or a
+    product crash mid-sitting loses nothing; the sitting resumes at
+    the first unanswered step.
+  - **Sitting end** — the score, straight into the debrief (HSU-1-05).
+  - Speak-to-fill mic on the note field **when the product under test
+    is up** (riding its transcribe route), honestly absent when it is
+    not (the deferred-decision default from the phase doc).
+- Out: the debrief packet content (HSU-1-05), scenario authoring UI
+  (YAML is the authoring surface; Phase 2 may revisit), multi-user
+  anything.
+
+## Acceptance criteria
+
+- [ ] `uat/web/` builds; the conductor serves it; the full loop —
+      home → setup → staged world → walkthrough → sitting end — works
+      against a real staged run.
+- [ ] Verdicts + notes + screenshots persist per step; killing the
+      browser mid-sitting and reopening resumes at the right step with
+      all prior verdicts intact.
+- [ ] A staging failure (bad deck that cannot even boot) renders
+      honestly with the log tail and offers retry/abort — never a
+      spinner.
+- [ ] A mid-run action (`bad-endpoint` restart, node kill) is visible
+      in the walkthrough as it happens.
+- [ ] The visual bar holds: no overflow at laptop widths, real
+      hover/active/disabled states, dark-first; screenshots committed
+      as evidence.
+- [ ] Component/store tests green (`npm test` in `uat/web/`); the
+      conductor's site-serving + verdict routes green under
+      `uv run pytest -q tests/uat/`.
+
+## Test plan
+
+- Unit: walkthrough store (step advance, resume math, verdict
+  casting), staging-status rendering.
+- Integration: Playwright against a real conductor + staged
+  `golden-local` run — cast all four verdict verbs, attach a
+  screenshot, refresh mid-sitting, resume.
+- Manual / device: the owner's smoke sitting in HSU-1-06.
+
+## Notes / open questions
+
+- The site talks only to the conductor; the conductor talks to the
+  product. One trust boundary, and the site keeps working while the
+  product is being deliberately broken.
+- "No prose in the UI" applies to the chrome (labels state WHAT);
+  scenario `do`/`expect` text is content, not chrome.

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-05-the-debrief.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-05-the-debrief.md
@@ -1,0 +1,85 @@
+# HSU-1-05 — The debrief + the triage protocol
+
+- **Project:** holdspeak-uat
+- **Phase:** 1
+- **Status:** backlog
+- **Depends on:** HSU-1-04
+- **Owner:** unassigned
+
+## Problem
+
+A pile of verdicts is not the deliverable — the *joint review* is: the
+owner and the agent looking at the same record and deciding, finding
+by finding, fix / won't-fix / by-design. That needs two things the
+verdicts alone don't give: a debrief packet shaped for both readers
+(markdown for the human, JSON for the agent), and a written protocol
+for the ritual so it happens the same way every sitting and its output
+lands somewhere durable.
+
+## Scope
+
+- In:
+  - **The debrief packet** — generated at sitting end into
+    `uat/_runs/<run_id>/debrief/`: `debrief.md` (the sitting header —
+    date, pack, deck(s), machine, product version/commit; the score;
+    coverage % against the ledger; every non-pass verdict with its
+    step, note, screenshot link, and the product log slice around the
+    step's time window; the pass list collapsed) and `debrief.json`
+    (the same, machine-shaped, stable schema). The log-slice
+    correlation is the agent's head start: a FAIL arrives with the
+    server's own words attached.
+  - **Findings** — each non-pass verdict becomes a finding with a
+    stable ID (`UAT-<run>-<n>`), a triage state
+    (`untriaged | fix | wont-fix | by-design | duplicate`), and a
+    disposition note. Triage states are written back to the run DB
+    (via conductor API — the site's sitting-end screen and the agent
+    can both set them).
+  - **The triage protocol** — `uat/TRIAGE.md`: the ritual. (1) The
+    human finishes the sitting. (2) The agent reads `debrief.json` +
+    the log slices and annotates each finding with a first-pass
+    hypothesis. (3) Owner + agent walk the findings together and set
+    dispositions. (4) Every `fix` is appended to
+    `pm/roadmap/holdspeak/BACKLOG.md` in that file's existing
+    candidate format, citing the finding ID and the debrief path —
+    the harness *proposes* the append (a generated block to paste or
+    apply), the commit rides the normal PMO gate.
+  - Conductor API: `POST /api/runs/{id}/debrief` (generate),
+    `GET /api/runs/{id}/debrief`, `PATCH /api/findings/{id}` (triage),
+    `GET /api/runs/{id}/findings/backlog-block` (the BACKLOG-ready
+    text).
+- Out: auto-filing GitHub issues (the product's actuator flow exists
+  for that; a UAT finding feeds BACKLOG, and BACKLOG feeds phases);
+  any automatic edit to `pm/roadmap/holdspeak/BACKLOG.md` (human-held
+  paste/apply, gate-committed); trend dashboards across sittings
+  (Phase 2 candidate).
+
+## Acceptance criteria
+
+- [ ] A finished sitting generates both packet files; `debrief.md`
+      opens readable with every non-pass finding carrying note +
+      screenshot link + a correctly-windowed product log slice.
+- [ ] `debrief.json` is schema-stable and tested (the agent-side
+      contract).
+- [ ] Coverage % in the packet matches HSU-1-03's math exactly.
+- [ ] Findings triage round-trips: set `fix` via the API, regenerate,
+      the disposition survives.
+- [ ] The backlog block renders in `BACKLOG.md`'s real candidate
+      format and cites finding ID + debrief path.
+- [ ] `uat/TRIAGE.md` states the four-step ritual and the disposition
+      vocabulary; tests green under `uv run pytest -q tests/uat/`.
+
+## Test plan
+
+- Unit: packet assembly from a fixture run DB (all verdict verbs
+  represented), log-window slicing, backlog-block formatting.
+- Integration: full loop — staged run, scripted verdicts via the
+  conductor API, generate, triage, regenerate.
+- Manual / device: the real triage of the first sitting is HSU-1-06's
+  closing beat.
+
+## Notes / open questions
+
+- Debrief packets live under gitignored `uat/_runs/`; a triaged
+  sitting worth keeping gets its packet copied into the relevant
+  roadmap evidence dir when a finding ships — the debrief cites, the
+  evidence file proves.

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-06-docs-and-first-sitting.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-06-docs-and-first-sitting.md
@@ -1,0 +1,78 @@
+# HSU-1-06 — Docs + the first sitting
+
+- **Project:** holdspeak-uat
+- **Phase:** 1
+- **Status:** backlog
+- **Depends on:** HSU-1-05
+- **Owner:** unassigned
+
+## Problem
+
+The rig is only real once a human has sat through it — the exact
+failure mode this project exists to prevent is a beautiful harness
+nobody runs (Phase 67's `PROTOCOL.md`). This story writes the docs
+that make the rig operable without this conversation in context, then
+closes the phase the only honest way: the owner runs the smoke pack
+live on this Mac, end to end, and the first findings get triaged
+through the real protocol.
+
+## Scope
+
+- In:
+  - **`uat/README.md`** — the operator doc: one-command start
+    (`uv run python -m uat.conductor`), the port map (conductor 8799 /
+    product-under-test 8788 / real hub 8765 untouched), how a sitting
+    flows, where runs/debriefs land, prerequisites per deck (which
+    need `.43`, which are fully local).
+  - **`uat/AUTHORING.md`** — how to add a scenario, a deck, a seed
+    manifest; the ledger-key rule; the honest-`expect` voice rule;
+    how to run contract validation.
+  - **Dogfood supersession** — `dogfood/PROTOCOL.md` gains a header
+    pointing here as the way UAT is now run; dogfood assets the
+    conductor reuses stay put and documented; anything the absorption
+    made dead is deleted, not left to rot.
+  - **The first sitting** — the owner runs the smoke pack live:
+    staging on `golden-43`, the walkthrough on real surfaces, the
+    `bad-endpoint` and `no-model` scenarios failing honestly, the
+    mid-run node kill observed, the debrief generated, and the joint
+    triage held — at least one finding dispositioned, and any `fix`
+    landed in `pm/roadmap/holdspeak/BACKLOG.md` through the gate.
+  - Evidence: the sitting's debrief packet + walkthrough screenshots
+    copied into this phase's evidence assets.
+- Out: fixing any product bug the sitting finds (findings feed
+  BACKLOG; fixes are holdspeak phases), Phase-2 scaffolding (the
+  ledger's uncovered keys are its input, recorded in the final
+  summary).
+
+## Acceptance criteria
+
+- [ ] Both docs exist and are sufficient: a cold reader can start the
+      conductor, run a sitting, and author a scenario without reading
+      harness source.
+- [ ] `dogfood/PROTOCOL.md` points here; no dead absorbed files
+      remain.
+- [ ] The sitting happened on real metal: a completed smoke-pack run
+      in the run DB with a generated debrief, every scenario visited,
+      real verdicts (a sitting of ten PASSes cast in ten seconds is
+      not a sitting — timestamps are part of the evidence).
+- [ ] The triage ritual was held per `uat/TRIAGE.md`; ≥1 finding
+      dispositioned; any `fix` visible in
+      `pm/roadmap/holdspeak/BACKLOG.md`.
+- [ ] Phase exit criteria in `current-phase-status.md` all check;
+      final summary written with the Phase-2 handoff (uncovered ledger
+      keys as the scenario backlog).
+
+## Test plan
+
+- Unit: n/a — docs + the live proof.
+- Integration: full suite green
+  (`uv run pytest -q` excluding `tests/e2e/test_metal.py`).
+- Manual / device: the sitting itself — owner-gated, on this Mac, with
+  `.43` up for the `golden-43` deck.
+
+## Notes / open questions
+
+- The sitting is the phase's closing gate and cannot be delegated to
+  an agent or a simulator — that is the point of the project.
+- Keep the smoke sitting short (~30–40 min) so it actually happens;
+  depth belongs to Phase 2's coverage pack.


### PR DESCRIPTION
## What

A new roadmap project, `pm/roadmap/holdspeak-uat/`, from the owner's direct ask: a robust UAT rig that forces a real **human** sitting — a guided local website that walks the scenario script step by step and captures a verdict per step, powerful enough to host HoldSpeak on this Mac, flip good/bad configurations, seed the desk, and stage mesh nodes. A sitting ends in a debrief packet the owner and the agent triage together; accepted findings feed `pm/roadmap/holdspeak/BACKLOG.md`.

## Phase 1 — The Mechanics (HSU-1-01…06, all backlog)

1. **The conductor** — standalone process hosting isolated HoldSpeak runs (per-run HOME, pinned ports, health, logs, restart-with-a-different-config as a first-class verb).
2. **Decks, seeds, and the mesh** — named config permutations incl. deliberately-bad ones (`bad-endpoint`, `no-model`), declarative desk seeding through the product's own routes, local `mesh serve` node spawn/kill.
3. **The scenario contract + the feature ledger** — schema'd scenario YAML; `uat/features.yaml` enumerating the shipped surface from the 90-phase record ("we have git" — coverage is derived, not remembered); the smoke pack.
4. **The guided site** — React+Vite walkthrough: do this / expect this / verdict (pass·fail·partial·skip) + note + screenshot, crash-safe resume, Signal-grade bar.
5. **The debrief + triage protocol** — markdown+JSON packet with per-finding product-log slices; the four-step joint-review ritual; BACKLOG-ready finding blocks.
6. **Docs + the first sitting** — operator + authoring docs, dogfood supersession, and the phase closes only when the owner has sat through the smoke pack live.

Decisions locked at scaffold (recorded in `current-phase-status.md`): standalone conductor (never an in-product route), absorb + supersede the Phase-67 dogfood harness, mechanics + one smoke pack only (full coverage = Phase 2), prefix `HSU`, code home `uat/`.

## Verification

Roadmap-only commit, no story flips. `.githooks/dw check holdspeak-uat` → ok; `.githooks/dw next holdspeak-uat` → HSU-1-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ