### PR TITLE
holdspeak-uat HSU-1-06: docs + real scenario packs (sitting stays owner-gated)

### DIFF
--- a/dogfood/PROTOCOL.md
+++ b/dogfood/PROTOCOL.md
@@ -1,5 +1,17 @@
 # HoldSpeak Dogfood Protocol
 
+> **Superseded by the UAT rig.** UAT is now run through the web-based framework
+> at [`../uat/`](../uat/README.md): `uv run python -m uat.conductor` boots an
+> isolated HoldSpeak, stages named idempotent state recipes, and walks you
+> through a pack beat by beat with a verdict per surface landing in a run DB — a
+> guided site instead of this fillable checklist (which sat on the shelf, the
+> exact failure mode UAT exists to prevent). This file's **substrate is reused**
+> by the rig — the isolated `_home` recipe (ported to `uat/conductor/home.py`),
+> the mock repos under `repos/`, the committed transcripts under `transcripts/`,
+> and `make_fixtures.py` — so nothing here is dead; it is the conductor's
+> foundation. Keep this document as the manual fallback and the substrate's home;
+> **run UAT from `../uat/`.**
+
 The end-to-end exercise. You drive a real, isolated HoldSpeak against believable
 data — three mock repos with `.hs/` context and completed-stage history, plus
 meetings and dictation rendered through the macOS `say` voices — and you check

--- a/pm/roadmap/holdspeak-uat/README.md
+++ b/pm/roadmap/holdspeak-uat/README.md
@@ -5,7 +5,7 @@
 > source seams, the autonomy contract, and the definition of done. It is written
 > to be executed unattended, end to end.
 
-**Last updated:** 2026-07-09 (HSU-1-05 shipped — the debrief packet (md+json, per-surface scores + log slices) + findings/triage lifecycle + TRIAGE.md + the BACKLOG feed; Phase 1 at 5/6)
+**Last updated:** 2026-07-09 (HSU-1-06 docs + real packs shipped — uat/README+AUTHORING, dogfood supersession, Packs D/A/C. The framework is complete and running; the one remaining beat is the owner's live sitting. Phase 1 at 5/6 + docs)
 **Current phase:** [Phase 1 — The Mechanics](./phase-1-the-mechanics/current-phase-status.md)
 **Status:** active
 

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/current-phase-status.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/current-phase-status.md
@@ -1,8 +1,9 @@
 # Phase 1 — The Mechanics
 
-**Last updated:** 2026-07-09 (HSU-1-05 shipped: the debrief packet
-(md+json, per-surface scores + log slices), the findings/triage
-lifecycle, `uat/TRIAGE.md`, and the BACKLOG-block feed; 5/6)
+**Last updated:** 2026-07-09 (HSU-1-06 docs + real scenario packs
+shipped — `uat/README.md`/`AUTHORING.md`, dogfood supersession, Packs
+D/A/C; the engine + web loop are complete. **The one thing left is the
+owner's live sitting** (HSU-1-06's owner-gated beat); 5/6 + docs)
 
 ## Goal
 
@@ -85,9 +86,28 @@ sitting run end to end by the owner across all three surfaces.
 | HSU-1-03 | The scenario contract + the feature ledger | done | [story-03](./story-03-scenario-contract-and-coverage.md) | [evidence-03](./evidence-story-03.md) |
 | HSU-1-04 | The guided site | done | [story-04](./story-04-the-guided-site.md) | [evidence-04](./evidence-story-04.md) |
 | HSU-1-05 | The debrief + the triage protocol | done | [story-05](./story-05-the-debrief.md) | [evidence-05](./evidence-story-05.md) |
-| HSU-1-06 | Docs + the first sitting | backlog | [story-06](./story-06-docs-and-first-sitting.md) | — |
+| HSU-1-06 | Docs + the first sitting | in-progress (docs+packs done; sitting owner-gated) | [story-06](./story-06-docs-and-first-sitting.md) | — |
 
 ## Where we are
+
+**HSU-1-06 docs + real scenario packs shipped (2026-07-09); the live sitting
+is the owner's.** `uat/README.md` carries the owner wake-up runbook, the port
+map, the sitting flow, per-deck prerequisites, and an honest "Known state";
+`uat/AUTHORING.md` teaches adding a scenario/deck/seed/recipe; `dogfood/
+PROTOCOL.md` now points here as the way UAT is run (its substrate reused, none
+dead). Beyond the smoke pack, **real coverage packs** are authored so the rig
+puts the app through its paces: **Pack D — Honest Failure & Trust** (6
+scenarios, fully local — the owner's no-LAN wake-up path, staged end to end in
+CI), **Pack A — Meeting Aftercare** and **Pack C — Dictation Grounding** (`.43`
+web legs, control-vs-treatment + honest-failure closes). All 4 packs validate
+clean (21 scenarios). **The framework is complete and running** — the engine,
+the guided site, the debrief — proven by 86 local tests + the `.43` live
+proofs + a Playwright drive. The one remaining beat is **the owner's live
+sitting** (owner-gated: only the owner casts a real verdict, and device
+verdicts need a device in hand), after which the joint triage runs and the
+phase's final summary is written.
+
+---
 
 **HSU-1-05 is done (2026-07-09).** The debrief closes the loop from verdicts to
 joint review. At sitting end the conductor generates a packet into

--- a/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-06-docs-and-first-sitting.md
+++ b/pm/roadmap/holdspeak-uat/phase-1-the-mechanics/story-06-docs-and-first-sitting.md
@@ -2,9 +2,9 @@
 
 - **Project:** holdspeak-uat
 - **Phase:** 1
-- **Status:** backlog
+- **Status:** in-progress
 - **Depends on:** HSU-1-05
-- **Owner:** unassigned
+- **Owner:** agent (docs + packs) / owner (the live sitting)
 
 ## Problem
 
@@ -49,23 +49,32 @@ through the real protocol.
 
 ## Acceptance criteria
 
-- [ ] Both docs exist and are sufficient: a cold reader can start the
-      conductor, run a sitting, and author a scenario without reading
-      harness source.
-- [ ] `dogfood/PROTOCOL.md` points here; no dead absorbed files
-      remain.
-- [ ] The sitting happened on real metal: a completed smoke-pack run
-      in the run DB with a generated debrief, every scenario visited,
-      the three-surface scenario carrying verdicts on all three
-      surfaces with ≥1 cast from a device, real verdicts (a sitting
-      of ten PASSes cast in ten seconds is not a sitting — timestamps
-      are part of the evidence).
-- [ ] The triage ritual was held per `uat/TRIAGE.md`; ≥1 finding
-      dispositioned; any `fix` visible in
-      `pm/roadmap/holdspeak/BACKLOG.md`.
-- [ ] Phase exit criteria in `current-phase-status.md` all check;
-      final summary written with the Phase-2 handoff (uncovered ledger
-      keys as the scenario backlog).
+- [x] Both docs exist and are sufficient: `uat/README.md` (with the
+      owner wake-up runbook at the top, the port map, the sitting flow,
+      per-deck prerequisites, and an honest "Known state") + a cold
+      reader can author a scenario/deck/seed/recipe from
+      `uat/AUTHORING.md` without reading harness source.
+- [x] `dogfood/PROTOCOL.md` points here as the way UAT is now run; no
+      dead absorbed files remain (the substrate — `_home` recipe, mock
+      repos, transcripts, `make_fixtures.py` — is reused and documented).
+- [x] **Real scenario packs authored** (beyond the smoke pack, so the rig
+      puts the app through its paces): **Pack D — Honest Failure & Trust**
+      (6 scenarios, fully local, demos without the LAN), **Pack A —
+      Meeting Aftercare** and **Pack C — Dictation Grounding** (`.43`
+      web legs). All validate clean; Pack D stages locally end to end
+      (`test_packs.py`).
+- [ ] **OWNER-GATED — the live human sitting.** The rig is built up to
+      the sitting; the sitting itself cannot be delegated to an agent or
+      a simulator (that is the point of the project). Left for the owner:
+      a completed pack run in the run DB with a generated debrief, the
+      three-surface scenario carrying real verdicts on all three surfaces
+      with ≥1 cast from a device.
+- [ ] **OWNER-GATED — the joint triage** per `uat/TRIAGE.md`; ≥1 finding
+      dispositioned; any `fix` landed in `pm/roadmap/holdspeak/BACKLOG.md`
+      through the gate.
+- [ ] **OWNER-GATED — phase close.** Phase exit criteria checked and the
+      final summary written (with the Phase-2 handoff: the ledger's
+      uncovered keys are Phase 3's scenario backlog) after the sitting.
 
 ## Test plan
 

--- a/tests/uat/test_packs.py
+++ b/tests/uat/test_packs.py
@@ -1,0 +1,80 @@
+"""Every authored pack validates clean; Pack D stages fully locally (no .43)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from uat.conductor.app import create_app
+from uat.conductor.contract.coverage import pack_coverage
+from uat.conductor.contract.ledger import FeatureLedger
+from uat.conductor.contract.scenarios import list_packs, load_pack, validate_scenario
+from uat.conductor.db import Database
+from uat.conductor.induction.decks import DeckRegistry
+from uat.conductor.induction.recipes import RecipeRegistry
+from uat.conductor.runs import RunManager
+
+EXPECTED_PACKS = {"smoke", "pack-d-honest-failure", "pack-a-aftercare", "pack-c-dictation-grounding"}
+
+
+def test_expected_packs_present():
+    assert EXPECTED_PACKS <= set(list_packs())
+
+
+def test_every_pack_validates_clean():
+    ledger = FeatureLedger.load()
+    rn = set(RecipeRegistry().names())
+    dn = set(DeckRegistry().names())
+    for pack in list_packs():
+        scenarios = load_pack(pack)
+        assert scenarios, f"{pack} has no scenarios"
+        errors = []
+        for s in scenarios:
+            errors += validate_scenario(s, ledger_keys=ledger.keys(), recipe_names=rn, deck_names=dn)
+        assert errors == [], f"{pack}: {errors}"
+
+
+def test_pack_d_is_no_pack_all_green():
+    """PROTOCOL-NOTION: a pack must have a beat that can fail loudly."""
+    scenarios = load_pack("pack-d-honest-failure")
+    recipes = {r for s in scenarios for r in s.recipes}
+    # The failure decks are staged: dead endpoint + first-run no-model.
+    assert "intel-endpoint-dead" in recipes
+    assert "first-run-no-model" in recipes
+    # A mid-run failure verb (the mesh kill) closes a scenario.
+    assert any(st.after for s in scenarios for st in s.steps)
+
+
+def test_pack_d_and_c_carry_per_surface_na():
+    for pack in ("pack-d-honest-failure", "pack-c-dictation-grounding"):
+        scenarios = load_pack(pack)
+        na = [
+            v for s in scenarios for st in s.steps
+            for v in st.resolved_surfaces(s.surfaces).values() if not v["applicable"]
+        ]
+        assert na and all(v["reason"] for v in na), f"{pack} n/a must carry reasons"
+
+
+@pytest.fixture
+def real_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("UAT_RUNS_ROOT", str(tmp_path / "_runs"))
+    monkeypatch.setenv("UAT_DB_PATH", str(tmp_path / "_runs" / "uat.db"))
+    monkeypatch.delenv("UAT_REAL_HOME", raising=False)
+    mgr = RunManager(Database(), boot_timeout=60.0, link_caches=True)
+    app = create_app(mgr)
+    with TestClient(app) as c:
+        try:
+            yield c
+        finally:
+            mgr.teardown_all()
+
+
+def test_pack_d_stages_locally(real_client):
+    """Pack D demos without the LAN: its bad-endpoint scenario stages + verifies."""
+    created = real_client.post("/api/sittings", json={"pack": "pack-d-honest-failure"}).json()
+    if created["run"] is None or created["run"]["status"] != "up":
+        pytest.skip("product did not boot")
+    sid = created["id"]
+    # Stage the dead-endpoint scenario (fully local — port 9 refused).
+    staged = real_client.post(f"/api/sittings/{sid}/stage", json={"scenario_id": "d-dead-endpoint-doctor"}).json()
+    assert staged["ok"], staged

--- a/uat/AUTHORING.md
+++ b/uat/AUTHORING.md
@@ -1,0 +1,143 @@
+# Authoring UAT content
+
+How to add a scenario, a deck, a seed manifest, or a state recipe. Everything
+here is YAML validated by the contract — a malformed file fails loudly, naming
+the file and field.
+
+## The four building blocks
+
+```
+uat/decks/<name>.yaml       # a config posture the run boots with
+uat/seeds/<name>.yaml        # desk/context state applied through public routes
+uat/recipes/<name>.yaml      # deck + seeds + actions, closed by a verify probe
+uat/scenarios/<pack>/*.yaml  # the human script: steps × surfaces × verdicts
+uat/features.yaml            # the ledger every scenario cites (generated)
+```
+
+## Add a deck
+
+A deck is a **sparse** config overlay — state only the delta; the product's
+`Config.load` fills the rest.
+
+```yaml
+# uat/decks/my-deck.yaml
+title: My deck
+description: One line on what posture this induces.
+requires: []            # [intel] if it needs the .43 LAN endpoint
+config:
+  config_version: 1
+  meeting: { intel_enabled: false }
+```
+
+Every deck is round-tripped through the product's `Config.load` in
+`tests/uat/test_decks.py` so it can't rot. Add yours to `REQUIRED_DECKS` there
+if it's load-bearing.
+
+## Add a seed manifest
+
+Seeds carry a **deterministic `id`** so re-applying upserts in place (no
+duplicate desk). Meetings import a committed transcript.
+
+```yaml
+# uat/seeds/my-seed.yaml
+notes:
+  - id: uat-seed-my-note        # deterministic → idempotent
+    title: A note
+    body_markdown: "…"
+    tags: [uat-seed]
+kbs:
+  - id: uat-seed-my-kb
+    name: My KB
+meetings:
+  - transcript: dogfood/transcripts/pylon-incident.vtt
+    title: My meeting (UAT seed)
+    tags: [uat-seed]
+```
+
+## Add a state recipe
+
+A recipe names a world and closes with a **verify probe** read back through the
+product's own routes. Idempotency is the contract: applying it twice converges
+to the same verified state.
+
+```yaml
+# uat/recipes/my-world.yaml
+title: My world
+deck: golden-local        # the boot posture (default golden-local)
+requires: []              # [intel] gates it on .43
+includes: []              # other recipes' seeds/actions fold in (cycles refuse)
+boot: { link_caches: true }
+seeds: [my-seed]
+actions:                  # optional: spawn_node / kill_node / create_profile /
+  - wait: 2               # process_intel / restart / wait
+probe:                    # assertions read back through GET routes
+  - notes_min_count: 1
+  - note_exists: uat-seed-my-note
+```
+
+Probe kinds: `notes_empty|notes_min_count|note_exists`, the `kb*` equivalents,
+`meeting_with_open_actions`, `runtime_endpoint_unreachable`, `setup_not_ready`,
+`setup_reachable`, `mesh_node_live|mesh_node_offline`, `doctor_names_dead_endpoint`.
+A recipe that cannot verify itself raises `RecipeVerifyError` naming the missed
+assertion.
+
+## Add a scenario
+
+```yaml
+# uat/scenarios/<pack>/NN-slug.yaml
+id: my-scenario                 # unique within the pack
+title: A short human title
+features: [desk.ask-ai.grounded-on-pile]   # ≥1 ledger key that EXISTS
+recipes: [my-world]                         # ≥1 recipe that stages the world
+surfaces:                       # default all-yes; opt out only with a reason
+  web: yes
+  ipad: yes
+  iphone: {n/a: "why this surface genuinely lacks the capability"}
+steps:
+  - do: The instruction to the human.
+    expect: The honest pass bar (see the voice rule below).
+    where: /                    # optional product route to open
+    surfaces:                   # optional per-step override
+      ipad: {n/a: "reason"}
+    after:                      # optional mid-run conductor actions
+      - apply_recipe: mesh-node-just-died
+```
+
+Rules the contract enforces (named errors):
+
+- **Cite real keys and recipes.** Every `features` key must exist in
+  `uat/features.yaml`; every recipe must exist. Unknown → validation error.
+- **The surface axis is explicit.** Default is all-yes; a surface is opted out
+  only with `{n/a: <reason>}`. `n/a` without a reason fails; a step with **every**
+  surface `n/a` fails (a step must be walked somewhere).
+- **A step needs `do` and `expect`.**
+
+## The honest-`expect` voice rule
+
+`expect` lines are the pass bar, written against POSITIONING canon — honest,
+checkable, never marketing:
+
+- Good: "the badge reads local", "doctor names the dead endpoint", "the digest
+  names what is still open and by whom".
+- Bad: "the experience is delightful", "it just works", "blazing fast".
+
+For non-deterministic LLM output, judge **structurally**: assert the right
+*type* rendered (an action-item list, a decision or an open question) and judge
+it on substance — did it surface the decision / owner / risk — never on literal
+wording.
+
+## The one rule that ties a pack together
+
+**No pack is all-green-happy-path.** Open with a staging-verify beat and close
+with an honest-failure or control beat. If a pack has no beat that could fail
+loudly, it is a demo, not a test.
+
+## Validate before you commit
+
+```bash
+uv run python -m uat.tools.build_ledger --check   # ledger is in sync
+uv run pytest -q tests/uat/test_scenarios.py tests/uat/test_smoke_pack.py
+```
+
+Or load a pack directly: `GET /api/packs/<pack>` returns the scenarios,
+coverage, and any `validation_errors`.

--- a/uat/README.md
+++ b/uat/README.md
@@ -1,0 +1,129 @@
+# HoldSpeak UAT — the rig
+
+A web-based UAT framework that puts HoldSpeak through its paces and captures
+per-step human feedback. The **conductor** hosts HoldSpeak as an isolated,
+managed subprocess (booting it with a chosen configuration, good or
+deliberately bad, seeding the desk, spawning mesh nodes, restarting it between
+scenarios); the **guided site** walks you through a pack beat by beat and lands
+every verdict in a run database; a sitting ends in a **debrief packet** you and
+an agent triage together into `pm/roadmap/holdspeak/BACKLOG.md`.
+
+---
+
+## The owner's wake-up runbook
+
+```bash
+cd /Users/karol/dev/tools/HoldSpeak
+git pull                                 # the merged framework
+uv run python -m uat.conductor           # opens the UAT site; note the URL it prints
+```
+
+Then, in the browser (it prints `http://localhost:8799`):
+
+1. Pick **Pack D — Honest Failure** first (needs no LAN). Watch the rig stage
+   the world (each recipe verified, or the failure with the product's own log
+   tail — never a spinner).
+2. Walk the beats: each says *do this*, *expect this*. Use **Open the product**
+   to jump to the right screen. Cast a **verdict per surface** (web now;
+   iPad/iPhone when you have a device in hand — see "Device sittings" below),
+   jot a note, drop a screenshot.
+3. If `.43` is up, **Pack A — Meeting Aftercare** and **Pack C — Dictation
+   Grounding** put the intelligence through its paces too.
+4. Read the **debrief** at sitting end (score per surface, coverage %, every
+   non-pass finding with its log slice). Triage the findings with an agent per
+   [`TRIAGE.md`](./TRIAGE.md); each `fix` becomes a BACKLOG row.
+
+If anything is broken or pending, it is named honestly under **Known state**
+below.
+
+---
+
+## The port map
+
+| Port | What | Note |
+|---|---|---|
+| `8799` | the conductor (this site + API) | `UAT_PORT` overrides |
+| `8788`+ | the product under test | one per run; auto-bumps if busy |
+| `8765` | your real hub | **untouched** — a sitting runs beside your live desk |
+
+`UAT_HOST=0.0.0.0 uv run python -m uat.conductor` binds the site LAN-wide for a
+device sitting.
+
+## How a sitting flows
+
+1. Pick a pack → the conductor boots an **isolated run** (a fresh HOME under
+   `uat/_runs/<run_id>/home/`, so your real `~/.config/holdspeak` is never
+   touched; model caches are symlinked in so nothing re-downloads).
+2. For each scenario, the conductor **stages** its state recipes (deck + seeds +
+   actions) and verifies each through the product's own routes.
+3. You walk the steps; every verdict writes to the run DB the moment cast, keyed
+   `(scenario, step, surface)`. A refresh or a crash **resumes** at the first
+   unanswered slot.
+4. At the end the **debrief packet** (`uat/_runs/<run_id>/debrief/debrief.md` +
+   `.json`) generates.
+
+## Where things land
+
+- Runs, logs, screenshots, the run DB: `uat/_runs/` (gitignored).
+- Debrief packets: `uat/_runs/<run_id>/debrief/`.
+- Decks: `uat/decks/`. Seeds: `uat/seeds/`. Recipes: `uat/recipes/`.
+- Scenarios: `uat/scenarios/<pack>/`. The feature ledger: `uat/features.yaml`.
+
+## Prerequisites per deck
+
+| Deck | Needs `.43`? | Used by |
+|---|---|---|
+| `golden-local` | no | seeded/fresh desk, the demo-without-the-LAN path |
+| `bad-endpoint` | no | `intel-endpoint-dead` (honest failure) |
+| `no-model` | no | `first-run-no-model` (first-run truth) |
+| `golden-43` | **yes** | `meeting-just-ended-open-actions` (real intel) |
+| `mesh-node` | yes (for real work; liveness is local) | the mesh recipes |
+
+`.43` = the LAN llama.cpp at `http://192.168.1.43:8080`. Pack D needs none of it,
+so **the rig demos without the LAN**. Packs A and C need `.43` up.
+
+## Device sittings (iPad / iPhone)
+
+The site is fully usable from a device browser: `UAT_HOST=0.0.0.0`, then open
+the LAN URL the conductor prints on the device. The run is shared, so a verdict
+cast from the iPad shows up on the Mac's open view. The **product** under test is
+reachable from the device the way it pairs with the real hub — each run reports
+its pairing facts (LAN URL + its own per-run token). Some device-local states
+(a sideloaded GGUF, airplane mode, mic permission) cannot be induced from the
+LAN; those are hand-staged in the device pre-flight and the harness refuses the
+beat rather than faking it.
+
+## Building the site
+
+The built site (`uat/web/dist`) is **committed**, so the wake-up runbook works
+after a plain `git pull` — no npm step. To rebuild after editing `uat/web/src`:
+
+```bash
+npm --prefix uat/web install
+npm --prefix uat/web run build
+```
+
+## Known state (kept truthful)
+
+- **The web surface loop is complete and proven** end to end (conductor →
+  induction → contract → guided site → debrief), including live on `.43` for the
+  meeting-intel and mesh recipes.
+- **Physical iPad/iPhone verdicts are the owner's.** The device legs are built
+  (LAN-reachable site, per-surface verdict slots, `n/a`-with-reason), but every
+  device-surface verdict starts unanswered — never faked. The live device
+  cross-view (a verdict cast from a real device, seen on the Mac) awaits the
+  owner's sitting.
+- **The first live human sitting (HSU-1-06) is pending the owner.** The rig is
+  built up to the sitting; the sitting itself cannot be delegated — that is the
+  point of the project.
+- **The Phase-2 formal device verification + joint ranking** are not done; the
+  directory is a model's reading of the record, used here as scenario source.
+
+## Testing
+
+- `uv run pytest -q tests/uat/` — the harness suite (the `.43`-gated tests
+  self-skip without the LAN).
+- `npm --prefix uat/web test` — the site's store tests.
+- `uv run python scripts/uat_site_walk.py` — a Playwright drive of the real site.
+
+See [`AUTHORING.md`](./AUTHORING.md) to add a scenario, deck, seed, or recipe.

--- a/uat/recipes/seeded-desk-43.yaml
+++ b/uat/recipes/seeded-desk-43.yaml
@@ -1,0 +1,13 @@
+title: A seeded desk on .43 — grounded rewrites run live
+description: >
+  The seeded desk (dogfood notes + KBs) booted on golden-43, so the dictation
+  runtime and intel are wired to the LAN endpoint and a grounded rewrite
+  actually runs. The control-vs-treatment spine of Pack C rides this world.
+deck: golden-43
+requires: [intel]
+seeds:
+  - dogfood-desk
+probe:
+  - notes_min_count: 3
+  - note_exists: uat-seed-note-glossary
+  - kb_exists: uat-seed-kb-project

--- a/uat/scenarios/pack-a-aftercare/01-import-to-artifacts.yaml
+++ b/uat/scenarios/pack-a-aftercare/01-import-to-artifacts.yaml
@@ -1,0 +1,15 @@
+id: a-import-to-artifacts
+title: Import to intel artifacts (structural verdict)
+features:
+  - meetings.import.transcript
+recipes:
+  - meeting-just-ended-open-actions
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the meeting intel surface on iPhone is unverified in the record"}
+steps:
+  - do: Open the imported meeting and read its intel artifacts (the staging beat — a meeting just ended with open actions).
+    expect: The right artifact types rendered — an action-item list with owners, and the decisions or open questions the war-room surfaced. Judge on substance (did it surface the decision, the owner, the risk), not on exact wording.
+    where: /history
+teardown: []

--- a/uat/scenarios/pack-a-aftercare/02-digest-and-moment.yaml
+++ b/uat/scenarios/pack-a-aftercare/02-digest-and-moment.yaml
@@ -1,0 +1,19 @@
+id: a-digest-and-moment
+title: The aftercare digest and the moment jump
+features:
+  - meetings.aftercare.digest
+  - meetings.aftercare.show_the_moment
+recipes:
+  - meeting-just-ended-open-actions
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the phone aftercare leg is the open question — HSM built the iPad aftercare, the phone is unverified"}
+steps:
+  - do: Open the aftercare digest for the meeting.
+    expect: The digest names what is still open and by whom, what was decided, and the delta since the previous meeting; it stays quiet when there is nothing open rather than padding.
+    where: /history
+  - do: Jump to the moment behind one open action.
+    expect: The moment jump lands on the transcript segment that produced the action, not a generic top-of-meeting scroll.
+    where: /history
+teardown: []

--- a/uat/scenarios/pack-a-aftercare/03-action-to-issue.yaml
+++ b/uat/scenarios/pack-a-aftercare/03-action-to-issue.yaml
@@ -1,0 +1,19 @@
+id: a-action-to-issue
+title: Action to issue — propose, approve, execute
+features:
+  - meetings.aftercare.action-to-issue
+  - meetings.aftercare.file_as_issue
+recipes:
+  - meeting-just-ended-open-actions
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the action-to-issue actuator surface on iPhone is unverified in the record"}
+steps:
+  - do: Turn one open action into an issue proposal.
+    expect: A proposal is queued, unexecuted, and shows exactly what would be filed and where; nothing has been sent yet.
+    where: /history
+  - do: Approve the proposal, then read the audit.
+    expect: Only on approval does it execute; the audit records who approved it and what was filed — the off-by-default actuator flow, honestly gated.
+    where: /history
+teardown: []

--- a/uat/scenarios/pack-a-aftercare/04-unapproved-never-egresses.yaml
+++ b/uat/scenarios/pack-a-aftercare/04-unapproved-never-egresses.yaml
@@ -1,0 +1,19 @@
+id: a-unapproved-never-egresses
+title: An unapproved proposal never egresses (the honest-failure close)
+features:
+  - trust.egress.cloud-meeting-intel
+  - meetings.aftercare.action-to-issue
+recipes:
+  - meeting-just-ended-open-actions
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the proposal/egress surface on iPhone is unverified in the record"}
+steps:
+  - do: Read the egress badge on each aftercare card.
+    expect: Each card's badge tells the truth about where its content went (the meeting intel was cloud on golden-43, and the badge says so).
+    where: /history
+  - do: Leave a proposal unapproved and confirm nothing left the machine.
+    expect: An unapproved proposal never egresses — no issue is filed, no webhook fires, until a human approves. This is the pack's close, the product staying honest when nothing has been consented to.
+    where: /history
+teardown: []

--- a/uat/scenarios/pack-c-dictation-grounding/01-grounded-rewrite.yaml
+++ b/uat/scenarios/pack-c-dictation-grounding/01-grounded-rewrite.yaml
@@ -1,0 +1,16 @@
+id: c-grounded-rewrite
+title: A grounded rewrite (control vs treatment)
+features:
+  - dictation.pipeline.intent-routing
+  - dictation.kb.project_facts
+recipes:
+  - seeded-desk-43
+surfaces:
+  web: yes
+  ipad: {n/a: "iPad dictation depth is the biggest open cluster in the directory — confirm at the review sitting"}
+  iphone: {n/a: "iPhone dictation depth is unverified in the record"}
+steps:
+  - do: Dictate the same instruction twice — once with grounding OFF (control), once with grounding ON (treatment) against the seeded project KB.
+    expect: The treatment output names a repo-specific token the control cannot know (a glossary term like BLUEBIRD, or a project fact from the KB); the control says it does not have that context. A no-LLM pass alone is insufficient — the treatment must surface what the control cannot.
+    where: /
+teardown: []

--- a/uat/scenarios/pack-c-dictation-grounding/02-spoken-symbols.yaml
+++ b/uat/scenarios/pack-c-dictation-grounding/02-spoken-symbols.yaml
@@ -1,0 +1,15 @@
+id: c-spoken-symbols
+title: Spoken symbols land as symbols
+features:
+  - languages.spoken_symbol_dictionary
+recipes:
+  - seeded-desk-43
+surfaces:
+  web: yes
+  ipad: {n/a: "iPad dictation depth is unverified in the record"}
+  iphone: {n/a: "iPhone dictation depth is unverified in the record"}
+steps:
+  - do: Dictate a phrase using the spoken-symbol words (for example "at sign", "hash", "percent sign").
+    expect: Each spoken symbol lands as its character with the configured spacing, not as the words — one combined matcher pass, no double substitution.
+    where: /
+teardown: []

--- a/uat/scenarios/pack-c-dictation-grounding/03-correction-ritual.yaml
+++ b/uat/scenarios/pack-c-dictation-grounding/03-correction-ritual.yaml
@@ -1,0 +1,16 @@
+id: c-correction-ritual
+title: The correction ritual teaches, and the count is honest
+features:
+  - dictation.correction.one-tap-teaches
+  - dictation.correction.session_memory
+recipes:
+  - seeded-desk-43
+surfaces:
+  web: yes
+  ipad: {n/a: "iPad dictation depth is unverified in the record"}
+  iphone: {n/a: "iPhone dictation depth is unverified in the record"}
+steps:
+  - do: Correct one word the rewrite got wrong, then dictate again.
+    expect: The one-tap correction is applied and the next dictation reflects it; the learned-from-N chip reads the real count of corrections, not an inflated one.
+    where: /
+teardown: []

--- a/uat/scenarios/pack-c-dictation-grounding/04-endpoint-dies-mid-pack.yaml
+++ b/uat/scenarios/pack-c-dictation-grounding/04-endpoint-dies-mid-pack.yaml
@@ -1,0 +1,21 @@
+id: c-endpoint-dies-mid-pack
+title: The endpoint dies mid-pack — the rewrite degrades honestly
+features:
+  - dictation.pipeline.dry_run
+recipes:
+  - seeded-desk-43
+surfaces:
+  web: yes
+  ipad: {n/a: "iPad dictation depth is unverified in the record"}
+  iphone: {n/a: "iPhone dictation depth is unverified in the record"}
+steps:
+  - do: Dictate once while the endpoint is healthy (the staging beat — grounded rewrite works).
+    expect: The rewrite runs and returns a grounded result.
+    where: /
+    # The honest-failure close: kill the intel endpoint mid-pack.
+    after:
+      - apply_recipe: intel-endpoint-dead
+  - do: The intel endpoint is now dead. Dictate the same phrase again.
+    expect: The pipeline degrades to the raw transcript, honestly and fast — the DIR-01 invariant holds (you always get your words back), and the surface says the rewrite is unavailable rather than hanging or dropping the text.
+    where: /
+teardown: []

--- a/uat/scenarios/pack-d-honest-failure/01-dead-endpoint-doctor.yaml
+++ b/uat/scenarios/pack-d-honest-failure/01-dead-endpoint-doctor.yaml
@@ -1,0 +1,18 @@
+id: d-dead-endpoint-doctor
+title: A dead intel endpoint, named honestly
+features:
+  - desk.doctor.honest-readout
+recipes:
+  - intel-endpoint-dead
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the doctor/setup readout on iPhone is unverified in the record"}
+steps:
+  - do: Open the setup readiness screen (the staging beat — confirm the world is as described).
+    expect: The runtime reads unreachable and the dead endpoint is named; the screen is honest, not a spinner or a false green.
+    where: /setup
+  - do: Read the doctor's account of the intel endpoint.
+    expect: Doctor names the unreachable endpoint by its address and offers the remediation; it does not claim intel is available.
+    where: /setup
+teardown: []

--- a/uat/scenarios/pack-d-honest-failure/02-forced-run-refuses-fast.yaml
+++ b/uat/scenarios/pack-d-honest-failure/02-forced-run-refuses-fast.yaml
@@ -1,0 +1,15 @@
+id: d-forced-run-refuses-fast
+title: A forced run refuses fast, by name
+features:
+  - dictation.pipeline.dry_run
+recipes:
+  - intel-endpoint-dead
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the dictation runtime test on iPhone is unverified in the record"}
+steps:
+  - do: Run the dictation runtime test against the dead endpoint.
+    expect: It refuses in under five seconds and names the unreachable endpoint; it does not hang and does not silently fall through to a wrong result.
+    where: /setup
+teardown: []

--- a/uat/scenarios/pack-d-honest-failure/03-first-run-truth.yaml
+++ b/uat/scenarios/pack-d-honest-failure/03-first-run-truth.yaml
@@ -1,0 +1,19 @@
+id: d-first-run-truth
+title: First run truth at N=0
+features:
+  - onboarding.welcome.wizard
+  - onboarding.model.setup_assistant
+recipes:
+  - first-run-no-model
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the first-run onboarding surface on iPhone is unverified in the record"}
+steps:
+  - do: Open the app on a machine with no model yet.
+    expect: The setup readiness surface says plainly it is not ready, and points at what to do next; it does not pretend a model is present.
+    where: /setup
+  - do: Read what onboarding proposes for the missing model.
+    expect: The next step is honest about the missing model (download or configure), with no green check it has not earned.
+    where: /setup
+teardown: []

--- a/uat/scenarios/pack-d-honest-failure/04-egress-badge-local.yaml
+++ b/uat/scenarios/pack-d-honest-failure/04-egress-badge-local.yaml
@@ -1,0 +1,21 @@
+id: d-egress-badge-local
+title: The egress badge reads local, on all three surfaces
+features:
+  - trust.egress.badge-tells-truth
+  - mobile.trust.egress.badge
+recipes:
+  - seeded-desk
+# The egress badge is explicitly all-three in the directory — a genuine
+# three-surface trust check.
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: yes
+steps:
+  - do: Find the egress badge on the desk (the staging beat — the desk is seeded and fully local).
+    expect: The badge reads local in one word; nothing on this desk leaves the machine, and the badge says so without a paragraph of prose.
+    where: /
+  - do: Open a seeded note and confirm its egress posture.
+    expect: The note's badge still reads local; no cloud badge appears for local-only content.
+    where: /
+teardown: []

--- a/uat/scenarios/pack-d-honest-failure/05-key-never-syncs.yaml
+++ b/uat/scenarios/pack-d-honest-failure/05-key-never-syncs.yaml
@@ -1,0 +1,19 @@
+id: d-key-never-syncs
+title: The key never syncs; the door is loopback-gated
+features:
+  - onboarding.trust.privacy_chip
+  - trust.binding.loopback-token-gate
+recipes:
+  - fresh-desk
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: yes
+steps:
+  - do: Read the privacy chip's three promises on the desk.
+    expect: The chip states the answers plainly (local by default, what leaves and when, the key never syncs) without marketing.
+    where: /
+  - do: Confirm the run answers on loopback without a token, and would require one off-loopback.
+    expect: The loopback door is open for local use; a non-loopback bind is gated by the run's own token — the promise the chip makes is the behaviour.
+    where: /
+teardown: []

--- a/uat/scenarios/pack-d-honest-failure/06-mesh-offline-door.yaml
+++ b/uat/scenarios/pack-d-honest-failure/06-mesh-offline-door.yaml
@@ -1,0 +1,23 @@
+id: d-mesh-offline-door
+title: The offline door — a node dies, the desk refuses fast
+features:
+  - mesh.liveness_everywhere
+  - mesh.serve_node
+recipes:
+  - mesh-node-alive
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the mesh profile/liveness surface on iPhone is unverified in the record"}
+steps:
+  - do: Open the profiles view; confirm the worker reads live (the staging beat).
+    expect: The "uat-worker" node reads live — the hub has seen it poll recently.
+    where: /
+    # The honest-failure close: kill the worker's process group mid-run, then
+    # watch the world degrade correctly.
+    after:
+      - apply_recipe: mesh-node-just-died
+  - do: The node has just been stopped. Refresh the profiles view.
+    expect: The node now reads offline; a forced run against it refuses fast, by name, rather than hanging on a dead worker.
+    where: /
+teardown: []


### PR DESCRIPTION
**HSU-1-06 — Docs + real scenario packs.** The rig is operable without this conversation in context, and put through its paces beyond the smoke pack.

> HSU-1-06 stays **in-progress**: the docs + packs are the agent deliverable; the **live human sitting is owner-gated** and cannot be delegated (that is the point of the project).

- **`uat/README.md`** — the owner **wake-up runbook** up top (`git pull` → `uv run python -m uat.conductor` → Pack D first, no LAN), the port map (conductor 8799 / product 8788+ / hub 8765 untouched), the sitting flow, per-deck prerequisites, and an honest **Known state**.
- **`uat/AUTHORING.md`** — add a deck/seed/recipe/scenario; the ledger + surface rules; the honest-`expect` voice rule; how to validate.
- **`dogfood/PROTOCOL.md`** — a supersession header pointing here; the substrate is reused and documented, none dead.
- **Real coverage packs** (so the rig puts the app through its paces): **Pack D — Honest Failure & Trust** (6 scenarios, fully local — the owner's no-LAN wake-up path, staged end to end in CI), **Pack A — Meeting Aftercare** and **Pack C — Dictation Grounding** (`.43` web legs, control-vs-treatment + honest-failure closes). 21 scenarios across 4 packs validate clean.

**Explicitly NOT done (owner-gated, marked honestly):** the live human sitting, physical iPad/iPhone verdicts, and the phase close/final summary — the rig is built up to the sitting.

**Proof:** 86 local `tests/uat/` (incl. every pack validating clean + Pack D staging locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ