### PR TITLE
holdspeak-uat: harness backlog #2 — honest learning-count + key-never-syncs

### DIFF
--- a/tests/uat/test_steering.py
+++ b/tests/uat/test_steering.py
@@ -1,0 +1,53 @@
+"""Live steering staged through the product's own /api/coders routes.
+
+Spawns a real tmux coder pane, proves peek shows it, the unarmed consent gate
+refuses keys, arming grants + audits — all fully local (no .43). Self-skips if
+tmux is absent or the product cannot boot; cleans up its tmux session.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from uat.conductor.db import Database
+from uat.conductor.runs import RunManager
+
+
+@pytest.fixture
+def real_manager(tmp_path, monkeypatch):
+    monkeypatch.setenv("UAT_RUNS_ROOT", str(tmp_path / "_runs"))
+    monkeypatch.setenv("UAT_DB_PATH", str(tmp_path / "_runs" / "uat.db"))
+    monkeypatch.delenv("UAT_REAL_HOME", raising=False)
+    mgr = RunManager(Database(), boot_timeout=60.0, link_caches=True)
+    try:
+        yield mgr
+    finally:
+        mgr.teardown_all()
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not installed")
+def test_awaiting_pane_and_consent_gate(real_manager):
+    run = real_manager.create_run(deck="golden-local")
+    if run.status != "up":
+        pytest.skip("product did not boot")
+    result = real_manager.apply_recipe(run.id, "agent-pane-awaiting-input")
+    assert result.probe["ok"], result.probe
+    kinds = {r["kind"]: r for r in result.probe["results"]}
+    assert kinds["pane_listed"]["ok"]
+    assert kinds["pane_shows"]["ok"]
+    # The consent gate: unarmed keys refuse.
+    assert kinds["keys_refused_unarmed"]["ok"], kinds["keys_refused_unarmed"]
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not installed")
+def test_arm_grants_and_audits(real_manager):
+    run = real_manager.create_run(deck="golden-local")
+    if run.status != "up":
+        pytest.skip("product did not boot")
+    result = real_manager.apply_recipe(run.id, "agent-pane-armed")
+    assert result.probe["ok"], result.probe
+    kinds = {r["kind"]: r for r in result.probe["results"]}
+    assert kinds["grant_live"]["ok"], kinds["grant_live"]
+    assert kinds["audit_min"]["ok"], kinds["audit_min"]

--- a/tests/uat/test_trust_dictation.py
+++ b/tests/uat/test_trust_dictation.py
@@ -1,0 +1,44 @@
+"""Two fully-local harness-backlog probes: honest learning-count + key-never-syncs."""
+
+from __future__ import annotations
+
+import pytest
+
+from uat.conductor.db import Database
+from uat.conductor.runs import RunManager
+
+
+@pytest.fixture
+def real_manager(tmp_path, monkeypatch):
+    monkeypatch.setenv("UAT_RUNS_ROOT", str(tmp_path / "_runs"))
+    monkeypatch.setenv("UAT_DB_PATH", str(tmp_path / "_runs" / "uat.db"))
+    monkeypatch.delenv("UAT_REAL_HOME", raising=False)
+    mgr = RunManager(Database(), boot_timeout=60.0, link_caches=True)
+    try:
+        yield mgr
+    finally:
+        mgr.teardown_all()
+
+
+def test_learned_correction_taught_has_honest_count(real_manager):
+    run = real_manager.create_run(deck="golden-local")
+    if run.status != "up":
+        pytest.skip("product did not boot")
+    result = real_manager.apply_recipe(run.id, "learned-correction-taught")
+    assert result.probe["ok"], result.probe
+    # The digest reads a real count, not vacuous.
+    digest = real_manager.product_client(run.id).get_json("/api/dictation/learning-digest")
+    assert digest["totals"]["corrections_made"] >= 1
+
+
+def test_profile_key_never_syncs_is_a_real_attack(real_manager):
+    run = real_manager.create_run(deck="golden-local")
+    if run.status != "up":
+        pytest.skip("product did not boot")
+    result = real_manager.apply_recipe(run.id, "profile-key-never-syncs")
+    # Non-vacuous: profile_exists forced the create; the secret is absent DESPITE it.
+    assert result.probe["ok"], result.probe
+    assert result.already_satisfied is False
+    blob = str(real_manager.product_client(run.id).get_json("/api/profiles"))
+    assert "UAT-SECRET-KEY-DO-NOT-LEAK" not in blob
+    assert any(p["id"] == "uat-leaky-profile" for p in real_manager.product_client(run.id).get_json("/api/profiles")["profiles"])

--- a/uat/conductor/induction/probes.py
+++ b/uat/conductor/induction/probes.py
@@ -68,9 +68,10 @@ class ProbeError(RuntimeError):
 class ProbeEvaluator:
     """Evaluates a probe spec against a booted run."""
 
-    def __init__(self, client: ProductClient, *, home: Path | None = None):
+    def __init__(self, client: ProductClient, *, home: Path | None = None, run_id: str | None = None):
         self.client = client
         self.home = home
+        self.run_id = run_id
 
     def evaluate(self, spec: list[Any] | None) -> ProbeReport:
         report = ProbeReport()
@@ -278,6 +279,87 @@ class ProbeEvaluator:
             time.sleep(3.0)
         return (False, f"node {name!r} still reads live within {timeout:.0f}s")
 
+    # --- live steering (via the product's /api/coders routes) -------------
+
+    def _steer_session(self, name: str) -> str:
+        from . import steering
+
+        return steering.session_name(self.run_id or "", name)
+
+    def _peek(self, name: str) -> dict:
+        from . import steering
+
+        session = self._steer_session(name)
+        key = steering.pane_key_for_session(self.client, session)
+        if key is None:
+            return {"_missing": True}
+        try:
+            return self.client.get_json(f"/api/coders/{steering.enc(key)}/peek")
+        except Exception:
+            return {"_missing": True}
+
+    def _check_pane_listed(self, arg):
+        from . import steering
+
+        name = str(arg if not isinstance(arg, dict) else arg.get("name"))
+        session = self._steer_session(name)
+        present = steering.pane_key_for_session(self.client, session) is not None
+        return (present, f"pane {session!r} {'listed' if present else 'absent'}")
+
+    def _check_pane_shows(self, arg):
+        name = str(arg.get("name"))
+        contains = str(arg.get("contains", ""))
+        peek = self._peek(name)
+        if peek.get("_missing"):
+            return (False, f"no pane for {name!r}")
+        blob = _json_str(peek)
+        ok = peek.get("peek", {}).get("status") == "live" and contains in blob
+        return (ok, f"peek live={peek.get('peek',{}).get('status')} contains={contains!r}:{contains in blob}")
+
+    def _check_pane_awaiting_input(self, arg):
+        name = str(arg if not isinstance(arg, dict) else arg.get("name"))
+        marker = arg.get("marker", "AWAITING-INPUT") if isinstance(arg, dict) else "AWAITING-INPUT"
+        peek = self._peek(name)
+        if peek.get("_missing"):
+            return (False, f"no pane for {name!r}")
+        live = peek.get("peek", {}).get("status") == "live"
+        shows = str(marker) in _json_str(peek)
+        return (live and shows, f"pane live={live} shows-prompt={shows}")
+
+    def _check_grant_live(self, arg):
+        from . import steering
+
+        name = str(arg if not isinstance(arg, dict) else arg.get("name"))
+        session = self._steer_session(name)
+        key = steering.pane_key_for_session(self.client, session)
+        try:
+            grants = self.client.get_json("/api/coders/steering/grants").get("grants", {})
+        except Exception:
+            grants = {}
+        live = key is not None and key in grants
+        return (live, f"grant for {key!r} {'live' if live else 'absent'}")
+
+    def _check_audit_min(self, arg):
+        n = int(arg if not isinstance(arg, dict) else arg.get("count", 1))
+        try:
+            audit = self.client.get_json("/api/coders/steering/audit").get("audit", [])
+        except Exception:
+            audit = []
+        return (len(audit) >= n, f"{len(audit)} audit rows (need ≥{n})")
+
+    def _check_keys_refused_unarmed(self, arg):
+        """Sending keys to an UNARMED pane must refuse (the consent gate)."""
+        from . import steering
+
+        name = str(arg if not isinstance(arg, dict) else arg.get("name"))
+        session = self._steer_session(name)
+        key = steering.pane_key_for_session(self.client, session)
+        if key is None:
+            return (False, f"no pane for {name!r}")
+        resp = self.client.post_json(f"/api/coders/{steering.enc(key)}/keys", {"keys": ["a"]})
+        refused = resp.status_code != 200
+        return (refused, f"unarmed keys refused={refused} (HTTP {resp.status_code})")
+
     # --- doctor (subprocess, product-routed) ------------------------------
 
     def _check_doctor_names_dead_endpoint(self, _arg):
@@ -303,6 +385,15 @@ class ProbeEvaluator:
         )
         return (named, "doctor output names the dead endpoint" if named else
                 "doctor did not name the dead endpoint")
+
+
+def _json_str(obj: Any) -> str:
+    import json
+
+    try:
+        return json.dumps(obj)
+    except (TypeError, ValueError):
+        return str(obj)
 
 
 def _split_assertion(assertion: Any) -> tuple[str, Any]:

--- a/uat/conductor/induction/probes.py
+++ b/uat/conductor/induction/probes.py
@@ -213,6 +213,29 @@ class ProbeEvaluator:
             time.sleep(2.0)
         return (False, f"timed out after {timeout:.0f}s: {last}")
 
+    # --- dictation learning + trust attacks ------------------------------
+
+    def _check_learning_digest_min(self, arg):
+        n = int(arg if not isinstance(arg, dict) else arg.get("count", 1))
+        try:
+            totals = self.client.get_json("/api/dictation/learning-digest").get("totals", {})
+        except Exception:
+            totals = {}
+        made = int(totals.get("corrections_made") or 0)
+        return (made >= n, f"learning digest corrections_made={made} (need ≥{n})")
+
+    def _check_absent_in_response(self, arg):
+        """A secret/string must NOT appear in a route's response (key-never-syncs,
+        no-secret-leak). arg = {path, text}."""
+        path = str(arg["path"])
+        text = str(arg["text"])
+        try:
+            blob = _json_str(self.client.get_json(path))
+        except Exception as exc:
+            return (False, f"could not read {path}: {exc}")
+        absent = text not in blob
+        return (absent, f"{text!r} {'absent from' if absent else 'LEAKED IN'} {path}")
+
     # --- runtime / first-run ---------------------------------------------
 
     def _check_runtime_endpoint_unreachable(self, _arg):

--- a/uat/conductor/induction/recipes.py
+++ b/uat/conductor/induction/recipes.py
@@ -196,7 +196,7 @@ class RecipeEngine:
 
         client = host.product_client(run_id)
         home = host.run_home(run_id)
-        evaluator = ProbeEvaluator(client, home=home)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
 
         # The combined probe is the target's own probe (includes stage the world;
         # the target's probe is the authoritative claim). Included recipes still
@@ -281,6 +281,27 @@ class RecipeEngine:
                 if n == 0:
                     break
             return {"action": "process_intel", "processed": total}
+        if kind in ("spawn_pane", "arm_pane", "send_keys", "steer_pane"):
+            from . import steering
+
+            opts = arg if isinstance(arg, dict) else {"name": str(arg)}
+            name = opts.get("name", "coder")
+            session = steering.session_name(run_id, name)
+            if kind == "spawn_pane":
+                command = opts.get("command", "bash -c 'echo AWAITING-INPUT; sleep 1200'")
+                res = host.spawn_pane(run_id, name, command)
+                return {"action": "spawn_pane", "name": name, "session": session, "result": res}
+            client_ = host.product_client(run_id)
+            if kind == "arm_pane":
+                res = steering.arm(client_, session, ttl_seconds=int(opts.get("ttl_seconds", 120)))
+                return {"action": "arm_pane", "name": name, "result": res}
+            if kind == "send_keys":
+                keys = opts.get("keys") or []
+                res = steering.send_keys(client_, session, list(keys))
+                return {"action": "send_keys", "name": name, "keys": keys, "result": res}
+            if kind == "steer_pane":
+                res = steering.steer(client_, session, str(opts.get("text", "")))
+                return {"action": "steer_pane", "name": name, "result": res}
         if kind == "create_profile":
             # Register a meshNode profile so the hub surfaces the node's
             # liveness (GET /api/profiles -> mesh_liveness). Idempotent via id.

--- a/uat/conductor/induction/recipes.py
+++ b/uat/conductor/induction/recipes.py
@@ -303,15 +303,26 @@ class RecipeEngine:
                 res = steering.steer(client_, session, str(opts.get("text", "")))
                 return {"action": "steer_pane", "name": name, "result": res}
         if kind == "create_profile":
-            # Register a meshNode profile so the hub surfaces the node's
-            # liveness (GET /api/profiles -> mesh_liveness). Idempotent via id.
-            name = arg["name"] if isinstance(arg, dict) else str(arg)
-            node = arg.get("node", name) if isinstance(arg, dict) else name
+            # Register a profile through the public route. Defaults to a meshNode
+            # (so the hub surfaces its liveness); any field the route accepts —
+            # including a bogus api_key to attack key-never-syncs — passes through.
+            opts = arg if isinstance(arg, dict) else {"name": str(arg)}
+            name = opts.get("name", "profile")
+            body = {"id": opts.get("id", f"uat-profile-{name}"), "name": name, "kind": opts.get("kind", "meshNode")}
+            for k in ("node", "api_key", "requires_key", "profile_id", "avatar", "role", "system_prompt"):
+                if k in opts:
+                    body[k] = opts[k]
+            resp = client.post_json("/api/profiles", body)
+            return {"action": "create_profile", "name": name, "status": resp.status_code}
+        if kind == "teach_correction":
+            # Record a dictation correction so the learned-from-N digest has a
+            # KNOWN count to check honestly against.
+            opts = arg if isinstance(arg, dict) else {}
             resp = client.post_json(
-                "/api/profiles",
-                {"id": f"uat-profile-{name}", "name": name, "kind": "meshNode", "node": node},
+                "/api/dictation/corrections",
+                {"kind": opts.get("kind", "intent"), "text": opts.get("text", "teh"), "value": opts.get("value", "the")},
             )
-            return {"action": "create_profile", "name": name, "node": node, "status": resp.status_code}
+            return {"action": "teach_correction", "status": resp.status_code}
         return {"action": kind, "error": f"unknown action {kind!r}"}
 
 

--- a/uat/conductor/induction/steering.py
+++ b/uat/conductor/induction/steering.py
@@ -1,0 +1,85 @@
+"""Live-steering staging — drive the product's own `/api/coders/*` routes.
+
+The product owns tmux and the steering registry; the harness only calls its
+routes (spawn a pane, peek it, arm a grant, send keys, read the audit). No tmux
+code and no ``holdspeak`` import here — the pane is resolved to its ``pane:%N``
+key through the product's own attach-to-any-pane discovery
+(``GET /api/coders/steering/panes``).
+
+Spawned tmux sessions are named ``uat-<run>-<name>`` so they're identifiable and
+never collide with the owner's real panes; the conductor kills them on teardown.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from urllib.parse import quote
+
+from .product_client import ProductClient
+
+
+def session_name(run_id: str, name: str) -> str:
+    short = run_id.replace("run-", "").split("-")[-1]
+    return f"uat-{short}-{name}"
+
+
+def pane_key_for_session(client: ProductClient, session: str) -> str | None:
+    """Resolve a tmux session name to its ``pane:%N`` steering key, or None."""
+    try:
+        panes = client.get_json("/api/coders/steering/panes").get("panes", [])
+    except Exception:
+        return None
+    for p in panes:
+        if p.get("session") == session:
+            return f"pane:{p.get('pane_id')}"
+    return None
+
+
+def enc(key: str) -> str:
+    """URL-encode a ``pane:%N`` key (the ``%`` must not read as an escape)."""
+    return quote(key, safe=":")
+
+
+def spawn(client: ProductClient, session: str, command: str) -> dict:
+    resp = client.post_json(
+        "/api/coders/factory/spawn", {"name": session, "command": command}
+    )
+    return {"status_code": resp.status_code, **(_json(resp))}
+
+
+def arm(client: ProductClient, session: str, ttl_seconds: int = 120) -> dict:
+    key = pane_key_for_session(client, session)
+    if key is None:
+        return {"ok": False, "error": f"no pane for session {session!r}"}
+    resp = client.post_json(f"/api/coders/{enc(key)}/arm", {"ttl_seconds": ttl_seconds})
+    return {"ok": resp.status_code == 200, "status_code": resp.status_code, "key": key, **_json(resp)}
+
+
+def send_keys(client: ProductClient, session: str, keys: list[str]) -> dict:
+    key = pane_key_for_session(client, session)
+    if key is None:
+        return {"ok": False, "error": f"no pane for session {session!r}"}
+    resp = client.post_json(f"/api/coders/{enc(key)}/keys", {"keys": keys})
+    return {"ok": resp.status_code == 200, "status_code": resp.status_code, "key": key, **_json(resp)}
+
+
+def steer(client: ProductClient, session: str, text: str) -> dict:
+    key = pane_key_for_session(client, session)
+    if key is None:
+        return {"ok": False, "error": f"no pane for session {session!r}"}
+    resp = client.post_json(f"/api/coders/{enc(key)}/steer", {"text": text})
+    return {"ok": resp.status_code == 200, "status_code": resp.status_code, "key": key, **_json(resp)}
+
+
+def kill_session(session: str) -> None:
+    """Tear down a spawned tmux session (cleanup; tmux is a system tool)."""
+    subprocess.run(["tmux", "kill-session", "-t", session], capture_output=True)
+
+
+def _json(resp) -> dict:
+    try:
+        body = resp.json()
+        return body if isinstance(body, dict) else {"body": body}
+    except (json.JSONDecodeError, ValueError):
+        return {}

--- a/uat/conductor/runs.py
+++ b/uat/conductor/runs.py
@@ -153,6 +153,7 @@ class RunManager:
         self.recipes = recipe_engine or RecipeEngine()
         self._runs: dict[str, tuple[Run, ProductProcess]] = {}
         self._node_managers: dict[str, NodeManager] = {}
+        self._steer_sessions: dict[str, set[str]] = {}
         self._lock = threading.RLock()
 
     # --- creation / boot --------------------------------------------------
@@ -336,6 +337,18 @@ class RunManager:
         with self._lock:
             return self._nodes(run_id).kill(name)
 
+    def spawn_pane(self, run_id: str, name: str, command: str) -> dict:
+        """Spawn a tmux coder pane via the product's factory route; track the
+        session so it's killed on teardown (no residue in the owner's tmux)."""
+        from .induction import steering
+
+        run = self._runs.get(run_id, (None, None))[0]
+        if run is None:
+            raise KeyError(run_id)
+        session = steering.session_name(run_id, name)
+        self._steer_sessions.setdefault(run_id, set()).add(session)
+        return steering.spawn(self.product_client(run_id), session, command)
+
     def list_nodes(self, run_id: str) -> list[dict]:
         return [n.to_dict() for n in self._nodes(run_id).list()]
 
@@ -362,6 +375,10 @@ class RunManager:
             nm = self._node_managers.pop(run_id, None)
             if nm is not None:
                 nm.kill_all()
+            for session in self._steer_sessions.pop(run_id, set()):
+                from .induction import steering
+
+                steering.kill_session(session)
             product.stop()
             run.status = "down"
             run.pid = None

--- a/uat/recipes/agent-pane-armed.yaml
+++ b/uat/recipes/agent-pane-armed.yaml
@@ -1,0 +1,14 @@
+title: An agent pane is armed for steering
+description: >
+  The awaiting pane plus an arming grant held — a steer would now be accepted,
+  and the arm is written to the audit trail. Fully local.
+deck: golden-local
+requires: []
+includes:
+  - agent-pane-awaiting-input
+actions:
+  - arm_pane: {name: coder, ttl_seconds: 300}
+  - wait: 1
+probe:
+  - grant_live: coder
+  - audit_min: 1

--- a/uat/recipes/agent-pane-awaiting-input.yaml
+++ b/uat/recipes/agent-pane-awaiting-input.yaml
@@ -1,0 +1,15 @@
+title: An agent pane is awaiting input
+description: >
+  Spawn a real tmux coder pane (via the product's factory route) that prints a
+  prompt and waits. Peek shows it live with the prompt, it's listed among the
+  panes, and sending keys while UNARMED refuses — the consent gate. Fully local
+  (tmux + the product's own /api/coders routes); no .43.
+deck: golden-local
+requires: []
+actions:
+  - spawn_pane: {name: coder, command: "bash -c 'echo AWAITING-MIGRATION-CONFIRM; sleep 1200'"}
+  - wait: 2
+probe:
+  - pane_listed: coder
+  - pane_shows: {name: coder, contains: AWAITING-MIGRATION-CONFIRM}
+  - keys_refused_unarmed: coder

--- a/uat/recipes/learned-correction-taught.yaml
+++ b/uat/recipes/learned-correction-taught.yaml
@@ -1,0 +1,11 @@
+title: A correction has been taught (known count)
+description: >
+  Record one dictation correction through the product's own route, so the
+  "learned from N" digest has a KNOWN count to check honestly against — the
+  honest-by-construction pillar. Fully local.
+deck: golden-local
+requires: []
+actions:
+  - teach_correction: {kind: intent, text: teh, value: the}
+probe:
+  - learning_digest_min: 1

--- a/uat/recipes/profile-key-never-syncs.yaml
+++ b/uat/recipes/profile-key-never-syncs.yaml
@@ -1,0 +1,19 @@
+title: A profile carries a key that never rides the wire
+description: >
+  Create a runtime profile with a bogus secret key through the public route,
+  then prove the secret NEVER appears in the profiles read-back — the
+  key-never-syncs promise, attacked rather than imagined. Fully local.
+deck: golden-local
+requires: []
+actions:
+  - create_profile:
+      id: uat-leaky-profile
+      name: Leaky profile
+      kind: onDevice
+      requires_key: true
+      api_key: UAT-SECRET-KEY-DO-NOT-LEAK
+probe:
+  # profile_exists forces the create to run (so the absence isn't vacuous —
+  # the secret is absent DESPITE a profile that was given one).
+  - profile_exists: uat-leaky-profile
+  - absent_in_response: {path: /api/profiles, text: UAT-SECRET-KEY-DO-NOT-LEAK}

--- a/uat/scenarios/pack-b-steering/05-live-steer-spine.yaml
+++ b/uat/scenarios/pack-b-steering/05-live-steer-spine.yaml
@@ -1,0 +1,27 @@
+id: b-live-steer-spine
+title: The live steering spine — peek, the consent gate, arm, audit
+features:
+  - steering.peek
+  - steering.attach_any_pane
+  - trust.steering.arming-grant
+  - steering.audit
+recipes:
+  - agent-pane-awaiting-input
+surfaces:
+  web: yes
+  ipad: yes
+  iphone: {n/a: "the terminal/steering surface has no compact iPhone form (directory: mobile.steering.* is iPad, not iPhone)"}
+steps:
+  - do: Open the coder pull-out and peek at the pane that is awaiting input (the staging beat — a real tmux pane was spawned and it printed its prompt).
+    expect: The peek shows the pane live with its prompt visible; watching is free — no grant was needed to read it.
+    where: /
+  - do: Without arming, try to send a keystroke to the pane.
+    expect: It refuses — an unarmed pane takes no keystroke. The consent gate holds before any input reaches the agent.
+    where: /
+  # Arm the pane mid-run (the explicit desk act), then read the audit.
+  - do: Arm the pane, then open the steering audit.
+    expect: The pane reads armed with a live countdown, and the audit trail shows the arm event (who/when/pane), heads and hashes only — the steer text is never stored.
+    where: /
+    after:
+      - apply_recipe: agent-pane-armed
+teardown: []

--- a/uat/scenarios/pack-c-dictation-grounding/06-honest-count.yaml
+++ b/uat/scenarios/pack-c-dictation-grounding/06-honest-count.yaml
@@ -5,6 +5,7 @@ features:
   - dictation.learning.digest
 recipes:
   - seeded-desk-43
+  - learned-correction-taught
 surfaces:
   web: yes
   ipad: yes   # directory: dictation.learning-digest.honest-count ipad=yes (iPad reads the learning digest with real learned-from-N reach; ios consumes /api/dictation/learning-digest)

--- a/uat/scenarios/pack-d-honest-failure/08-profile-key-never-reappears.yaml
+++ b/uat/scenarios/pack-d-honest-failure/08-profile-key-never-reappears.yaml
@@ -4,6 +4,7 @@ features:
   - trust.secrets.profile-key-never-syncs
 recipes:
   - seeded-desk
+  - profile-key-never-syncs
 # The re-eval's finding #5 + task #19: trust.secrets.profile-key-never-syncs is
 # a MUST, all-three in the directory (web/ipad/iphone: yes), and was written in
 # the imagined voice. This stages the attack: supply a secret to an ingress,


### PR DESCRIPTION
Two more re-eval-flagged beats become machine-verifiable, both fully local. Stacked on #328.

- **Honest learning-count** — `teach_correction` verb + `learning_digest_min` probe: record a real correction, assert the "learned from N" digest reads a KNOWN count. Recipe `learned-correction-taught`; wired into `pack-c/06`.
- **Key-never-syncs, attacked** — `create_profile` generalized to carry a bogus `api_key`; `absent_in_response` probe: create a profile GIVEN a secret, then prove the secret NEVER appears in the read-back. A `profile_exists` guard makes the absence non-vacuous. Recipe `profile-key-never-syncs`; wired into `pack-d/08`.

Proven live (both probe ok, non-vacuous). 98 local tests (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWNwHDFD8prLGXtToBoSZQ