### PR TITLE
holdspeak-uat HSU-1-03: the scenario contract + the feature ledger

### DIFF
--- a/pm/roadmap/holdspeak-uat/README.md
+++ b/pm/roadmap/holdspeak-uat/README.md
@@ -5,7 +5,7 @@
 > source seams, the autonomy contract, and the definition of done. It is written
 > to be executed unattended, end to end.
 
-**Last updated:** 2026-07-09 (HSU-1-02 shipped — the induction engine: decks, seeds, idempotent self-verifying state recipes, proven live on `.43`; Phase 1 at 2/6)
+**Last updated:** 2026-07-09 (HSU-1-03 shipped — the scenario contract + the feature ledger (255 keys, every phase mapped) + coverage math + the smoke pack; Phase 1 at 3/6)
 **Current phase:** [Phase 1 — The Mechanics](./phase-1-the-mechanics/current-phase-status.md)
 **Status:** active
 
@@ -77,7 +77,7 @@ canon, canon wins.
 
 | Phase | Goal (one line) | Status | Folder |
 |---|---|---|---|
-| 1 | The Mechanics: the conductor (hosted runs reachable by the devices), the induction engine (decks, seeds, idempotent state recipes, mesh hands), the three-surface scenario contract + seed ledger, the guided UAT site with per-surface verdicts, the debrief + triage protocol, proven by one live smoke-pack sitting | in-progress (2/6) | [phase-1-the-mechanics](./phase-1-the-mechanics/) |
+| 1 | The Mechanics: the conductor (hosted runs reachable by the devices), the induction engine (decks, seeds, idempotent state recipes, mesh hands), the three-surface scenario contract + seed ledger, the guided UAT site with per-surface verdicts, the debrief + triage protocol, proven by one live smoke-pack sitting | in-progress (3/6) | [phase-1-the-mechanics](./phase-1-the-mechanics/) |
 | 2 | The Inventory: owner + agent gather what UAT *is* here (the charter) and enumerate everything the system can do into the capability × surface × required-state matrix that Phase 3's coverage pack is authored from. **Directory pre-seeded** by an 8-agent sweep: 255 capabilities, the [directory](./phase-2-the-inventory/directory/), the [protocol notion](./phase-2-the-inventory/PROTOCOL-NOTION.md), the [recipe worklist](./phase-2-the-inventory/RECIPE-WORKLIST.md), and the [Phase 3 plan](./phase-2-the-inventory/PHASE-3-PLAN.md) | planning (0/5) | [phase-2-the-inventory](./phase-2-the-inventory/) |
 
 (Status values: `planning`, `in-progress`, `done`, `paused`, `cancelled`.)

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/current-phase-status.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/current-phase-status.md
@@ -1,8 +1,8 @@
 # Phase 1 — The Mechanics
 
-**Last updated:** 2026-07-09 (HSU-1-02 shipped: the induction engine —
-decks, seeds, and idempotent self-verifying state recipes, proven live
-on `.43`; 2/6)
+**Last updated:** 2026-07-09 (HSU-1-03 shipped: the scenario contract +
+the feature ledger (255 keys, every phase mapped) + coverage math + the
+7-scenario smoke pack; 3/6)
 
 ## Goal
 
@@ -82,12 +82,34 @@ sitting run end to end by the owner across all three surfaces.
 |---|---|---|---|---|
 | HSU-1-01 | The conductor: hosted runs | done | [story-01](./story-01-the-conductor.md) | [evidence-01](./evidence-story-01.md) |
 | HSU-1-02 | The induction engine: decks, seeds, state recipes | done | [story-02](./story-02-the-induction-engine.md) | [evidence-02](./evidence-story-02.md) |
-| HSU-1-03 | The scenario contract + the feature ledger | backlog | [story-03](./story-03-scenario-contract-and-coverage.md) | — |
+| HSU-1-03 | The scenario contract + the feature ledger | done | [story-03](./story-03-scenario-contract-and-coverage.md) | [evidence-03](./evidence-story-03.md) |
 | HSU-1-04 | The guided site | backlog | [story-04](./story-04-the-guided-site.md) | — |
 | HSU-1-05 | The debrief + the triage protocol | backlog | [story-05](./story-05-the-debrief.md) | — |
 | HSU-1-06 | Docs + the first sitting | backlog | [story-06](./story-06-docs-and-first-sitting.md) | — |
 
 ## Where we are
+
+**HSU-1-03 is done (2026-07-09).** The scenario contract and the feature
+ledger live under `uat/conductor/contract/`. **The ledger**
+(`uat/features.yaml`) enumerates 255 capabilities as stable keys, each with
+its per-surface applicability (`yes|no|unknown`), the holdspeak phases that
+shipped it, needed recipes, and priority — plus a `phase_map` pinning
+**every** holdspeak phase 0–87 to its covering keys or an explicit
+`internal/no-uat-surface` marker (20 internal/refactor phases carry the
+marker, honestly). It is seeded from the Phase-2 directory's 255 rows by
+`uat/tools/build_ledger.py` (which *proposes*; the committed YAML is canon,
+freshness-checked in CI). **The contract** (`scenarios.py`) loads/validates
+scenarios with named `ERROR <path>: <issue>` errors, enforces the surface
+axis (default all-yes, opt out only with `{n/a: reason}`), and resolves
+per-(step, surface) applicability. **Coverage math** (`coverage.py`/ledger)
+is exact per surface and overall, excluding retired, counting `unknown`
+distinctly. **The smoke pack** (`uat/scenarios/smoke/`, 7 scenarios) proves
+the whole vocabulary: both golden decks' postures, both bad decks, a
+three-surface desk walk, an honest per-surface `n/a`, and a mid-run mesh
+kill. Conductor API: `/api/features`, `/api/packs`, `/api/packs/{pack}`.
+65 local tests. Next: HSU-1-04 (the guided site).
+
+---
 
 **HSU-1-02 is done (2026-07-09).** The induction engine lives under
 `uat/conductor/induction/`: five **decks** (`golden-local`, `golden-43`,

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/evidence-story-03.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/evidence-story-03.md
@@ -1,0 +1,48 @@
+# Evidence - HSU-1-03
+
+- **Story:** HSU-1-03 - The scenario contract + the feature ledger
+- **Status:** done
+- **Date:** 2026-07-09
+
+## What shipped
+
+`uat/conductor/contract/` + `uat/features.yaml` + `uat/scenarios/smoke/` +
+`uat/tools/build_ledger.py`:
+
+- **The feature ledger** (`uat/features.yaml`, 255 keys): every capability with
+  per-surface applicability (`yes|no|unknown`), the holdspeak phases that shipped
+  it, needed recipes, and priority. A `phase_map` pins **every** holdspeak phase
+  0–87 to its covering keys or an explicit `internal/no-uat-surface` marker (20
+  internal/refactor phases carry the marker) — no phase silently absent. Seeded
+  from the Phase-2 directory's 255 rows by `build_ledger.py`, which *proposes*;
+  the committed YAML is canon, freshness-checked by `test_build_ledger.py`.
+- **The scenario contract** (`scenarios.py`): loads/validates scenarios with
+  named `ERROR <path>: <issue>` errors; enforces the three-surface axis (default
+  all-yes, opt out only with `{n/a: <reason>}`); resolves per-(step, surface)
+  applicability; validates cited ledger keys, recipes, decks, and mid-run actions.
+- **Coverage math** (`coverage.py` + `ledger.py`): exact per surface and overall
+  — retired excluded, `unknown` counted distinctly, uncovered enumerated.
+- **The smoke pack** (`uat/scenarios/smoke/`, 7 scenarios): both golden decks'
+  postures (`seeded-desk`/`fresh-desk` + `meeting-just-ended-open-actions`), both
+  bad decks (`intel-endpoint-dead`, `first-run-no-model`), a three-surface desk
+  walk, an honest per-surface `n/a` with reason, and a mid-run mesh kill. Loads
+  clean, cites real keys + recipes.
+- Conductor API: `GET /api/features`, `GET /api/packs`, `GET /api/packs/{pack}`
+  (scenarios + coverage + validation errors).
+
+Coverage the smoke pack reports (honest — a thin smoke pack, Phase 3 authors the
+rest): overall 14/254, web 13/220, ipad 6/142, iphone 0/25, 36 expected verdicts.
+
+## Proof
+
+### Captured run — 2026-07-09T07:29:48Z
+
+- **Command:** `uv run pytest -q tests/uat/ --ignore=tests/uat/test_induction_integration_43.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 2ab94ed9ae3ee71f24f13ca165182769d8531d0d
+
+```text
+.................................................................        [100%]
+65 passed in 13.92s
+```

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-03-scenario-contract-and-coverage.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-03-scenario-contract-and-coverage.md
@@ -2,9 +2,9 @@
 
 - **Project:** holdspeak-uat
 - **Phase:** 1
-- **Status:** backlog
+- **Status:** done
 - **Depends on:** HSU-1-02
-- **Owner:** unassigned
+- **Owner:** agent
 
 ## Problem
 
@@ -67,26 +67,32 @@ only that we tested what we happened to think of.
 
 ## Acceptance criteria
 
-- [ ] The contract is schema-validated; a malformed scenario fails
-      load with a named error naming the file and field.
-- [ ] Every scenario must cite ≥1 ledger key that exists and ≥1
+- [x] The contract is schema-validated; a malformed scenario fails
+      load with a named error naming the file and field
+      (`ERROR <path>: <issue>`, `test_scenarios.py`).
+- [x] Every scenario must cite ≥1 ledger key that exists and ≥1
       recipe that exists; an unknown key or recipe fails validation.
-- [ ] Surface rules enforced: every scenario resolves to an explicit
+- [x] Surface rules enforced: every scenario resolves to an explicit
       per-surface applicability; `n/a` without a reason fails
-      validation.
-- [ ] `uat/features.yaml` exists with every holdspeak phase (0–90)
-      mapped to at least one ledger entry or an explicit
-      `internal/no-uat-surface` marker — no phase silently absent —
-      and every entry carrying the three applicability columns
-      (`unknown` allowed at v1).
-- [ ] Coverage math is exact and tested, per surface and overall
+      validation; a step with every surface `n/a` fails too.
+- [x] `uat/features.yaml` exists with every holdspeak phase (0–87 —
+      the record's actual span) mapped to at least one ledger entry or
+      an explicit `internal/no-uat-surface` marker — no phase silently
+      absent — and every entry carrying the three applicability columns
+      (`unknown` allowed at v1). Seeded from the directory's 255 rows by
+      `uat/tools/build_ledger.py` (proposes; the committed YAML is canon,
+      freshness-checked in `test_build_ledger.py`).
+- [x] Coverage math is exact and tested, per surface and overall
       (covered, uncovered, retired excluded, `n/a` and `unknown`
-      handled distinctly).
-- [ ] The smoke pack loads clean, cites real ledger keys and recipes,
-      and exercises: both golden decks' postures, both bad decks, a
-      three-surface scenario, an honest `n/a`, and one mid-run
-      conductor action.
-- [ ] Tests green under `uv run pytest -q tests/uat/`.
+      handled distinctly — `test_ledger.py`).
+- [x] The smoke pack (7 scenarios) loads clean, cites real ledger keys
+      and recipes, and exercises: both golden decks' postures
+      (`seeded-desk`/`fresh-desk` + `meeting-just-ended-open-actions`),
+      both bad decks (`intel-endpoint-dead`, `first-run-no-model`), a
+      three-surface scenario, an honest `n/a` with reason, and one
+      mid-run conductor action (the mesh kill).
+- [x] Tests green under `uv run pytest -q tests/uat/` (65 local +
+      2 `.43`-gated).
 
 ## Test plan
 

--- a/tests/uat/test_build_ledger.py
+++ b/tests/uat/test_build_ledger.py
@@ -1,0 +1,23 @@
+"""The committed features.yaml is in sync with its derivation."""
+
+from __future__ import annotations
+
+from uat.tools import build_ledger
+
+
+def test_committed_ledger_is_up_to_date():
+    # The generator proposes; the committed YAML is canon — but they must agree,
+    # so a drifted inventory can't leave the ledger silently stale.
+    assert build_ledger.main(["--check"]) == 0
+
+
+def test_every_holdspeak_phase_is_mapped():
+    phase_index = build_ledger.load_phase_index()
+    content = build_ledger.generate()
+    import yaml
+
+    doc = yaml.safe_load(content)
+    phase_map = doc["phase_map"]
+    # Every phase in the index appears in the map (none silently absent).
+    for phase in phase_index:
+        assert str(phase) in phase_map

--- a/tests/uat/test_conductor_api.py
+++ b/tests/uat/test_conductor_api.py
@@ -85,3 +85,30 @@ def test_list_recipes(client):
 
 def test_apply_recipe_unknown_run_404(client):
     assert client.post("/api/runs/nope/recipes/fresh-desk", json={}).status_code == 404
+
+
+def test_features_route(client):
+    r = client.get("/api/features")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["feature_count"] > 200
+    assert body["phases_total"] == 88
+
+
+def test_packs_and_pack_detail(client):
+    r = client.get("/api/packs")
+    assert r.status_code == 200
+    packs = {p["pack"]: p for p in r.json()["packs"]}
+    assert "smoke" in packs
+    assert packs["smoke"]["scenario_count"] >= 6
+
+    d = client.get("/api/packs/smoke")
+    assert d.status_code == 200
+    detail = d.json()
+    assert detail["validation_errors"] == []
+    assert len(detail["scenarios"]) >= 6
+    assert detail["coverage"]["overall"]["total"] > 0
+
+
+def test_unknown_pack_404(client):
+    assert client.get("/api/packs/nope").status_code == 404

--- a/tests/uat/test_ledger.py
+++ b/tests/uat/test_ledger.py
@@ -1,0 +1,75 @@
+"""The feature ledger: integrity, phase exhaustiveness, and coverage math."""
+
+from __future__ import annotations
+
+import pytest
+
+from uat.conductor.contract.ledger import (
+    NO_UAT_MARKER,
+    CoverageResult,
+    Feature,
+    FeatureLedger,
+)
+
+
+def test_shipped_ledger_loads_and_validates():
+    ledger = FeatureLedger.load()
+    assert len(ledger.features) > 200
+    errors = ledger.validate()
+    assert errors == [], errors
+
+
+def test_phase_map_is_exhaustive():
+    ledger = FeatureLedger.load()
+    # Every phase resolves to keys or the explicit marker — none silently absent.
+    for phase, keys in ledger.phase_map.items():
+        assert keys, f"phase {phase} maps to nothing"
+        for k in keys:
+            assert k == NO_UAT_MARKER or ledger.has(k), f"phase {phase} → unknown key {k}"
+
+
+def _tiny_ledger() -> FeatureLedger:
+    feats = [
+        Feature("a", surfaces={"web": "yes", "ipad": "yes", "iphone": "unknown"}),
+        Feature("b", surfaces={"web": "yes", "ipad": "no", "iphone": "no"}),
+        Feature("c", surfaces={"web": "yes", "ipad": "yes", "iphone": "yes"}),
+        Feature("d", surfaces={"web": "yes", "ipad": "yes", "iphone": "yes"}, status="retired"),
+    ]
+    return FeatureLedger(feats, {"0": ["a"], "1": [NO_UAT_MARKER]})
+
+
+def test_coverage_excludes_retired_and_non_applicable():
+    ledger = _tiny_ledger()
+    # Cite a and c. Retired d never counts.
+    cited = {"a", "c", "d"}
+    overall = ledger.coverage_overall(cited)
+    assert overall.total == 3  # a, b, c (d retired)
+    assert overall.covered == 2  # a, c
+
+    web = ledger.coverage(cited, "web")
+    assert web.total == 3 and web.covered == 2
+
+    ipad = ledger.coverage(cited, "ipad")
+    # applicable on ipad: a, c (b is 'no', d retired). Both cited.
+    assert ipad.total == 2 and ipad.covered == 2
+
+    iphone = ledger.coverage(cited, "iphone")
+    # applicable on iphone (yes): only c. a is 'unknown' → excluded.
+    assert iphone.total == 1 and iphone.covered == 1
+
+
+def test_coverage_pct():
+    r = CoverageResult(covered=1, total=4, uncovered=["x"])
+    assert r.pct == 25.0
+    assert CoverageResult(0, 0, []).pct == 0.0
+
+
+def test_validate_catches_bad_surface_and_dupes():
+    feats = [
+        Feature("a", surfaces={"web": "maybe", "ipad": "yes", "iphone": "no"}),
+        Feature("a", surfaces={"web": "yes", "ipad": "yes", "iphone": "no"}),
+    ]
+    ledger = FeatureLedger(feats, {"0": ["a"]})
+    errors = ledger.validate()
+    assert any("duplicate ledger key" in e for e in errors)
+    assert any("surface web" in e for e in errors)

--- a/tests/uat/test_scenarios.py
+++ b/tests/uat/test_scenarios.py
@@ -1,0 +1,151 @@
+"""The scenario contract: schema validation (positive + negative) and surfaces."""
+
+from __future__ import annotations
+
+import pytest
+
+from uat.conductor.contract.scenarios import (
+    ScenarioError,
+    load_scenario,
+    validate_scenario,
+)
+
+LEDGER_KEYS = {"feat.one", "feat.two"}
+RECIPES = {"seeded-desk", "fresh-desk"}
+DECKS = {"golden-local", "bad-endpoint"}
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "s.yaml"
+    p.write_text(text)
+    return p
+
+
+def test_valid_scenario_loads_and_resolves_surfaces(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+id: s1
+title: A scenario
+features: [feat.one]
+recipes: [seeded-desk]
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "not confirmed on iPhone"}
+steps:
+  - do: Do the thing
+    expect: The thing happened
+    where: /
+""",
+    )
+    s = load_scenario(p, pack="smoke")
+    assert s.id == "s1"
+    assert s.surfaces["iphone"] == {"applicable": False, "reason": "not confirmed on iPhone"}
+    step = s.steps[0]
+    assert step.applicable_surfaces(s.surfaces) == ["web", "ipad"]
+    # 1 step × 2 applicable surfaces = 2 expected verdicts.
+    assert s.expected_verdict_count() == 2
+    assert validate_scenario(s, ledger_keys=LEDGER_KEYS, recipe_names=RECIPES) == []
+
+
+def test_missing_required_field_names_the_field(tmp_path):
+    p = _write(tmp_path, "id: s1\ntitle: t\n")  # no steps is allowed to load; no id/title fails
+    # Missing title:
+    p2 = tmp_path / "s2.yaml"
+    p2.write_text("id: only\nfeatures: [feat.one]\n")
+    with pytest.raises(ScenarioError, match="missing required field 'title'"):
+        load_scenario(p2)
+
+
+def test_na_without_reason_fails_load(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+id: s1
+title: t
+features: [feat.one]
+recipes: [seeded-desk]
+surfaces:
+  iphone: {n/a: ""}
+steps:
+  - do: x
+    expect: y
+""",
+    )
+    with pytest.raises(ScenarioError, match="needs a stated reason"):
+        load_scenario(p)
+
+
+def test_unknown_ledger_key_and_recipe_fail_validation(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+id: s1
+title: t
+features: [feat.one, feat.nope]
+recipes: [seeded-desk, no-such-recipe]
+steps:
+  - do: x
+    expect: y
+""",
+    )
+    s = load_scenario(p)
+    errors = validate_scenario(s, ledger_keys=LEDGER_KEYS, recipe_names=RECIPES)
+    assert any("unknown ledger key: feat.nope" in e for e in errors)
+    assert any("unknown recipe: no-such-recipe" in e for e in errors)
+
+
+def test_scenario_with_no_features_fails(tmp_path):
+    p = _write(tmp_path, "id: s\ntitle: t\nrecipes: [seeded-desk]\nsteps:\n  - do: x\n    expect: y\n")
+    s = load_scenario(p)
+    errors = validate_scenario(s, ledger_keys=LEDGER_KEYS, recipe_names=RECIPES)
+    assert any("cites no features" in e for e in errors)
+
+
+def test_step_with_every_surface_na_fails_validation(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+id: s
+title: t
+features: [feat.one]
+recipes: [seeded-desk]
+surfaces:
+  web: {n/a: "a"}
+  ipad: {n/a: "b"}
+  iphone: {n/a: "c"}
+steps:
+  - do: x
+    expect: y
+""",
+    )
+    s = load_scenario(p)
+    errors = validate_scenario(s, ledger_keys=LEDGER_KEYS, recipe_names=RECIPES)
+    assert any("no applicable surface" in e for e in errors)
+
+
+def test_after_action_unknown_recipe_fails(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+id: s
+title: t
+features: [feat.one]
+recipes: [seeded-desk]
+steps:
+  - do: x
+    expect: y
+    after:
+      - apply_recipe: no-such-recipe
+""",
+    )
+    s = load_scenario(p)
+    errors = validate_scenario(s, ledger_keys=LEDGER_KEYS, recipe_names=RECIPES, deck_names=DECKS)
+    assert any("apply_recipe names unknown recipe: no-such-recipe" in e for e in errors)
+
+
+def test_step_missing_do_or_expect_fails_load(tmp_path):
+    p = _write(tmp_path, "id: s\ntitle: t\nfeatures: [feat.one]\nrecipes: [seeded-desk]\nsteps:\n  - do: only\n")
+    with pytest.raises(ScenarioError, match="needs both 'do' and 'expect'"):
+        load_scenario(p)

--- a/tests/uat/test_smoke_pack.py
+++ b/tests/uat/test_smoke_pack.py
@@ -1,0 +1,68 @@
+"""The smoke pack loads clean, cites real keys/recipes, and covers the vocabulary."""
+
+from __future__ import annotations
+
+from uat.conductor.contract.coverage import pack_coverage
+from uat.conductor.contract.ledger import FeatureLedger
+from uat.conductor.contract.scenarios import load_pack, validate_scenario
+from uat.conductor.induction.decks import DeckRegistry
+from uat.conductor.induction.recipes import RecipeRegistry
+
+
+def _load():
+    ledger = FeatureLedger.load()
+    scenarios = load_pack("smoke")
+    return ledger, scenarios
+
+
+def test_smoke_pack_validates_clean():
+    ledger, scenarios = _load()
+    recipe_names = set(RecipeRegistry().names())
+    deck_names = set(DeckRegistry().names())
+    errors = []
+    for s in scenarios:
+        errors += validate_scenario(
+            s, ledger_keys=ledger.keys(), recipe_names=recipe_names, deck_names=deck_names
+        )
+    assert errors == [], errors
+    assert 6 <= len(scenarios) <= 9
+
+
+def test_smoke_pack_exercises_the_whole_vocabulary():
+    _, scenarios = _load()
+    recipes_used = {r for s in scenarios for r in s.recipes}
+    # Both golden postures (local seeding + .43 meeting/mesh) and both bad decks.
+    assert {"seeded-desk", "fresh-desk"} & recipes_used  # golden-local postures
+    assert "meeting-just-ended-open-actions" in recipes_used  # golden-43 intel
+    assert "mesh-node-alive" in recipes_used  # mesh
+    assert "intel-endpoint-dead" in recipes_used  # bad-endpoint
+    assert "first-run-no-model" in recipes_used  # no-model
+
+    # A three-surface scenario exists (all three applicable on ≥1 step).
+    def all_three(scn):
+        return all(scn.surfaces[s]["applicable"] for s in ("web", "ipad", "iphone"))
+
+    assert any(all_three(s) for s in scenarios), "no fully three-surface scenario"
+
+    # An honest per-surface n/a with a reason exists somewhere.
+    na = [
+        v
+        for s in scenarios
+        for st in s.steps
+        for v in st.resolved_surfaces(s.surfaces).values()
+        if not v["applicable"]
+    ]
+    assert na and all(v["reason"] for v in na), "n/a must carry a reason"
+
+    # A mid-run conductor action exists (the mesh kill between steps).
+    assert any(st.after for s in scenarios for st in s.steps), "no mid-run action"
+
+
+def test_smoke_pack_coverage_is_per_surface():
+    ledger, scenarios = _load()
+    cov = pack_coverage(scenarios, ledger)
+    assert cov["overall"]["covered"] >= 1
+    for s in ("web", "ipad", "iphone"):
+        assert cov[s]["total"] >= cov[s]["covered"] >= 0
+        assert 0.0 <= cov[s]["pct"] <= 100.0
+    assert cov["expected_verdicts"] > 0

--- a/uat/conductor/app.py
+++ b/uat/conductor/app.py
@@ -164,6 +164,87 @@ def create_app(manager: RunManager | None = None) -> FastAPI:
             raise HTTPException(status_code=404, detail=f"no such node: {name}")
         return {"name": name, "killed": True}
 
+    # --- the scenario contract + feature ledger (HSU-1-03) ---------------
+
+    from .contract.ledger import FeatureLedger
+    from .contract import scenarios as scen_mod
+    from .contract.coverage import pack_coverage
+    from .contract.scenarios import ScenarioError, load_pack, validate_scenario
+
+    def _ledger() -> FeatureLedger:
+        cached = getattr(app.state, "ledger", None)
+        if cached is None:
+            cached = FeatureLedger.load()
+            app.state.ledger = cached
+        return cached
+
+    def _recipe_names() -> set[str]:
+        return set(mgr().recipes.registry.names())
+
+    def _deck_names() -> set[str]:
+        return set(mgr().decks.names())
+
+    @app.get("/api/features")
+    def features() -> Any:
+        ledger = _ledger()
+        return {
+            "version": ledger.raw.get("version"),
+            "feature_count": len(ledger.features),
+            "phases_total": len(ledger.phase_map),
+            "features": [
+                {
+                    "key": f.key,
+                    "title": f.title,
+                    "domain": f.domain,
+                    "phases": f.phases,
+                    "surfaces": f.surfaces,
+                    "priority": f.priority,
+                    "status": f.status,
+                }
+                for f in ledger.features
+            ],
+        }
+
+    @app.get("/api/packs")
+    def packs() -> Any:
+        ledger = _ledger()
+        out = []
+        for name in scen_mod.list_packs():
+            try:
+                scenarios = load_pack(name)
+            except ScenarioError as exc:
+                out.append({"pack": name, "error": str(exc)})
+                continue
+            cov = pack_coverage(scenarios, ledger)
+            out.append(
+                {
+                    "pack": name,
+                    "scenario_count": len(scenarios),
+                    "coverage": {"overall": cov["overall"], "web": cov["web"], "ipad": cov["ipad"], "iphone": cov["iphone"]},
+                    "expected_verdicts": cov["expected_verdicts"],
+                }
+            )
+        return {"packs": out}
+
+    @app.get("/api/packs/{pack}")
+    def pack_detail(pack: str) -> Any:
+        ledger = _ledger()
+        try:
+            scenarios = load_pack(pack)
+        except ScenarioError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        errors: list[str] = []
+        for s in scenarios:
+            errors += validate_scenario(
+                s, ledger_keys=ledger.keys(), recipe_names=_recipe_names(), deck_names=_deck_names()
+            )
+        return {
+            "pack": pack,
+            "scenarios": [s.to_dict() for s in scenarios],
+            "coverage": pack_coverage(scenarios, ledger),
+            "validation_errors": errors,
+        }
+
     @app.on_event("shutdown")
     def _shutdown() -> None:
         mgr().teardown_all()

--- a/uat/conductor/contract/__init__.py
+++ b/uat/conductor/contract/__init__.py
@@ -1,0 +1,9 @@
+"""The scenario contract + the feature ledger.
+
+The **scenario** is the unit of UAT; the **ledger** is what it cites. This
+package loads and validates both, and computes coverage — per surface and
+overall — against the enumerated shipped surface. Pure data + math over YAML;
+no ``holdspeak`` import.
+"""
+
+from __future__ import annotations

--- a/uat/conductor/contract/coverage.py
+++ b/uat/conductor/contract/coverage.py
@@ -1,0 +1,45 @@
+"""Coverage math over a pack — per surface and overall.
+
+Given a pack (a set of scenarios) and the ledger, compute what fraction of the
+live shipped surface the pack touches. A feature counts toward a surface's
+coverage only if the pack cites it AND a scenario citing it is applicable on
+that surface — a pack that never walks the iPhone leg does not get to claim
+iPhone coverage.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .ledger import SURFACES, FeatureLedger
+from .scenarios import Scenario
+
+
+def cited_keys(scenarios: list[Scenario]) -> set[str]:
+    keys: set[str] = set()
+    for s in scenarios:
+        keys.update(s.features)
+    return keys
+
+
+def cited_keys_on_surface(scenarios: list[Scenario], surface: str) -> set[str]:
+    keys: set[str] = set()
+    for s in scenarios:
+        if s.surfaces.get(surface, {}).get("applicable"):
+            keys.update(s.features)
+    return keys
+
+
+def pack_coverage(scenarios: list[Scenario], ledger: FeatureLedger) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "scenario_count": len(scenarios),
+        "cited_features": sorted(cited_keys(scenarios)),
+        "overall": ledger.coverage_overall(cited_keys(scenarios)).to_dict(),
+    }
+    for s in SURFACES:
+        report[s] = ledger.coverage(cited_keys_on_surface(scenarios, s), s).to_dict()
+    report["unknown_cells"] = {
+        s: sum(1 for f in ledger.live() if f.surfaces.get(s) == "unknown") for s in SURFACES
+    }
+    report["expected_verdicts"] = sum(sc.expected_verdict_count() for sc in scenarios)
+    return report

--- a/uat/conductor/contract/ledger.py
+++ b/uat/conductor/contract/ledger.py
@@ -1,0 +1,172 @@
+"""The feature ledger — the enumerated shipped surface, and coverage math.
+
+`uat/features.yaml` lists every shipped capability as a stable key with its
+per-surface applicability (`yes|no|unknown`), the holdspeak phases that shipped
+it, and its `phase_map` (every phase → covering keys, or `internal/no-uat-surface`).
+A scenario cites ledger keys; a debrief computes coverage against them.
+
+Coverage is honest about the three answers a surface cell can hold: `yes`
+(applicable — counts toward the denominator), `no` (the surface genuinely lacks
+it — excluded), `unknown` (not yet resolved — excluded from the denominator but
+counted so a debrief can say how much is still unknown).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SURFACES = ("web", "ipad", "iphone")
+NO_UAT_MARKER = "internal/no-uat-surface"
+
+
+def ledger_path() -> Path:
+    override = os.environ.get("UAT_FEATURES_PATH")
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parents[3] / "uat" / "features.yaml"
+
+
+class LedgerError(ValueError):
+    pass
+
+
+@dataclass
+class Feature:
+    key: str
+    title: str = ""
+    domain: str = ""
+    phases: list[int] = field(default_factory=list)
+    surfaces: dict[str, str] = field(default_factory=dict)
+    recipes: list[str] = field(default_factory=list)
+    priority: str = "unknown"
+    status: str = "live"
+
+    def applicable_on(self, surface: str) -> bool:
+        return self.surfaces.get(surface) == "yes"
+
+    @property
+    def retired(self) -> bool:
+        return self.status == "retired"
+
+
+@dataclass
+class CoverageResult:
+    covered: int
+    total: int
+    uncovered: list[str]
+
+    @property
+    def pct(self) -> float:
+        return round(100.0 * self.covered / self.total, 1) if self.total else 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "covered": self.covered,
+            "total": self.total,
+            "pct": self.pct,
+            "uncovered": self.uncovered,
+        }
+
+
+class FeatureLedger:
+    def __init__(self, features: list[Feature], phase_map: dict[str, list[str]], raw: dict | None = None):
+        self.features = features
+        self._by_key = {f.key: f for f in features}
+        self.phase_map = phase_map
+        self.raw = raw or {}
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "FeatureLedger":
+        path = Path(path) if path else ledger_path()
+        if not path.exists():
+            raise LedgerError(f"feature ledger not found: {path}")
+        doc = yaml.safe_load(path.read_text()) or {}
+        features = []
+        for entry in doc.get("features") or []:
+            features.append(
+                Feature(
+                    key=entry["key"],
+                    title=entry.get("title", ""),
+                    domain=entry.get("domain", ""),
+                    phases=list(entry.get("phases") or []),
+                    surfaces={s: str(entry.get("surfaces", {}).get(s, "unknown")) for s in SURFACES},
+                    recipes=list(entry.get("recipes") or []),
+                    priority=entry.get("priority", "unknown"),
+                    status=entry.get("status", "live"),
+                )
+            )
+        return cls(features, doc.get("phase_map") or {}, raw=doc)
+
+    # --- reads ------------------------------------------------------------
+
+    def keys(self) -> set[str]:
+        return set(self._by_key)
+
+    def get(self, key: str) -> Feature | None:
+        return self._by_key.get(key)
+
+    def has(self, key: str) -> bool:
+        return key in self._by_key
+
+    def live(self) -> list[Feature]:
+        return [f for f in self.features if not f.retired]
+
+    # --- integrity --------------------------------------------------------
+
+    def validate(self, *, phases_expected: int | None = None) -> list[str]:
+        """Structural integrity: unique keys, valid surface cells, phase-exhaustive.
+
+        Returns a list of error strings (empty = clean).
+        """
+        errors: list[str] = []
+        seen: set[str] = set()
+        for f in self.features:
+            if f.key in seen:
+                errors.append(f"duplicate ledger key: {f.key}")
+            seen.add(f.key)
+            for s in SURFACES:
+                if f.surfaces.get(s) not in ("yes", "no", "unknown"):
+                    errors.append(f"{f.key}: surface {s} must be yes|no|unknown, got {f.surfaces.get(s)!r}")
+        # Phase exhaustiveness: every phase in the map resolves to keys or the marker.
+        for phase, keys in self.phase_map.items():
+            if not keys:
+                errors.append(f"phase {phase} maps to nothing (needs keys or {NO_UAT_MARKER})")
+            for k in keys:
+                if k != NO_UAT_MARKER and k not in self._by_key:
+                    errors.append(f"phase {phase} cites unknown ledger key: {k}")
+        if phases_expected is not None and len(self.phase_map) != phases_expected:
+            errors.append(
+                f"phase_map has {len(self.phase_map)} phases, expected {phases_expected}"
+            )
+        return errors
+
+    # --- coverage ---------------------------------------------------------
+
+    def coverage(self, cited_keys: set[str], surface: str) -> CoverageResult:
+        """Coverage on one surface: applicable (yes) features cited by the pack."""
+        applicable = [f for f in self.live() if f.applicable_on(surface)]
+        covered = [f for f in applicable if f.key in cited_keys]
+        uncovered = sorted(f.key for f in applicable if f.key not in cited_keys)
+        return CoverageResult(len(covered), len(applicable), uncovered)
+
+    def coverage_overall(self, cited_keys: set[str]) -> CoverageResult:
+        """Coverage over all live features regardless of surface."""
+        live = self.live()
+        covered = [f for f in live if f.key in cited_keys]
+        uncovered = sorted(f.key for f in live if f.key not in cited_keys)
+        return CoverageResult(len(covered), len(live), uncovered)
+
+    def coverage_report(self, cited_keys: set[str]) -> dict[str, Any]:
+        report: dict[str, Any] = {"overall": self.coverage_overall(cited_keys).to_dict()}
+        for s in SURFACES:
+            report[s] = self.coverage(cited_keys, s).to_dict()
+        # How much of each surface is still 'unknown' — honest at v1.
+        report["unknown_cells"] = {
+            s: sum(1 for f in self.live() if f.surfaces.get(s) == "unknown") for s in SURFACES
+        }
+        return report

--- a/uat/conductor/contract/scenarios.py
+++ b/uat/conductor/contract/scenarios.py
@@ -1,0 +1,263 @@
+"""The scenario contract — the unit of UAT, loaded and validated.
+
+A scenario (`uat/scenarios/<pack>/<nn>-<slug>.yaml`) declares the world to
+stage (`recipes`), what it covers (`features`, ledger keys), the three-surface
+applicability (`surfaces`, default all-yes, opted out only with `{n/a: reason}`),
+and ordered `steps` (each an instruction, an honest expectation, an optional
+`where` route to open, an optional per-step surface override, and optional
+`after` conductor actions performed before the next step).
+
+Validation produces **named, greppable** errors — `ERROR <file>: <issue>` — so a
+malformed scenario fails loudly, naming the file and field.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .ledger import SURFACES
+
+
+def scenarios_dir() -> Path:
+    override = os.environ.get("UAT_SCENARIOS_DIR")
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parents[3] / "uat" / "scenarios"
+
+
+class ScenarioError(ValueError):
+    pass
+
+
+def _parse_surface(value: Any) -> dict:
+    """Normalise a surface cell to {applicable: bool, reason: str|None}.
+
+    Allowed forms: ``yes`` / ``true`` (applicable), or ``{n/a: <reason>}`` /
+    ``{na: <reason>}`` (opted out, reason required). Anything else raises.
+    """
+    if value in (True, "yes", "Yes", "y"):
+        return {"applicable": True, "reason": None}
+    if isinstance(value, dict):
+        for k in ("n/a", "na", "n_a"):
+            if k in value:
+                reason = str(value[k] or "").strip()
+                if not reason:
+                    raise ScenarioError("n/a surface needs a stated reason")
+                return {"applicable": False, "reason": reason}
+    raise ScenarioError(
+        f"surface value must be 'yes' or {{n/a: <reason>}}, got {value!r}"
+    )
+
+
+@dataclass
+class Step:
+    index: int
+    do: str
+    expect: str
+    where: str | None = None
+    surfaces: dict[str, Any] = field(default_factory=dict)  # raw per-step overrides
+    after: list[Any] = field(default_factory=list)
+
+    def resolved_surfaces(self, scenario_surfaces: dict[str, dict]) -> dict[str, dict]:
+        """Effective per-surface applicability for this step (step overrides scenario)."""
+        out: dict[str, dict] = {}
+        for s in SURFACES:
+            if s in self.surfaces:
+                out[s] = _parse_surface(self.surfaces[s])
+            else:
+                out[s] = scenario_surfaces.get(s, {"applicable": True, "reason": None})
+        return out
+
+    def applicable_surfaces(self, scenario_surfaces: dict[str, dict]) -> list[str]:
+        return [s for s, v in self.resolved_surfaces(scenario_surfaces).items() if v["applicable"]]
+
+
+@dataclass
+class Scenario:
+    id: str
+    title: str
+    pack: str
+    features: list[str]
+    recipes: list[str]
+    surfaces: dict[str, dict]  # resolved {surface: {applicable, reason}}
+    steps: list[Step]
+    teardown: list[Any] = field(default_factory=list)
+    source: str = ""
+
+    def expected_verdict_count(self) -> int:
+        """Total (step, surface) verdicts a full sitting of this scenario casts."""
+        return sum(len(step.applicable_surfaces(self.surfaces)) for step in self.steps)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "pack": self.pack,
+            "features": self.features,
+            "recipes": self.recipes,
+            "surfaces": self.surfaces,
+            "steps": [
+                {
+                    "index": s.index,
+                    "do": s.do,
+                    "expect": s.expect,
+                    "where": s.where,
+                    "surfaces": s.resolved_surfaces(self.surfaces),
+                    "after": s.after,
+                }
+                for s in self.steps
+            ],
+            "teardown": self.teardown,
+            "expected_verdict_count": self.expected_verdict_count(),
+        }
+
+
+def load_scenario(path: Path, pack: str | None = None) -> Scenario:
+    path = Path(path)
+    try:
+        doc = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise ScenarioError(f"ERROR {path}: not valid YAML: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise ScenarioError(f"ERROR {path}: top level must be a mapping")
+
+    def need(field_name: str) -> Any:
+        if field_name not in doc:
+            raise ScenarioError(f"ERROR {path}: missing required field '{field_name}'")
+        return doc[field_name]
+
+    sid = str(need("id"))
+    title = str(need("title"))
+    features = list(doc.get("features") or [])
+    recipes = list(doc.get("recipes") or [])
+
+    # Scenario-level surfaces: default all-yes, override with {n/a: reason}.
+    raw_surfaces = doc.get("surfaces") or {}
+    surfaces: dict[str, dict] = {}
+    for s in SURFACES:
+        try:
+            surfaces[s] = _parse_surface(raw_surfaces.get(s, "yes"))
+        except ScenarioError as exc:
+            raise ScenarioError(f"ERROR {path}: surface {s}: {exc}") from exc
+
+    raw_steps = doc.get("steps") or []
+    steps: list[Step] = []
+    for i, raw in enumerate(raw_steps):
+        if not isinstance(raw, dict):
+            raise ScenarioError(f"ERROR {path}: step {i} must be a mapping")
+        if "do" not in raw or "expect" not in raw:
+            raise ScenarioError(f"ERROR {path}: step {i} needs both 'do' and 'expect'")
+        step = Step(
+            index=i,
+            do=str(raw["do"]),
+            expect=str(raw["expect"]),
+            where=raw.get("where"),
+            surfaces=raw.get("surfaces") or {},
+            after=list(raw.get("after") or []),
+        )
+        # Validate per-step surface overrides eagerly (names the file+step).
+        try:
+            step.resolved_surfaces(surfaces)
+        except ScenarioError as exc:
+            raise ScenarioError(f"ERROR {path}: step {i} surface: {exc}") from exc
+        steps.append(step)
+
+    return Scenario(
+        id=sid,
+        title=title,
+        pack=pack or path.parent.name,
+        features=features,
+        recipes=recipes,
+        surfaces=surfaces,
+        steps=steps,
+        teardown=list(doc.get("teardown") or []),
+        source=str(path),
+    )
+
+
+def validate_scenario(
+    scenario: Scenario,
+    *,
+    ledger_keys: set[str],
+    recipe_names: set[str],
+    deck_names: set[str] | None = None,
+) -> list[str]:
+    """Cross-reference a scenario against the ledger + recipe/deck registries."""
+    errors: list[str] = []
+    src = scenario.source
+
+    if not scenario.features:
+        errors.append(f"ERROR {src}: scenario cites no features (need ≥1 ledger key)")
+    for key in scenario.features:
+        if key not in ledger_keys:
+            errors.append(f"ERROR {src}: unknown ledger key: {key}")
+
+    if not scenario.recipes:
+        errors.append(f"ERROR {src}: scenario names no recipes (need ≥1)")
+    for r in scenario.recipes:
+        if r not in recipe_names:
+            errors.append(f"ERROR {src}: unknown recipe: {r}")
+
+    if not scenario.steps:
+        errors.append(f"ERROR {src}: scenario has no steps")
+
+    for step in scenario.steps:
+        applicable = step.applicable_surfaces(scenario.surfaces)
+        if not applicable:
+            errors.append(
+                f"ERROR {src}: step {step.index} has no applicable surface "
+                "(every surface n/a — a step must be walked somewhere)"
+            )
+        for action in step.after:
+            errors.extend(_validate_action(action, src, step.index, recipe_names, deck_names))
+
+    return errors
+
+
+def _validate_action(action: Any, src: str, step_index: int, recipe_names, deck_names) -> list[str]:
+    if not isinstance(action, dict) or len(action) != 1:
+        return [f"ERROR {src}: step {step_index} after-action must be a single-key mapping: {action!r}"]
+    (kind, arg), = action.items()
+    if kind == "apply_recipe":
+        name = arg["name"] if isinstance(arg, dict) else str(arg)
+        if name not in recipe_names:
+            return [f"ERROR {src}: step {step_index} apply_recipe names unknown recipe: {name}"]
+    elif kind == "restart":
+        deck = (arg or {}).get("deck") if isinstance(arg, dict) else None
+        if deck and deck_names is not None and deck not in deck_names:
+            return [f"ERROR {src}: step {step_index} restart names unknown deck: {deck}"]
+    elif kind in ("kill_node", "spawn_node", "wait"):
+        pass
+    else:
+        return [f"ERROR {src}: step {step_index} unknown after-action: {kind}"]
+    return []
+
+
+def load_pack(pack: str, directory: Path | None = None) -> list[Scenario]:
+    base = Path(directory) if directory else scenarios_dir()
+    pack_dir = base / pack
+    if not pack_dir.exists():
+        raise ScenarioError(f"unknown pack: {pack} (looked in {base})")
+    scenarios = [load_scenario(p, pack=pack) for p in sorted(pack_dir.glob("*.yaml"))]
+    _check_unique_ids(scenarios, pack_dir)
+    return scenarios
+
+
+def _check_unique_ids(scenarios: list[Scenario], pack_dir: Path) -> None:
+    seen: set[str] = set()
+    for s in scenarios:
+        if s.id in seen:
+            raise ScenarioError(f"ERROR {pack_dir}: duplicate scenario id: {s.id}")
+        seen.add(s.id)
+
+
+def list_packs(directory: Path | None = None) -> list[str]:
+    base = Path(directory) if directory else scenarios_dir()
+    if not base.exists():
+        return []
+    return sorted(p.name for p in base.iterdir() if p.is_dir())

--- a/uat/features.yaml
+++ b/uat/features.yaml
@@ -1,0 +1,3827 @@
+# The feature ledger — the enumerated shipped surface of HoldSpeak.
+#
+# Derived from the record (Phase-2 inventory + the holdspeak phase index) by
+# uat/tools/build_ledger.py, then reviewed by hand. Scenarios cite these keys;
+# debriefs compute coverage against them. `unknown` surface cells are honest at
+# v1 — Phase 2 (The Inventory) owns making this exhaustive and resolving them.
+#
+# phase_map pins every holdspeak phase to the keys covering it, or the
+# internal/no-uat-surface marker — no phase silently absent.
+#
+# Regenerate: uv run python -m uat.tools.build_ledger
+version: 1
+generated_by: uat/tools/build_ledger.py (proposes; committed YAML is canon)
+source:
+  inventory: pm/roadmap/holdspeak-uat/phase-2-the-inventory/directory/_raw-inventory-rows.json
+  phase_index: pm/roadmap/holdspeak/README.md
+  phases_total: 88
+features:
+- key: activity.candidates.meeting
+  title: Activity-derived meeting candidates
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 9
+  - 13
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - seeded-activity-ledger
+  priority: spot
+  status: live
+- key: activity.enrichment.connectors
+  title: Opt-in activity enrichment connectors (GitHub/Jira)
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 9
+  - 11
+  - 13
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - seeded-activity-ledger
+  priority: should
+  status: live
+- key: activity.ledger.browser_history
+  title: Private local activity ledger from browser history
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 8
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - seeded-activity-ledger
+  priority: should
+  status: live
+- key: activity.prebriefing.dictate_with_this
+  title: '''Dictate with this'' — feed a selected activity record into the next dictation'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 53
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: activity.prebriefing.nudges
+  title: Source-cited activity pre-briefing nudges
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 8
+  - 9
+  - 53
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - seeded-activity-ledger
+  - seeded-desk
+  priority: should
+  status: live
+- key: actuators.connector.github_issue
+  title: File a GitHub issue from an approved proposal
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 38
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: actuators.connector.webhook_post
+  title: POST to an allow-listed webhook from an approved proposal
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 38
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: actuators.governance.gate
+  title: Actuators stay off unless master switch + per-project allow-list enable them
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 37
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: actuators.live.pending_actions_panel
+  title: Approve/reject proposals live during a meeting
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 38
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - proposal-pending-approval
+  priority: should
+  status: live
+- key: actuators.proposal.approve_execute
+  title: Approve or reject a proposed side effect (propose→approve→execute)
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 37
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: actuators.slack.send
+  title: Send a meeting digest or follow-up draft to Slack
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 61
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - slack-webhook-configured
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: agents.answer_coder.ai_drafted
+  title: Have AI draft an answer to a coder, then approve-then-inject
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - agent-pane-awaiting-input
+  - model-installed-on-device
+  priority: must
+  status: live
+- key: agents.answer_coder.by_voice
+  title: Answer a waiting coding agent by voice from your device
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - agent-pane-awaiting-input
+  - hub-reachable-on-lan
+  priority: must
+  status: live
+- key: agents.answer_coder.dropped_context
+  title: Answer a coder from dropped meeting/artifact context
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - agent-pane-awaiting-input
+  - seeded-desk
+  priority: should
+  status: live
+- key: agents.companion.board_select_target
+  title: Pick which waiting coder your answer goes to
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - multiple-agents-awaiting
+  priority: should
+  status: live
+- key: agents.companion.meetings_remote_control
+  title: Start and stop desktop meetings from the device
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - hub-reachable-on-lan
+  priority: should
+  status: live
+- key: agents.companion.pair_desktop
+  title: Point the iPad/iPhone at your desktop server as a companion
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - hub-reachable-on-lan
+  priority: must
+  status: live
+- key: agents.desk.live_coders
+  title: See your live coding agents on the desk and their questions
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - agent-pane-awaiting-input
+  - hub-reachable-on-lan
+  priority: must
+  status: live
+- key: agents.dictation.into_your_mac
+  title: Dictate into any focused Mac app from the device
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: unknown
+    iphone: 'yes'
+  recipes:
+  - mesh-node-alive
+  - hub-reachable-on-lan
+  - focused-mac-app
+  priority: must
+  status: live
+- key: agents.mesh.queue_inbox
+  title: See all mesh jobs and pending approvals in one queue
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - proposal-pending-approval
+  - hub-reachable-on-lan
+  priority: must
+  status: live
+- key: agents.mesh.runs_on_dispatch
+  title: Run a workflow step on a chosen mesh node
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - hub-reachable-on-lan
+  - model-installed-on-device
+  priority: should
+  status: live
+- key: ask.atom.lasso_ask_keep
+  title: Ask AI over lassoed context and keep or bin the printed card
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - model-installed-on-device
+  priority: must
+  status: live
+- key: ask.composer.speak_to_fill
+  title: Speak to fill the Ask composer (and any input) by voice
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mic-permission-granted
+  priority: should
+  status: live
+- key: ask.web.ground_this_ask
+  title: Ground an ask with priced references
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 83
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: ask.web.models_door
+  title: The models front door (open a chat on any model)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 83
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: spot
+  status: live
+- key: ask.web.persona_threads
+  title: Persistent persona conversations
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 83
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: should
+  status: live
+- key: ask.web.token_auth_arrival
+  title: Authenticated arrival on a token-guarded hub
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 83
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - token-guarded-hub
+  priority: must
+  status: live
+- key: belt.approval.import_run_chain
+  title: Imported meetings receive typed plugin artifacts
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 80
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - imported-meeting-no-artifacts
+  priority: should
+  status: live
+- key: belt.approval_leg
+  title: 'HANDOFF: approve a story flip from the desk (dw gate)'
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 82
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - proposal-pending-approval
+  - belt-with-registered-rails-repo
+  priority: must
+  status: live
+- key: belt.conveyor
+  title: The delivery belt / mission-control conveyor
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 82
+  - 86
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - belt-with-registered-rails-repo
+  priority: should
+  status: live
+- key: belt.receipts
+  title: Belt station lights + evidence in place
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 86
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - belt-with-registered-rails-repo
+  priority: spot
+  status: live
+- key: config.cockpit.copilot_setup
+  title: Configure every dictation/pipeline knob from the web cockpit (no file editing)
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 40
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: config.memory.curate_corrections
+  title: View, add, delete, and clear persistent corrections
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 40
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: config.settings.searchable
+  title: Sectioned, searchable settings with progressive disclosure
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 42
+  - 43
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: desk.ambient_recorder_agents
+  title: Fire your saved agents and crews against the live transcript
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - recording-in-progress
+  - saved-agent-exists
+  priority: spot
+  status: live
+- key: desk.ask-ai.grounded-on-pile
+  title: Lasso a pile of objects and Ask AI about exactly that pile
+  domain: public-docs-claims
+  phases:
+  - 73
+  - 83
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: desk.coders.agents-on-the-desk
+  title: Live coding agents appear on the desk as objects that demand you when blocked
+  domain: public-docs-claims
+  phases:
+  - 87
+  - 89
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: desk.coders.answer-grounded-or-ai-drafted
+  title: Answer a blocked agent by typing, speaking, dropping a record, or AI-drafting
+  domain: public-docs-claims
+  phases:
+  - 78
+  - 87
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: desk.data.schema-safe-upgrades
+  title: Upgrades back your database up before touching it and refuse newer-build data
+  domain: public-docs-claims
+  phases:
+  - 50
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: desk.diorama.front_door
+  title: Open the DeskOS diorama as the app front door
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - fresh-desk
+  priority: must
+  status: live
+- key: desk.diorama.lasso_bundle_file
+  title: Lasso objects into a bundle and file them
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.diorama.meeting_spill
+  title: Spill a meeting into its parts on the desk
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: desk.doctor.honest-readout
+  title: holdspeak doctor reports what is actually broken
+  domain: public-docs-claims
+  phases:
+  - 50
+  - 84
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: desk.front-door.spatial-objects
+  title: 'The Desk is the front door: every mode''s output lives as an object in one world'
+  domain: public-docs-claims
+  phases:
+  - 73
+  - 83
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: desk.knowledge_bases
+  title: Create and use knowledge bases and directories on the desk
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.models.open-a-model-chat
+  title: Open a chat pinned to any model the hub can run
+  domain: public-docs-claims
+  phases:
+  - 84
+  - 85
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: should
+  status: live
+- key: desk.personas.conversation-thread
+  title: 'Talk to your personas: a persistent conversation, each reply badged for where it ran'
+  domain: public-docs-claims
+  phases:
+  - 83
+  - 87
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.presence.qlippy-opt-in
+  title: 'Qlippy the mascot: opt-in desktop presence that only interrupts for moments that need you'
+  domain: public-docs-claims
+  phases:
+  - 41
+  - 56
+  surfaces:
+    web: unknown
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - proposal-pending-approval
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: desk.recipes.in_world_authoring
+  title: Author a recipe (persona/chain) in-world without modals
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.sync.profile-shape-across-surfaces
+  title: Profile shapes sync across your surfaces so the same named profile is available everywhere
+  domain: public-docs-claims
+  phases:
+  - 84
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: desk.web.agent_rail_run
+  title: Run an agent persona from the rail
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: desk.web.answer_waiting_coder
+  title: Answer a waiting coder by voice
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 78
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: desk.web.create_in_world
+  title: Create a primitive in-world (no dialog)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: desk.web.four_doors_ia
+  title: Four doors, not fourteen (Home/Dictation/Meetings/Studio)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 70
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - fresh-desk
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.web.free_placement
+  title: Arrange desk objects by drag, persisted per-device
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 71
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: desk.web.front_door
+  title: The Desk is the web front door
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 71
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - seeded-desk
+  priority: must
+  status: live
+- key: desk.web.mic_waveform
+  title: Reactive mic waveform meter
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 69
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: desk.web.objects_float
+  title: Primitives render as floating sprites with depth
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 71
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.web.one_arrival
+  title: One first-run arrival (/welcome)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 70
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  - fresh-desk
+  priority: must
+  status: live
+- key: desk.web.pullout_open
+  title: Open an object into a pull-out
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: desk.web.qlippy_life
+  title: Qlippy lives on the desk (opt-in)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 71
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: desk.web.queue_hud
+  title: The always-on Queue HUD
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 69
+  - 77
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: desk.web.record_orb
+  title: The Record orb drives the hub recorder
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.web.transcribe_everywhere
+  title: Hold-to-talk voice on every desk input
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 78
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: desk.web.zones_file_dive
+  title: File objects into zones and dive in
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 71
+  - 73
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: desk.workbench.visual_builder
+  title: Build a visual intelligence workflow on the Workbench
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: devices.audio.remote_ingest
+  title: Remote device audio ingest (AIPI-Lite)
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 14
+  - 17
+  - 21
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - mesh-node-alive
+  - fresh-desk
+  priority: spot
+  status: live
+- key: devices.companion.agent_waiting
+  title: AIPI companion signals a waiting agent
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 20
+  - 22
+  - 23
+  surfaces:
+    web: 'no'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - agent-pane-awaiting-input
+  - mesh-node-alive
+  priority: spot
+  status: live
+- key: devices.health.status
+  title: Device health reporting
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 17
+  - 22
+  - 23
+  - 24
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - mesh-node-alive
+  priority: spot
+  status: live
+- key: dictation.activity-prebriefing.cited-nudges
+  title: Activity pre-briefing offers what you touched recently as source-cited dictation context
+  domain: public-docs-claims
+  phases:
+  - 53
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.agent_hooks.claude_codex
+  title: Agent hooks report cwd/session/awaiting state
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 18
+  - 19
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: should
+  status: live
+- key: dictation.blocks.author
+  title: Author dictation blocks (intent classes)
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 1
+  - 4
+  - 18
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - dictation-pipeline-enabled
+  priority: should
+  status: live
+- key: dictation.clipboard.token
+  title: Clipboard token injection
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 1
+  - 3
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: spot
+  status: live
+- key: dictation.correction.one-tap-teaches
+  title: One tap on a wrong result teaches the correction memory
+  domain: public-docs-claims
+  phases:
+  - 45
+  - 48
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: dictation.correction.session_memory
+  title: Copilot learns from your corrections and nudges future routing
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 39
+  - 40
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: dictation.journal.review
+  title: Review every dictation in a durable Journal (said→typed timeline)
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 45
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: dictation.journal.said-to-typed
+  title: 'Every dictation lands in the journal: said, typed, route, latency'
+  domain: public-docs-claims
+  phases:
+  - 45
+  - 48
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.kb.project_facts
+  title: Project KB placeholder enrichment
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 1
+  - 3
+  - 47
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-project-kb
+  priority: should
+  status: live
+- key: dictation.language.99-whisper-languages
+  title: The spoken language setting pins any of Whisper's 99 languages
+  domain: public-docs-claims
+  phases:
+  - 59
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.learning-digest.honest-count
+  title: The learning digest reports a real learned-from-N-similar count, honest at zero
+  domain: public-docs-claims
+  phases:
+  - 48
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - fresh-desk
+  priority: must
+  status: live
+- key: dictation.learning.digest
+  title: '''What HoldSpeak learned'' digest over your corrections'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 48
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.learning.trust_signals
+  title: '''Learned from N similar'' chips inline where you work'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 48
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: dictation.moment_of_truth.correct_inline
+  title: Correct a dictation in the moment ('Was that right? → Fix it → Taught')
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 45
+  - 48
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: dictation.pipeline.dry_run
+  title: Dry-run / preview a dictation transformation
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 3
+  - 4
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - dictation-pipeline-enabled
+  priority: must
+  status: live
+- key: dictation.pipeline.enable
+  title: Enable the dictation pipeline
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 1
+  - 3
+  - 18
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - dictation-pipeline-enabled
+  priority: must
+  status: live
+- key: dictation.pipeline.intent-routing
+  title: The dictation pipeline routes rough speech by intent and rewrites for its target
+  domain: public-docs-claims
+  phases:
+  - 52
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: dictation.pipeline.preview-before-type
+  title: Preview mode shows the rewrite first; Type commits, Discard drops it
+  domain: public-docs-claims
+  phases:
+  - 60
+  - 75
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: dictation.preview_before_type
+  title: Preview a dictation before it types
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 75
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.project_context.hs_files
+  title: Teach a repo via .hs/ project context files
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 3
+  - 18
+  - 19
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-hs-context-repo
+  priority: should
+  status: live
+- key: dictation.punctuation.spoken
+  title: Spoken punctuation words
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 1
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: spot
+  status: live
+- key: dictation.replay.through_current_pipeline
+  title: Replay a past dictation through the current pipeline (before→after)
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 45
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.replay.watch-routing-change
+  title: Replay an old utterance through the updated pipeline and watch the routing change
+  domain: public-docs-claims
+  phases:
+  - 45
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.rewrite.multi_pass
+  title: Multi-pass rewrite refinement of dictated text
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 39
+  - 40
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - intel-endpoint-dead
+  priority: should
+  status: live
+- key: dictation.runtime.backend_picker
+  title: Pick the dictation LLM runtime backend
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 1
+  - 3
+  - 18
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: should
+  status: live
+- key: dictation.runtime.openai_compatible
+  title: Route dictation through an OpenAI-compatible endpoint
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 3
+  - 18
+  - 19
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - dictation-pipeline-enabled
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: dictation.suggestions.quality_gate
+  title: Project-doc suggestions stop repeating what's already written
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 39
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: dictation.symbol-dictionary.spoken-vocabulary
+  title: The spoken-symbol dictionary types your own vocabulary
+  domain: public-docs-claims
+  phases:
+  - 59
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: dictation.target.model_assisted_detection
+  title: Model-assisted fallback for where dictation gets typed
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 39
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - intel-endpoint-dead
+  priority: should
+  status: live
+- key: dictation.target.profile_detection
+  title: Target-profile detection & override
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 1
+  - 18
+  - 19
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - dictation-pipeline-enabled
+  priority: should
+  status: live
+- key: dictation.telemetry.depth_readiness
+  title: See per-stage dictation latency (p50/p95) and copilot state
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 39
+  - 40
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: dictation.voice-commands.keyword-to-action
+  title: Voice commands map a spoken keyword to a real action
+  domain: public-docs-claims
+  phases:
+  - 52
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: dictation.voice-typing.hold-to-talk
+  title: 'Hold the hotkey, speak, release: text lands in the active app'
+  domain: public-docs-claims
+  phases:
+  - 42
+  - 65
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: dictation.voice_typing.hold_to_talk
+  title: Hold-to-talk voice typing
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 0
+  - 1
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: dictation.wake-word.hands-free-preview
+  title: Say the wake phrase and it listens hands-free, previewed never typed until confirmed
+  domain: public-docs-claims
+  phases:
+  - 60
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: factory.kill
+  title: Kill a session from the desk (consent-gated)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 90
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-session-live
+  - agent-pane-armed
+  priority: must
+  status: live
+- key: factory.spawn_rename
+  title: Spawn and rename sessions from the desk
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 90
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - agent-session-live
+  priority: should
+  status: live
+- key: kb.project.discovery_nudge
+  title: Ambient nudge when a detected project has no knowledge
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 47
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: kb.project.facts_and_context
+  title: 'Teach the copilot about a project: Project Facts + Project Context'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 47
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: kb.project.guided_setup
+  title: Guided .hs/ setup + copyable 'draft with your coding agent' prompt
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 47
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: spot
+  status: live
+- key: languages.spoken_language
+  title: Pin the spoken transcription language
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 59
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - non-english-speaker
+  priority: should
+  status: live
+- key: languages.spoken_symbol_dictionary
+  title: Teach spoken words to type as symbols
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 59
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - seeded-symbol-dictionary
+  priority: should
+  status: live
+- key: macros.voice_commands.board
+  title: Map a spoken keyword to a system action on the Voice Commands board
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 52
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: macros.voice_commands.fire_while_dictating
+  title: Fire a mapped action by speaking its keyword during dictation
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 52
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: meetings.actions.review_edit
+  title: Review and edit accepted action items
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 6
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: meetings.aftercare.action-to-issue
+  title: An accepted action item becomes a human-approved filed issue
+  domain: public-docs-claims
+  phases:
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: meetings.aftercare.close-the-loop
+  title: Meeting aftercare shows what is open, decided, and changed since last time
+  domain: public-docs-claims
+  phases:
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: meetings.aftercare.digest
+  title: '''Your next move'' aftercare digest on the meeting detail'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: meetings.aftercare.file_as_issue
+  title: File an accepted meeting action as a GitHub issue (via proposal)
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: meetings.aftercare.followup_draft
+  title: Draft a local follow-up summary from a meeting (preview + copy)
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: spot
+  status: live
+- key: meetings.aftercare.show_the_moment
+  title: '''Show me the moment'' — jump to the transcript segment behind a result'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: meetings.aftercare.transcript-moment-jump
+  title: Jump to the transcript moment that justifies any result
+  domain: public-docs-claims
+  phases:
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: spot
+  status: live
+- key: meetings.archive.delete
+  title: Delete a meeting from the archive
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 55
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: meetings.archive.facet-search
+  title: The archive is searchable and filterable by date, speaker, tag, and open actions
+  domain: public-docs-claims
+  phases:
+  - 55
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: meetings.archive.faceted_search
+  title: Filter the meeting archive by date/speaker/tag/open-actions
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 55
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk-many-meetings
+  priority: should
+  status: live
+- key: meetings.artifacts.cards
+  title: View meeting artifacts as elevated cards
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 6
+  - 36
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: meetings.capture.live
+  title: Record a live meeting
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 2
+  - 6
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: meetings.capture.live-mic-system-audio
+  title: Capture mic and system audio live with speaker labels
+  domain: public-docs-claims
+  phases:
+  - 36
+  - 55
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: meetings.export.local_handoff
+  title: Export a meeting as local Markdown/JSON
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 7
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: meetings.import.audio
+  title: Import an audio recording as a meeting
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 55
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - intel-endpoint-dead
+  - recording-file-on-disk
+  priority: must
+  status: live
+- key: meetings.import.recording-and-transcript
+  title: Import a recording or transcript file into the full intelligence pipeline
+  domain: public-docs-claims
+  phases:
+  - 55
+  - 57
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: meetings.import.transcript
+  title: Import a .vtt/.srt/.txt transcript as a meeting
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 57
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - transcript-file-on-disk
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: meetings.intel.cloud_endpoint
+  title: Run meeting intelligence on a cloud/homelab endpoint
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 2
+  - 16
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: meetings.intel.intent-scored-chain
+  title: The transcript is intent-scored and a chain of plugins runs per meeting
+  domain: public-docs-claims
+  phases:
+  - 36
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: should
+  status: live
+- key: meetings.intel.multi_intent_routing
+  title: Multi-intent routing over meeting windows
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 2
+  - 27
+  - 36
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: meetings.plugins.14-typed-artifacts
+  title: 14 built-in LLM-backed plugins extract typed artifacts from a transcript
+  domain: public-docs-claims
+  phases:
+  - 36
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: meetings.plugins.fourteen_synthesizers
+  title: 14 built-in LLM meeting synthesizer plugins
+  domain: dictation / meetings / activity / connectors / devices
+  phases:
+  - 16
+  - 27
+  - 28
+  - 29
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: meetings.proposals.review-anywhere
+  title: Review every pending proposal for a meeting wherever it was created
+  domain: public-docs-claims
+  phases:
+  - 49
+  - 61
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: mesh.handoff.node_events_to_hub
+  title: 'HANDOFF: remote node rail-events → hub observer'
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 88
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - mesh-node-alive
+  priority: spot
+  status: live
+- key: mesh.handoff.web_run_to_node
+  title: 'HANDOFF: web run → hub relay → mesh worker'
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 85
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mesh.liveness_everywhere
+  title: Mesh liveness on every surface
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 85
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - mesh-node-just-died
+  priority: should
+  status: live
+- key: mesh.profile_node
+  title: A profile names a mesh node (meshNode kind)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 85
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - mesh-node-just-died
+  priority: must
+  status: live
+- key: mesh.serve_node
+  title: Turn any machine into a mesh edge (holdspeak mesh serve)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 85
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.artifacts.run_born.materialize
+  title: Run-born artifacts materialize on the iPad desk without duplicating
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: should
+  status: live
+- key: mobile.belt.diorama.render
+  title: The rails belt renders on the iPad diorama
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: should
+  status: live
+- key: mobile.belt.rails.journal
+  title: The rails journal renders on the iPad diorama
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: mobile.capture.airgapped_notetaker
+  title: Run the full meeting notetaker fully offline (airplane mode)
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  - model-installed-on-device
+  - airplane-mode-on
+  priority: must
+  status: live
+- key: mobile.capture.floating_recorder
+  title: Dock, float, or minimize the recorder as an OS-like widget
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - recording-in-progress
+  priority: spot
+  status: live
+- key: mobile.capture.ink_into_intelligence
+  title: Turn handwritten ink into intelligence (the magic pencil)
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: 'no'
+  recipes:
+  - seeded-desk
+  - meeting-with-ink-notes
+  priority: should
+  status: live
+- key: mobile.capture.live_capture_canvas
+  title: Watch utterances float as bubbles and tack them to a spatial board
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - recording-in-progress
+  priority: should
+  status: live
+- key: mobile.capture.mark_moment
+  title: Mark a moment during recording and jump back to it
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - recording-in-progress
+  priority: should
+  status: live
+- key: mobile.capture.meeting_record
+  title: Record a meeting on the iPad with a live transcript
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - mic-permission-granted
+  priority: must
+  status: live
+- key: mobile.capture.on_device_diarization
+  title: See who's talking (on-device speaker diarization)
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - two-speaker-recording
+  priority: spot
+  status: live
+- key: mobile.capture.pencil_notebook
+  title: Take Apple Pencil handwritten notes in a per-meeting notebook
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: 'no'
+  recipes:
+  - seeded-desk
+  - meeting-open
+  priority: should
+  status: live
+- key: mobile.capture.pencil_to_mermaid
+  title: Sketch a diagram with the Pencil and get a Mermaid diagram
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: unknown
+    iphone: 'no'
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: mobile.capture.realtime_mir
+  title: Get live intelligence markers during a meeting
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - recording-in-progress
+  - model-installed-on-device
+  priority: spot
+  status: live
+- key: mobile.capture.voice_correction
+  title: Reject an artifact by voice and have the local model re-route
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - model-installed-on-device
+  priority: spot
+  status: live
+- key: mobile.desk.compact.capture_canvas
+  title: The capture canvas at compact width with tap-to-tack
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: mobile.desk.compact.hold_bar_teleprompter
+  title: The hold-bar teleprompter on the iPhone dictate surface
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.desk.compact.lane
+  title: The desk renders as a filtered lane on the iPhone
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - fresh-desk
+  priority: must
+  status: live
+- key: mobile.desk.compact.pullout
+  title: The migrating pull-out on compact width
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: mobile.dictation.commandsboard.author
+  title: Author voice-command macros on the iPad CommandsBoard
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: mobile.dictation.language.spoken
+  title: Spoken (non-English) language at every iPad transcription site
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: mobile.dictation.macros.fire
+  title: Voice-command macros fire over the remote relay from iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.dictation.prebriefing.nudge
+  title: Activity pre-briefing nudge cards feed the iPad dictation model
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.dictation.symbols.dictionary
+  title: Spoken-symbol dictionary applies user symbols on iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: mobile.dictation.teleprompter.preview
+  title: iPad voice teleprompter with opt-in preview receipt
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.meeting.aftercare.file_issue
+  title: File a meeting action item as a GitHub issue from the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - seeded-desk
+  priority: must
+  status: live
+- key: mobile.meeting.archive.facets
+  title: Search and facet the meeting archive on the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: mobile.meeting.artifact.provenance
+  title: Artifact provenance ring and sources on iPad meeting artifacts
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - seeded-desk
+  priority: spot
+  status: live
+- key: mobile.meeting.import.picker
+  title: Import a meeting recording or transcript from the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: should
+  status: live
+- key: mobile.meeting.learning.reader
+  title: Read the learning-loop digest on the iPad Dictate tab
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: mobile.meeting.proposals.review
+  title: Approve or reject actuator proposals in the iPad review queue
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - proposal-pending-approval
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: mobile.mesh.serve.consent_toggle
+  title: Flip one toggle to serve the mesh from the phone
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - mesh-node-alive
+  - first-run-no-model
+  priority: must
+  status: live
+- key: mobile.mesh.serve.execute_ask
+  title: A desk ask executes on the phone's own model, badged mesh
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.models.import_and_manage
+  title: Import and manage on-device models (Files sideload + AirDrop + HF download)
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  - model-file-in-files-app
+  priority: must
+  status: live
+- key: mobile.models.inference_mode_setting
+  title: Choose where inference runs (local / homelab / any endpoint)
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: unknown
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - endpoint-reachable
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: mobile.models.on_device_inference
+  title: Run meeting intelligence fully on-device (Mode A, local GGUF)
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - model-installed-on-device
+  - meeting-just-ended-open-actions
+  - airplane-mode-on
+  priority: must
+  status: live
+- key: mobile.models.per_device_defaults
+  title: Get the right model tier for your device automatically
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  priority: spot
+  status: live
+- key: mobile.profiles.active_picker
+  title: Pick the active runtime profile on the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - first-run-no-model
+  priority: must
+  status: live
+- key: mobile.profiles.key_never_syncs
+  title: A profile's API key never leaves the device / never syncs
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.profiles.manage_advanced
+  title: Manage the profile list and assign per-agent profiles on the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: mobile.steering.attach_arm_steer
+  title: Attach, arm, and steer a live agent session from the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.steering.audit_trail
+  title: Steering actions are audited and readable back on the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: should
+  status: live
+- key: mobile.steering.factory_lifecycle
+  title: Spawn, rename, and kill agent sessions from the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.steering.key_palette
+  title: Send raw keys to an agent pane from the iPad key palette
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: mobile.steering.node_relay
+  title: Steer an agent on any machine via the iPad node relay
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: mobile.steering.pane_picker
+  title: Pick and attach to any agent pane from the iPad
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: should
+  status: live
+- key: mobile.trust.egress.badge
+  title: One honest egress badge on every mobile surface
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: mobile.trust.github.honesty
+  title: GitHub tile tells the truth about paired vs configured
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: mobile.workbench.graph.author
+  title: Author a runnable graph (blueprint) on the iPad and sync it to the hub
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: mobile.workbench.run.warning
+  title: The run UI renders the hub's warning on unhonored graph features
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: models.byo.three-backends
+  title: 'Bring your own LLM: GGUF in-process, MLX on Apple Silicon, or any OpenAI-compatible endpoint'
+  domain: public-docs-claims
+  phases:
+  - 65
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - first-run-no-model
+  priority: must
+  status: live
+- key: models.mesh.serve-another-machine
+  title: A profile can name another of your machines to execute runs on it
+  domain: public-docs-claims
+  phases:
+  - 85
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - mesh-node-alive
+  - mesh-node-just-died
+  priority: must
+  status: live
+- key: models.profiles.runs-on-per-agent
+  title: 'Runtime profiles: a named target you point work at, per agent'
+  domain: public-docs-claims
+  phases:
+  - 84
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: onboarding.first_dictation.reward
+  title: Guided first-dictation with a live success reward
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 42
+  - 43
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  priority: should
+  status: live
+- key: onboarding.model.setup_assistant
+  title: Guided runtime model setup with a one-click 'Test my runtime'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 42
+  - 43
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  priority: should
+  status: live
+- key: onboarding.trust.privacy_chip
+  title: Ambient Trust & Privacy chip + 'what can leave this machine' panel
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 42
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - intel-endpoint-dead
+  priority: should
+  status: live
+- key: onboarding.welcome.wizard
+  title: Full-screen /welcome first-run wizard to first dictation
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 42
+  - 43
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  priority: must
+  status: live
+- key: plugins.authoring.write-your-own
+  title: Write your own meeting plugin or connector against a documented contract
+  domain: public-docs-claims
+  phases:
+  - 38
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: presence.desktop.hud
+  title: Ambient desktop presence HUD showing dictation state
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 41
+  - 43
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: presence.toggle.config_backed
+  title: Turn desktop presence on/off from a settings toggle (live start/stop)
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 43
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: should
+  status: live
+- key: qlippy.decision_cards
+  title: Qlippy sliding cards for four moments
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 56
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - presence-and-mascot-enabled
+  - proposal-pending-approval
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: qlippy.native_hud_overlay
+  title: Qlippy native desktop HUD overlay
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 41
+  - 56
+  surfaces:
+    web: unknown
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - presence-and-mascot-enabled
+  - proposal-pending-approval
+  - linux-or-macos-desktop
+  priority: spot
+  status: live
+- key: qlippy.presence_dock
+  title: Qlippy ambient presence dock
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 56
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - presence-and-mascot-enabled
+  priority: should
+  status: live
+- key: rails.ground_run
+  title: Ground any run on the rails
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 88
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - belt-with-registered-rails-repo
+  - agent-session-live
+  priority: should
+  status: live
+- key: rails.observer_journal
+  title: The ambient rails journal (opt-in)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 88
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - belt-with-registered-rails-repo
+  - mesh-node-alive
+  priority: spot
+  status: live
+- key: release.backup_restore.cli
+  title: Back up and restore the whole HoldSpeak database from the CLI
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 50
+  surfaces:
+    web: 'no'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: release.doctor.database_check
+  title: doctor reports database + config health honestly
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 50
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: release.schema.safe_upgrade
+  title: 'Safe schema upgrade: backup-then-apply older, refuse newer'
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 50
+  surfaces:
+    web: 'no'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: runtime.doctor_egress
+  title: Honest doctor + one egress badge derivation
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 84
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - intel-endpoint-dead
+  priority: should
+  status: live
+- key: runtime.pick_everywhere
+  title: Meeting-intel and dictation run on a picked profile
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 84
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: should
+  status: live
+- key: runtime.run_born_artifact
+  title: A run answer becomes a real artifact
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 74
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: should
+  status: live
+- key: runtime.web.profiles_editor
+  title: Runtime profiles editor (/profiles)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 84
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: steering.arm_steer
+  title: Arm and steer a session (consent-gated)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 87
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-session-live
+  - agent-pane-armed
+  - agent-pane-recycled
+  priority: must
+  status: live
+- key: steering.attach_any_pane
+  title: Attach to any tmux pane
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 89
+  - 90
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - hand-started-tmux-pane
+  priority: should
+  status: live
+- key: steering.audit
+  title: The steering audit trail
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 87
+  - 89
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - agent-session-live
+  priority: should
+  status: live
+- key: steering.classify
+  title: Classify what a session surfaces
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 87
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  - proposal-pending-approval
+  priority: should
+  status: live
+- key: steering.cross_machine
+  title: 'HANDOFF: steer a session on another machine'
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 89
+  - 90
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - remote-steer-node-alive
+  - remote-steer-node-offline
+  priority: must
+  status: live
+- key: steering.ground
+  title: Ground a steer with a desk object
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 87
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - agent-session-live
+  - agent-pane-armed
+  - seeded-desk
+  priority: must
+  status: live
+- key: steering.keys
+  title: Send any key to a session (key palette)
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 89
+  - 90
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-session-live
+  - agent-pane-armed
+  - agent-runaway
+  priority: must
+  status: live
+- key: steering.peek
+  title: Watch a live agent session from the desk
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 87
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-session-live
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: sync.capability.model_manifest
+  title: See which of your nodes can run which model
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - model-installed-on-device
+  priority: should
+  status: live
+- key: sync.content.cross_device
+  title: Have a meeting captured on one device appear on another
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - two-devices-paired
+  priority: must
+  status: live
+- key: sync.contracts.parity_spine
+  title: The cross-surface JSON-Schema contract spine (parity foundation)
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: sync.integrity.roundtrip
+  title: All 10 primitive kinds round-trip across the sync wire byte-faithfully
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: must
+  status: live
+- key: sync.organization.kb_directory_travels
+  title: Have knowledge bases and directories flow across surfaces
+  domain: HoldSpeak Mobile
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - two-devices-paired
+  priority: should
+  status: live
+- key: sync.storage.doctor_panel
+  title: The readiness / doctor panel in iPad Settings
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  - first-run-no-model
+  priority: should
+  status: live
+- key: sync.storage.refuse_newer
+  title: The iPad store refuses a newer schema and backs up before migrating
+  domain: HoldSpeak Mobile phases 18-27
+  phases: []
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: trust.architecture_map
+  title: The rendered architecture map
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 66
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes: []
+  priority: skip
+  status: live
+- key: trust.binding.loopback-token-gate
+  title: Web runtime binds loopback by default; off-loopback binds refuse without an auth token
+  domain: public-docs-claims
+  phases:
+  - 41
+  - 50
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: trust.device.psk-audio-link
+  title: Paired device audio link authenticates with a constant-time PSK, same-LAN scope
+  domain: public-docs-claims
+  phases:
+  - 53
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: trust.egress.badge-tells-truth
+  title: The egress badge names local vs the exact endpoint on every card
+  domain: public-docs-claims
+  phases:
+  - 58
+  - 62
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: trust.egress.cloud-meeting-intel
+  title: Cloud meeting intel egress only on explicit provider choice
+  domain: public-docs-claims
+  phases:
+  - 61
+  - 62
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - intel-endpoint-dead
+  priority: must
+  status: live
+- key: trust.egress.connector-cli-enrichment
+  title: Connector CLI enrichment sends only entity IDs to the user's own gh/jira tools
+  domain: public-docs-claims
+  phases:
+  - 38
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - seeded-desk
+  priority: spot
+  status: live
+- key: trust.egress.deferred-intel-webhook
+  title: Deferred-intel failure webhook sends queue stats only, no transcript, opt-in
+  domain: public-docs-claims
+  phases:
+  - 36
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes:
+  - intel-endpoint-dead
+  priority: spot
+  status: live
+- key: trust.egress.desk-github-issue
+  title: Desk GitHub issue files title+body through the user's own gh CLI on approval
+  domain: public-docs-claims
+  phases:
+  - 37
+  - 49
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: trust.egress.desk-webhook-connector
+  title: Desk webhook connector sends previewed text to one configured endpoint on per-send approval
+  domain: public-docs-claims
+  phases:
+  - 37
+  - 38
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: trust.egress.mesh-relay
+  title: Mesh relay moves only prompt+result between hub and the node you named, no keys transit
+  domain: public-docs-claims
+  phases:
+  - 85
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - mesh-node-alive
+  - mesh-node-just-died
+  priority: must
+  status: live
+- key: trust.egress.missioncontrol-receipts
+  title: 'Mission-control belt is GET-only: reads open PRs via the user''s own gh, composes nothing'
+  domain: public-docs-claims
+  phases:
+  - 88
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+- key: trust.egress.send-to-slack-double-optin
+  title: Send to Slack requires URL config plus per-send approval, URL never rides payloads
+  domain: public-docs-claims
+  phases:
+  - 61
+  - 62
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - meeting-just-ended-open-actions
+  - proposal-pending-approval
+  priority: must
+  status: live
+- key: trust.egress.wake-model-download
+  title: Wake-word enable triggers a one-time inbound model download, no audio ever egresses
+  domain: public-docs-claims
+  phases:
+  - 60
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - first-run-no-model
+  priority: should
+  status: live
+- key: trust.egress_badge
+  title: Egress badge on every actionable card
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 62
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - proposal-pending-approval
+  - learned-correction-taught
+  - meeting-just-ended-open-actions
+  priority: must
+  status: live
+- key: trust.no-telemetry
+  title: No telemetry, crash reporting, or background beaconing anywhere
+  domain: public-docs-claims
+  phases:
+  - 58
+  - 62
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: trust.positioning_readme
+  title: The README/front-door pitch and comparison
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 58
+  - 64
+  surfaces:
+    web: unknown
+    ipad: unknown
+    iphone: unknown
+  recipes: []
+  priority: spot
+  status: live
+- key: trust.secrets.profile-key-never-syncs
+  title: Runtime profile keys never sync; a key supplied to any ingress never reappears on a read
+  domain: public-docs-claims
+  phases:
+  - 84
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: trust.steering.arming-grant
+  title: Session steering requires an in-memory arming grant, TTL'd and pane-pinned; hub restart disarms
+  domain: public-docs-claims
+  phases:
+  - 87
+  - 89
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: trust.steering.named-key-allowlist
+  title: Only allow-listed named keys reach tmux; an arbitrary string can never become a keystroke
+  domain: public-docs-claims
+  phases:
+  - 89
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: trust.steering.relay-node-owns-grant
+  title: 'Cross-machine steering: the typing node owns the grant and audit; only command+node token cross'
+  domain: public-docs-claims
+  phases:
+  - 89
+  - 90
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - mesh-node-alive
+  - mesh-node-just-died
+  priority: must
+  status: live
+- key: trust.steering.session-factory-gates
+  title: 'Session factory: spawn/rename name-allow-listed, kill gated exactly like a steer'
+  domain: public-docs-claims
+  phases:
+  - 90
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - agent-pane-awaiting-input
+  priority: must
+  status: live
+- key: ui.signal.design_system
+  title: Signal dark-first UI across every web surface
+  domain: HoldSpeak desktop phases 30-53
+  phases:
+  - 30
+  - 44
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  priority: spot
+  status: live
+- key: wakeword.hands_free_arm
+  title: Wake word arms HoldSpeak hands-free
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 60
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - fresh-desk
+  - wake-word-enabled
+  - first-run-no-model
+  priority: must
+  status: live
+- key: wakeword.preview_before_type
+  title: Wake result previews before it types (consent gate)
+  domain: 'HoldSpeak desktop phases 54-67 — productization: meeting/tra'
+  phases:
+  - 60
+  surfaces:
+    web: 'yes'
+    ipad: unknown
+    iphone: unknown
+  recipes:
+  - wake-word-enabled
+  - wake-result-pending-preview
+  priority: must
+  status: live
+- key: workbench.web.generation_theater
+  title: The generation theater
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 69
+  - 81
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  - mesh-node-alive
+  priority: spot
+  status: live
+- key: workbench.web.node_canvas
+  title: The /workbench node canvas
+  domain: HoldSpeak desktop phases 68-90
+  phases:
+  - 69
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: unknown
+  recipes:
+  - seeded-desk
+  priority: should
+  status: live
+phase_map:
+  '0':
+  - dictation.voice_typing.hold_to_talk
+  '1':
+  - dictation.blocks.author
+  - dictation.clipboard.token
+  - dictation.kb.project_facts
+  - dictation.pipeline.enable
+  - dictation.punctuation.spoken
+  - dictation.runtime.backend_picker
+  - dictation.target.profile_detection
+  - dictation.voice_typing.hold_to_talk
+  '2':
+  - meetings.capture.live
+  - meetings.intel.cloud_endpoint
+  - meetings.intel.multi_intent_routing
+  '3':
+  - dictation.clipboard.token
+  - dictation.kb.project_facts
+  - dictation.pipeline.dry_run
+  - dictation.pipeline.enable
+  - dictation.project_context.hs_files
+  - dictation.runtime.backend_picker
+  - dictation.runtime.openai_compatible
+  '4':
+  - dictation.blocks.author
+  - dictation.pipeline.dry_run
+  '5':
+  - internal/no-uat-surface
+  '6':
+  - meetings.actions.review_edit
+  - meetings.artifacts.cards
+  - meetings.capture.live
+  '7':
+  - meetings.export.local_handoff
+  '8':
+  - activity.ledger.browser_history
+  - activity.prebriefing.nudges
+  '9':
+  - activity.candidates.meeting
+  - activity.enrichment.connectors
+  - activity.prebriefing.nudges
+  '10':
+  - internal/no-uat-surface
+  '11':
+  - activity.enrichment.connectors
+  '12':
+  - internal/no-uat-surface
+  '13':
+  - activity.candidates.meeting
+  - activity.enrichment.connectors
+  '14':
+  - devices.audio.remote_ingest
+  '15':
+  - internal/no-uat-surface
+  '16':
+  - meetings.intel.cloud_endpoint
+  - meetings.plugins.fourteen_synthesizers
+  '17':
+  - devices.audio.remote_ingest
+  - devices.health.status
+  '18':
+  - dictation.agent_hooks.claude_codex
+  - dictation.blocks.author
+  - dictation.pipeline.enable
+  - dictation.project_context.hs_files
+  - dictation.runtime.backend_picker
+  - dictation.runtime.openai_compatible
+  - dictation.target.profile_detection
+  '19':
+  - dictation.agent_hooks.claude_codex
+  - dictation.project_context.hs_files
+  - dictation.runtime.openai_compatible
+  - dictation.target.profile_detection
+  '20':
+  - devices.companion.agent_waiting
+  '21':
+  - devices.audio.remote_ingest
+  '22':
+  - devices.companion.agent_waiting
+  - devices.health.status
+  '23':
+  - devices.companion.agent_waiting
+  - devices.health.status
+  '24':
+  - devices.health.status
+  '25':
+  - internal/no-uat-surface
+  '26':
+  - internal/no-uat-surface
+  '27':
+  - meetings.intel.multi_intent_routing
+  - meetings.plugins.fourteen_synthesizers
+  '28':
+  - meetings.plugins.fourteen_synthesizers
+  '29':
+  - meetings.plugins.fourteen_synthesizers
+  '30':
+  - ui.signal.design_system
+  '31':
+  - internal/no-uat-surface
+  '32':
+  - internal/no-uat-surface
+  '33':
+  - internal/no-uat-surface
+  '34':
+  - internal/no-uat-surface
+  '35':
+  - internal/no-uat-surface
+  '36':
+  - meetings.artifacts.cards
+  - meetings.capture.live-mic-system-audio
+  - meetings.intel.intent-scored-chain
+  - meetings.intel.multi_intent_routing
+  - meetings.plugins.14-typed-artifacts
+  - trust.egress.deferred-intel-webhook
+  '37':
+  - actuators.governance.gate
+  - actuators.proposal.approve_execute
+  - trust.egress.desk-github-issue
+  - trust.egress.desk-webhook-connector
+  '38':
+  - actuators.connector.github_issue
+  - actuators.connector.webhook_post
+  - actuators.live.pending_actions_panel
+  - plugins.authoring.write-your-own
+  - trust.egress.connector-cli-enrichment
+  - trust.egress.desk-webhook-connector
+  '39':
+  - dictation.correction.session_memory
+  - dictation.rewrite.multi_pass
+  - dictation.suggestions.quality_gate
+  - dictation.target.model_assisted_detection
+  - dictation.telemetry.depth_readiness
+  '40':
+  - config.cockpit.copilot_setup
+  - config.memory.curate_corrections
+  - dictation.correction.session_memory
+  - dictation.rewrite.multi_pass
+  - dictation.telemetry.depth_readiness
+  '41':
+  - desk.presence.qlippy-opt-in
+  - presence.desktop.hud
+  - qlippy.native_hud_overlay
+  - trust.binding.loopback-token-gate
+  '42':
+  - config.settings.searchable
+  - dictation.voice-typing.hold-to-talk
+  - onboarding.first_dictation.reward
+  - onboarding.model.setup_assistant
+  - onboarding.trust.privacy_chip
+  - onboarding.welcome.wizard
+  '43':
+  - config.settings.searchable
+  - onboarding.first_dictation.reward
+  - onboarding.model.setup_assistant
+  - onboarding.welcome.wizard
+  - presence.desktop.hud
+  - presence.toggle.config_backed
+  '44':
+  - ui.signal.design_system
+  '45':
+  - dictation.correction.one-tap-teaches
+  - dictation.journal.review
+  - dictation.journal.said-to-typed
+  - dictation.moment_of_truth.correct_inline
+  - dictation.replay.through_current_pipeline
+  - dictation.replay.watch-routing-change
+  '46':
+  - internal/no-uat-surface
+  '47':
+  - dictation.kb.project_facts
+  - kb.project.discovery_nudge
+  - kb.project.facts_and_context
+  - kb.project.guided_setup
+  '48':
+  - dictation.correction.one-tap-teaches
+  - dictation.journal.said-to-typed
+  - dictation.learning-digest.honest-count
+  - dictation.learning.digest
+  - dictation.learning.trust_signals
+  - dictation.moment_of_truth.correct_inline
+  '49':
+  - meetings.aftercare.action-to-issue
+  - meetings.aftercare.close-the-loop
+  - meetings.aftercare.digest
+  - meetings.aftercare.file_as_issue
+  - meetings.aftercare.followup_draft
+  - meetings.aftercare.show_the_moment
+  - meetings.aftercare.transcript-moment-jump
+  - meetings.proposals.review-anywhere
+  - trust.egress.desk-github-issue
+  '50':
+  - desk.data.schema-safe-upgrades
+  - desk.doctor.honest-readout
+  - release.backup_restore.cli
+  - release.doctor.database_check
+  - release.schema.safe_upgrade
+  - trust.binding.loopback-token-gate
+  '51':
+  - internal/no-uat-surface
+  '52':
+  - dictation.pipeline.intent-routing
+  - dictation.voice-commands.keyword-to-action
+  - macros.voice_commands.board
+  - macros.voice_commands.fire_while_dictating
+  '53':
+  - activity.prebriefing.dictate_with_this
+  - activity.prebriefing.nudges
+  - dictation.activity-prebriefing.cited-nudges
+  - trust.device.psk-audio-link
+  '54':
+  - internal/no-uat-surface
+  '55':
+  - meetings.archive.delete
+  - meetings.archive.facet-search
+  - meetings.archive.faceted_search
+  - meetings.capture.live-mic-system-audio
+  - meetings.import.audio
+  - meetings.import.recording-and-transcript
+  '56':
+  - desk.presence.qlippy-opt-in
+  - qlippy.decision_cards
+  - qlippy.native_hud_overlay
+  - qlippy.presence_dock
+  '57':
+  - meetings.import.recording-and-transcript
+  - meetings.import.transcript
+  '58':
+  - trust.egress.badge-tells-truth
+  - trust.no-telemetry
+  - trust.positioning_readme
+  '59':
+  - dictation.language.99-whisper-languages
+  - dictation.symbol-dictionary.spoken-vocabulary
+  - languages.spoken_language
+  - languages.spoken_symbol_dictionary
+  '60':
+  - dictation.pipeline.preview-before-type
+  - dictation.wake-word.hands-free-preview
+  - trust.egress.wake-model-download
+  - wakeword.hands_free_arm
+  - wakeword.preview_before_type
+  '61':
+  - actuators.slack.send
+  - meetings.proposals.review-anywhere
+  - trust.egress.cloud-meeting-intel
+  - trust.egress.send-to-slack-double-optin
+  '62':
+  - trust.egress.badge-tells-truth
+  - trust.egress.cloud-meeting-intel
+  - trust.egress.send-to-slack-double-optin
+  - trust.egress_badge
+  - trust.no-telemetry
+  '63':
+  - internal/no-uat-surface
+  '64':
+  - trust.positioning_readme
+  '65':
+  - dictation.voice-typing.hold-to-talk
+  - models.byo.three-backends
+  '66':
+  - trust.architecture_map
+  '67':
+  - internal/no-uat-surface
+  '68':
+  - internal/no-uat-surface
+  '69':
+  - desk.web.mic_waveform
+  - desk.web.queue_hud
+  - workbench.web.generation_theater
+  - workbench.web.node_canvas
+  '70':
+  - desk.web.four_doors_ia
+  - desk.web.one_arrival
+  '71':
+  - desk.web.free_placement
+  - desk.web.front_door
+  - desk.web.objects_float
+  - desk.web.qlippy_life
+  - desk.web.zones_file_dive
+  '72':
+  - internal/no-uat-surface
+  '73':
+  - desk.ask-ai.grounded-on-pile
+  - desk.front-door.spatial-objects
+  - desk.web.agent_rail_run
+  - desk.web.create_in_world
+  - desk.web.free_placement
+  - desk.web.front_door
+  - desk.web.objects_float
+  - desk.web.one_arrival
+  - desk.web.pullout_open
+  - desk.web.record_orb
+  - desk.web.zones_file_dive
+  '74':
+  - runtime.run_born_artifact
+  '75':
+  - dictation.pipeline.preview-before-type
+  - dictation.preview_before_type
+  '76':
+  - internal/no-uat-surface
+  '77':
+  - desk.web.queue_hud
+  '78':
+  - desk.coders.answer-grounded-or-ai-drafted
+  - desk.web.answer_waiting_coder
+  - desk.web.transcribe_everywhere
+  '79':
+  - internal/no-uat-surface
+  '80':
+  - belt.approval.import_run_chain
+  '81':
+  - workbench.web.generation_theater
+  '82':
+  - belt.approval_leg
+  - belt.conveyor
+  '83':
+  - ask.web.ground_this_ask
+  - ask.web.models_door
+  - ask.web.persona_threads
+  - ask.web.token_auth_arrival
+  - desk.ask-ai.grounded-on-pile
+  - desk.front-door.spatial-objects
+  - desk.personas.conversation-thread
+  '84':
+  - desk.doctor.honest-readout
+  - desk.models.open-a-model-chat
+  - desk.sync.profile-shape-across-surfaces
+  - models.profiles.runs-on-per-agent
+  - runtime.doctor_egress
+  - runtime.pick_everywhere
+  - runtime.web.profiles_editor
+  - trust.secrets.profile-key-never-syncs
+  '85':
+  - desk.models.open-a-model-chat
+  - mesh.handoff.web_run_to_node
+  - mesh.liveness_everywhere
+  - mesh.profile_node
+  - mesh.serve_node
+  - models.mesh.serve-another-machine
+  - trust.egress.mesh-relay
+  '86':
+  - belt.conveyor
+  - belt.receipts
+  '87':
+  - desk.coders.agents-on-the-desk
+  - desk.coders.answer-grounded-or-ai-drafted
+  - desk.personas.conversation-thread
+  - steering.arm_steer
+  - steering.audit
+  - steering.classify
+  - steering.ground
+  - steering.peek
+  - trust.steering.arming-grant

--- a/uat/scenarios/smoke/01-desk-seeded-walk.yaml
+++ b/uat/scenarios/smoke/01-desk-seeded-walk.yaml
@@ -1,0 +1,26 @@
+id: smoke-desk-seeded-walk
+title: A seeded desk, read on all three surfaces
+features:
+  - desk.ask-ai.grounded-on-pile
+  - kb.project.facts_and_context
+recipes:
+  - seeded-desk
+# Three-surface by default; the note-detail view is opted out on iPhone with a
+# stated reason (an honest n/a, never a silent absence).
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: yes
+steps:
+  - do: Open the desk and look at the notes.
+    expect: Three notes are present — "Q3 architecture decisions", "Standup — pylon incident follow-ups", and "Project glossary".
+    where: /
+  - do: Open the "Project glossary" note.
+    expect: The note body shows the three glossary terms (BLUEBIRD, Pylon, Questline).
+    where: /
+    surfaces:
+      iphone: {n/a: "the note-detail view is not confirmed on the iPhone form factor (directory row unknown)"}
+  - do: Open the two knowledge bases on the desk.
+    expect: The Project KB and the Incident runbooks KB are both present and openable.
+    where: /
+teardown: []

--- a/uat/scenarios/smoke/02-dictation-runtime.yaml
+++ b/uat/scenarios/smoke/02-dictation-runtime.yaml
@@ -1,0 +1,19 @@
+id: smoke-dictation-runtime
+title: The dictation pipeline, on a fresh desk
+features:
+  - dictation.pipeline.enable
+  - dictation.pipeline.dry_run
+recipes:
+  - fresh-desk
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the dictation runtime configuration surface is not confirmed on the iPhone form factor (directory row unknown)"}
+steps:
+  - do: Open the dictation runtime settings.
+    expect: The pipeline configuration is shown with its stages; the current posture reads honestly (disabled on the fresh-desk deck).
+    where: /dictation
+  - do: Read the runtime backend the pipeline would route through.
+    expect: The configured backend is named plainly (no LLM is wired on golden-local, and the screen says so rather than implying one).
+    where: /dictation
+teardown: []

--- a/uat/scenarios/smoke/03-meeting-roundtrip.yaml
+++ b/uat/scenarios/smoke/03-meeting-roundtrip.yaml
@@ -1,0 +1,23 @@
+id: smoke-meeting-roundtrip
+title: A meeting round-trip — import to open actions
+features:
+  - meetings.import.transcript
+  - meetings.aftercare.digest
+  - meetings.aftercare.show_the_moment
+recipes:
+  - meeting-just-ended-open-actions
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the meeting aftercare surface on iPhone is unverified in the record (HSM built the iPad aftercare; the phone leg is the open question)"}
+steps:
+  - do: Open the meeting history and find the imported meeting.
+    expect: The meeting titled Pylon incident war room (UAT seed) is listed, its intel status reads done, and it shows at least one open action.
+    where: /history
+  - do: Open the meeting and read its intel artifacts.
+    expect: The right artifact types rendered — an action-item list with owners, and the decisions/open questions the war-room surfaced (judge on substance, not exact wording).
+    where: /history
+  - do: Open the aftercare digest and jump to the moment behind one open action.
+    expect: The digest names what is still open and by whom; the moment-jump lands on the transcript segment that produced it.
+    where: /history
+teardown: []

--- a/uat/scenarios/smoke/04-bad-endpoint-honest-failure.yaml
+++ b/uat/scenarios/smoke/04-bad-endpoint-honest-failure.yaml
@@ -1,0 +1,19 @@
+id: smoke-bad-endpoint-honest-failure
+title: A dead endpoint, named honestly
+features:
+  - desk.doctor.honest-readout
+  - dictation.pipeline.dry_run
+recipes:
+  - intel-endpoint-dead
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the doctor/runtime-test surface on iPhone is unverified in the record"}
+steps:
+  - do: Open the setup readiness screen and read the runtime state.
+    expect: The runtime is reported as unreachable and the dead endpoint is named — no spinner, no false green.
+    where: /setup
+  - do: Run the runtime test.
+    expect: It refuses in under five seconds and names the unreachable endpoint; it does not hang waiting on a dead port.
+    where: /setup
+teardown: []

--- a/uat/scenarios/smoke/05-first-run-no-model.yaml
+++ b/uat/scenarios/smoke/05-first-run-no-model.yaml
@@ -1,0 +1,19 @@
+id: smoke-first-run-no-model
+title: First run truth at N=0
+features:
+  - onboarding.welcome.wizard
+  - onboarding.model.setup_assistant
+recipes:
+  - first-run-no-model
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the first-run onboarding surface on iPhone is unverified in the record"}
+steps:
+  - do: Open the app for the first time on a machine with no model yet.
+    expect: The setup readiness surface says plainly it is not ready — it points at what to do next, and does not pretend a model is present.
+    where: /setup
+  - do: Read what the onboarding proposes.
+    expect: The next step is honest about the missing model (download or configure), with no green checkmark it has not earned.
+    where: /setup
+teardown: []

--- a/uat/scenarios/smoke/06-mesh-node-lifecycle.yaml
+++ b/uat/scenarios/smoke/06-mesh-node-lifecycle.yaml
@@ -1,0 +1,24 @@
+id: smoke-mesh-node-lifecycle
+title: A mesh node, alive then gone
+features:
+  - mesh.serve_node
+  - mesh.liveness_everywhere
+  - mesh.profile_node
+recipes:
+  - mesh-node-alive
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the mesh profile/liveness surface on iPhone is unverified in the record"}
+steps:
+  - do: Open the profiles view and find the mesh worker.
+    expect: The "uat-worker" node reads live — the hub has seen it poll recently.
+    where: /
+    # A mid-run conductor action: kill the worker's process group before the
+    # next step, so the human watches the world break in real time.
+    after:
+      - apply_recipe: mesh-node-just-died
+  - do: The node has just been stopped. Refresh the profiles view.
+    expect: The "uat-worker" node now reads offline; a forced run against it refuses fast, by name, rather than hanging.
+    where: /
+teardown: []

--- a/uat/scenarios/smoke/07-egress-badge-trust.yaml
+++ b/uat/scenarios/smoke/07-egress-badge-trust.yaml
@@ -1,0 +1,20 @@
+id: smoke-egress-badge-trust
+title: The egress badge tells the truth, on all three surfaces
+features:
+  - trust.egress.badge-tells-truth
+recipes:
+  - seeded-desk
+# The egress badge and the key-never-syncs promise are explicitly all-three in
+# the directory — this is a genuine three-surface trust check.
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: yes
+steps:
+  - do: Find the egress badge on the desk.
+    expect: The badge reads local. Nothing on this fully-local desk leaves the machine, and the badge says so in one word, not a paragraph.
+    where: /
+  - do: Open a seeded note and confirm its egress posture.
+    expect: The note's egress badge still reads local; no cloud badge appears for local-only content.
+    where: /
+teardown: []

--- a/uat/tools/build_ledger.py
+++ b/uat/tools/build_ledger.py
@@ -1,0 +1,180 @@
+"""Propose `uat/features.yaml` from the record — the ledger's derivation.
+
+The owner's standing point: *we have git; coverage is derived from the record,
+not remembered.* This script walks two sources already in the repo —
+
+- the Phase-2 inventory sweep (`_raw-inventory-rows.json`, 255 capabilities
+  with per-surface applicability, phases, needed recipes, priority), and
+- the holdspeak phase index (`pm/roadmap/holdspeak/README.md`, phases 0–N) —
+
+and emits a proposed `uat/features.yaml`: every capability as a stable ledger
+key with its per-surface applicability columns, plus a `phase_map` that pins
+**every** holdspeak phase to the keys that cover it (or an explicit
+`internal/no-uat-surface` marker — no phase silently absent).
+
+The script *proposes*; the committed YAML is canon (Phase 2 makes it
+exhaustive and resolves the `unknown`s). Run:
+
+    uv run python -m uat.tools.build_ledger            # writes uat/features.yaml
+    uv run python -m uat.tools.build_ledger --check    # fail if out of date
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+INVENTORY = (
+    REPO
+    / "pm/roadmap/holdspeak-uat/phase-2-the-inventory/directory/_raw-inventory-rows.json"
+)
+PHASE_INDEX = REPO / "pm/roadmap/holdspeak/README.md"
+LEDGER = REPO / "uat/features.yaml"
+
+NO_UAT_MARKER = "internal/no-uat-surface"
+
+_SURFACE = {"Y": "yes", "y": "yes", "n": "no", "N": "no", "?": "unknown"}
+_PRIORITY = {
+    "must-test": "must",
+    "should-test": "should",
+    "spot-check": "spot",
+    "skip": "skip",
+}
+
+
+def _surface(value: str | None) -> str:
+    return _SURFACE.get(str(value or "").strip(), "unknown")
+
+
+def _parse_phases(raw: str | None) -> list[int]:
+    """Pull the HS-<n> desktop phase numbers from a row's phases field."""
+    if not raw:
+        return []
+    nums = {int(m) for m in re.findall(r"HS-(\d+)", str(raw))}
+    return sorted(nums)
+
+
+def load_phase_index() -> dict[int, str]:
+    """Every holdspeak phase number → its one-line title (the authoritative set)."""
+    phases: dict[int, str] = {}
+    # | <n> | <title> | <status> | <folder> | — a lenient status column so
+    # hyphenated states (in-progress) and decorated ones still match.
+    row = re.compile(r"^\|\s*(\d+)\s*\|\s*(.+?)\s*\|\s*[^|]+\|")
+    for line in PHASE_INDEX.read_text().splitlines():
+        m = row.match(line)
+        if m:
+            phases[int(m.group(1))] = m.group(2).strip()
+    return phases
+
+
+def build_entries(rows: list[dict]) -> list[dict]:
+    by_key: dict[str, dict] = {}
+    for r in rows:
+        key = r["key"]
+        entry = {
+            "key": key,
+            "title": r.get("title", ""),
+            "domain": _domain_slug(r.get("domain", "")),
+            "phases": _parse_phases(r.get("phases")),
+            "surfaces": {
+                "web": _surface(r.get("w")),
+                "ipad": _surface(r.get("ip")),
+                "iphone": _surface(r.get("ph")),
+            },
+            "recipes": list(r.get("recipes") or []),
+            "priority": _PRIORITY.get(str(r.get("prio") or "").strip(), "unknown"),
+            "status": "live",
+        }
+        if key in by_key:
+            # The inventory can list a capability twice (two domains touch it);
+            # merge phases + recipes so the ledger key stays unique.
+            prev = by_key[key]
+            prev["phases"] = sorted(set(prev["phases"]) | set(entry["phases"]))
+            prev["recipes"] = sorted(set(prev["recipes"]) | set(entry["recipes"]))
+        else:
+            by_key[key] = entry
+    return sorted(by_key.values(), key=lambda e: e["key"])
+
+
+def _domain_slug(domain: str) -> str:
+    # The inventory's domain is a long prose string; keep a short leading token.
+    head = domain.split("(")[0].strip()
+    return head[:60]
+
+
+def build_phase_map(entries: list[dict], phase_index: dict[int, str]) -> dict[str, list[str]]:
+    by_phase: dict[int, list[str]] = {p: [] for p in phase_index}
+    for e in entries:
+        for p in e["phases"]:
+            by_phase.setdefault(p, []).append(e["key"])
+    out: dict[str, list[str]] = {}
+    for p in sorted(phase_index):
+        keys = sorted(set(by_phase.get(p, [])))
+        out[str(p)] = keys or [NO_UAT_MARKER]
+    return out
+
+
+def render_yaml(entries: list[dict], phase_map: dict[str, list[str]], phase_index: dict[int, str]) -> str:
+    import yaml
+
+    doc = {
+        "version": 1,
+        "generated_by": "uat/tools/build_ledger.py (proposes; committed YAML is canon)",
+        "source": {
+            "inventory": str(INVENTORY.relative_to(REPO)),
+            "phase_index": str(PHASE_INDEX.relative_to(REPO)),
+            "phases_total": len(phase_index),
+        },
+        "features": entries,
+        "phase_map": phase_map,
+    }
+    header = (
+        "# The feature ledger — the enumerated shipped surface of HoldSpeak.\n"
+        "#\n"
+        "# Derived from the record (Phase-2 inventory + the holdspeak phase index) by\n"
+        "# uat/tools/build_ledger.py, then reviewed by hand. Scenarios cite these keys;\n"
+        "# debriefs compute coverage against them. `unknown` surface cells are honest at\n"
+        "# v1 — Phase 2 (The Inventory) owns making this exhaustive and resolving them.\n"
+        "#\n"
+        "# phase_map pins every holdspeak phase to the keys covering it, or the\n"
+        f"# {NO_UAT_MARKER} marker — no phase silently absent.\n"
+        "#\n"
+        "# Regenerate: uv run python -m uat.tools.build_ledger\n"
+    )
+    return header + yaml.safe_dump(doc, sort_keys=False, width=100, allow_unicode=True)
+
+
+def generate() -> str:
+    rows = json.loads(INVENTORY.read_text())
+    phase_index = load_phase_index()
+    entries = build_entries(rows)
+    phase_map = build_phase_map(entries, phase_index)
+    return render_yaml(entries, phase_map, phase_index)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true", help="fail if features.yaml is stale")
+    ap.add_argument("--out", default=str(LEDGER))
+    args = ap.parse_args(argv)
+
+    content = generate()
+    out = Path(args.out)
+    if args.check:
+        current = out.read_text() if out.exists() else ""
+        if current != content:
+            print(f"features.yaml is stale — re-run: uv run python -m uat.tools.build_ledger", file=sys.stderr)
+            return 1
+        print("features.yaml is up to date.")
+        return 0
+    out.write_text(content)
+    print(f"wrote {out} ({content.count(chr(10))} lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**HSU-1-03 — The scenario contract + the feature ledger.** The scenario is the unit of UAT; the ledger is what it cites.

- **`uat/features.yaml`** — 255 capabilities as stable keys, each with per-surface applicability (`yes|no|unknown`), the holdspeak phases that shipped it, needed recipes, and priority. A `phase_map` pins **every** holdspeak phase 0–87 to its covering keys or an explicit `internal/no-uat-surface` marker (20 internal/refactor phases carry it) — no phase silently absent. Seeded from the Phase-2 directory's 255 rows by `uat/tools/build_ledger.py` (proposes; committed YAML is canon, freshness-checked in CI).
- **`uat/conductor/contract/`** — the scenario loader + validation (named `ERROR <path>: <issue>`), the three-surface axis (opt out only with `{n/a: <reason>}`), and exact per-surface + overall coverage math (retired excluded, `unknown` counted distinctly).
- **`uat/scenarios/smoke/`** — 7 scenarios proving the whole vocabulary: both golden decks' postures, both bad decks, a three-surface desk walk, an honest per-surface `n/a`, and a mid-run mesh kill.
- Conductor API: `GET /api/features`, `GET /api/packs`, `GET /api/packs/{pack}`.

**Proof:** 65 local `tests/uat/` (schema validation positive+negative, ledger integrity + phase exhaustiveness, coverage math per surface, smoke-pack vocabulary). Still no `holdspeak` import. Evidence: `pm/roadmap/holdspeak-uat/phase-1-the-mechanics/evidence-story-03.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ