### PR TITLE
HS-93-07: make configured YOLO authority promptless

### DIFF
--- a/apple/App/MeetingCapture/AppSettings.swift
+++ b/apple/App/MeetingCapture/AppSettings.swift
@@ -60,7 +60,7 @@ struct SettingsView: View {
                     if !cfg.isLocal { endpointCard }
                     egressRow
                     meshServeCard
-                    label("CONTROL MODE")
+                    label("CONTROL POSTURE")
                     controlModeCard
                     label("TRANSCRIPTION")
                     whisperCard
@@ -195,21 +195,21 @@ struct SettingsView: View {
                 .foregroundStyle(Sig.faint)
             if !controlModeState.isEmpty && controlModeState != "saving" {
                 Text(controlModeState).font(.system(size: 11, weight: .heavy, design: .rounded))
-                    .foregroundStyle(controlModeState == "Control mode updated" ? Sig.ok : Sig.warn)
+                    .foregroundStyle(controlModeState == "Control posture updated for future operations" ? Sig.ok : Sig.warn)
             }
         }
         .padding(16).signalCard(radius: 20)
     }
 
     private func loadControlMode() {
-        guard let client = peer.client() else { controlModeState = "Pair a desktop to change Control mode."; return }
+        guard let client = peer.client() else { controlModeState = "Pair a desktop to change Control posture."; return }
         Task {
             do {
                 let policy = try await client.authorityPolicy()
                 controlMode = policy.controlMode
                 controlModeState = ""
             } catch {
-                controlModeState = "Control mode unavailable on the paired desktop. Check the connection and retry."
+                controlModeState = "Control posture is unavailable on the paired desktop. Check the connection and retry."
             }
         }
     }
@@ -221,9 +221,9 @@ struct SettingsView: View {
             do {
                 let policy = try await client.setControlMode(mode)
                 controlMode = policy.controlMode
-                controlModeState = "Control mode updated"
+                controlModeState = "Control posture updated for future operations"
             } catch {
-                controlModeState = "Control mode was not changed. Check the paired desktop and retry."
+                controlModeState = "Control posture was not changed. Check the paired desktop and retry."
             }
         }
     }

--- a/apple/App/MeetingCapture/DeskDioramaStage.swift
+++ b/apple/App/MeetingCapture/DeskDioramaStage.swift
@@ -6466,6 +6466,11 @@ struct DioStage: View {
         steerSheet?.question = peek.awaitingResponse ? peek.question : nil
         steerSheet?.armed = peek.grant.armed
         steerSheet?.remaining = peek.grant.expiresInSeconds ?? 0
+        steerSheet?.paneId = peek.paneId
+        steerSheet?.operation = peek.operation
+        steerSheet?.policy = peek.policy
+        steerSheet?.commitment = peek.commitment
+        steerSheet?.armCommitment = peek.armCommitment ?? "Arm this pane"
     }
 
     private func steerArm() {
@@ -6492,10 +6497,18 @@ struct DioStage: View {
         guard let client = desktopClient, let ss = steerSheet else { return }
         let node = ss.node.isEmpty ? nil : ss.node
         Task { @MainActor in
-            if let r = try? await client.coderKeys(key: ss.paneKey, keys: [key], node: node) {
-                steerSheet?.fate = r.isDelivered ? label : (r.detail ?? r.status)
+            if let r = try? await client.coderKeys(
+                key: ss.paneKey, keys: [key],
+                expectedPaneId: ss.paneId, node: node
+            ) {
+                steerSheet?.fate = r.isDelivered
+                    ? (r.receipt.map { "Receipt \($0.id)" } ?? label)
+                    : (r.detail ?? r.status)
                 steerSheet?.fateOK = r.isDelivered
                 if r.didRevoke { steerSheet?.armed = false }
+                if ["pane_identity_required", "pane_mismatch", "pane_gone"].contains(r.status) {
+                    steerSheet?.paneId = nil; steerSheet?.policy = nil
+                }
             }
         }
     }
@@ -6505,10 +6518,18 @@ struct DioStage: View {
         guard let client = desktopClient, let ss = steerSheet else { return }
         let node = ss.node.isEmpty ? nil : ss.node
         Task { @MainActor in
-            if let r = try? await client.steerCoder(key: ss.paneKey, text: text, submit: submit, node: node) {
-                steerSheet?.fate = r.isDelivered ? "steered" : (r.detail ?? r.status)
+            if let r = try? await client.steerCoder(
+                key: ss.paneKey, text: text, submit: submit,
+                expectedPaneId: ss.paneId, node: node
+            ) {
+                steerSheet?.fate = r.isDelivered
+                    ? (r.receipt.map { "Receipt \($0.id)" } ?? "steered")
+                    : (r.detail ?? r.status)
                 steerSheet?.fateOK = r.isDelivered
                 if r.didRevoke { steerSheet?.armed = false }
+                if ["pane_identity_required", "pane_mismatch", "pane_gone"].contains(r.status) {
+                    steerSheet?.paneId = nil; steerSheet?.policy = nil
+                }
             }
         }
     }
@@ -6545,6 +6566,9 @@ struct DioStage: View {
         let options = [""] + ss.nodes
         let idx = options.firstIndex(of: ss.node) ?? 0
         ss.node = options[(idx + 1) % options.count]
+        ss.paneId = nil; ss.operation = nil; ss.policy = nil
+        ss.commitment = nil; ss.armCommitment = "Arm this pane"
+        ss.armed = false; ss.remaining = 0
         steerSheet = ss
     }
 

--- a/apple/App/MeetingCapture/DeskSteer.swift
+++ b/apple/App/MeetingCapture/DeskSteer.swift
@@ -1,12 +1,10 @@
 import SwiftUI
 
 // HSM-27-02 — the terminal surface on the diorama. The iPad's counterpart to
-// the web desk's SessionPullout: attach to a pane (peek, read-only), arm it
-// (hold-to-arm → countdown), and manipulate it — a KEY PALETTE (^C, arrows,
-// Escape), the voice-first composer, and the factory (spawn in the picker;
-// rename + a confirm-gated kill in the armed surface). The whole thing drives
-// through HSM-27-01's client; the consent spine holds on glass — watch free,
-// manipulate armed, the countdown visible, kill confirmed.
+// the web desk's SessionPullout: attach to a pane (peek, read-only), then
+// consume the Hub's policy decision. Secure/Normal use an exact pane grant;
+// YOLO can steer a registered pane directly while identity, allowed keys,
+// audit, and Receipts remain mandatory.
 //
 // This view is presentational: DioStage owns the async client calls + the
 // peek poll and passes the state in, so the surface stays testable and the
@@ -45,6 +43,14 @@ struct SteerSheetState: Equatable {
     var panes: [PaneInfo]          // the machine's pane list (the picker)
     var fate: String               // the last act's fate, in place ("" = none)
     var fateOK: Bool
+    var paneId: String? = nil
+    var operation: CoderSteeringOperation? = nil
+    var policy: CoderSteeringPolicy? = nil
+    var commitment: CoderSteeringCommitment? = nil
+    var armCommitment: String = "Arm this pane"
+
+    var postureAuthorized: Bool { policy?.usesControlPosture == true }
+    var canSteer: Bool { armed || postureAuthorized }
 }
 
 struct DioSteerSheet: View {
@@ -67,7 +73,6 @@ struct DioSteerSheet: View {
     @State private var spawnName: String = ""
     @State private var showPanes: Bool = false
     @State private var confirmKill: Bool = false
-    @State private var holdProgress: CGFloat = 0
 
     var body: some View {
         ZStack {
@@ -77,7 +82,7 @@ struct DioSteerSheet: View {
                 Divider().overlay(.white.opacity(0.08))
                 if showPanes { paneStrip }
                 paneView
-                if state.armed { armedFoot }
+                if state.canSteer { armedFoot }
             }
             .frame(width: maxW, height: maxH)
             .background(RoundedRectangle(cornerRadius: 24, style: .continuous).fill(.ultraThinMaterial)
@@ -119,7 +124,23 @@ struct DioSteerSheet: View {
 
     private var armChip: some View {
         Group {
-            if state.armed {
+            if state.postureAuthorized {
+                HStack(spacing: 6) {
+                    Text("\(ProductLanguage.controlModeLabel(state.policy?.mode ?? "yolo")) · direct")
+                        .font(.system(size: 11, weight: .black, design: .rounded))
+                        .foregroundStyle(DioPal.accent)
+                        .padding(.horizontal, 10).frame(height: 30)
+                        .background(Capsule().fill(DioPal.accent.opacity(0.14))
+                            .overlay(Capsule().strokeBorder(DioPal.accent.opacity(0.5), lineWidth: 1)))
+                    if state.armed {
+                        Button(action: onDisarm) {
+                            Text("Controls \(mmss(state.remaining))")
+                                .font(.system(size: 10, weight: .black, design: .monospaced))
+                                .foregroundStyle(DioPal.muted)
+                        }.buttonStyle(.plain)
+                    }
+                }
+            } else if state.armed {
                 Button(action: onDisarm) {
                     Text("⏻ \(mmss(state.remaining))")
                         .font(.system(size: 12, weight: .black, design: .monospaced)).foregroundStyle(DioPal.accent)
@@ -127,19 +148,13 @@ struct DioSteerSheet: View {
                         .background(Capsule().fill(DioPal.accent.opacity(0.14)).overlay(Capsule().strokeBorder(DioPal.accent.opacity(0.5), lineWidth: 1)))
                 }.buttonStyle(.plain)
             } else {
-                Text("ARM")
-                    .font(.system(size: 12, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.text)
-                    .padding(.horizontal, 13).frame(height: 30)
-                    .background(Capsule().fill(.white.opacity(0.08))
-                        .overlay(GeometryReader { g in Capsule().fill(DioPal.accent.opacity(0.3)).frame(width: g.size.width * holdProgress) })
-                        .clipShape(Capsule())
-                        .overlay(Capsule().strokeBorder(.white.opacity(0.18), lineWidth: 1)))
-                    .gesture(
-                        LongPressGesture(minimumDuration: 0.6)
-                            .onChanged { _ in withAnimation(.linear(duration: 0.6)) { holdProgress = 1 } }
-                            .onEnded { _ in holdProgress = 0; onArm() }
-                    )
-                    .onTapGesture { withAnimation { holdProgress = 0 } }
+                Button(action: onArm) {
+                    Text(state.armCommitment)
+                        .font(.system(size: 12, weight: .black, design: .rounded)).tracking(1).foregroundStyle(DioPal.text)
+                        .padding(.horizontal, 13).frame(height: 30)
+                        .background(Capsule().fill(.white.opacity(0.08))
+                            .overlay(Capsule().strokeBorder(.white.opacity(0.18), lineWidth: 1)))
+                }.buttonStyle(.plain)
             }
         }
     }
@@ -195,10 +210,16 @@ struct DioSteerSheet: View {
         }
     }
 
-    // MARK: the armed foot — key palette, composer, factory
+    // MARK: the authorized foot — key palette, composer, factory
 
     private var armedFoot: some View {
         VStack(spacing: 9) {
+            if let operation = state.operation, let policy = state.policy {
+                Text("Send text or allowed keys to pane \(operation.destination ?? "unresolved") · \(policy.authorityBasis == "control_posture" ? ProductLanguage.controlModeLabel(policy.mode ?? "yolo") + " control posture" : "armed pane grant") · Receipt after every attempt")
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .foregroundStyle(DioPal.muted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
             // KEY PALETTE
             HStack(spacing: 6) {
                 Text("KEYS").font(.system(size: 9, weight: .black, design: .monospaced)).tracking(1).foregroundStyle(DioPal.muted)
@@ -235,7 +256,13 @@ struct DioSteerSheet: View {
             // SESSION — kill (rename lives here on the couch build)
             HStack(spacing: 8) {
                 Text("SESSION").font(.system(size: 9, weight: .black, design: .monospaced)).tracking(1).foregroundStyle(DioPal.muted)
-                if confirmKill {
+                if !state.armed {
+                    Button(action: onArm) {
+                        Text("Arm pane for rename and kill")
+                            .font(.system(size: 11, weight: .heavy, design: .rounded))
+                            .foregroundStyle(DioPal.muted)
+                    }.buttonStyle(.plain)
+                } else if confirmKill {
                     Button(action: onKill) {
                         Text("⌫ Kill — sure?").font(.system(size: 12, weight: .heavy, design: .rounded)).foregroundStyle(.white)
                             .padding(.horizontal, 11).frame(height: 30).background(Capsule().fill(INTERRUPT))

--- a/apple/App/MeetingCapture/QueuePresence.swift
+++ b/apple/App/MeetingCapture/QueuePresence.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Foundation
-import Contracts
 
 // HSM-14-19 "The Desk" decomposition: the run-queue + presence transparency layer (HSM-14-15) — the
 // app-wide Job queue (RunQueueStore/QueueHUD, the Dynamic-Island-style pill -> ledger) and the

--- a/apple/App/MeetingCapture/QueuePresence.swift
+++ b/apple/App/MeetingCapture/QueuePresence.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Foundation
+import Contracts
 
 // HSM-14-19 "The Desk" decomposition: the run-queue + presence transparency layer (HSM-14-15) — the
 // app-wide Job queue (RunQueueStore/QueueHUD, the Dynamic-Island-style pill -> ledger) and the
@@ -366,6 +367,16 @@ struct QueueHUD: View {
                 LabeledContent("Decision", value: projection.decisionKind)
                 LabeledContent("Destination", value: projection.actualDestination ?? "Not reached")
                 LabeledContent("Authority", value: projection.authorityBasis ?? "Not required")
+                if let mode = projection.controlMode {
+                    LabeledContent(
+                        "Control posture",
+                        value: ProductLanguage.controlModeLabel(mode)
+                            + (projection.policyVersion.map { " · \($0)" } ?? "")
+                    )
+                }
+                if let effect = projection.effectClass {
+                    LabeledContent("Effect", value: effect)
+                }
                 LabeledContent("Attempt", value: projection.attempt.map(String.init) ?? "—")
                 LabeledContent("Outcome", value: projection.outcome)
                 LabeledContent("Source", value: "\(projection.sourceKind) · \(projection.sourceId)")
@@ -483,6 +494,16 @@ struct QueueHUD: View {
                     Text("·").foregroundStyle(Sig.faint)
                     Text(proposal.target ?? "").font(.system(size: 11, weight: .semibold))
                 }.foregroundStyle(Sig.faint).lineLimit(1)
+                if let mode = proposal.policySnapshot?.mode {
+                    Text(
+                        "\(ProductLanguage.controlModeLabel(mode)) · "
+                        + "\(proposal.policySnapshot?.authorityBasis ?? "authority pending") · "
+                        + "\(proposal.operation?.destination ?? proposal.target ?? "destination unavailable")"
+                    )
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .foregroundStyle(Sig.faint)
+                    .lineLimit(1)
+                }
             }
             Spacer(minLength: 4)
             Button {

--- a/apple/Sources/Contracts/MissionControl.swift
+++ b/apple/Sources/Contracts/MissionControl.swift
@@ -90,6 +90,46 @@ public struct BeltStory: Codable, Equatable, Sendable {
 
 // MARK: - Presence: steering (Phase 87)
 
+public struct CoderSteeringOperation: Codable, Equatable, Sendable {
+    public var effectClass: String?
+    public var destination: String?
+    public var consequence: String?
+}
+
+public struct CoderSteeringPolicy: Codable, Equatable, Sendable {
+    public var mode: String?
+    public var source: String?
+    public var policyVersion: String?
+    public var outcome: String?
+    public var reasonCode: String?
+    public var authorityBasis: String?
+    public var nextState: String?
+    public var requiresGrant: Bool?
+
+    public var usesControlPosture: Bool {
+        outcome == "allowed" && authorityBasis == "control_posture"
+    }
+}
+
+public struct CoderSteeringCommitment: Codable, Equatable, Sendable {
+    public var effect: String?
+    public var destination: String?
+    public var authorityBasis: String?
+    public var nextState: String?
+    public var receipt: String?
+}
+
+public struct CoderSteeringReceipt: Codable, Equatable, Sendable {
+    public var id: String
+    public var sourceRef: String?
+    public var actualDestination: String?
+    public var authorityBasis: String?
+    public var controlMode: String?
+    public var policyVersion: String?
+    public var effectClass: String?
+    public var outcome: String?
+}
+
 public struct CoderSessionPeek: Codable, Equatable, Sendable {
     public var key: String
     public var agent: String
@@ -97,6 +137,11 @@ public struct CoderSessionPeek: Codable, Equatable, Sendable {
     public var awaitingResponse: Bool
     public var question: String?
     public var updatedAt: String?
+    public var paneId: String?
+    public var operation: CoderSteeringOperation?
+    public var policy: CoderSteeringPolicy?
+    public var commitment: CoderSteeringCommitment?
+    public var armCommitment: String?
     public var grant: Grant
     public var peek: Peek
 
@@ -121,10 +166,16 @@ public struct CoderSessionPeek: Codable, Equatable, Sendable {
 
     public init(key: String, agent: String, stale: Bool, awaitingResponse: Bool,
                 question: String? = nil, updatedAt: String? = nil,
-                grant: Grant, peek: Peek) {
+                grant: Grant, peek: Peek, paneId: String? = nil,
+                operation: CoderSteeringOperation? = nil,
+                policy: CoderSteeringPolicy? = nil,
+                commitment: CoderSteeringCommitment? = nil,
+                armCommitment: String? = nil) {
         self.key = key; self.agent = agent; self.stale = stale
         self.awaitingResponse = awaitingResponse; self.question = question
         self.updatedAt = updatedAt; self.grant = grant; self.peek = peek
+        self.paneId = paneId; self.operation = operation; self.policy = policy
+        self.commitment = commitment; self.armCommitment = armCommitment
     }
 }
 
@@ -146,10 +197,17 @@ public struct SteerResult: Codable, Equatable, Sendable {
     public var auditId: Int?
     public var revoked: Bool?
     public var detail: String?
+    public var operation: CoderSteeringOperation?
+    public var policy: CoderSteeringPolicy?
+    public var receipt: CoderSteeringReceipt?
     public init(status: String, paneId: String? = nil, submitted: Bool? = nil,
-                auditId: Int? = nil, revoked: Bool? = nil, detail: String? = nil) {
+                auditId: Int? = nil, revoked: Bool? = nil, detail: String? = nil,
+                operation: CoderSteeringOperation? = nil,
+                policy: CoderSteeringPolicy? = nil,
+                receipt: CoderSteeringReceipt? = nil) {
         self.status = status; self.paneId = paneId; self.submitted = submitted
         self.auditId = auditId; self.revoked = revoked; self.detail = detail
+        self.operation = operation; self.policy = policy; self.receipt = receipt
     }
 
     /// The consent grammar the surface reads from the shape alone: a
@@ -170,14 +228,18 @@ public struct SteeringAuditEntry: Codable, Equatable, Sendable {
     public var submit: Bool
     public var outcome: String
     public var detail: String?
+    public var operation: CoderSteeringOperation?
+    public var policySnapshot: CoderSteeringPolicy?
     public init(id: Int, ts: String, sessionKey: String, agent: String,
                 paneId: String? = nil, textSha256: String, textHead: String,
                 grounding: [String] = [], submit: Bool, outcome: String,
-                detail: String? = nil) {
+                detail: String? = nil, operation: CoderSteeringOperation? = nil,
+                policySnapshot: CoderSteeringPolicy? = nil) {
         self.id = id; self.ts = ts; self.sessionKey = sessionKey; self.agent = agent
         self.paneId = paneId; self.textSha256 = textSha256; self.textHead = textHead
         self.grounding = grounding; self.submit = submit; self.outcome = outcome
-        self.detail = detail
+        self.detail = detail; self.operation = operation
+        self.policySnapshot = policySnapshot
     }
 }
 

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Authority.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Authority.swift
@@ -7,15 +7,16 @@ import Contracts
 /// The desktop's one authority preset. It affects future operations only.
 public struct AuthorityPolicy: Codable, Equatable, Sendable {
     public var controlMode: String
+    public var controlModeLabel: String?
+    public var controlModeDescription: String?
+    public var policyVersion: String?
     public var source: String?
+    public var appliesTo: String?
     public var precedence: [String]?
     public var hardInvariants: [String]?
+    public var supportedFamilies: [String]?
+    public var unsupportedFamilyBehavior: String?
 
-    enum CodingKeys: String, CodingKey {
-        case controlMode = "control_mode"
-        case source, precedence
-        case hardInvariants = "hard_invariants"
-    }
 }
 
 extension HTTPDesktopClient {

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Inbox.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Inbox.swift
@@ -38,15 +38,39 @@ public struct MeshInboxProposal: Codable, Equatable, Sendable, Identifiable {
     public var status: String?
     public var createdAt: String?   // ISO string — the timestamps rule (never Date)
     public var commitment: MeshProposalCommitment?
+    public var operation: MeshProposalOperation?
+    public var policySnapshot: MeshProposalPolicy?
 
     public init(id: String, origin: String? = nil, meetingId: String? = nil,
                 target: String? = nil, action: String? = nil, preview: String? = nil,
                 status: String? = nil, createdAt: String? = nil,
-                commitment: MeshProposalCommitment? = nil) {
+                commitment: MeshProposalCommitment? = nil,
+                operation: MeshProposalOperation? = nil,
+                policySnapshot: MeshProposalPolicy? = nil) {
         self.id = id; self.origin = origin; self.meetingId = meetingId
         self.target = target; self.action = action; self.preview = preview
         self.status = status; self.createdAt = createdAt; self.commitment = commitment
+        self.operation = operation; self.policySnapshot = policySnapshot
     }
+
+}
+
+public struct MeshProposalOperation: Codable, Equatable, Sendable {
+    public var effectClass: String?
+    public var destination: String?
+    public var consequence: String?
+
+}
+
+public struct MeshProposalPolicy: Codable, Equatable, Sendable {
+    public var mode: String?
+    public var source: String?
+    public var policyVersion: String?
+    public var outcome: String?
+    public var reasonCode: String?
+    public var authorityBasis: String?
+    public var nextState: String?
+
 }
 
 public struct MeshProposalCommitment: Codable, Equatable, Sendable {

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Projections.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Projections.swift
@@ -25,6 +25,9 @@ public struct DeskProjectionDTO: Codable, Equatable, Sendable, Identifiable {
     public var sourceId: String
     public var sourceApi: String
     public var detailUrl: String
+    public var controlMode: String?
+    public var policyVersion: String?
+    public var effectClass: String?
     public var severity: String
     public var dismissed: Bool
 }

--- a/apple/Sources/Providers/Desktop/HTTPDesktopClient+Steering.swift
+++ b/apple/Sources/Providers/Desktop/HTTPDesktopClient+Steering.swift
@@ -5,8 +5,9 @@ import FoundationNetworking
 import Contracts
 
 // HSM-26-03 — the consent spine on the wire (Phase 87). The iPad attaches to a
-// live session (peek, read-only), arms it (a grant that pins the pane's %N and
-// counts down), and steers it (voice-first, audited). The refusals are
+// live session (peek, read-only), consumes the Hub's policy decision, and
+// steers it (voice-first, audited). Secure/Normal may arm a bounded grant;
+// YOLO binds the expected registered pane id without an arm prompt. Refusals are
 // first-class DATA, not errors: an unarmed or recycled-pane steer comes back as
 // a typed SteerResult (a 409 body), so the surface re-offers ARM from the shape
 // alone — never a thrown toast. Own request helpers (the +Ask precedent).
@@ -147,10 +148,14 @@ extension HTTPDesktopClient {
     /// revoking refusal (recycled pane / expiry) sets `revoked` so the surface
     /// re-offers ARM.
     public func steerCoder(key: String, text: String, submit: Bool = true,
+                           expectedPaneId: String? = nil,
                            grounding: [RailsGroundingRef]? = nil, node: String? = nil) async throws -> SteerResult {
         let (path, keyInBody) = steerVerb(node: node, key: key, verb: "steer")
         var body: [String: Any] = ["text": text, "submit": submit]
         if keyInBody { body["key"] = key }
+        if let expectedPaneId, !expectedPaneId.isEmpty {
+            body["expected_pane_id"] = expectedPaneId
+        }
         if let g = grounding, !g.isEmpty {
             body["grounding"] = ["rails": g.map { ["repo": $0.repo, "project": $0.project, "kind": $0.kind, "id": $0.id] }]
         }
@@ -180,10 +185,15 @@ extension HTTPDesktopClient {
     /// keys (`.interrupt`, arrows, `.escape`) through the chokepoint. 200 →
     /// delivered; 409 → a typed refusal (a revoking one re-offers ARM). A
     /// `node` routes through the relay (HS-89-03).
-    public func coderKeys(key: String, keys: [SteerKey], node: String? = nil) async throws -> SteerResult {
+    public func coderKeys(key: String, keys: [SteerKey],
+                          expectedPaneId: String? = nil,
+                          node: String? = nil) async throws -> SteerResult {
         let (path, keyInBody) = steerVerb(node: node, key: key, verb: "keys")
         var body: [String: Any] = ["keys": keys.map { $0.wire }]
         if keyInBody { body["key"] = key }
+        if let expectedPaneId, !expectedPaneId.isEmpty {
+            body["expected_pane_id"] = expectedPaneId
+        }
         let data = try await sendSteerAllowing409(makeSteerRequest(path: path, method: "POST", jsonBody: body))
         guard let res = try? HoldSpeakContracts.decoder().decode(SteerResult.self, from: data) else {
             throw DesktopClientError.malformed

--- a/apple/Tests/ProvidersTests/AuthorityClientTests.swift
+++ b/apple/Tests/ProvidersTests/AuthorityClientTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import Contracts
+@testable import Providers
+
+final class AuthorityClientTests: XCTestCase {
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var body = Data()
+        nonisolated(unsafe) static var lastRequest: URLRequest?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            Self.lastRequest = request
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Self.body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    private func client() -> HTTPDesktopClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubProtocol.self]
+        return HTTPDesktopClient(
+            config: .init(baseURL: URL(string: "http://desk.local:8000")!, token: "tok"),
+            session: URLSession(configuration: config)
+        )
+    }
+
+    func testAuthorityPolicyDecodesTheSharedVersionedPosture() async throws {
+        StubProtocol.body = Data(#"""
+        {"control_mode":"yolo","control_mode_label":"YOLO",
+         "control_mode_description":"Runs eligible configured work without HoldSpeak approval prompts.",
+         "policy_version":"operation-policy/v2","source":"config",
+         "applies_to":"future_operations_only",
+         "precedence":["hard_invariants","control_mode"],
+         "hard_invariants":["destination_binding","payload_binding"],
+         "supported_families":["external_write"],
+         "unsupported_family_behavior":"refused"}
+        """#.utf8)
+
+        let policy = try await client().authorityPolicy()
+        XCTAssertEqual(policy.controlMode, "yolo")
+        XCTAssertEqual(policy.controlModeLabel, "YOLO")
+        XCTAssertEqual(policy.policyVersion, "operation-policy/v2")
+        XCTAssertEqual(policy.appliesTo, "future_operations_only")
+        XCTAssertEqual(policy.unsupportedFamilyBehavior, "refused")
+        XCTAssertEqual(StubProtocol.lastRequest?.url?.path, "/api/authority/policy")
+        XCTAssertEqual(
+            StubProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization"),
+            "Bearer tok"
+        )
+    }
+}

--- a/apple/Tests/ProvidersTests/MeshInboxClientTests.swift
+++ b/apple/Tests/ProvidersTests/MeshInboxClientTests.swift
@@ -72,6 +72,15 @@ final class MeshInboxClientTests: XCTestCase {
         {"id": "prop-d", "origin": "desk", "meeting_id": null,
          "target": "slack", "action": "send_message",
          "preview": "Digest → #eng-updates", "status": "proposed",
+         "operation": {"effect_class": "slack/post_message",
+                       "destination": "slack:sha256:fixed",
+                       "consequence": "execute_now"},
+         "policy_snapshot": {"mode": "neutral", "source": "config",
+                             "policy_version": "operation-policy/v2",
+                             "outcome": "authorization_required",
+                             "reason_code": "per_action_authorization_required",
+                             "authority_basis": "per_action_required",
+                             "next_state": "awaiting_authorization"},
          "created_at": "2026-07-05T10:01:00"}
       ],
       "counts": {"queued": 2, "running": 0, "failed": 1, "pending_approvals": 2}
@@ -95,6 +104,11 @@ final class MeshInboxClientTests: XCTestCase {
         XCTAssertNil(desk?.meetingId)
         XCTAssertEqual(desk?.target, "slack")
         XCTAssertEqual(desk?.preview, "Digest → #eng-updates")
+        XCTAssertEqual(desk?.operation?.effectClass, "slack/post_message")
+        XCTAssertEqual(desk?.operation?.destination, "slack:sha256:fixed")
+        XCTAssertEqual(desk?.policySnapshot?.mode, "neutral")
+        XCTAssertEqual(desk?.policySnapshot?.policyVersion, "operation-policy/v2")
+        XCTAssertEqual(desk?.policySnapshot?.nextState, "awaiting_authorization")
 
         XCTAssertEqual(inbox.counts?.pendingApprovals, 2)
         XCTAssertEqual(inbox.counts?.failed, 1)

--- a/apple/Tests/ProvidersTests/ProjectionClientTests.swift
+++ b/apple/Tests/ProvidersTests/ProjectionClientTests.swift
@@ -55,7 +55,9 @@ final class ProjectionClientTests: XCTestCase {
           "authority_basis":"explicit_capture","attempt":null,"outcome":"recoverable",
           "timestamp":"2026-07-11T01:00:00Z","correlation_id":"meeting:m1",
           "source_kind":"meeting","source_id":"m1","source_api":"/api/meetings/m1",
-          "detail_url":"/history?meeting=m1","severity":"error","dismissed":false}],
+          "detail_url":"/history?meeting=m1","control_mode":"yolo",
+          "policy_version":"operation-policy/v2","effect_class":"slack/post_message",
+          "severity":"error","dismissed":false}],
          "counts":{"needs_attention":1,"receipts":0},
          "subject_counts":{"meeting:m1":{"needs_attention":1,"receipts":0}},
          "page":{"offset":0,"limit":50,"total":1,"has_more":false}}
@@ -64,6 +66,9 @@ final class ProjectionClientTests: XCTestCase {
         XCTAssertEqual(result.projections.first?.subjectRef, "meeting:m1")
         XCTAssertEqual(result.projections.first?.actualDestination, "this_machine")
         XCTAssertEqual(result.projections.first?.attentionState, "needs_attention")
+        XCTAssertEqual(result.projections.first?.controlMode, "yolo")
+        XCTAssertEqual(result.projections.first?.policyVersion, "operation-policy/v2")
+        XCTAssertEqual(result.projections.first?.effectClass, "slack/post_message")
         XCTAssertEqual(result.page.total, 1)
         XCTAssertEqual(StubProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization"), "Bearer tok")
     }

--- a/apple/Tests/ProvidersTests/SteeringClientTests.swift
+++ b/apple/Tests/ProvidersTests/SteeringClientTests.swift
@@ -62,7 +62,11 @@ final class SteeringClientTests: XCTestCase {
         route("/api/coders/claude:s1/peek", 200, #"""
         {"key":"claude:s1","agent":"claude","stale":false,"awaiting_response":true,
          "question":"merge?","updated_at":"2026-07-08T10:00:00Z",
+         "pane_id":"%5",
+         "arm_commitment":"Arm pane %5 for 15 minutes",
          "grant":{"armed":true,"expires_in_seconds":840},
+         "operation":{"effect_class":"terminal/type_text_and_keys","destination":"%5"},
+         "policy":{"mode":"yolo","outcome":"allowed","reason_code":"registered_steering_posture_allowed","authority_basis":"control_posture","policy_version":"operation-policy/v2"},
          "peek":{"status":"live","hash":"abc","lines":["$ make","ok"]}}
         """#)
         let peek = try await client().coderPeek(key: "claude:s1")
@@ -70,6 +74,10 @@ final class SteeringClientTests: XCTestCase {
         XCTAssertEqual(peek.peek.lines?.count, 2)
         XCTAssertTrue(peek.grant.armed)
         XCTAssertEqual(peek.grant.expiresInSeconds, 840)
+        XCTAssertEqual(peek.paneId, "%5")
+        XCTAssertEqual(peek.armCommitment, "Arm pane %5 for 15 minutes")
+        XCTAssertTrue(peek.policy?.usesControlPosture == true)
+        XCTAssertEqual(peek.policy?.reasonCode, "registered_steering_posture_allowed")
     }
 
     func testArmReturnsTheGrant() async throws {
@@ -100,15 +108,21 @@ final class SteeringClientTests: XCTestCase {
 
     func testSteerDeliversAndCarriesGrounding() async throws {
         route("/api/coders/claude:s1/steer", 200,
-              #"{"status":"delivered","pane_id":"%5","submitted":false,"audit_id":7}"#)
+              #"{"status":"delivered","pane_id":"%5","submitted":false,"audit_id":7,"policy":{"mode":"yolo","outcome":"allowed","authority_basis":"control_posture"},"receipt":{"id":"steering:7","source_ref":"coder_session:claude:s1","actual_destination":"%5","authority_basis":"control_posture","control_mode":"yolo","policy_version":"operation-policy/v2","effect_class":"terminal/type_text_and_keys","outcome":"delivered"}}"#)
         let refs = [RailsGroundingRef(repo: "holdspeak", project: "holdspeak", kind: "story", id: "HS-88-05")]
-        let res = try await client().steerCoder(key: "claude:s1", text: "ship it", submit: false, grounding: refs)
+        let res = try await client().steerCoder(
+            key: "claude:s1", text: "ship it", submit: false,
+            expectedPaneId: "%5", grounding: refs
+        )
         XCTAssertTrue(res.isDelivered)
         XCTAssertEqual(res.paneId, "%5")
+        XCTAssertEqual(res.receipt?.id, "steering:7")
+        XCTAssertTrue(res.policy?.usesControlPosture == true)
         // The grounding rides the body as rails refs.
         let sent = String(decoding: StubProtocol.lastBody ?? Data(), as: UTF8.self)
         XCTAssertTrue(sent.contains("\"rails\""))
         XCTAssertTrue(sent.contains("HS-88-05"))
+        XCTAssertTrue(sent.contains("\"expected_pane_id\":\"%5\""))
     }
 
     func testSteerRefusalRevokesAndReoffersARM() async throws {
@@ -126,12 +140,15 @@ final class SteeringClientTests: XCTestCase {
         route("/api/coders/steering/audit", 200, #"""
         {"audit":[{"id":7,"ts":"2026-07-08T10:00:00Z","session_key":"claude:s1","agent":"claude",
          "pane_id":"%5","text_sha256":"abc","text_head":"ship it","grounding":["rails:story:HS-88-05"],
-         "submit":false,"outcome":"delivered","detail":null}]}
+         "submit":false,"outcome":"delivered","detail":null,
+         "operation":{"effect_class":"terminal/type_text_and_keys","destination":"%5"},
+         "policy_snapshot":{"mode":"yolo","authority_basis":"control_posture","policy_version":"operation-policy/v2"}}]}
         """#)
         let trail = try await client().steeringAudit(sessionKey: "claude:s1")
         XCTAssertEqual(trail.count, 1)
         XCTAssertEqual(trail[0].outcome, "delivered")
         XCTAssertEqual(trail[0].grounding, ["rails:story:HS-88-05"])
+        XCTAssertEqual(trail[0].policySnapshot?.authorityBasis, "control_posture")
     }
 
     // MARK: - Phase-89/90 parity (the iPad catches up)
@@ -139,12 +156,16 @@ final class SteeringClientTests: XCTestCase {
     func testKeysDeliverNamedAndLiteral() async throws {
         route("/api/coders/claude:s1/keys", 200,
               #"{"status":"delivered","pane_id":"%5","keys":"C-c"}"#)
-        let res = try await client().coderKeys(key: "claude:s1", keys: [.interrupt, .literal("/find"), .down])
+        let res = try await client().coderKeys(
+            key: "claude:s1", keys: [.interrupt, .literal("/find"), .down],
+            expectedPaneId: "%5"
+        )
         XCTAssertTrue(res.isDelivered)
         let sent = String(decoding: StubProtocol.lastBody ?? Data(), as: UTF8.self)
         XCTAssertTrue(sent.contains("\"C-c\""))       // a named key is a bare string
         XCTAssertTrue(sent.contains("\"literal\""))   // a literal run is an object
         XCTAssertTrue(sent.contains("/find"))
+        XCTAssertTrue(sent.contains("\"expected_pane_id\":\"%5\""))
     }
 
     func testKeysRefusalIsData() async throws {
@@ -158,11 +179,14 @@ final class SteeringClientTests: XCTestCase {
 
     func testKeysToANodeRouteThroughTheRelayWithKeyInBody() async throws {
         route("/api/coders/relay/beta/keys", 200, #"{"status":"delivered","node":"beta","pane_id":"%5"}"#)
-        let res = try await client().coderKeys(key: "pane:%5", keys: [.interrupt], node: "beta")
+        let res = try await client().coderKeys(
+            key: "pane:%5", keys: [.interrupt], expectedPaneId: "%5", node: "beta"
+        )
         XCTAssertTrue(res.isDelivered)
         let sent = String(decoding: StubProtocol.lastBody ?? Data(), as: UTF8.self)
         XCTAssertTrue(sent.contains("\"key\""))        // the key rides the BODY on the relay
         XCTAssertTrue(sent.contains("pane:%5"))
+        XCTAssertTrue(sent.contains("\"expected_pane_id\":\"%5\""))
     }
 
     func testSteerToANodeRoutesThroughTheRelay() async throws {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,31 +308,37 @@ the answer goes. A failed delivery keeps the question on the desk.
 
 ### The steering chokepoint
 
-The web desk can also steer a live session directly: watch its pane, arm it,
-and type into it. Watching is free and read only, a hash gated peek that costs
-a poll only while a pull-out is open. Every keystroke, by contrast, passes one
-function, `coder_steering.deliver`, and there is no other path to the pane. That
-function checks the arming grant, re-resolves the session's current pane, and
-sends only to the exact pane identity that was pinned when the grant was issued,
-so nothing can be retargeted between the check and the keystroke. A recycled or
-expired grant refuses and revokes. The send itself reuses the same tmux
-transport the answer loop uses. Every delivery and every refusal writes a row to
-the steering audit, a hash and a heading of the text, never the whole steer. A
+The web desk can also steer a live session directly: watch its pane, resolve
+authority, and type into it. Watching is free and read only, a hash-gated peek
+that costs a poll only while a pull-out is open. Every text delivery, by
+contrast, passes one function, `coder_steering.deliver`, and there is no other
+path to the pane. The central operation policy selects the authority invariant:
+Secure and Normal consume an exact, bounded pane grant; YOLO accepts the
+registered pane as posture authority without manufacturing a grant. The pane
+identity captured by the read side rides the request, and the chokepoint
+re-resolves the session target immediately before delivery. It sends only to
+the verified canonical `%N`, so a missing, recycled, or retargeted pane refuses
+before a keystroke. An invalid grant also revokes. The send itself reuses the
+same tmux transport the answer loop uses. Every delivery and every refusal
+writes the operation and policy snapshot plus a bounded text fingerprint to the
+steering audit, never the whole steer, and projects a source-linked Receipt. A
 test greps the codebase to keep the transport's call sites pinned to that one
-chokepoint. Nothing here leaves the machine; the model is a consent boundary,
-not an egress, and lives in [SECURITY.md](SECURITY.md).
+chokepoint. The local path does not leave the machine; its authority model lives
+in [SECURITY.md](SECURITY.md).
 
 That chokepoint later grew from a reply channel into full manipulation without
 loosening. Real keys (`C-c`, `Escape`, arrows) pass a sibling function,
-`coder_steering.deliver_keys`, with the same grant check and audit and its own
-pinned census; a named key is allow-listed or refused by name, never handed to
-`tmux` raw. A `pane:%N` key steers any tmux pane on the machine, not only a
-tracked session, pinned and re-verified the same way. And `coder_steering_relay`
-reaches another machine: it forwards a command to a configured node whose own
-copy of this chokepoint executes it, so the machine that types owns the grant and
-the audit while the hub only relays and names where the key landed. Each addition
-is more reach over the exact same spine: watch free, manipulate armed, re-verify
-every key, refuse and revoke, audit everything.
+`coder_steering.deliver_keys`, with the same policy-selected identity check and
+audit and its own pinned census; a named key is allow-listed or refused by name,
+never handed to `tmux` raw. A `pane:%N` key steers any exact tmux pane on the
+machine, not only a tracked session, and is re-verified the same way. And
+`coder_steering_relay` reaches another machine: it forwards the command and
+expected identity to a configured node whose own copy of this chokepoint
+resolves policy and executes it. The machine that types owns the authority
+decision and audit while the hub only relays and names where the key landed.
+Each addition is more reach over the same spine: watch free, resolve a bounded
+grant or eligible posture, re-verify every target, preserve the key allow-list,
+and audit every attempt.
 
 The lifecycle joins it in `coder_factory.py`: `spawn` and `rename` are
 name-validated audited acts (the name is an allow-list, passed as its own

--- a/docs/AUTHORITY.md
+++ b/docs/AUTHORITY.md
@@ -32,19 +32,30 @@ The resolver always applies the same precedence:
 4. Control mode;
 5. the feature default.
 
-Unsupported operation families keep their current behavior. They never inherit
-a permissive YOLO default.
+Unsupported operation families refuse. They never inherit a permissive YOLO
+default.
 
 | Family | Secure | Normal | YOLO |
 |---|---|---|---|
 | Dictation commit | Preview before typing | Follow the configured preview setting | Commit directly |
-| Coder steering | Exact pane grant, up to 5 min | Exact pane grant, up to 15 min | Exact pane grant, up to 60 min |
-| Slack/webhook/GitHub write | Per-action authorization | Per-action authorization | Per-action authorization or an exact fixed-destination grant |
+| Coder steering | Exact pane grant, up to 5 min | Exact pane grant, up to 15 min | Direct text/allowed-key delivery to the registered pane; no arm prompt |
+| Slack/webhook/GitHub write | Per-action authorization or exact short grant | Per-action authorization or exact short grant | Direct execution for a configured fixed destination; no HoldSpeak approval prompt |
 | Cadence | Explicit `run-now`; no background loop | Configured cadence may run | Configured cadence may run |
 
 Changing modes affects operations created afterward. Changing a configured
 Slack, webhook, or GitHub destination revokes reusable grants bound to the old
-configuration.
+configuration. Changing modes revokes active reusable grants and in-memory
+Coder pane grants; a Coder attempt resolved afterward uses the new posture.
+
+Coder steering never treats a session name as sufficient destination identity.
+The read-side pane snapshot supplies the expected tmux `%N`; every delivery
+re-resolves the current registry target and sends only to that canonical pane.
+A missing, gone, or changed pane refuses before a keystroke. Secure and Normal
+use the existing bounded in-memory grant. YOLO uses the central posture decision
+for a registered session or exact `pane:%N`, while the key allow-list, payload,
+pane identity, audit, and source-linked Receipt remain mandatory. Destructive
+session factory operations retain their separate grant/confirmation path until
+that operation family receives its own policy treatment.
 
 ## Grants
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -92,42 +92,47 @@ SQLCipher) becomes warranted and should be its own story.
    a live Coder session is a this-device consequential act (nothing leaves the
    machine), gated by a consent model rather than an egress row. Watching is
    free: the pull-out's peek is read-only, hash-gated, never a keystroke.
-   Steering requires an **arming grant**: issued per session by an explicit
-   Desk act, TTL'd by Control mode (5 min Secure, 15 min Normal, 60 min YOLO;
-   60 min hard cap), pinned to the pane's
-   unique tmux `%N` identity at grant time, and held **in memory only**, so a
-   hub restart disarms everything. Every keystroke re-verifies that the
-   registry's current pane still resolves to the pinned identity; a recycled
-   or retargeted pane refuses AND revokes the grant. Expiry is checked on
-   every read; disarm is one act. Enforcement lives in one hub-side
-   chokepoint, not in any UI. Steers within an armed window are auto-approved
-   by the grant and every delivery (and refusal) is audited.
+   Secure and Normal steering require an **arming grant**: issued per session
+   by an explicit Desk act, TTL'd by Control mode (5 min Secure, 15 min Normal;
+   60 min hard cap), pinned to the pane's unique tmux `%N` identity, and held
+   **in memory only**, so a hub restart disarms everything. YOLO does not ask
+   for that arm grant for text and allowed-key delivery to a registered session
+   or exact `pane:%N`. The pane id captured by peek rides the delivery request;
+   the chokepoint re-resolves the registry target immediately before every send
+   and refuses a missing, recycled, or retargeted pane. It sends only to the
+   verified canonical `%N`. Mode changes invalidate old grants. Enforcement
+   lives in one hub-side chokepoint, not in either client. Every delivery and
+   refusal is audited with its operation-policy snapshot and projects as a
+   source-linked Desk Receipt.
 
-   **Full manipulation** widens the reach without loosening the consent.
+   **Full manipulation** widens the reach without loosening the invariants.
    (a) *Any key*, not just text: control and named keys (`C-c`, `Escape`,
    arrows) go through a second chokepoint, `coder_steering.deliver_keys`, with
-   the same grant re-check and audit; a named key must be on an allow-list or it
-   is refused by name and never handed to `tmux`, so an arbitrary string can
-   never become a keystroke. (b) *Any pane*, not just registered sessions: a
+   the same authority and identity check plus audit; a named key must be on an
+   allow-list or it is refused by name and never handed to `tmux`, so an
+   arbitrary string can never become a keystroke. (b) *Any pane*, not just
+   registered sessions: a
    `pane:%N` key steers a raw tmux pane (one you started by hand), pinned and
-   re-verified exactly like a tracked session; watching any pane is free,
-   manipulating any pane is armed. (c) *Any configured machine*:
+   re-verified exactly like a tracked session; watching any pane is free, and
+   Secure/Normal manipulation is armed while eligible YOLO steering uses the
+   exact pane as posture authority. (c) *Any configured machine*:
    `coder_steering_relay` forwards a command to a node named in
    `HOLDSPEAK_STEER_NODES`, which executes it against its own tmux.
-   **The machine that types owns the grant and writes the audit**; the hub is a
-   relay, never the authority over another machine's terminal, and only the
-   command (text/keys) plus the node's own bearer token cross the wire. A node
-   that does not answer refuses by name (`node_offline`), never a hang. Both
-   chokepoints are pinned by a census test; there is no autonomous path, so a
-   person is behind every key.
+   **The machine that types resolves the policy or grant and writes the audit**;
+   the hub is a relay, never the authority over another machine's terminal, and
+   only the command (text/keys), expected pane identity, and the node's own
+   bearer token cross the wire. A node that does not answer refuses by name
+   (`node_offline`), never a hang. Both chokepoints are pinned by a census test;
+   YOLO still exposes only the registered text/allowed-key capability, not an
+   arbitrary remote executable operation.
 
    **The session factory** (`coder_factory.py`) adds the lifecycle on the same
    terms. `spawn` and `rename` take a session name, which is user input, so the
-   name is held to a strict allow-list (first character a letter or underscore,
+   name is held to a strict allow-list (first character alphanumeric or underscore,
    so it can never be read as a flag) and passed as its own argument, never a
    shell string; a bad name refuses by name before tmux runs. `kill` is the most
-   consequential act, so it is gated exactly like a steer: it requires the
-   grant, re-verifies the pinned pane, drops the grant afterward, and audits.
+   consequential act, so it retains a separate arm grant: it re-verifies the
+   pinned pane, drops the grant afterward, and audits.
    The destructive tmux verbs live in that one module, pinned by a census, and
    every lifecycle act is audited with a plain heading.
 6. **Rails as material** (`grounding_rails.py`, `rails_observer.py`):

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -511,26 +511,30 @@ action on the desk, and the repository's own commit gate keeps the final say.
 
 ## Steer A Session From The Desk
 
-Watching is free; steering is armed; every steer is audited. Nothing here
-leaves your machine.
+Watching is free; every steer resolves authority and is audited. Local steering
+does not leave your machine.
 
 Click any session pin on the belt, or the "Watch live" chip in a coder card,
 and the session pull-out opens with a live view of that Coder session's terminal pane.
 The view is read only: it updates on its own, marks itself stale when the
 session has gone quiet, and never sends a keystroke.
 
-To reply, you arm the session first. Press and hold the ARM chip. The chip
-becomes a countdown; the grant lasts fifteen minutes, and one tap disarms it.
-Arming pins the exact terminal pane at that moment, and every keystroke
-re-checks that the pane you armed is still the pane in front of you. If the
-session's pane was replaced, the steer refuses and the grant is dropped, so a
-reply meant for one session can never land in another. A restart of the hub
-disarms everything.
+The pull-out names the exact pane and the Control posture used for steering. In
+Secure, click **Arm pane** for a five-minute exact-pane grant. In Normal, the
+same deliberate action grants fifteen minutes. The chip becomes a countdown;
+one click disarms it. In YOLO, an eligible registered session reads **YOLO ·
+direct** and needs no HoldSpeak arm prompt for text or allowed keys. It does not
+gain arbitrary terminal authority: the pane identity captured by the live view
+rides every delivery, and the hub re-checks that identity immediately before a
+keystroke. A missing or replaced pane refuses, so a reply meant for one session
+cannot land in another. Changing posture or restarting the hub clears existing
+pane grants.
 
-Once armed, the composer appears. Speak your reply by holding the mic, or type
-it. The paper-plane toggle chooses whether a return is pressed after the text
-lands, so a multi-part steer can stay in the Coder session's input box. Send, and the
-reply lands in the pane exactly as you composed it.
+Once the exact grant or YOLO posture is ready, the composer appears. Speak your
+reply by holding the mic, or type it. The paper-plane toggle chooses whether a
+return is pressed after the text lands, so a multi-part steer can stay in the
+Coder session's input box. Send, and the reply lands in the pane exactly as you
+composed it.
 
 You can carry desk objects into a steer. Open the grounding picker in the
 composer, choose a meeting or an artifact, and its content rides in ahead of
@@ -546,48 +550,53 @@ correlated story's status through the same proposal the belt uses, the commit
 gate keeping the final say.
 
 Every reply and every refusal is written to the steering audit: who, when, which
-session, which pane, and a hash of the text. Read it back with
-`GET /api/coders/steering/audit`.
+session and pane, the exact operation-policy snapshot, and a bounded text
+fingerprint. The result also appears as a Receipt on the Coder session. Read the
+source audit with `GET /api/coders/steering/audit`.
 
 ### Take Over A Session: Any Key, Any Pane, Any Machine
 
-Steering is not only typing text. Under the same arming grant you can send real
-keys: interrupt a runaway with `C-c`, dismiss a prompt with `Escape`, or drive a
-menu with the arrows and `Enter`. Keys go through the same one path and the same
-audit as a text reply, so the trail reads like what you did: `C-c`,
+Steering is not only typing text. Under the same resolved authority you can send
+real keys: interrupt a runaway with `C-c`, dismiss a prompt with `Escape`, or
+drive a menu with the arrows and `Enter`. Keys go through the same one path and
+the same audit as a text reply, so the trail reads like what you did: `C-c`,
 `Down Down Enter`. A key that is not a real terminal key is refused by name and
 never sent (`POST /api/coders/{key}/keys`).
 
 The session does not have to be one HoldSpeak already knows. Every tmux pane on
 the machine is listed at `GET /api/coders/steering/panes`, including a shell you
-opened by hand. Watch any of them free; to steer one, arm it by its pane id
-(`pane:%N`). Arming pins that exact pane the same way, so a pane you attach to by
-hand is as safe to steer as a tracked session.
+opened by hand. Watch any of them free. Secure and Normal ask you to arm its
+exact pane id (`pane:%N`); YOLO can use that exact selection directly. Either
+path re-verifies the canonical pane before delivery, so a pane you attach to by
+hand has the same identity protection as a tracked session.
 
 And the machine does not have to be this one. With a node configured
 (`HOLDSPEAK_STEER_NODES`), the desk relays a watch, an arm, a steer, or a key
 sequence to that node, which runs it against its own terminal. The machine that
-types owns the consent and keeps the audit: the far node checks its own grant
-and records its own keystroke, and the relay only names where it landed. A node
-that does not answer refuses by name, at once, rather than leaving you waiting.
+types owns the authority decision and audit: the far node resolves its own
+Control posture or grant, re-checks the expected pane, and records the attempt.
+The relay only carries the command and expected identity. A node that does not
+answer refuses by name, at once, rather than leaving you waiting.
 
-The rule never changes as the reach grows: watching is free, manipulating is
-armed, the pane is re-checked before every key, a recycled pane refuses and drops
-the grant, and every key is audited. There is no autonomous mode; a person is
-behind each keystroke or nothing is sent.
+The rule never changes as the reach grows: watching is free; Secure and Normal
+use a bounded exact-pane grant; eligible YOLO steering uses the registered pane
+and posture without another prompt; the pane is re-checked before every key; a
+recycled pane refuses; and every attempt leaves a Receipt. YOLO removes the
+HoldSpeak prompt, not the destination, identity, payload, or key checks.
 
 You do all of this from the desk, not a terminal. Open the Panes list at the
 bottom of the desk to see every tmux pane on the machine, and attach to any one.
-Once you arm it, a row of keys appears next to the composer: one tap sends `^C` to
-stop a runaway, or the arrows and `Enter` to drive a menu. A chip in the header
-shows which machine you are steering, this Mac or a paired node.
+When authority is ready, a row of keys appears next to the composer: one tap
+sends `^C` to stop a runaway, or the arrows and `Enter` to drive a menu. A chip
+in the header shows which machine you are steering, this Mac or a paired node.
 
 The desk can also make and end sessions. The Panes list has a field to spawn a
 new session by name (the name is checked, so it can never carry a stray command).
-An armed session shows a Rename control and a Kill control; Kill asks you to
-confirm, because ending a session cannot be undone, and it goes through the same
-armed check as a keystroke. Spawn, steer, rename, and kill each leave their own
-line in the audit.
+The Desk keeps Rename and Kill in a separate session-control window even when
+YOLO can steer directly. Kill requires that arm and asks you to confirm, because
+ending a session cannot be undone; Rename retains its strict name/argument
+validation while its full policy classification remains open. Spawn, steer,
+rename, and kill each leave their own line in the audit.
 
 ## Ground A Run On The Rails
 

--- a/holdspeak/coder_steering.py
+++ b/holdspeak/coder_steering.py
@@ -24,7 +24,7 @@ import subprocess
 import threading
 import time
 from datetime import datetime
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional
 
 Runner = Callable[..., "subprocess.CompletedProcess[str]"]
 Clock = Callable[[], float]
@@ -170,8 +170,9 @@ def awaiting_transitions(
 
 # --- The arming grant (HS-87-02): consent with a countdown ---------------
 #
-# Watching is free; ANY keystroke toward a pane requires an active
-# grant for that session. One file owns consent: the store is
+# Watching is free; Secure/Normal keystrokes require an active grant for that
+# session. YOLO consumes registered-pane posture authority later in the same
+# chokepoint. One file owns the bounded grant store: it is
 # in-memory and module-level — a hub restart disarms everything (fail
 # closed, a phase decision, not a gap). Expiry is a lazy sweep on
 # read; there is no background timer. The clock is monotonic so a
@@ -183,6 +184,7 @@ ARM_MIN_TTL_SECONDS = 10
 
 _GRANTS: dict[str, dict[str, Any]] = {}
 _GRANTS_LOCK = threading.Lock()
+_PANE_ID_RE = re.compile(r"^%[0-9]+$")
 
 
 def resolve_pane_identity(
@@ -340,20 +342,39 @@ def active_grants(*, clock: Clock = time.monotonic) -> dict[str, dict[str, Any]]
     now = clock()
     with _GRANTS_LOCK:
         return {
-            key: {
-                "pane_id": grant["pane_id"],
-                "expires_in_seconds": max(0, int(grant["expires_at"] - now)),
-                "issued_at": grant["issued_at"],
-                "actor": grant["actor"],
-                "operation_family": grant["operation_family"],
-                "effect_class": grant["effect_class"],
-                "destination": grant["destination"],
-                "data_classes": list(grant["data_classes"]),
-                "resource_scope": grant["resource_scope"],
-                "control_mode": grant["control_mode"],
-            }
+            key: _grant_view(grant, now=now)
             for key, grant in _GRANTS.items()
         }
+
+
+def _grant_view(grant: Mapping[str, Any], *, now: float) -> dict[str, Any]:
+    return {
+        "pane_id": grant["pane_id"],
+        "expires_in_seconds": max(0, int(grant["expires_at"] - now)),
+        "issued_at": grant["issued_at"],
+        "actor": grant["actor"],
+        "operation_family": grant["operation_family"],
+        "effect_class": grant["effect_class"],
+        "destination": grant["destination"],
+        "data_classes": list(grant["data_classes"]),
+        "resource_scope": grant["resource_scope"],
+        "control_mode": grant["control_mode"],
+    }
+
+
+def policy_grant(
+    key: str, *, clock: Clock = time.monotonic
+) -> Optional[dict[str, Any]]:
+    """Return the grant snapshot without consuming expiry.
+
+    The resolver needs the exact binding, but ``require_grant`` remains the
+    authoritative expiry/identity check so an expired delivery keeps its typed
+    ``expired`` refusal and revocation frame.
+    """
+    now = clock()
+    with _GRANTS_LOCK:
+        grant = _GRANTS.get(key)
+        return {**_grant_view(grant, now=now), "state": "active"} if grant else None
 
 
 def require_grant(
@@ -407,17 +428,101 @@ def require_grant(
     }
 
 
-def clear_grants() -> None:
-    """Test seam. A real restart clears the store by construction."""
+def require_posture_authority(
+    current_target: Optional[str],
+    expected_pane_id: Optional[str],
+    *,
+    runner: Optional[Runner] = None,
+) -> dict[str, Any]:
+    """Verify a registered YOLO target without manufacturing an arm grant.
+
+    The expected ``%N`` identity comes from the read-side session/pane snapshot
+    and rides the delivery request. The registry target is resolved again now;
+    the send may use only that freshly verified canonical id. A missing,
+    malformed, gone, or changed identity refuses before one keystroke.
+    """
+    expected = str(expected_pane_id or "").strip()
+    if not _PANE_ID_RE.fullmatch(expected):
+        return {
+            "status": "pane_identity_required",
+            "detail": "a registered pane identity is required — nothing was typed",
+        }
+    if not current_target:
+        return {
+            "status": "pane_gone",
+            "detail": "registry has no pane — nothing was typed",
+        }
+    identity = resolve_pane_identity(current_target, runner=runner)
+    if identity["status"] != "ok":
+        return identity
+    if identity["pane_id"] != expected:
+        return {
+            "status": "pane_mismatch",
+            "detail": (
+                f"pane {identity['pane_id']!r} is not the expected "
+                f"{expected!r} — nothing was typed"
+            ),
+        }
+    return {"status": "ok", "pane_id": expected}
+
+
+def _require_delivery_authority(
+    key: str,
+    current_target: Optional[str],
+    *,
+    expected_pane_id: Optional[str],
+    policy_snapshot: Optional[Mapping[str, Any]],
+    runner: Optional[Runner],
+    clock: Clock,
+) -> dict[str, Any]:
+    """Consume the central decision, then run the invariant check it names."""
+    policy = dict(policy_snapshot or {})
+    if not policy:
+        return require_grant(key, current_target, runner=runner, clock=clock)
+    if policy.get("outcome") != "allowed":
+        if policy.get("outcome") == "grant_required":
+            return {"status": "unarmed", "detail": "arm this exact pane to steer"}
+        reason = str(policy.get("reason_code") or "steering_policy_refused")
+        status = (
+            "pane_identity_required"
+            if reason == "registered_steering_destination_required"
+            else "policy_refused"
+        )
+        return {
+            "status": status,
+            "detail": (
+                "a current registered session and pane identity are required — "
+                "nothing was typed"
+                if status == "pane_identity_required"
+                else f"operation policy refused steering: {reason}"
+            ),
+        }
+    basis = str(policy.get("authority_basis") or "")
+    if basis == "control_posture":
+        return require_posture_authority(
+            current_target, expected_pane_id, runner=runner
+        )
+    if basis == "scoped_grant":
+        return require_grant(key, current_target, runner=runner, clock=clock)
+    return {
+        "status": "authority_unresolved",
+        "detail": "operation policy supplied no usable steering authority",
+    }
+
+
+def clear_grants() -> int:
+    """Clear the in-memory store and return how many grants were revoked."""
     with _GRANTS_LOCK:
+        count = len(_GRANTS)
         _GRANTS.clear()
+    return count
 
 
 # --- Deliver (HS-87-03): THE chokepoint ------------------------------------
 #
-# The only path by which steering text reaches a pane. require_grant
-# verifies the pinned identity against what the registry points at
-# NOW; the send itself targets the verified `%N` (not the target
+# The only path by which steering text reaches a pane. The central policy
+# selects an exact grant or registered-pane posture check; either re-verifies
+# what the registry points at NOW. The send targets the verified `%N` (not the target
 # string, so nothing can re-resolve between check and keystroke); the
 # send craft is `tmux_transport.send_text_to_pane` verbatim — literal
 # text, submit as its own raw `\r`. Every attempt lands one audit
@@ -430,6 +535,57 @@ def _default_audit(**kw: Any) -> int:
     return hsdb.get_database().steering.record(**kw)
 
 
+def _audit_delivery_result(
+    record: Callable[..., int],
+    result: dict[str, Any],
+    *,
+    key: str,
+    agent: str,
+    pane_id: Optional[str],
+    text: str,
+    grounding: list[Any],
+    submit: bool,
+    operation: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    operation_payload = dict(operation)
+    policy_payload = dict(policy)
+    try:
+        result["audit_id"] = record(
+            session_key=key,
+            agent=agent,
+            pane_id=pane_id,
+            text=text,
+            grounding=grounding,
+            submit=submit,
+            outcome=result["status"],
+            detail=result.get("detail"),
+            operation=operation_payload,
+            policy_snapshot=policy_payload,
+        )
+    except Exception:
+        result["audit_id"] = None
+    if operation_payload:
+        result["operation"] = operation_payload
+    if policy_payload:
+        result["policy"] = policy_payload
+    if result["audit_id"] is not None:
+        result["receipt"] = {
+            "id": f"steering:{result['audit_id']}",
+            "source_ref": f"coder_session:{key}",
+            "actual_destination": pane_id
+            or operation_payload.get("destination")
+            or "unresolved pane",
+            "authority_basis": policy_payload.get("authority_basis")
+            or "armed_pane_grant",
+            "control_mode": policy_payload.get("mode"),
+            "policy_version": policy_payload.get("policy_version"),
+            "effect_class": operation_payload.get("effect_class"),
+            "outcome": result["status"],
+        }
+    return result
+
+
 def deliver(
     key: str,
     text: str,
@@ -438,12 +594,15 @@ def deliver(
     agent: str = "",
     submit: bool = True,
     grounding_refs: Optional[list[Any]] = None,
+    expected_pane_id: Optional[str] = None,
+    operation: Optional[Mapping[str, Any]] = None,
+    policy_snapshot: Optional[Mapping[str, Any]] = None,
     runner: Optional[Runner] = None,
     clock: Clock = time.monotonic,
     transport: Optional[Callable[..., Any]] = None,
     audit: Optional[Callable[..., int]] = None,
 ) -> dict[str, Any]:
-    """Deliver one steer into an armed session's verified pane.
+    """Deliver one steer into a policy-authorized, verified pane.
 
     Statuses: ``delivered``, ``empty_text``, the `require_grant`
     refusals verbatim (``unarmed`` / ``expired`` / ``pane_mismatch`` /
@@ -453,26 +612,33 @@ def deliver(
     """
     record = audit or _default_audit
     refs = list(grounding_refs or [])
+    operation_payload = dict(operation or {})
+    policy_payload = dict(policy_snapshot or {})
 
     def _audited(result: dict[str, Any], *, pane_id: Optional[str]) -> dict[str, Any]:
-        try:
-            result["audit_id"] = record(
-                session_key=key,
-                agent=agent,
-                pane_id=pane_id,
-                text=text,
-                grounding=refs,
-                submit=submit,
-                outcome=result["status"],
-                detail=result.get("detail"),
-            )
-        except Exception:
-            result["audit_id"] = None
-        return result
+        return _audit_delivery_result(
+            record,
+            result,
+            key=key,
+            agent=agent,
+            pane_id=pane_id,
+            text=text,
+            grounding=refs,
+            submit=submit,
+            operation=operation_payload,
+            policy=policy_payload,
+        )
 
     if not str(text or "").strip():
         return _audited({"status": "empty_text"}, pane_id=None)
-    check = require_grant(key, current_target, runner=runner, clock=clock)
+    check = _require_delivery_authority(
+        key,
+        current_target,
+        expected_pane_id=expected_pane_id,
+        policy_snapshot=policy_snapshot,
+        runner=runner,
+        clock=clock,
+    )
     if check["status"] != "ok":
         return _audited(dict(check), pane_id=None)
     pane_id = check["pane_id"]
@@ -566,14 +732,16 @@ def deliver_keys(
     *,
     current_target: Optional[str],
     agent: str = "",
+    expected_pane_id: Optional[str] = None,
+    operation: Optional[Mapping[str, Any]] = None,
+    policy_snapshot: Optional[Mapping[str, Any]] = None,
     runner: Optional[Runner] = None,
     clock: Clock = time.monotonic,
     transport: Optional[Callable[..., Any]] = None,
     audit: Optional[Callable[..., int]] = None,
 ) -> dict[str, Any]:
-    """Deliver a key sequence into an armed session's verified pane — the
-    control chokepoint, the SAME grant → verify ``%N`` → send → audit shape
-    as :func:`deliver`, sending keys instead of text.
+    """Deliver keys through the same policy → verify ``%N`` → send → audit
+    chokepoint as :func:`deliver`.
 
     Statuses: ``delivered``, ``empty_keys``, ``unknown_key`` (with the
     offending key in ``detail``), the `require_grant` refusals verbatim, or
@@ -583,28 +751,35 @@ def deliver_keys(
     record = audit or _default_audit
     normalized, bad = normalize_keys(keys)
     head = render_keys(normalized)
+    operation_payload = dict(operation or {})
+    policy_payload = dict(policy_snapshot or {})
 
     def _audited(result: dict[str, Any], *, pane_id: Optional[str]) -> dict[str, Any]:
-        try:
-            result["audit_id"] = record(
-                session_key=key,
-                agent=agent,
-                pane_id=pane_id,
-                text=head or (f"<unknown_key: {bad}>" if bad else ""),
-                grounding=[],
-                submit=False,
-                outcome=result["status"],
-                detail=result.get("detail"),
-            )
-        except Exception:
-            result["audit_id"] = None
-        return result
+        return _audit_delivery_result(
+            record,
+            result,
+            key=key,
+            agent=agent,
+            pane_id=pane_id,
+            text=head or (f"<unknown_key: {bad}>" if bad else ""),
+            grounding=[],
+            submit=False,
+            operation=operation_payload,
+            policy=policy_payload,
+        )
 
     if bad is not None:
         return _audited({"status": "unknown_key", "detail": bad}, pane_id=None)
     if not normalized:
         return _audited({"status": "empty_keys"}, pane_id=None)
-    check = require_grant(key, current_target, runner=runner, clock=clock)
+    check = _require_delivery_authority(
+        key,
+        current_target,
+        expected_pane_id=expected_pane_id,
+        policy_snapshot=policy_snapshot,
+        runner=runner,
+        clock=clock,
+    )
     if check["status"] != "ok":
         return _audited(dict(check), pane_id=None)
     pane_id = check["pane_id"]
@@ -650,7 +825,9 @@ __all__ = [
     "normalize_keys",
     "render_keys",
     "peek_pane",
+    "policy_grant",
     "require_grant",
+    "require_posture_authority",
     "resolve_pane_identity",
     "resolve_pane_target",
     "strip_ansi",

--- a/holdspeak/coder_steering_relay.py
+++ b/holdspeak/coder_steering_relay.py
@@ -1,18 +1,18 @@
 """Cross-machine steering relay (HS-89-03) — the third limit falls.
 
 Phase 87 could only steer LOCAL tmux. This reaches another machine: the far
-node runs its OWN steering routes + tmux + consent spine; the hub RELAYS a
+node runs its OWN steering routes + tmux + authority spine; the hub RELAYS a
 peek/arm/steer/keys command to it over authenticated HTTP, and the node
-executes against its own local tmux.
+executes against its own local tmux and control posture.
 
-The security model is deliberate: **the machine that types owns the consent
-AND the audit.** The far node checks its own grant and writes its own audit
+The security model is deliberate: **the machine that types owns the authority
+AND the audit.** The far node checks its own policy/grant and writes its own audit
 row for the keystroke it delivers — the hub is a relay, not the authority
 over someone else's terminal. Honest liveness: a node that does not answer in
 time refuses BY NAME (`node_offline`), never a hang, never a fabricated
-success. Only the command (text / keys) + the pane key cross the wire; the
-node resolves its own panes, and no secret leaves the hub beyond the node's
-own bearer token.
+success. Only the command (text / keys), pane key, and expected pane identity
+cross the wire; the node resolves its own panes, and no secret leaves the hub
+beyond the node's own bearer token.
 """
 from __future__ import annotations
 

--- a/holdspeak/db/actuators.py
+++ b/holdspeak/db/actuators.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from typing import Any, Optional
 
 from ..actuator_authority import authority_binding
-from ..operation_policy import describe_operation, normalize_control_mode
+from ..operation_policy import describe_operation, normalize_control_mode, resolve_policy
 from ..logging_config import get_logger
 from .base import BaseRepository
 from .models import (
@@ -62,6 +62,9 @@ class ActuatorRepository(BaseRepository):
         reversible: bool = False,
         required_capabilities: Optional[list[str]] = None,
         origin: str = "meeting",
+        control_mode: str = "neutral",
+        policy_source: str = "config",
+        fixed_destination: Optional[bool] = None,
     ) -> ActuatorProposalRecord:
         """Persist a `proposed` proposal (idempotent on `idempotency_key`).
 
@@ -104,6 +107,11 @@ class ActuatorRepository(BaseRepository):
             [str(c).strip().lower() for c in (required_capabilities or []) if str(c).strip()],
             fallback="[]",
         )
+        destination_is_fixed = (
+            bool(fixed_destination)
+            if fixed_destination is not None
+            else clean_target.lower() in {"slack", "webhook", "github"}
+        )
         operation = describe_operation(
             operation_id=f"actuator:{proposal_id}",
             family="external_write",
@@ -116,13 +124,19 @@ class ActuatorRepository(BaseRepository):
             data_classes=("proposed_content", "connector_metadata"),
             project_scope=str((payload or {}).get("project") or (payload or {}).get("repo") or "") or None,
             resource_scope=clean_meeting_id or str(window_id).strip() or None,
-            fixed_destination=clean_target.lower() in {"slack", "webhook", "github"},
+            fixed_destination=destination_is_fixed,
             consequence=(
                 "execute_now" if clean_target.lower() in {"slack", "webhook", "github"}
                 else "queue_executor"
             ),
         )
         operation_json = self._json_dumps(operation.to_dict(), fallback="{}")
+        policy = resolve_policy(
+            operation,
+            mode=control_mode,
+            source=str(policy_source or "config"),
+        )
+        policy_snapshot_json = self._json_dumps(policy.to_dict(), fallback="{}")
 
         with self._connection() as conn:
             cursor = conn.execute(
@@ -135,7 +149,7 @@ class ActuatorRepository(BaseRepository):
                     operation_json, policy_snapshot_json, created_at, updated_at
                 )
                 VALUES (?, ?, ?, ?, ?, ?, ?, 'proposed', 'unreviewed', 'proposed',
-                        'not_started', ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?)
+                        'not_started', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(idempotency_key) DO NOTHING
                 """,
                 (
@@ -153,6 +167,7 @@ class ActuatorRepository(BaseRepository):
                     int(bool(reversible)),
                     caps_json,
                     operation_json,
+                    policy_snapshot_json,
                     now,
                     now,
                 ),
@@ -166,7 +181,15 @@ class ActuatorRepository(BaseRepository):
                     )
                     VALUES (?, 'system', NULL, 'proposed', ?, ?)
                     """,
-                    (proposal_id, "proposal recorded", now),
+                    (
+                        proposal_id,
+                        (
+                            "proposal recorded; "
+                            f"policy={policy.policy_version} mode={policy.mode} "
+                            f"outcome={policy.outcome}"
+                        ),
+                        now,
+                    ),
                 )
             row = conn.execute(
                 "SELECT * FROM actuator_proposals WHERE idempotency_key = ?",

--- a/holdspeak/db/core.py
+++ b/holdspeak/db/core.py
@@ -46,7 +46,7 @@ log = get_logger("db")
 
 # Default database location
 DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "holdspeak" / "holdspeak.db"
-SCHEMA_VERSION = 21  # v21: content-free first-value events + idempotent paired delivery (HS-93-05)
+SCHEMA_VERSION = 22  # v22: steering operation/policy receipts (HS-93-07)
 
 
 class SchemaVersionError(RuntimeError):
@@ -1190,7 +1190,9 @@ CREATE TABLE IF NOT EXISTS steering_audit (
     grounding_json TEXT NOT NULL DEFAULT '[]',
     submit INTEGER NOT NULL DEFAULT 1,
     outcome TEXT NOT NULL,
-    detail TEXT
+    detail TEXT,
+    operation_json TEXT NOT NULL DEFAULT '{}',
+    policy_snapshot_json TEXT NOT NULL DEFAULT '{}'
 );
 CREATE INDEX IF NOT EXISTS idx_steering_audit_ts ON steering_audit(ts);
 CREATE INDEX IF NOT EXISTS idx_steering_audit_key ON steering_audit(session_key);
@@ -1553,6 +1555,23 @@ class Database:
                         WHEN status = 'failed' THEN 'failed'
                         ELSE 'not_started' END"""
             )
+        # v22 (HS-93-07): the existing steering audit is also the source of
+        # Coder Receipts. Preserve the exact operation and central policy
+        # decision used by each new attempt; old rows retain honest empty
+        # snapshots and continue projecting with their legacy grant basis.
+        steering_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(steering_audit)").fetchall()
+        }
+        steering_receipt_columns = {
+            "operation_json": "TEXT NOT NULL DEFAULT '{}'",
+            "policy_snapshot_json": "TEXT NOT NULL DEFAULT '{}'",
+        }
+        for column, sql_type in steering_receipt_columns.items():
+            if steering_cols and column not in steering_cols:
+                conn.execute(
+                    f"ALTER TABLE steering_audit ADD COLUMN {column} {sql_type}"
+                )
         conn.execute(
             """
             INSERT OR IGNORE INTO activity_privacy_settings

--- a/holdspeak/db/projections.py
+++ b/holdspeak/db/projections.py
@@ -33,6 +33,9 @@ class DeskProjection:
     source_id: str
     source_api: str
     detail_url: str
+    control_mode: Optional[str] = None
+    policy_version: Optional[str] = None
+    effect_class: Optional[str] = None
     severity: str = "normal"
     dismissed: bool = False
     version: int = 1
@@ -212,7 +215,10 @@ class ProjectionRepository(BaseRepository):
                 subject_label = target.title()
             policy = self._json_loads_dict(row["policy_snapshot_json"])
             operation = self._json_loads_dict(row["operation_json"])
-            needs = status in {"proposed", "approved", "failed"}
+            policy_refused = (
+                status == "proposed" and policy.get("outcome") == "refused"
+            )
+            needs = status in {"proposed", "approved", "failed"} and not policy_refused
             action_names = {
                 "slack": ("send to Slack", "Slack send"),
                 "webhook": ("post to Custom webhook", "Custom webhook post"),
@@ -226,21 +232,51 @@ class ProjectionRepository(BaseRepository):
                 "failed": f"{noun} failed",
                 "rejected": f"{noun} rejected",
             }
+            if policy_refused:
+                titles["proposed"] = f"{noun} refused"
+            mode = str(policy.get("mode") or "").strip() or None
+            mode_label = {
+                "safe": "Secure",
+                "neutral": "Normal",
+                "yolo": "YOLO",
+            }.get(mode or "", mode or "Control posture")
+            summary = (
+                f"{mode_label} refused this unregistered destination. "
+                "Configure the destination before trying again."
+                if policy_refused
+                else (
+                    f"{mode_label} authorized this configured effect. "
+                    "The exact effect and source remain on this Receipt."
+                    if policy.get("authority_basis") == "control_posture"
+                    else (
+                        "The exact proposed effect and source remain on this Receipt."
+                        if source_ref
+                        else "The exact proposed effect remains in its source record."
+                    )
+                )
+            )
             result.append(DeskProjection(
                 id=f"actuator:{row['id']}:{status}",
                 projection_kind="attention" if needs else "receipt",
                 subject_ref=subject_ref, subject_label=subject_label,
                 title=titles.get(status, f"{target.title()} action: {status}"),
-                summary=(
-                    "The exact proposed effect and source remain on this Receipt."
-                    if source_ref
-                    else "The exact proposed effect remains in its source record."
-                ),
-                reason_code=f"effect_{status}", decision_kind="authorization",
+                summary=summary,
+                reason_code=str(
+                    policy.get("reason_code") or f"effect_{status}"
+                ), decision_kind="authorization",
                 attention_state="needs_attention" if needs else "resolved",
                 actual_destination=str(row["approved_destination"] or operation.get("destination") or target),
-                authority_basis=str(policy.get("authorization_basis") or "per_action_required"),
-                attempt=None, outcome=str(row["execution_state"] or status),
+                authority_basis=str(
+                    policy.get("authority_basis")
+                    or policy.get("authorization_basis")
+                    or "per_action_required"
+                ),
+                attempt=None,
+                outcome=(
+                    "refused"
+                    if policy_refused
+                    else str(row["execution_state"] or status)
+                ),
                 timestamp=str(row["updated_at"]), correlation_id=f"actuator:{row['id']}",
                 source_kind="actuator_proposal", source_id=str(row["id"]),
                 source_api=(
@@ -253,7 +289,11 @@ class ProjectionRepository(BaseRepository):
                     if meeting_id
                     else f"/?open={source_ref}" if source_ref else "/"
                 ),
-                severity="error" if status == "failed" else "normal",
+                control_mode=mode,
+                policy_version=str(policy.get("policy_version") or "") or None,
+                effect_class=str(operation.get("effect_class") or "") or None,
+                severity="error" if status == "failed" or policy_refused else "normal",
+                version=2,
             ))
         return result
 

--- a/holdspeak/db/projections.py
+++ b/holdspeak/db/projections.py
@@ -373,19 +373,42 @@ class ProjectionRepository(BaseRepository):
             outcome = str(row["outcome"])
             refused = outcome != "delivered"
             key = str(row["session_key"])
+            operation = self._json_loads_dict(row["operation_json"])
+            policy = self._json_loads_dict(row["policy_snapshot_json"])
+            mode = str(policy.get("mode") or "").strip() or None
+            mode_label = {
+                "safe": "Secure",
+                "neutral": "Normal",
+                "yolo": "YOLO",
+            }.get(mode or "", mode or "Control posture")
+            authority_basis = str(
+                policy.get("authority_basis") or "armed_pane_grant"
+            )
             result.append(DeskProjection(
                 id=f"steering:{row['id']}", projection_kind="attention" if refused else "receipt",
                 subject_ref=f"coder_session:{key}", subject_label=key,
                 title="Coder steer refused" if refused else "Coder steer delivered",
-                summary="The source audit retains the bounded text fingerprint and delivery detail.",
+                summary=(
+                    f"{mode_label} used the registered pane as posture authority. "
+                    "The bounded fingerprint and delivery detail remain in the source audit."
+                    if authority_basis == "control_posture"
+                    else "The source audit retains the bounded text fingerprint and delivery detail."
+                ),
                 reason_code=f"steering_{outcome}", decision_kind="execution",
                 attention_state="needs_attention" if refused else "resolved",
-                actual_destination=str(row["pane_id"] or "unresolved pane"),
-                authority_basis="armed_pane_grant", attempt=1, outcome=outcome,
+                actual_destination=str(
+                    row["pane_id"]
+                    or operation.get("destination")
+                    or "unresolved pane"
+                ),
+                authority_basis=authority_basis, attempt=1, outcome=outcome,
                 timestamp=str(row["ts"]), correlation_id=f"steering:{key}",
                 source_kind="steering_audit", source_id=str(row["id"]),
                 source_api=f"/api/coders/steering/audit?session_key={key}",
-                detail_url=f"/?open={key}", severity="error" if refused else "normal",
+                detail_url=f"/?open={key}", control_mode=mode,
+                policy_version=str(policy.get("policy_version") or "") or None,
+                effect_class=str(operation.get("effect_class") or "") or None,
+                severity="error" if refused else "normal", version=2,
             ))
         return result
 

--- a/holdspeak/db/steering.py
+++ b/holdspeak/db/steering.py
@@ -42,6 +42,8 @@ class SteeringAuditEntry:
     submit: bool
     outcome: str
     detail: Optional[str]
+    operation: dict[str, Any]
+    policy_snapshot: dict[str, Any]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -56,6 +58,8 @@ class SteeringAuditEntry:
             "submit": self.submit,
             "outcome": self.outcome,
             "detail": self.detail,
+            "operation": dict(self.operation),
+            "policy_snapshot": dict(self.policy_snapshot),
         }
 
 
@@ -71,6 +75,8 @@ class SteeringAuditRepository(BaseRepository):
         submit: bool = True,
         outcome: str,
         detail: Optional[str] = None,
+        operation: Optional[dict[str, Any]] = None,
+        policy_snapshot: Optional[dict[str, Any]] = None,
     ) -> int:
         """One audit row per steer attempt; returns the row id."""
         digest = hashlib.sha256(str(text).encode("utf-8", "replace")).hexdigest()
@@ -80,8 +86,9 @@ class SteeringAuditRepository(BaseRepository):
                 """
                 INSERT INTO steering_audit
                     (session_key, agent, pane_id, text_sha256, text_head,
-                     grounding_json, submit, outcome, detail)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     grounding_json, submit, outcome, detail, operation_json,
+                     policy_snapshot_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_key,
@@ -93,6 +100,8 @@ class SteeringAuditRepository(BaseRepository):
                     1 if submit else 0,
                     outcome,
                     detail,
+                    self._json_dumps(dict(operation or {}), fallback="{}"),
+                    self._json_dumps(dict(policy_snapshot or {}), fallback="{}"),
                 ),
             )
             return int(cursor.lastrowid or 0)
@@ -104,7 +113,8 @@ class SteeringAuditRepository(BaseRepository):
         limit = max(1, min(int(limit), 500))
         query = (
             "SELECT id, ts, session_key, agent, pane_id, text_sha256, "
-            "text_head, grounding_json, submit, outcome, detail "
+            "text_head, grounding_json, submit, outcome, detail, "
+            "operation_json, policy_snapshot_json "
             "FROM steering_audit "
         )
         params: tuple[Any, ...] = ()
@@ -128,6 +138,8 @@ class SteeringAuditRepository(BaseRepository):
                 submit=bool(row[8]),
                 outcome=str(row[9]),
                 detail=row[10],
+                operation=self._json_loads_dict(row[11]),
+                policy_snapshot=self._json_loads_dict(row[12]),
             )
             for row in rows
         ]

--- a/holdspeak/main.py
+++ b/holdspeak/main.py
@@ -501,9 +501,11 @@ def _run_control_mode_command(args) -> int:
         config.control_mode = control_mode_wire(args.mode)
         config.save()
         if previous != config.control_mode:
+            from . import coder_steering
             from .db import get_database
 
             get_database().actuators.revoke_active_grants(reason="control_mode_changed")
+            coder_steering.clear_grants()
     payload = {
         "control_mode": config.control_mode,
         "control_mode_label": control_mode_label(config.control_mode),

--- a/holdspeak/operation_policy.py
+++ b/holdspeak/operation_policy.py
@@ -12,8 +12,8 @@ from dataclasses import asdict, dataclass
 from typing import Any, Iterable, Mapping, Optional
 
 
-POLICY_CONTRACT_VERSION = 1
-POLICY_VERSION = "operation-policy/v1"
+POLICY_CONTRACT_VERSION = 2
+POLICY_VERSION = "operation-policy/v2"
 CONTROL_MODES = frozenset({"safe", "neutral", "yolo"})
 INITIAL_FAMILIES = frozenset(
     {"dictation_commit", "coder_steering", "external_write", "sync_cadence"}
@@ -66,6 +66,9 @@ class PolicyDecision:
     outcome: str
     reason_code: str
     consequence: str
+    authority_basis: str
+    next_state: str
+    eligible: bool
     requires_review: bool
     requires_authorization: bool
     requires_grant: bool
@@ -189,7 +192,7 @@ def resolve_policy(
     configured_preview: bool = False,
     explicit_authorization: bool = False,
 ) -> PolicyDecision:
-    """Resolve one future operation. Unsupported families keep current behavior."""
+    """Resolve one future operation; unknown families always fail closed."""
     selected = normalize_control_mode(mode)
     precedence = (
         "hard_invariants",
@@ -204,9 +207,12 @@ def resolve_policy(
             mode=selected,
             source=source,
             precedence=precedence,
-            outcome="current_behavior",
-            reason_code="unsupported_family_current_behavior",
+            outcome="refused",
+            reason_code="unsupported_operation_family",
             consequence=operation.consequence,
+            authority_basis="none",
+            next_state="refused",
+            eligible=False,
             requires_review=False,
             requires_authorization=False,
             requires_grant=False,
@@ -223,54 +229,88 @@ def resolve_policy(
             if review
             else "dictation_commit_allowed",
             consequence="content_only",
+            authority_basis="configured_preview" if review else "direct_gesture",
+            next_state="awaiting_review" if review else "execute_now",
+            eligible=True,
             requires_review=review,
             requires_authorization=False,
             requires_grant=False,
         )
 
     if operation.family == "coder_steering":
-        # Pane identity + an expiring grant remain invariant in every mode.
+        # YOLO steering is delivered in a later HS-93-07 slice. Until the
+        # registered-session execution path consumes posture authority itself,
+        # this known family remains eligible but explicitly grant-gated.
+        matched = grant_matches(grant, operation)
         return PolicyDecision(
             mode=selected,
             source=source,
             precedence=precedence,
-            outcome="allowed" if grant_matches(grant, operation) else "grant_required",
+            outcome="allowed" if matched else "grant_required",
             reason_code="steering_grant_active"
-            if grant_matches(grant, operation)
+            if matched
             else "steering_grant_required",
             consequence="execute_now",
+            authority_basis="scoped_grant" if matched else "none",
+            next_state="execute_now" if matched else "awaiting_grant",
+            eligible=True,
             requires_review=False,
             requires_authorization=False,
             requires_grant=True,
         )
 
     if operation.family == "external_write":
-        reusable = (
-            selected == "yolo"
-            and operation.fixed_destination
-            and grant_matches(grant, operation)
+        scoped = grant_matches(grant, operation)
+        posture_allowed = selected == "yolo" and operation.fixed_destination
+        allowed = posture_allowed or scoped or explicit_authorization
+        refused = selected == "yolo" and not operation.fixed_destination and not allowed
+        outcome = (
+            "allowed"
+            if allowed
+            else "refused"
+            if refused
+            else "authorization_required"
         )
-        allowed = reusable or explicit_authorization
+        authority_basis = (
+            "control_posture"
+            if posture_allowed
+            else "scoped_grant"
+            if scoped
+            else "per_action_decision"
+            if explicit_authorization
+            else "per_action_required"
+            if outcome == "authorization_required"
+            else "none"
+        )
         return PolicyDecision(
             mode=selected,
             source=source,
             precedence=precedence,
-            outcome="allowed"
-            if allowed
-            else ("grant_required" if selected == "yolo" else "authorization_required"),
+            outcome=outcome,
             reason_code=(
-                "fixed_destination_grant_active"
-                if reusable
+                "configured_destination_posture_allowed"
+                if posture_allowed
+                else "scoped_grant_active"
+                if scoped
                 else "per_action_authorization_accepted"
                 if explicit_authorization
-                else "fixed_destination_grant_required"
-                if selected == "yolo"
+                else "registered_destination_required"
+                if refused
                 else "per_action_authorization_required"
             ),
             consequence=operation.consequence,
-            requires_review=True,
-            requires_authorization=not allowed,
-            requires_grant=selected == "yolo" and not explicit_authorization,
+            authority_basis=authority_basis,
+            next_state=(
+                "execute_now"
+                if allowed
+                else "refused"
+                if refused
+                else "awaiting_authorization"
+            ),
+            eligible=not refused,
+            requires_review=not allowed and not refused,
+            requires_authorization=outcome == "authorization_required",
+            requires_grant=False,
         )
 
     # Sync preserves auth/schema/config invariants in all modes. Safe asks for a
@@ -285,6 +325,9 @@ def resolve_policy(
         if manual
         else "configured_sync_cadence_allowed",
         consequence="queue_executor",
+        authority_basis="per_action_required" if manual else "configured_cadence",
+        next_state="awaiting_authorization" if manual else "queue_executor",
+        eligible=True,
         requires_review=False,
         requires_authorization=manual,
         requires_grant=False,

--- a/holdspeak/operation_policy.py
+++ b/holdspeak/operation_policy.py
@@ -158,7 +158,10 @@ def operation_for_proposal(
 
 
 def grant_matches(
-    grant: Optional[Mapping[str, Any]], operation: OperationDescriptor
+    grant: Optional[Mapping[str, Any]],
+    operation: OperationDescriptor,
+    *,
+    mode: Optional[str] = None,
 ) -> bool:
     if not grant or str(grant.get("state") or "") != "active":
         return False
@@ -169,6 +172,9 @@ def grant_matches(
     if str(grant.get("effect_class") or "") != operation.effect_class:
         return False
     if str(grant.get("destination") or "") != operation.destination:
+        return False
+    grant_mode = str(grant.get("control_mode") or "").strip().lower()
+    if mode and grant_mode and grant_mode != normalize_control_mode(mode):
         return False
     allowed_data = {str(item) for item in grant.get("data_classes", [])}
     if not set(operation.data_classes).issubset(allowed_data):
@@ -238,29 +244,49 @@ def resolve_policy(
         )
 
     if operation.family == "coder_steering":
-        # YOLO steering is delivered in a later HS-93-07 slice. Until the
-        # registered-session execution path consumes posture authority itself,
-        # this known family remains eligible but explicitly grant-gated.
-        matched = grant_matches(grant, operation)
+        matched = selected != "yolo" and grant_matches(grant, operation, mode=selected)
+        posture_allowed = selected == "yolo" and operation.fixed_destination
+        refused = selected == "yolo" and not operation.fixed_destination
+        allowed = posture_allowed or matched
         return PolicyDecision(
             mode=selected,
             source=source,
             precedence=precedence,
-            outcome="allowed" if matched else "grant_required",
-            reason_code="steering_grant_active"
-            if matched
-            else "steering_grant_required",
+            outcome="allowed"
+            if allowed
+            else "refused"
+            if refused
+            else "grant_required",
+            reason_code=(
+                "registered_steering_posture_allowed"
+                if posture_allowed
+                else "steering_grant_active"
+                if matched
+                else "registered_steering_destination_required"
+                if refused
+                else "steering_grant_required"
+            ),
             consequence="execute_now",
-            authority_basis="scoped_grant" if matched else "none",
-            next_state="execute_now" if matched else "awaiting_grant",
-            eligible=True,
+            authority_basis=(
+                "control_posture"
+                if posture_allowed
+                else "scoped_grant"
+                if matched
+                else "none"
+            ),
+            next_state="execute_now"
+            if allowed
+            else "refused"
+            if refused
+            else "awaiting_grant",
+            eligible=not refused,
             requires_review=False,
             requires_authorization=False,
-            requires_grant=True,
+            requires_grant=selected != "yolo",
         )
 
     if operation.family == "external_write":
-        scoped = grant_matches(grant, operation)
+        scoped = grant_matches(grant, operation, mode=selected)
         posture_allowed = selected == "yolo" and operation.fixed_destination
         allowed = posture_allowed or scoped or explicit_authorization
         refused = selected == "yolo" and not operation.fixed_destination and not allowed

--- a/holdspeak/plugins/actuator_executor.py
+++ b/holdspeak/plugins/actuator_executor.py
@@ -3,8 +3,9 @@
 This is the one place an actuator's external side effect actually happens — so
 it is where the phase invariant is enforced in code:
 
-    No external side effect occurs without an explicit, audited, per-action
-    human approval — and what executes is exactly what was previewed.
+    No external side effect occurs without explicit, audited authority — a
+    per-action decision, scoped grant, or captured control posture — and what
+    executes is exactly what was previewed.
 
 `ActuatorExecutor.execute(proposal_id)` acts on an **approved** proposal and,
 before any outbound call:
@@ -232,6 +233,7 @@ class ActuatorExecutor:
                     "action": getattr(proposal, "action", ""),
                     "preview": getattr(proposal, "preview", ""),
                     "reversible": bool(getattr(proposal, "reversible", False)),
+                    "policy": getattr(proposal, "policy_snapshot", {}),
                     "error": getattr(proposal, "error", None),
                 }
             )

--- a/holdspeak/web/routes/actuator_shared.py
+++ b/holdspeak/web/routes/actuator_shared.py
@@ -88,8 +88,56 @@ def actuator_result_event(proposal: Any) -> dict[str, Any]:
         "action": getattr(proposal, "action", ""),
         "preview": getattr(proposal, "preview", ""),
         "reversible": bool(getattr(proposal, "reversible", False)),
+        "policy": getattr(proposal, "policy_snapshot", {}),
         "error": getattr(proposal, "error", None),
     }
+
+
+def apply_control_posture(
+    ctx: WebContext,
+    db: Any,
+    proposal: Any,
+    *,
+    executors: dict[str, Any],
+) -> Any:
+    """Execute a proposal whose immutable creation snapshot authorizes it.
+
+    This is the zero-prompt YOLO seam. It never re-resolves against the current
+    configuration: changing posture affects future proposals only. Only a
+    fixed, registered destination with a concrete executor can cross the seam;
+    payload/destination/preview parity is still rechecked by ActuatorExecutor
+    immediately before the effect.
+    """
+
+    if proposal.status != "proposed":
+        return proposal
+    policy = dict(getattr(proposal, "policy_snapshot", {}) or {})
+    if not (
+        policy.get("outcome") == "allowed"
+        and policy.get("authority_basis") == "control_posture"
+    ):
+        return proposal
+
+    from ...operation_policy import operation_for_proposal
+
+    operation = operation_for_proposal(proposal)
+    execute = executors.get(proposal.target)
+    if not operation.fixed_destination or execute is None:
+        return proposal
+
+    updated = db.actuators.transition_proposal(
+        proposal.id,
+        to_status="approved",
+        actor=f"control-posture:{policy.get('mode') or 'unknown'}",
+        detail="configured operation authorized by captured control posture",
+        policy_snapshot=policy,
+    )
+    return execute(
+        ctx,
+        db,
+        updated,
+        actor=f"control-posture:{policy.get('mode') or 'unknown'}",
+    )
 
 
 def decide_proposal(
@@ -129,20 +177,30 @@ def decide_proposal(
     try:
         policy_snapshot = None
         if clean == "approved":
-            from ...config import Config
             from ...operation_policy import operation_for_proposal, resolve_policy
 
             operation = operation_for_proposal(existing, actor=actor)
             grant_record = db.actuators.get_grant(grant_id) if grant_id else None
             grant = grant_record.to_dict() if grant_record else None
+            captured = dict(getattr(existing, "policy_snapshot", {}) or {})
+            if captured.get("outcome") == "refused":
+                raise ValueError(
+                    "captured operation policy refuses this unregistered effect"
+                )
             policy_decision = resolve_policy(
-                operation, mode=Config.load().control_mode, source="config", grant=grant,
-                explicit_authorization=True,
+                operation,
+                mode=str(captured.get("mode") or "neutral"),
+                source=str(captured.get("source") or "config"),
+                grant=grant,
+                explicit_authorization=not bool(grant_id),
             )
-            if grant_id and policy_decision.reason_code != "fixed_destination_grant_active":
+            if grant_id and policy_decision.authority_basis != "scoped_grant":
                 raise ValueError("scoped grant is not active for this exact operation and mode")
+            if policy_decision.outcome != "allowed":
+                raise ValueError(
+                    "captured operation policy does not authorize this effect"
+                )
             policy_snapshot = policy_decision.to_dict()
-            policy_snapshot["authorization_basis"] = "scoped_grant" if grant_id else "per_action_decision"
         updated = db.actuators.transition_proposal(
             proposal_id, to_status=clean, actor=actor,
             policy_snapshot=policy_snapshot, grant_id=grant_id,

--- a/holdspeak/web/routes/authority.py
+++ b/holdspeak/web/routes/authority.py
@@ -32,17 +32,22 @@ def build_authority_router(ctx: WebContext) -> APIRouter:
         from ...operation_policy import (
             HARD_INVARIANTS,
             INITIAL_FAMILIES,
+            POLICY_CONTRACT_VERSION,
             POLICY_VERSION,
         )
-        from ...product_language import control_mode_label
+        from ...product_language import control_mode_label, PRODUCT_LANGUAGE
 
         mode = Config.load().control_mode
         return JSONResponse(
             {
-                "version": 1,
+                "version": POLICY_CONTRACT_VERSION,
                 "policy_version": POLICY_VERSION,
                 "control_mode": mode,
                 "control_mode_label": control_mode_label(mode),
+                "control_mode_description": (
+                    PRODUCT_LANGUAGE.control_mode_description(mode)
+                ),
+                "applies_to": "future_operations_only",
                 "source": "config",
                 "precedence": [
                     "hard_invariants",
@@ -53,7 +58,7 @@ def build_authority_router(ctx: WebContext) -> APIRouter:
                 ],
                 "hard_invariants": list(HARD_INVARIANTS),
                 "supported_families": sorted(INITIAL_FAMILIES),
-                "unsupported_family_behavior": "current_behavior",
+                "unsupported_family_behavior": "refused",
             }
         )
 
@@ -193,10 +198,10 @@ def build_authority_router(ctx: WebContext) -> APIRouter:
                     status_code=409,
                 )
             control_mode = Config.load().control_mode
-            if control_mode != "yolo":
+            if control_mode == "yolo":
                 return JSONResponse(
                     {
-                        "error": "Reusable external-write grants require YOLO. Approve this exact action instead."
+                        "error": "YOLO uses the captured posture for eligible configured operations. Use Secure or Normal to issue a bounded grant."
                     },
                     status_code=409,
                 )

--- a/holdspeak/web/routes/authority.py
+++ b/holdspeak/web/routes/authority.py
@@ -96,6 +96,11 @@ def build_authority_router(ctx: WebContext) -> APIRouter:
                 if previous != requested
                 else 0
             )
+            from ... import coder_steering
+
+            revoked_coder_grants = (
+                coder_steering.clear_grants() if previous != requested else 0
+            )
             return JSONResponse(
                 {
                     "control_mode": requested,
@@ -105,6 +110,7 @@ def build_authority_router(ctx: WebContext) -> APIRouter:
                     "applies_to": "future_operations_only",
                     "source": "config",
                     "revoked_grants": revoked,
+                    "revoked_coder_grants": revoked_coder_grants,
                 }
             )
         except Exception as exc:

--- a/holdspeak/web/routes/desk_actuators.py
+++ b/holdspeak/web/routes/desk_actuators.py
@@ -29,6 +29,7 @@ from ...web_requests import _CompanionSlackRequest, _ProposalDecisionRequest
 from ..context import WebContext
 from ..runtime_support import error_500
 from .actuator_shared import (
+    apply_control_posture,
     decide_proposal,
     execute_github_proposal,
     execute_slack_proposal,
@@ -117,7 +118,8 @@ def build_desk_actuators_router(ctx: WebContext) -> APIRouter:
         text = str(payload.text or "").strip()
         if not text:
             return JSONResponse({"success": False, "error": "text is required"}, status_code=400)
-        if not Config.load().meeting.slack_webhook_url:
+        config = Config.load()
+        if not config.meeting.slack_webhook_url:
             return JSONResponse(
                 {"success": False, "error": "Slack is not configured on the host (set the webhook URL in Settings first)"},
                 status_code=400,
@@ -147,6 +149,8 @@ def build_desk_actuators_router(ctx: WebContext) -> APIRouter:
                 payload={"body": {"text": body}, **source_payload},
                 reversible=False,
                 required_capabilities=["actuator"],
+                control_mode=config.control_mode,
+                fixed_destination=True,
             )
             ctx.broadcast(
                 "actuator_proposed",
@@ -160,6 +164,12 @@ def build_desk_actuators_router(ctx: WebContext) -> APIRouter:
                     "preview": proposal.preview,
                     "reversible": bool(proposal.reversible),
                 },
+            )
+            proposal = apply_control_posture(
+                ctx,
+                db,
+                proposal,
+                executors={"slack": execute_slack_proposal},
             )
             return JSONResponse({"success": True, "proposal": proposal_to_dict(proposal)})
         except ValueError as e:
@@ -210,7 +220,8 @@ def build_desk_actuators_router(ctx: WebContext) -> APIRouter:
         text = str(payload.text or "").strip()
         if not text:
             return JSONResponse({"success": False, "error": "text is required"}, status_code=400)
-        if not Config.load().meeting.companion_webhook_url:
+        config = Config.load()
+        if not config.meeting.companion_webhook_url:
             return JSONResponse(
                 {"success": False, "error": "Webhook is not configured on the host (set companion_webhook_url first)"},
                 status_code=400,
@@ -234,12 +245,19 @@ def build_desk_actuators_router(ctx: WebContext) -> APIRouter:
                 target="webhook", action="post_message", preview=body,
                 payload={"body": {"text": body}, **source_payload},
                 reversible=False, required_capabilities=["actuator"],
+                control_mode=config.control_mode, fixed_destination=True,
             )
             ctx.broadcast("actuator_proposed", {
                 "id": proposal.id, "meeting_id": proposal.meeting_id, "plugin_id": proposal.plugin_id,
                 "status": proposal.status, "target": proposal.target, "action": proposal.action,
                 "preview": proposal.preview, "reversible": bool(proposal.reversible),
             })
+            proposal = apply_control_posture(
+                ctx,
+                db,
+                proposal,
+                executors={"webhook": execute_webhook_proposal},
+            )
             return JSONResponse({"success": True, "proposal": proposal_to_dict(proposal)})
         except ValueError as e:
             return JSONResponse({"success": False, "error": str(e)}, status_code=400)
@@ -281,7 +299,9 @@ def build_desk_actuators_router(ctx: WebContext) -> APIRouter:
         text = str(payload.text or "").strip()
         if not text:
             return JSONResponse({"success": False, "error": "text is required"}, status_code=400)
-        repo = str(payload.repo or "").strip() or str(Config.load().meeting.companion_github_repo or "").strip()
+        config = Config.load()
+        configured_repo = str(config.meeting.companion_github_repo or "").strip()
+        repo = str(payload.repo or "").strip() or configured_repo
         if not repo:
             return JSONResponse(
                 {"success": False, "error": "No GitHub repo (set companion_github_repo on the host, or pass repo)"},
@@ -312,12 +332,20 @@ def build_desk_actuators_router(ctx: WebContext) -> APIRouter:
                 target="github", action="create_issue", preview=preview,
                 payload={"repo": repo, "title": title, "body": text, **source_payload}, reversible=False,
                 required_capabilities=["actuator"],
+                control_mode=config.control_mode,
+                fixed_destination=bool(configured_repo and repo == configured_repo),
             )
             ctx.broadcast("actuator_proposed", {
                 "id": proposal.id, "meeting_id": proposal.meeting_id, "plugin_id": proposal.plugin_id,
                 "status": proposal.status, "target": proposal.target, "action": proposal.action,
                 "preview": proposal.preview, "reversible": bool(proposal.reversible),
             })
+            proposal = apply_control_posture(
+                ctx,
+                db,
+                proposal,
+                executors={"github": execute_github_proposal},
+            )
             return JSONResponse({"success": True, "proposal": proposal_to_dict(proposal)})
         except ValueError as e:
             return JSONResponse({"success": False, "error": str(e)}, status_code=400)

--- a/holdspeak/web/routes/meetings/aftercare.py
+++ b/holdspeak/web/routes/meetings/aftercare.py
@@ -168,9 +168,11 @@ def build_aftercare_router(ctx: WebContext) -> APIRouter:
 
         Closing the loop reuses the existing propose -> approve -> execute flow:
         this records a `proposed` proposal only. Nothing leaves the machine here —
-        execution still requires a separate human approval (the decision endpoint)
-        plus `allow_actuators` + the per-project allow-list + a host-injected
-        connector. No new write primitive; idempotent per (meeting, action item).
+        Secure and Normal still require a bounded authority decision, while YOLO
+        refuses this ad-hoc destination because it is not host-configured. The
+        executor also requires `allow_actuators`, the per-project allow-list, and
+        a host-injected connector. No new write primitive; idempotent per
+        (meeting, action item).
         """
         repo = str(payload.repo or "").strip()
         if not repo:
@@ -179,6 +181,7 @@ def build_aftercare_router(ctx: WebContext) -> APIRouter:
                 status_code=400,
             )
         try:
+            from ....config import Config
             from ....db import get_database
             from ....plugins.builtin.github_issue_actuator import (
                 GithubIssueActuator,
@@ -226,6 +229,8 @@ def build_aftercare_router(ctx: WebContext) -> APIRouter:
                 payload=spec["payload"],
                 reversible=spec["reversible"],
                 required_capabilities=spec["required_capabilities"],
+                control_mode=Config.load().control_mode,
+                fixed_destination=False,
             )
             # HS-56-03: the live in-meeting path already broadcasts proposals;
             # the aftercare path now does too, with the identical wire-safe
@@ -283,7 +288,8 @@ def build_aftercare_router(ctx: WebContext) -> APIRouter:
                 },
                 status_code=400,
             )
-        if not Config.load().meeting.slack_webhook_url:
+        config = Config.load()
+        if not config.meeting.slack_webhook_url:
             return JSONResponse(
                 {
                     "success": False,
@@ -325,6 +331,8 @@ def build_aftercare_router(ctx: WebContext) -> APIRouter:
                 payload={"body": {"text": text}},
                 reversible=False,  # a posted message cannot be unsent
                 required_capabilities=["actuator"],
+                control_mode=config.control_mode,
+                fixed_destination=True,
             )
             # The same wire-safe shape every proposal broadcast uses (the
             # human preview only — never the machine payload).
@@ -343,6 +351,12 @@ def build_aftercare_router(ctx: WebContext) -> APIRouter:
                     if hasattr(proposal.created_at, "isoformat")
                     else proposal.created_at,
                 },
+            )
+            proposal = actuator_shared.apply_control_posture(
+                ctx,
+                db,
+                proposal,
+                executors={"slack": actuator_shared.execute_slack_proposal},
             )
             return JSONResponse(
                 {"success": True, "proposal": _proposal_to_dict(proposal)}

--- a/holdspeak/web/routes/mesh.py
+++ b/holdspeak/web/routes/mesh.py
@@ -99,6 +99,9 @@ def build_mesh_router(ctx: WebContext) -> APIRouter:
             proposals = []
             for p in db.actuators.list_pending_proposals(limit=50):
                 operation = operation_for_proposal(p)
+                policy = dict(getattr(p, "policy_snapshot", {}) or {})
+                if policy.get("outcome") == "refused":
+                    continue
                 proposals.append({
                     "id": p.id,
                     "origin": p.origin,
@@ -111,6 +114,7 @@ def build_mesh_router(ctx: WebContext) -> APIRouter:
                     "authorization_state": p.authorization_state,
                     "execution_state": p.execution_state,
                     "operation": operation.to_dict(),
+                    "policy_snapshot": policy,
                     "commitment": commitment_labels(operation),
                     "created_at": p.created_at,
                 })

--- a/holdspeak/web/routes/system/coder_steering_routes.py
+++ b/holdspeak/web/routes/system/coder_steering_routes.py
@@ -1,11 +1,5 @@
-"""The steering surface (HS-87-01/02/03): attach, arm, steer, audit.
+"""Coder steering routes: watch, authorize, deliver, audit, and factory."""
 
-Carved from `coders.py` (the Phase-79 single-concern budget): the
-coder BOARD (who receives a spoken answer) stays there; STEERING
-(watch a pane, arm it, type into it under the consent spine) lives
-here. Shared with the board: `_coder_frame` and `_session_age_seconds`,
-imported from `coders.py` (one owner each, no duplication).
-"""
 from __future__ import annotations
 
 import asyncio
@@ -19,6 +13,14 @@ from ....logging_config import get_logger
 from ...context import WebContext
 from ...runtime_support import error_500
 from .coders import _coder_frame, _session_age_seconds
+from .coder_steering_support import (
+    active_policy_grant,
+    canonical_pane_id,
+    compose_from_body,
+    expected_pane_id,
+    steering_commitment,
+    steering_policy,
+)
 
 log = get_logger("web.routes.system.steering")
 
@@ -36,11 +38,9 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         when the key is malformed or the session is gone.
         """
         if key.startswith("pane:"):
-            pane_id = key[len("pane:"):].strip()
-            if not pane_id:
-                return JSONResponse(
-                    {"error": "key must be pane:%N"}, status_code=400
-                )
+            pane_id = canonical_pane_id(key[len("pane:") :])
+            if pane_id is None:
+                return JSONResponse({"error": "key must be pane:%N"}, status_code=400)
             # A synthetic session over the raw pane — `resolve_pane_target`
             # reads `tmux_pane`, so the whole spine (arm pins %N, steer/keys
             # re-verify it) works unchanged. Fresh `updated_at`: a raw pane
@@ -52,7 +52,9 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
                 session_id=pane_id,
                 awaiting_response=False,
                 question=None,
-                updated_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                updated_at=datetime.now(timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
                 tmux_pane=pane_id,
                 last_assistant_text=None,
             )
@@ -65,11 +67,7 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
                 {"error": "key must be agent:session_id"}, status_code=400
             )
         session = next(
-            (
-                s
-                for s in list_agent_sessions(agent=agent)
-                if s.session_id == session_id
-            ),
+            (s for s in list_agent_sessions(agent=agent) if s.session_id == session_id),
             None,
         )
         if session is None:
@@ -118,7 +116,7 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
             return session
         stale, _age = _session_is_stale(session)
         _sweep_and_frame()
-        grant = coder_steering.active_grants().get(key)
+        grant = active_policy_grant(key)
         envelope: dict[str, Any] = {
             "key": key,
             "agent": session.agent,
@@ -133,21 +131,57 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         }
         target = coder_steering.resolve_pane_target(session)
         if target is None:
+            operation, policy = steering_policy(
+                key,
+                None,
+                operation_kind="type_text_and_keys",
+                data_classes=("typed_text", "key_events"),
+                registered=False,
+                grant=grant,
+            )
+            envelope.update(
+                operation=operation,
+                policy=policy,
+                commitment=steering_commitment(operation, policy),
+            )
             envelope["peek"] = {"status": "no_pane"}
             return JSONResponse(envelope)
+        pane_id = canonical_pane_id(target)
+        if pane_id is None:
+            identity = await asyncio.to_thread(
+                coder_steering.resolve_pane_identity, target
+            )
+            pane_id = (
+                canonical_pane_id(identity.get("pane_id"))
+                if identity.get("status") == "ok"
+                else None
+            )
+        operation, policy = steering_policy(
+            key,
+            pane_id,
+            operation_kind="type_text_and_keys",
+            data_classes=("typed_text", "key_events"),
+            registered=not stale,
+            grant=grant,
+        )
+        envelope.update(
+            pane_id=pane_id,
+            operation=operation,
+            policy=policy,
+            commitment=steering_commitment(operation, policy),
+        )
         from ....config import Config
         from ....operation_policy import steering_ttl_for_mode
+
         preset_ttl = steering_ttl_for_mode(Config.load().control_mode)
-        envelope["arm_commitment"] = f"Arm pane {target} for {preset_ttl // 60} minutes"
+        envelope["arm_commitment"] = f"Arm pane {pane_id or target} for {preset_ttl // 60} minutes"
         envelope["peek"] = await asyncio.to_thread(
             coder_steering.peek_pane, target, lines=lines, last_hash=last_hash
         )
         return JSONResponse(envelope)
 
     @router.post("/api/coders/{key}/arm")
-    async def api_coder_arm(
-        key: str, payload: Optional[dict[str, Any]] = None
-    ) -> Any:
+    async def api_coder_arm(key: str, payload: Optional[dict[str, Any]] = None) -> Any:
         """Arm a session for steering (HS-87-02) — the explicit desk act.
 
         Pins the pane's `%N` identity at grant time; refuses a stale
@@ -233,8 +267,8 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         """Every tmux pane on the machine (HS-89-02) — the discovery behind
         attach-to-any-pane. Read-only (no grant): the desk lists panes with
         their session/window/command/title so a human can watch any of them
-        free, then arm the one they mean by its `pane:%N` key. No tmux
-        server is an honest empty list."""
+        free, then resolve authority for its exact `pane:%N` key. No tmux server
+        is an honest empty list."""
         from .... import coder_steering
 
         try:
@@ -243,20 +277,20 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         except Exception as e:
             return error_500("steering panes", e, log)
 
-    # --- cross-machine steering (HS-89-03) ---------------------------------
-    #
-    # Relay a steering verb to a CONFIGURED node's own steering routes. The
-    # node executes against its OWN tmux and enforces its OWN consent + audit
-    # (the machine that types owns the record). A quiet node refuses by name
-    # (502 node_offline); the node's own typed refusal rides through as 409.
+    # A configured remote node owns its tmux authority and authoritative audit;
+    # this hub only relays its typed success/refusal (HS-89-03).
 
-    async def _relay(node: str, verb: str, key: str, *, method: str = "POST", body: Any = None):
+    async def _relay(
+        node: str, verb: str, key: str, *, method: str = "POST", body: Any = None
+    ):
         from .... import coder_steering_relay
 
         result = await asyncio.to_thread(
             coder_steering_relay.relay, node, verb, key, method=method, body=body
         )
-        return JSONResponse(result, status_code=coder_steering_relay.relay_http_code(result))
+        return JSONResponse(
+            result, status_code=coder_steering_relay.relay_http_code(result)
+        )
 
     @router.get("/api/coders/relay/{node}/peek")
     async def api_relay_peek(
@@ -275,7 +309,9 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         return await _relay(node, "arm", key, body=ttl)
 
     @router.post("/api/coders/relay/{node}/disarm")
-    async def api_relay_disarm(node: str, payload: Optional[dict[str, Any]] = None) -> Any:
+    async def api_relay_disarm(
+        node: str, payload: Optional[dict[str, Any]] = None
+    ) -> Any:
         body = payload if isinstance(payload, dict) else {}
         key = str(body.get("key", "")).strip()
         if not key:
@@ -283,7 +319,9 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         return await _relay(node, "disarm", key, body={})
 
     @router.post("/api/coders/relay/{node}/steer")
-    async def api_relay_steer(node: str, payload: Optional[dict[str, Any]] = None) -> Any:
+    async def api_relay_steer(
+        node: str, payload: Optional[dict[str, Any]] = None
+    ) -> Any:
         body = payload if isinstance(payload, dict) else {}
         key = str(body.get("key", "")).strip()
         if not key:
@@ -292,81 +330,15 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         return await _relay(node, "steer", key, body=forwarded)
 
     @router.post("/api/coders/relay/{node}/keys")
-    async def api_relay_keys(node: str, payload: Optional[dict[str, Any]] = None) -> Any:
+    async def api_relay_keys(
+        node: str, payload: Optional[dict[str, Any]] = None
+    ) -> Any:
         body = payload if isinstance(payload, dict) else {}
         key = str(body.get("key", "")).strip()
         if not key:
             return JSONResponse({"error": "key is required"}, status_code=400)
-        return await _relay(node, "keys", key, body={"keys": body.get("keys")})
-
-    def _compose_from_body(body: dict[str, Any]):
-        """Message + optional grounding → the composed steer (HS-87-04).
-
-        A JSONResponse on any refusal (bad text, bad grounding shape,
-        unknown refs, over-cap); otherwise the compose result dict from
-        `grounding.compose_steer`. Hydration is the SAME helper the ask
-        route uses — one grounding truth.
-        """
-        from ....db import get_database
-        from ....grounding import (
-            GROUNDING_EXPANDS,
-            GROUNDING_MAX_REFS,
-            compose_steer,
-            hydrate_refs,
-        )
-
-        text = body.get("text")
-        if not isinstance(text, str) or not text.strip():
-            return JSONResponse({"error": "text is required"}, status_code=400)
-        grounding = body.get("grounding")
-        if grounding is None:
-            return compose_steer(text, [])
-        if not isinstance(grounding, dict):
-            return JSONResponse(
-                {"error": "grounding must be an object"}, status_code=400
-            )
-        raw_m = grounding.get("meeting_ids")
-        raw_a = grounding.get("artifact_ids")
-        raw_r = grounding.get("rails")
-        meeting_ids = (
-            [str(x).strip() for x in raw_m if str(x).strip()]
-            if isinstance(raw_m, list)
-            else []
-        )
-        artifact_ids = (
-            [str(x).strip() for x in raw_a if str(x).strip()]
-            if isinstance(raw_a, list)
-            else []
-        )
-        rails_refs = [x for x in raw_r if isinstance(x, dict)] if isinstance(raw_r, list) else []
-        expand = str(grounding.get("expand") or "summary").strip() or "summary"
-        if expand not in GROUNDING_EXPANDS:
-            return JSONResponse(
-                {"error": f"expand {expand!r} is not one of {list(GROUNDING_EXPANDS)}"},
-                status_code=400,
-            )
-        if len(meeting_ids) + len(artifact_ids) + len(rails_refs) > GROUNDING_MAX_REFS:
-            return JSONResponse(
-                {"error": f"grounding is capped at {GROUNDING_MAX_REFS} refs"},
-                status_code=400,
-            )
-        blocks, unknown = hydrate_refs(
-            get_database(), meeting_ids, artifact_ids, expand
-        )
-        # HS-88-01: rails objects ground through the same block type,
-        # CLI-mediated per repo — a receipt, folded in after desk objects.
-        if rails_refs:
-            from ....grounding_rails import hydrate_rails_refs
-
-            r_blocks, r_unknown = hydrate_rails_refs(rails_refs)
-            blocks = list(blocks) + r_blocks
-            unknown = list(unknown) + r_unknown
-        if unknown:
-            return JSONResponse(
-                {"error": "grounding ids not on this hub", "unknown_ids": unknown},
-                status_code=400,
-            )
-        return compose_steer(text, blocks)
+        forwarded = {item: value for item, value in body.items() if item != "key"}
+        return await _relay(node, "keys", key, body=forwarded)
 
     @router.post("/api/coders/{key}/steer")
     async def api_coder_steer(
@@ -378,10 +350,9 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         hydrates them through the SAME helper the ask route uses, fences
         them with provenance headers, and caps the context — over-cap
         refuses at compose time (executed == previewed). `preview: true`
-        returns the exact composed text WITHOUT sending. An unarmed
-        steer is a typed 409 (the desk shows the ARM affordance); a
-        revoking refusal broadcasts its frame. Delivered or refused, the
-        attempt is audited.
+        returns the exact composed text WITHOUT sending. Secure/Normal consume
+        a bounded pane grant; eligible YOLO steering consumes the registered
+        pane posture. Delivered or refused, the attempt is audited.
         """
         from .... import coder_steering
 
@@ -392,7 +363,7 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         if isinstance(session, JSONResponse):
             return session
         body = payload if isinstance(payload, dict) else {}
-        composed = _compose_from_body(body)
+        composed = compose_from_body(body)
         if isinstance(composed, JSONResponse):
             return composed
         if composed["status"] == "over_cap":
@@ -408,6 +379,18 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
                 },
                 status_code=409,
             )
+        target = coder_steering.resolve_pane_target(session)
+        stale, _age = _session_is_stale(session)
+        grant = active_policy_grant(key)
+        pane_id = expected_pane_id(key, body, grant)
+        operation, policy = steering_policy(
+            key,
+            pane_id,
+            operation_kind="type_text",
+            data_classes=("typed_text",),
+            registered=not stale,
+            grant=grant,
+        )
         submit = bool(body.get("submit", True))
         if bool(body.get("preview")):
             # Executed == previewed: the SAME composed text the send uses.
@@ -418,9 +401,11 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
                     "context_bytes": composed["context_bytes"],
                     "cap_bytes": composed["cap_bytes"],
                     "refs": composed["refs"],
+                    "operation": operation,
+                    "policy": policy,
+                    "commitment": steering_commitment(operation, policy),
                 }
             )
-        target = coder_steering.resolve_pane_target(session)
         result = await asyncio.to_thread(
             coder_steering.deliver,
             key,
@@ -429,17 +414,18 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
             agent=session.agent,
             submit=submit,
             grounding_refs=composed["refs"],
+            expected_pane_id=pane_id,
+            operation=operation,
+            policy_snapshot=policy,
         )
-        if result.get("revoked"):
-            _coder_frame(ctx, key)  # the disarm is visible everywhere, now
+        if result.get("audit_id") is not None or result.get("revoked"):
+            _coder_frame(ctx, key)
         if result["status"] == "delivered":
             return JSONResponse(result)
         return JSONResponse(result, status_code=409)
 
     @router.post("/api/coders/{key}/keys")
-    async def api_coder_keys(
-        key: str, payload: Optional[dict[str, Any]] = None
-    ) -> Any:
+    async def api_coder_keys(key: str, payload: Optional[dict[str, Any]] = None) -> Any:
         """Send a KEY sequence through THE chokepoint (HS-89-01).
 
         Full key control: `C-c` to interrupt a runaway, arrows/`Escape`/
@@ -447,9 +433,9 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         `{"keys": [...]}` where each item is a named key (a string like
         `"C-c"`, or `{"key": "C-c"}`) or a literal run (`{"literal": "…"}`).
         Named keys are held to an allow-list — an unknown key is refused by
-        name (409 `unknown_key`), never sent. Unarmed is a typed 409 (the
-        desk shows ARM); a revoking refusal broadcasts its frame. Delivered
-        or refused, every key sequence is audited.
+        name (409 `unknown_key`), never sent. Missing authority is a typed 409;
+        a revoking refusal broadcasts its frame. Delivered or refused, every
+        key sequence is audited.
         """
         from .... import coder_steering
 
@@ -461,23 +447,34 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
             return session
         body = payload if isinstance(payload, dict) else {}
         target = coder_steering.resolve_pane_target(session)
+        stale, _age = _session_is_stale(session)
+        grant = active_policy_grant(key)
+        pane_id = expected_pane_id(key, body, grant)
+        operation, policy = steering_policy(
+            key,
+            pane_id,
+            operation_kind="send_keys",
+            data_classes=("key_events",),
+            registered=not stale,
+            grant=grant,
+        )
         result = await asyncio.to_thread(
             coder_steering.deliver_keys,
             key,
             body.get("keys"),
             current_target=target,
             agent=session.agent,
+            expected_pane_id=pane_id,
+            operation=operation,
+            policy_snapshot=policy,
         )
-        if result.get("revoked"):
-            _coder_frame(ctx, key)  # the disarm is visible everywhere, now
+        if result.get("audit_id") is not None or result.get("revoked"):
+            _coder_frame(ctx, key)
         if result["status"] == "delivered":
             return JSONResponse(result)
         return JSONResponse(result, status_code=409)
 
-    # --- the session factory (HS-90-01) ------------------------------------
-    #
-    # Lifecycle acts. spawn/rename are name-validated audited create/label
-    # acts; kill is gated exactly like a steer (armed + verified %N + audit).
+    # Session factory: audited create/label acts; kill remains grant-gated.
 
     @router.post("/api/coders/factory/spawn")
     async def api_factory_spawn(payload: Optional[dict[str, Any]] = None) -> Any:
@@ -530,7 +527,9 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
         )
         if result.get("revoked"):
             _coder_frame(ctx, key)
-        return JSONResponse(result, status_code=200 if result["status"] == "killed" else 409)
+        return JSONResponse(
+            result, status_code=200 if result["status"] == "killed" else 409
+        )
 
     @router.get("/api/coders/steering/audit")
     async def api_coder_steering_audit(

--- a/holdspeak/web/routes/system/coder_steering_routes.py
+++ b/holdspeak/web/routes/system/coder_steering_routes.py
@@ -183,7 +183,7 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
             )
         body = payload if isinstance(payload, dict) else {}
         from ....config import Config
-        from ....operation_policy import steering_ttl_for_mode
+        from ....operation_policy import POLICY_VERSION, steering_ttl_for_mode
 
         control_mode = Config.load().control_mode
         ttl = coder_steering.clamp_ttl(
@@ -196,7 +196,7 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
             return JSONResponse(result, status_code=409)
         result["control_mode"] = control_mode
         result["commitment"] = f"Arm pane {result['pane_id']} for {ttl // 60} minutes"
-        result["policy_version"] = "operation-policy/v1"
+        result["policy_version"] = POLICY_VERSION
         _coder_frame(ctx, key)
         return JSONResponse(result)
 

--- a/holdspeak/web/routes/system/coder_steering_support.py
+++ b/holdspeak/web/routes/system/coder_steering_support.py
@@ -1,0 +1,154 @@
+"""Shared composition and policy helpers for the Coder steering routes."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Optional
+
+from fastapi.responses import JSONResponse
+
+_PANE_ID_RE = re.compile(r"^%[0-9]+$")
+
+
+def canonical_pane_id(value: Any) -> Optional[str]:
+    pane_id = str(value or "").strip()
+    return pane_id if _PANE_ID_RE.fullmatch(pane_id) else None
+
+
+def active_policy_grant(key: str) -> Optional[dict[str, Any]]:
+    from .... import coder_steering
+
+    return coder_steering.policy_grant(key)
+
+
+def expected_pane_id(
+    key: str,
+    body: Mapping[str, Any],
+    grant: Optional[Mapping[str, Any]],
+) -> Optional[str]:
+    supplied = canonical_pane_id(body.get("expected_pane_id"))
+    if supplied:
+        return supplied
+    if key.startswith("pane:"):
+        return canonical_pane_id(key[len("pane:") :])
+    if grant:
+        return canonical_pane_id(grant.get("pane_id"))
+    return None
+
+
+def steering_policy(
+    key: str,
+    pane_id: Optional[str],
+    *,
+    operation_kind: str,
+    data_classes: tuple[str, ...],
+    registered: bool,
+    grant: Optional[Mapping[str, Any]] = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Describe one exact pane effect and consume the central resolver."""
+    from ....config import Config
+    from ....operation_policy import describe_operation, resolve_policy
+
+    operation = describe_operation(
+        operation_id=f"coder:{key}:{operation_kind}",
+        family="coder_steering",
+        effect_class="terminal/type_text_and_keys",
+        actor="owner",
+        destination=pane_id or "unresolved_pane",
+        data_classes=data_classes,
+        resource_scope=key,
+        fixed_destination=bool(registered and pane_id),
+        consequence="execute_now",
+    )
+    decision = resolve_policy(
+        operation,
+        mode=Config.load().control_mode,
+        source="config",
+        grant=grant,
+    )
+    return operation.to_dict(), decision.to_dict()
+
+
+def steering_commitment(
+    operation: Mapping[str, Any], policy: Mapping[str, Any]
+) -> dict[str, str]:
+    pane = str(operation.get("destination") or "unresolved pane")
+    return {
+        "effect": "Send text or allowed keys",
+        "destination": f"pane {pane}" if pane.startswith("%") else pane,
+        "authority_basis": str(policy.get("authority_basis") or "none"),
+        "next_state": str(policy.get("next_state") or "refused"),
+        "receipt": "A Receipt is recorded after every attempt.",
+    }
+
+
+def compose_from_body(body: dict[str, Any]) -> dict[str, Any] | JSONResponse:
+    """Hydrate bounded Desk/rails grounding into the exact steer payload."""
+    from ....db import get_database
+    from ....grounding import (
+        GROUNDING_EXPANDS,
+        GROUNDING_MAX_REFS,
+        compose_steer,
+        hydrate_refs,
+    )
+
+    text = body.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return JSONResponse({"error": "text is required"}, status_code=400)
+    grounding = body.get("grounding")
+    if grounding is None:
+        return compose_steer(text, [])
+    if not isinstance(grounding, dict):
+        return JSONResponse({"error": "grounding must be an object"}, status_code=400)
+    raw_m = grounding.get("meeting_ids")
+    raw_a = grounding.get("artifact_ids")
+    raw_r = grounding.get("rails")
+    meeting_ids = (
+        [str(item).strip() for item in raw_m if str(item).strip()]
+        if isinstance(raw_m, list)
+        else []
+    )
+    artifact_ids = (
+        [str(item).strip() for item in raw_a if str(item).strip()]
+        if isinstance(raw_a, list)
+        else []
+    )
+    rails_refs = (
+        [item for item in raw_r if isinstance(item, dict)]
+        if isinstance(raw_r, list)
+        else []
+    )
+    expand = str(grounding.get("expand") or "summary").strip() or "summary"
+    if expand not in GROUNDING_EXPANDS:
+        return JSONResponse(
+            {"error": f"expand {expand!r} is not one of {list(GROUNDING_EXPANDS)}"},
+            status_code=400,
+        )
+    if len(meeting_ids) + len(artifact_ids) + len(rails_refs) > GROUNDING_MAX_REFS:
+        return JSONResponse(
+            {"error": f"grounding is capped at {GROUNDING_MAX_REFS} refs"},
+            status_code=400,
+        )
+    blocks, unknown = hydrate_refs(get_database(), meeting_ids, artifact_ids, expand)
+    if rails_refs:
+        from ....grounding_rails import hydrate_rails_refs
+
+        rail_blocks, rail_unknown = hydrate_rails_refs(rails_refs)
+        blocks = list(blocks) + rail_blocks
+        unknown = list(unknown) + rail_unknown
+    if unknown:
+        return JSONResponse(
+            {"error": "grounding ids not on this hub", "unknown_ids": unknown},
+            status_code=400,
+        )
+    return compose_steer(text, blocks)
+
+
+__all__ = [
+    "active_policy_grant",
+    "canonical_pane_id",
+    "compose_from_body",
+    "expected_pane_id",
+    "steering_commitment",
+    "steering_policy",
+]

--- a/pm/roadmap/holdspeak-mobile/contracts/fixtures/steering-and-rails-sample.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/fixtures/steering-and-rails-sample.json
@@ -7,9 +7,65 @@
     "awaiting_response": true,
     "question": "Should we merge #305?",
     "updated_at": "2026-07-08T10:00:00Z",
+    "pane_id": "%5",
+    "arm_commitment": "Arm pane %5 for 60 minutes",
+    "operation": {
+      "operation_id": "coder:claude:9244985d-2dd6-4abf-a33c-7a099253c728:type_text_and_keys",
+      "family": "coder_steering",
+      "effect_class": "terminal/type_text_and_keys",
+      "actor": "owner",
+      "destination": "%5",
+      "data_classes": [
+        "typed_text",
+        "key_events"
+      ],
+      "project_scope": null,
+      "resource_scope": "claude:9244985d-2dd6-4abf-a33c-7a099253c728",
+      "fixed_destination": true,
+      "consequence": "execute_now",
+      "version": 2
+    },
+    "policy": {
+      "mode": "yolo",
+      "source": "config",
+      "precedence": [
+        "hard_invariants",
+        "revocation",
+        "scoped_grant",
+        "control_mode",
+        "feature_default"
+      ],
+      "outcome": "allowed",
+      "reason_code": "registered_steering_posture_allowed",
+      "consequence": "execute_now",
+      "authority_basis": "control_posture",
+      "next_state": "execute_now",
+      "eligible": true,
+      "requires_review": false,
+      "requires_authorization": false,
+      "requires_grant": false,
+      "hard_invariants": [
+        "authentication",
+        "secret_custody",
+        "destination_binding",
+        "payload_binding",
+        "pane_identity",
+        "audit_receipt",
+        "configuration_integrity",
+        "schema_safety"
+      ],
+      "policy_version": "operation-policy/v2"
+    },
+    "commitment": {
+      "effect": "Send text or allowed keys",
+      "destination": "pane %5",
+      "authority_basis": "control_posture",
+      "next_state": "execute_now",
+      "receipt": "A Receipt is recorded after every attempt."
+    },
     "grant": {
-      "armed": true,
-      "expires_in_seconds": 842
+      "armed": false,
+      "expires_in_seconds": null
     },
     "peek": {
       "status": "live",
@@ -27,6 +83,62 @@
     "awaiting_response": false,
     "question": null,
     "updated_at": "2026-07-08T10:00:00Z",
+    "pane_id": "%5",
+    "arm_commitment": "Arm pane %5 for 60 minutes",
+    "operation": {
+      "operation_id": "coder:claude:9244985d-2dd6-4abf-a33c-7a099253c728:type_text_and_keys",
+      "family": "coder_steering",
+      "effect_class": "terminal/type_text_and_keys",
+      "actor": "owner",
+      "destination": "%5",
+      "data_classes": [
+        "typed_text",
+        "key_events"
+      ],
+      "project_scope": null,
+      "resource_scope": "claude:9244985d-2dd6-4abf-a33c-7a099253c728",
+      "fixed_destination": true,
+      "consequence": "execute_now",
+      "version": 2
+    },
+    "policy": {
+      "mode": "yolo",
+      "source": "config",
+      "precedence": [
+        "hard_invariants",
+        "revocation",
+        "scoped_grant",
+        "control_mode",
+        "feature_default"
+      ],
+      "outcome": "allowed",
+      "reason_code": "registered_steering_posture_allowed",
+      "consequence": "execute_now",
+      "authority_basis": "control_posture",
+      "next_state": "execute_now",
+      "eligible": true,
+      "requires_review": false,
+      "requires_authorization": false,
+      "requires_grant": false,
+      "hard_invariants": [
+        "authentication",
+        "secret_custody",
+        "destination_binding",
+        "payload_binding",
+        "pane_identity",
+        "audit_receipt",
+        "configuration_integrity",
+        "schema_safety"
+      ],
+      "policy_version": "operation-policy/v2"
+    },
+    "commitment": {
+      "effect": "Send text or allowed keys",
+      "destination": "pane %5",
+      "authority_basis": "control_posture",
+      "next_state": "execute_now",
+      "receipt": "A Receipt is recorded after every attempt."
+    },
     "grant": {
       "armed": false,
       "expires_in_seconds": null
@@ -45,6 +157,7 @@
   "steer_request": {
     "text": "run the full suite and read the tail",
     "submit": false,
+    "expected_pane_id": "%5",
     "grounding": {
       "meeting_ids": [],
       "artifact_ids": [],
@@ -63,7 +176,63 @@
     "status": "delivered",
     "pane_id": "%5",
     "submitted": false,
-    "audit_id": 7
+    "audit_id": 7,
+    "operation": {
+      "operation_id": "coder:claude:9244985d-2dd6-4abf-a33c-7a099253c728:type_text",
+      "family": "coder_steering",
+      "effect_class": "terminal/type_text_and_keys",
+      "actor": "owner",
+      "destination": "%5",
+      "data_classes": [
+        "typed_text"
+      ],
+      "project_scope": null,
+      "resource_scope": "claude:9244985d-2dd6-4abf-a33c-7a099253c728",
+      "fixed_destination": true,
+      "consequence": "execute_now",
+      "version": 2
+    },
+    "policy": {
+      "mode": "yolo",
+      "source": "config",
+      "precedence": [
+        "hard_invariants",
+        "revocation",
+        "scoped_grant",
+        "control_mode",
+        "feature_default"
+      ],
+      "outcome": "allowed",
+      "reason_code": "registered_steering_posture_allowed",
+      "consequence": "execute_now",
+      "authority_basis": "control_posture",
+      "next_state": "execute_now",
+      "eligible": true,
+      "requires_review": false,
+      "requires_authorization": false,
+      "requires_grant": false,
+      "hard_invariants": [
+        "authentication",
+        "secret_custody",
+        "destination_binding",
+        "payload_binding",
+        "pane_identity",
+        "audit_receipt",
+        "configuration_integrity",
+        "schema_safety"
+      ],
+      "policy_version": "operation-policy/v2"
+    },
+    "receipt": {
+      "id": "steering:7",
+      "source_ref": "coder_session:claude:9244985d-2dd6-4abf-a33c-7a099253c728",
+      "actual_destination": "%5",
+      "authority_basis": "control_posture",
+      "control_mode": "yolo",
+      "policy_version": "operation-policy/v2",
+      "effect_class": "terminal/type_text_and_keys",
+      "outcome": "delivered"
+    }
   },
   "steer_result_refused": {
     "status": "pane_mismatch",
@@ -84,7 +253,53 @@
     ],
     "submit": false,
     "outcome": "delivered",
-    "detail": null
+    "detail": null,
+    "operation": {
+      "operation_id": "coder:claude:9244985d-2dd6-4abf-a33c-7a099253c728:type_text",
+      "family": "coder_steering",
+      "effect_class": "terminal/type_text_and_keys",
+      "actor": "owner",
+      "destination": "%5",
+      "data_classes": [
+        "typed_text"
+      ],
+      "project_scope": null,
+      "resource_scope": "claude:9244985d-2dd6-4abf-a33c-7a099253c728",
+      "fixed_destination": true,
+      "consequence": "execute_now",
+      "version": 2
+    },
+    "policy_snapshot": {
+      "mode": "yolo",
+      "source": "config",
+      "precedence": [
+        "hard_invariants",
+        "revocation",
+        "scoped_grant",
+        "control_mode",
+        "feature_default"
+      ],
+      "outcome": "allowed",
+      "reason_code": "registered_steering_posture_allowed",
+      "consequence": "execute_now",
+      "authority_basis": "control_posture",
+      "next_state": "execute_now",
+      "eligible": true,
+      "requires_review": false,
+      "requires_authorization": false,
+      "requires_grant": false,
+      "hard_invariants": [
+        "authentication",
+        "secret_custody",
+        "destination_binding",
+        "payload_binding",
+        "pane_identity",
+        "audit_receipt",
+        "configuration_integrity",
+        "schema_safety"
+      ],
+      "policy_version": "operation-policy/v2"
+    }
   },
   "rails_grounding_ref": {
     "repo": "holdspeak",

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/coder-session-peek.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/coder-session-peek.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://holdspeak.dev/contracts/v0/coder-session-peek.schema.json",
   "title": "CoderSessionPeek",
-  "description": "The read-only window into a live agent session's tmux pane. Source: GET /api/coders/{key}/peek (holdspeak/web/routes/system/coder_steering_routes.py, Phase 87). Presence class: read, never synced. Watching is free; the grant sub-object reports arming state without issuing one.",
+  "description": "The read-only window into a live Coder pane plus the Hub-owned policy decision for its next text/allowed-key delivery.",
   "type": "object",
   "additionalProperties": false,
   "required": ["key", "agent", "stale", "awaiting_response", "updated_at", "grant", "peek"],
@@ -13,6 +13,22 @@
     "awaiting_response": { "type": "boolean" },
     "question": { "type": ["string", "null"] },
     "updated_at": { "type": "string", "description": "the registry record's last-updated instant" },
+    "pane_id": { "type": ["string", "null"], "description": "canonical tmux identity captured for the next request" },
+    "arm_commitment": { "type": "string" },
+    "operation": { "$ref": "https://holdspeak.dev/contracts/v0/operation-policy.schema.json#/$defs/operation" },
+    "policy": { "$ref": "https://holdspeak.dev/contracts/v0/operation-policy.schema.json#/$defs/policy" },
+    "commitment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["effect", "destination", "authority_basis", "next_state", "receipt"],
+      "properties": {
+        "effect": { "type": "string" },
+        "destination": { "type": "string" },
+        "authority_basis": { "type": "string" },
+        "next_state": { "type": "string" },
+        "receipt": { "type": "string" }
+      }
+    },
     "grant": {
       "type": "object",
       "additionalProperties": false,

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/operation-policy.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/operation-policy.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://holdspeak.dev/contracts/v0/operation-policy.schema.json",
+  "title": "OperationPolicy",
+  "description": "The Hub-owned operation descriptor and resolved policy decision consumed by Web and Swift clients.",
+  "$defs": {
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "operation_id": { "type": "string" },
+        "family": { "type": "string" },
+        "effect_class": { "type": "string" },
+        "actor": { "type": "string" },
+        "destination": { "type": "string" },
+        "data_classes": { "type": "array", "items": { "type": "string" } },
+        "project_scope": { "type": ["string", "null"] },
+        "resource_scope": { "type": ["string", "null"] },
+        "fixed_destination": { "type": "boolean" },
+        "consequence": { "type": "string" },
+        "version": { "type": "integer" }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": { "enum": ["safe", "neutral", "yolo"] },
+        "source": { "type": "string" },
+        "precedence": { "type": "array", "items": { "type": "string" } },
+        "outcome": { "type": "string" },
+        "reason_code": { "type": "string" },
+        "consequence": { "type": "string" },
+        "authority_basis": { "type": "string" },
+        "next_state": { "type": "string" },
+        "eligible": { "type": "boolean" },
+        "requires_review": { "type": "boolean" },
+        "requires_authorization": { "type": "boolean" },
+        "requires_grant": { "type": "boolean" },
+        "hard_invariants": { "type": "array", "items": { "type": "string" } },
+        "policy_version": { "type": "string" }
+      }
+    }
+  }
+}

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/steer-request.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/steer-request.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://holdspeak.dev/contracts/v0/steer-request.schema.json",
   "title": "SteerRequest",
-  "description": "A steer toward an armed session. Source: POST /api/coders/{key}/steer body (holdspeak/web/routes/system/coder_steering_routes.py, Phase 87/88). Carries the composed text, the submit flag, and optional grounding (desk objects + rails refs).",
+  "description": "A steer toward a policy-authorized session. It carries the text, submit flag, expected pane identity, and optional grounding.",
   "type": "object",
   "additionalProperties": false,
   "required": ["text"],
@@ -10,6 +10,7 @@
     "text": { "type": "string", "minLength": 1 },
     "submit": { "type": "boolean", "description": "press Enter after the text; default true" },
     "preview": { "type": "boolean", "description": "return the composed text without sending (executed == previewed)" },
+    "expected_pane_id": { "type": "string", "pattern": "^%[0-9]+$", "description": "the pane identity captured by peek; mandatory for grantless registered-session delivery" },
     "grounding": { "$ref": "https://holdspeak.dev/contracts/v0/steer-grounding.schema.json" }
   }
 }

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/steer-result.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/steer-result.schema.json
@@ -2,12 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://holdspeak.dev/contracts/v0/steer-result.schema.json",
   "title": "SteerResult",
-  "description": "The outcome of a steer through the one chokepoint. Source: POST /api/coders/{key}/steer result (holdspeak/coder_steering.py deliver, Phase 87). Delivered carries the verified pane_id + audit_id; every other status is a typed refusal (unarmed/expired/pane_mismatch/pane_gone/transport_error/grounding_over_cap), and a revoking refusal disarms.",
+  "description": "The outcome of a text/key delivery through the one policy and identity chokepoint. Delivered carries the verified pane, audit, policy, and Receipt; refusals remain typed data.",
   "type": "object",
   "additionalProperties": false,
   "required": ["status"],
   "properties": {
-    "status": { "enum": ["delivered", "unarmed", "expired", "pane_mismatch", "pane_gone", "tmux_absent", "error", "transport_error", "empty_text", "grounding_over_cap", "preview"] },
+    "status": { "enum": ["delivered", "unarmed", "expired", "pane_identity_required", "pane_mismatch", "pane_gone", "tmux_absent", "error", "transport_error", "authority_unresolved", "policy_refused", "empty_text", "empty_keys", "unknown_key", "grounding_over_cap", "preview"] },
     "pane_id": { "type": "string" },
     "submitted": { "type": "boolean" },
     "audit_id": { "type": ["integer", "null"] },
@@ -15,6 +15,24 @@
     "detail": { "type": "string" },
     "text": { "type": "string", "description": "present only on preview: the exact composed text" },
     "context_bytes": { "type": "integer" },
-    "cap_bytes": { "type": "integer" }
+    "cap_bytes": { "type": "integer" },
+    "keys": { "type": "string" },
+    "operation": { "$ref": "https://holdspeak.dev/contracts/v0/operation-policy.schema.json#/$defs/operation" },
+    "policy": { "$ref": "https://holdspeak.dev/contracts/v0/operation-policy.schema.json#/$defs/policy" },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source_ref", "actual_destination", "authority_basis", "outcome"],
+      "properties": {
+        "id": { "type": "string" },
+        "source_ref": { "type": "string" },
+        "actual_destination": { "type": "string" },
+        "authority_basis": { "type": "string" },
+        "control_mode": { "type": ["string", "null"] },
+        "policy_version": { "type": ["string", "null"] },
+        "effect_class": { "type": ["string", "null"] },
+        "outcome": { "type": "string" }
+      }
+    }
   }
 }

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/steering-audit-entry.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/steering-audit-entry.schema.json
@@ -5,7 +5,7 @@
   "description": "One remembered steer, delivered or refused. Source: GET /api/coders/steering/audit (holdspeak/db/steering.py, Phase 87). Privacy-respecting: the text's sha256 + first 120 chars, never the full steer.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["id", "ts", "session_key", "agent", "text_sha256", "text_head", "grounding", "submit", "outcome"],
+  "required": ["id", "ts", "session_key", "agent", "text_sha256", "text_head", "grounding", "submit", "outcome", "operation", "policy_snapshot"],
   "properties": {
     "id": { "type": "integer" },
     "ts": { "type": "string", "format": "date-time" },
@@ -17,6 +17,8 @@
     "grounding": { "type": "array", "items": { "type": "string" }, "description": "the ref tokens that rode along" },
     "submit": { "type": "boolean" },
     "outcome": { "type": "string", "description": "the steer's status (delivered or a refusal reason)" },
-    "detail": { "type": ["string", "null"] }
+    "detail": { "type": ["string", "null"] },
+    "operation": { "$ref": "https://holdspeak.dev/contracts/v0/operation-policy.schema.json#/$defs/operation" },
+    "policy_snapshot": { "$ref": "https://holdspeak.dev/contracts/v0/operation-policy.schema.json#/$defs/policy" }
   }
 }

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -7,11 +7,12 @@
 **Last updated:** 2026-07-11 — **Phase 91, One React Surface, IN PROGRESS
 (9/10); Phase 92, The Coalescence, PLANNED with all ten stories carrying
 pre-close implementation but no accepted owner/device outcome; Phase 93,
-Effortless HoldSpeak, IN PROGRESS with HS-93-01 through HS-93-06 carrying
-automated implementation evidence but not yet accepted. HS-93-06 now exposes
-an explicit, atomic choice between retained Meeting sync-conflict versions and
-truthful partial-intelligence Retry/Skip on History and the Desk, without false
-Ready state.** The Web is
+Effortless HoldSpeak, IN PROGRESS with HS-93-01 through HS-93-07 carrying
+automated implementation evidence but not yet accepted. HS-93-07 now snapshots
+future-operation policy and lets YOLO execute fixed configured Integrations with
+the posture as authority, no HoldSpeak approval/grant prompt, invariant checks
+intact, and a source-linked Receipt; unknown or unregistered effects refuse.**
+The Web is
 one Vite/React 19 tree and Phase 92 added substantial language, trust,
 first-value, capture, relationship, capability, destination, authority, and
 Desk-memory substrate. The experience audit found that the product is not yet

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -9,9 +9,10 @@
 pre-close implementation but no accepted owner/device outcome; Phase 93,
 Effortless HoldSpeak, IN PROGRESS with HS-93-01 through HS-93-07 carrying
 automated implementation evidence but not yet accepted. HS-93-07 now snapshots
-future-operation policy and lets YOLO execute fixed configured Integrations with
-the posture as authority, no HoldSpeak approval/grant prompt, invariant checks
-intact, and a source-linked Receipt; unknown or unregistered effects refuse.**
+future-operation policy and lets YOLO execute fixed configured Integrations and
+steer a registered, re-verified Coder pane with the posture as authority and no
+HoldSpeak approval/grant/arm prompt. Invariants remain intact, every attempt
+leaves a source-linked Receipt, and unknown or unresolved effects refuse.**
 The Web is
 one Vite/React 19 tree and Phase 92 added substantial language, trust,
 first-value, capture, relationship, capability, destination, authority, and

--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/current-phase-status.md
@@ -2,17 +2,19 @@
 
 **Status:** IN PROGRESS (0/9). HS-93-01 through HS-93-05 have automated
 implementation slices verified through Web/Hub/Swift lanes; HS-93-06 now has
-Web/Hub conflict and partial-intelligence recovery slices. API-backed production
+Web/Hub conflict and partial-intelligence recovery slices; HS-93-07 now has a
+versioned configured-Integration control-posture slice. API-backed production
 Web captures exist where recorded, with supplementary simulator evidence, but
-all six stories remain open for their remaining implementation, owner, and
+all seven stories remain open for their remaining implementation, owner, and
 physical-device gates.
 Phase 91 remains the roadmap's current phase; Phase 92 substrate is not accepted
 as a simplified product.
 
-**Last updated:** 2026-07-11 (HS-93-06 now adds truthful partial Meeting
-intelligence plus atomic Retry remaining/Skip remaining on History and the Desk;
-full long-capture, real-fault, offline-sync, owner, and physical-device gates
-remain open).
+**Last updated:** 2026-07-11 (HS-93-07 is now in progress: policy v2 snapshots
+future-operation posture, configured Integrations execute without a HoldSpeak
+prompt in YOLO, unregistered/unknown effects refuse, and React/Swift render the
+same action and Receipt fields; broader family, owner, and device gates remain
+open).
 
 ## Goal
 
@@ -126,7 +128,7 @@ prove the daily experience through sustained owner use on Web, iPhone, and iPad.
 | HS-93-04 | Power lives on the Desk | in progress | [story-04](./story-04-power-appears-in-context.md) | [progress record](./progress-story-04.md) |
 | HS-93-05 | Your words never disappear | in progress | [story-05](./story-05-your-words-never-disappear.md) | [progress record](./progress-story-05.md) |
 | HS-93-06 | A meeting survives real life | in progress | [story-06](./story-06-a-meeting-survives-real-life.md) | [progress record](./progress-story-06.md) |
-| HS-93-07 | Secure, Normal, or YOLO | backlog | [story-07](./story-07-decisions-explain-themselves.md) | — |
+| HS-93-07 | Secure, Normal, or YOLO | in progress | [story-07](./story-07-decisions-explain-themselves.md) | [progress record](./progress-story-07.md) |
 | HS-93-08 | The Desk works for every body | backlog | [story-08](./story-08-the-desk-works-for-every-body.md) | — |
 | HS-93-09 | The owner can live here | backlog | [story-09](./story-09-the-owner-can-live-here.md) | — |
 
@@ -194,6 +196,23 @@ a running worker. API-backed production captures prove partial, skipped, and
 requeued Web states with zero failed API responses. The story remains open for
 native parity, long-duration memory/checkpoint traces, the complete real fault
 matrix, airplane-mode exactly-once sync, and owner and physical-device evidence.
+
+HS-93-07 now carries its first authority slice through the existing Integration
+lifecycle. Operation-policy v2 snapshots mode, source, reason, authority basis,
+destination, effect, eligibility, and next state when a proposal is created, so
+a later posture change cannot widen it. Secure and Normal retain exact
+per-action decisions or bounded scoped grants. YOLO uses the captured posture
+itself for a fixed configured Slack, Webhook, or GitHub destination, runs the
+existing parity-checked executor without a HoldSpeak approval/grant prompt, and
+returns the resulting Receipt to the source subject. An unregistered destination
+or unknown operation refuses without entering the Web/native approval queue.
+
+Web Settings, the Desk Integration inspector, Meeting History, Desk Receipts,
+and flagship Swift Settings/Queue/Receipt details consume the shared policy
+fields rather than a private client matrix. The story remains open for the full
+dictation/inference/Coder/Mission-Control/sync/cadence/destructive matrix,
+grant-use source Receipts, Qlippy treatment, production walks, owner prediction,
+and physical iPhone/iPad evidence.
 
 Phase 91 remains the roadmap's current phase and its owner/Swift close gate is
 non-waivable. Phase 92 still has broad automated implementation but no accepted

--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/current-phase-status.md
@@ -2,19 +2,19 @@
 
 **Status:** IN PROGRESS (0/9). HS-93-01 through HS-93-05 have automated
 implementation slices verified through Web/Hub/Swift lanes; HS-93-06 now has
-Web/Hub conflict and partial-intelligence recovery slices; HS-93-07 now has a
-versioned configured-Integration control-posture slice. API-backed production
-Web captures exist where recorded, with supplementary simulator evidence, but
-all seven stories remain open for their remaining implementation, owner, and
-physical-device gates.
+Web/Hub conflict and partial-intelligence recovery slices; HS-93-07 now has
+versioned configured-Integration and registered Coder-steering
+control-posture slices. API-backed production Web captures exist where
+recorded, with supplementary simulator evidence, but all seven stories remain
+open for their remaining implementation, owner, and physical-device gates.
 Phase 91 remains the roadmap's current phase; Phase 92 substrate is not accepted
 as a simplified product.
 
-**Last updated:** 2026-07-11 (HS-93-07 is now in progress: policy v2 snapshots
-future-operation posture, configured Integrations execute without a HoldSpeak
-prompt in YOLO, unregistered/unknown effects refuse, and React/Swift render the
-same action and Receipt fields; broader family, owner, and device gates remain
-open).
+**Last updated:** 2026-07-11 (HS-93-07 now carries policy v2 through configured
+Integrations and registered Coder steering. YOLO steers an exact verified pane
+without a HoldSpeak arm prompt; Secure/Normal retain bounded grants; every
+attempt audits the immutable operation/policy and returns a source-linked
+Receipt. Broader family, owner, and device gates remain open).
 
 ## Goal
 
@@ -197,8 +197,8 @@ requeued Web states with zero failed API responses. The story remains open for
 native parity, long-duration memory/checkpoint traces, the complete real fault
 matrix, airplane-mode exactly-once sync, and owner and physical-device evidence.
 
-HS-93-07 now carries its first authority slice through the existing Integration
-lifecycle. Operation-policy v2 snapshots mode, source, reason, authority basis,
+HS-93-07 now carries two authority slices through the existing Integration and
+Coder lifecycles. Operation-policy v2 snapshots mode, source, reason, authority basis,
 destination, effect, eligibility, and next state when a proposal is created, so
 a later posture change cannot widen it. Secure and Normal retain exact
 per-action decisions or bounded scoped grants. YOLO uses the captured posture
@@ -207,12 +207,22 @@ existing parity-checked executor without a HoldSpeak approval/grant prompt, and
 returns the resulting Receipt to the source subject. An unregistered destination
 or unknown operation refuses without entering the Web/native approval queue.
 
-Web Settings, the Desk Integration inspector, Meeting History, Desk Receipts,
-and flagship Swift Settings/Queue/Receipt details consume the shared policy
-fields rather than a private client matrix. The story remains open for the full
-dictation/inference/Coder/Mission-Control/sync/cadence/destructive matrix,
-grant-use source Receipts, Qlippy treatment, production walks, owner prediction,
-and physical iPhone/iPad evidence.
+Coder text and allowed-key delivery now consumes the same resolver. Secure and
+Normal retain the exact, expiring pane grant; YOLO uses a registered session or
+exact raw pane as posture authority without a HoldSpeak arm prompt. The pane id
+captured by peek rides the request, the typing node re-resolves the target
+immediately before delivery, and missing or changed identity refuses before a
+keystroke. The key allow-list is unchanged. Every attempt stores the operation
+and policy snapshot in the existing audit and projects a source-linked Coder
+Receipt. The Desk keeps factory controls separate; their full policy
+classification remains open.
+
+Web Settings, the Desk Integration inspector, Meeting History, Coder pull-out,
+Desk Receipts, and flagship Swift Settings/Queue/Coder/Receipt details consume
+the shared policy fields rather than a private client matrix. The story remains
+open for the full dictation/inference/Coder-factory/Mission-Control/sync/cadence/
+destructive matrix, general grant-use source Receipts, Qlippy treatment,
+production walks, owner prediction, and physical iPhone/iPad evidence.
 
 Phase 91 remains the roadmap's current phase and its owner/Swift close gate is
 non-waivable. Phase 92 still has broad automated implementation but no accepted
@@ -282,6 +292,11 @@ use; no final summary exists.
   Skip are atomic Meeting-scoped decisions that cannot overwrite a running job,
   and Skip never sets an intelligence completion timestamp — HS-93-06
   partial-intelligence contract.
+- 2026-07-11 — Registered Coder text and allowed-key delivery consumes central
+  policy: Secure/Normal use a bounded exact-pane grant; YOLO uses posture with no
+  arm prompt; the typing node still re-resolves the read-side `%N`, preserves
+  the key allow-list, and records a source-linked Receipt for every attempt.
+  Factory rename/kill authority remains separate — HS-93-07 Coder contract.
 - 2026-07-11 — Phase 91 remains current and the roadmap pointer does not move —
   Delivery Workbench live state.
 

--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/progress-story-07.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/progress-story-07.md
@@ -1,0 +1,97 @@
+# HS-93-07 progress record — Secure, Normal, or YOLO
+
+**Captured:** 2026-07-11<br>
+**Baseline:** `main` at `6a93e494` (merged HS-93-06 recovery slices)<br>
+**After build:** current `agent/hs-93-07-secure-normal-yolo` working tree; no
+commit identity claimed<br>
+**Acceptance status:** in progress — one configured-Integration policy slice is
+implemented across Hub, React, and flagship Swift. The complete operation-family
+matrix, owner walks, and physical-device evidence remain open.
+
+## First vertical slice: configured Integration authority is the posture
+
+The Phase-92 resolver had two behaviors that contradicted the Phase-93 product
+contract: YOLO required a reusable external-write grant before a configured
+destination could run, and an unknown family inherited `current_behavior`.
+Policy was also re-resolved when the owner approved, so changing the setting
+could silently alter an already-visible proposal.
+
+This slice makes one bounded path truthful:
+
+1. `operation-policy/v2` snapshots mode, source, effect, destination,
+   consequence, eligibility, reason, authority basis, and next state when the
+   proposal is first recorded. An idempotent repeat returns the original
+   snapshot unchanged.
+2. Secure and Normal keep exact per-action decisions. A matching bounded grant
+   may authorize them; grants are no longer a YOLO prerequisite.
+3. YOLO immediately authorizes only a fixed configured Slack, Webhook, or
+   GitHub destination. The posture is recorded as the authority basis and the
+   existing executor still verifies the durable payload, destination, preview,
+   effect, configuration, and audit binding immediately before egress.
+4. The effect produces the same executed/failed actuator record and a
+   source-linked Desk Receipt. Repeating an idempotency key never repeats an
+   executed effect.
+5. An unregistered destination or unknown operation family resolves to a named
+   refusal. It does not enter the Web or native pending-approval queue, and a
+   forged decision call cannot widen it.
+6. Changing posture revokes active grants but does not alter existing proposal
+   snapshots. A Normal proposal remains Normal and still requires its original
+   decision after the global posture becomes YOLO.
+
+No new registry, receipt store, side-effect path, or client-specific policy
+matrix was added.
+
+## Shared client expression
+
+- Web Settings names Control posture, its shared policy version, future-only
+  effect, retained proposal snapshots, and any grant revocation.
+- The Desk Integration action point names practical posture before the action,
+  then renders the exact effect, normalized destination, authority basis, and
+  next state returned by the Hub. A YOLO response goes directly to its Receipt;
+  it never renders an approval button.
+- Meeting History consumes the same proposal policy and does not offer an
+  approval action for a refused operation.
+- Desk Receipt details include control posture, policy version, effect,
+  destination, authority basis, reason, outcome, and source.
+- Flagship Swift decodes the same policy snapshot in Queue and the same Receipt
+  fields in Desk memory. Its authority client now correctly uses the shared
+  snake-case decoder rather than conflicting explicit coding keys.
+
+## Verification completed for this slice
+
+| Lane | Result |
+|---|---|
+| Full Python unit suite | 2,899 passed |
+| Configured Slack/Webhook/GitHub plus Meeting Slack Integration routes | 65 passed |
+| Full Web architecture, type, component, and production-build check | 113 sources; 31 files / 162 tests passed; typecheck and build passed |
+| Full flagship Swift package | 545 passed, 9 skipped, 0 failed |
+| Product-copy and API-surface guards | 12 passed; 3,939 census candidates, 0 violations |
+| Docs and backend/frontend density guards | 28 passed |
+| Python lint, whitespace, and roadmap validation | clean |
+
+The PMO commit gate is run against the final staged tree before this slice is
+committed.
+
+## Acceptance still required
+
+No HS-93-07 acceptance checkbox changes in this slice. Still required:
+
+- complete central coverage for dictation delivery, inference, Coder
+  steering/factory operations, Mission Control/workflows, sync, cadence, and
+  destructive Desk mutations;
+- zero-prompt YOLO execution for every eligible registered operation, including
+  Coder session authority without weakening pane identity or key/payload checks;
+- Secure/Normal bounded grant issue/use/revoke presentation and source-linked
+  use Receipts;
+- shared Qlippy, Mission Control, Coder, Cadence, History, Desk, and native Queue
+  treatment with no consequential fallback verb;
+- control/treatment production walks, exact prompt counts, owner prediction and
+  Receipt-findability verdicts;
+- physical Web/iPhone/iPad evidence with exact build, device, destination, and
+  operation provenance.
+
+The next autonomous development slice should carry registered Coder steering
+through policy v2: YOLO must require no HoldSpeak arm prompt while pane identity,
+registered capability, changed-target refusal, bounded execution, and the
+source-linked Receipt remain mandatory. Secure and Normal keep their deliberate,
+bounded authority paths.

--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/progress-story-07.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/progress-story-07.md
@@ -4,9 +4,10 @@
 **Baseline:** `main` at `6a93e494` (merged HS-93-06 recovery slices)<br>
 **After build:** current `agent/hs-93-07-secure-normal-yolo` working tree; no
 commit identity claimed<br>
-**Acceptance status:** in progress — one configured-Integration policy slice is
-implemented across Hub, React, and flagship Swift. The complete operation-family
-matrix, owner walks, and physical-device evidence remain open.
+**Acceptance status:** in progress — configured-Integration and registered
+Coder-steering policy slices are implemented across Hub, React, and flagship
+Swift. The complete operation-family matrix, owner walks, and physical-device
+evidence remain open.
 
 ## First vertical slice: configured Integration authority is the posture
 
@@ -41,6 +42,42 @@ This slice makes one bounded path truthful:
 No new registry, receipt store, side-effect path, or client-specific policy
 matrix was added.
 
+## Second vertical slice: registered Coder steering uses the posture
+
+The existing steering path already had the right hard boundary—one text
+chokepoint, one allowed-key chokepoint, canonical tmux pane identity, and an
+audit—but every posture still required an arm grant. This slice carries that
+path through operation-policy v2 without turning YOLO into general shell
+authority:
+
+1. Peek names the exact pane, operation, policy decision, commitment, authority
+   basis, and Receipt promise. Secure and Normal continue to require their
+   bounded exact-pane grant. Eligible YOLO text and allowed-key delivery uses
+   the registered pane and Control posture directly, with no HoldSpeak arm
+   prompt or synthetic grant.
+2. The client sends the pane identity from its read-side snapshot. Immediately
+   before text or keys reach tmux, the hub re-resolves the registry target and
+   sends only to the verified canonical `%N`. A missing, malformed, gone,
+   recycled, or changed pane refuses before one keystroke.
+3. YOLO does not widen the terminal payload. Text still uses the literal text
+   transport and named keys still pass the existing allow-list. The Desk keeps
+   rename/kill in a separate deliberate control window while their full policy
+   classification remains open. An exact `pane:%N` attachment is eligible; an
+   unresolved destination is not.
+4. The machine that types owns policy and audit. The relay forwards the
+   expected identity, but a configured far node resolves its own posture or
+   grant, re-verifies its own pane, executes locally, and records the result.
+5. Every attempt records the operation and immutable policy snapshot in the
+   existing steering audit and projects a source-linked Coder Receipt with
+   destination, authority, posture, effect, and outcome. Coder frames refresh
+   Desk memory after both delivery and refusal.
+6. A posture change clears in-memory Coder grants through both Web and CLI
+   control paths. Grant matching also refuses a grant minted under another
+   posture, so a stale authority object cannot silently widen a later attempt.
+
+No alternate transport, client-side policy resolver, durable shell capability,
+or second Receipt store was added.
+
 ## Shared client expression
 
 - Web Settings names Control posture, its shared policy version, future-only
@@ -56,17 +93,28 @@ matrix was added.
 - Flagship Swift decodes the same policy snapshot in Queue and the same Receipt
   fields in Desk memory. Its authority client now correctly uses the shared
   snake-case decoder rather than conflicting explicit coding keys.
+- Web and flagship Swift Coder pull-outs consume the Hub's pane, operation,
+  policy, and commitment. Both show direct YOLO steering without an arm control,
+  keep Secure/Normal arm and revoke behavior, and show the exact authority and
+  Receipt fate beside the action.
+- Both Desk clients keep session rename/kill in a separate explicit control
+  window; this slice does not grant those factory operations posture authority.
+  A changed-target refusal clears the local binding and requires a fresh peek;
+  clients cannot infer posture eligibility from their own settings.
 
 ## Verification completed for this slice
 
 | Lane | Result |
 |---|---|
-| Full Python unit suite | 2,899 passed |
+| Canonical Python suite (`test_metal.py` excluded per repo contract) | 3,802 passed, 37 skipped; 2 non-failing transcript-import teardown warnings recorded |
+| Full Python unit suite on the final tree | 2,911 passed |
+| Coder policy, identity, key, route, audit, projection, migration, and mode-revocation lane | 108 passed |
 | Configured Slack/Webhook/GitHub plus Meeting Slack Integration routes | 65 passed |
-| Full Web architecture, type, component, and production-build check | 113 sources; 31 files / 162 tests passed; typecheck and build passed |
+| Full Web architecture, type, component, and production-build check | 113 sources; 31 files / 166 tests passed; typecheck and build passed |
 | Full flagship Swift package | 545 passed, 9 skipped, 0 failed |
-| Product-copy and API-surface guards | 12 passed; 3,939 census candidates, 0 violations |
-| Docs and backend/frontend density guards | 28 passed |
+| Generated flagship iOS app | Debug iPhoneSimulator build succeeded with code signing disabled |
+| Mobile steering contract fixtures | JSON Schema validator passed |
+| Product-copy, language, docs-drift, API-surface, and density guards | 45 passed; controlled census has 0 violations |
 | Python lint, whitespace, and roadmap validation | clean |
 
 The PMO commit gate is run against the final staged tree before this slice is
@@ -77,21 +125,22 @@ committed.
 No HS-93-07 acceptance checkbox changes in this slice. Still required:
 
 - complete central coverage for dictation delivery, inference, Coder
-  steering/factory operations, Mission Control/workflows, sync, cadence, and
+  factory/destructive operations, Mission Control/workflows, sync, cadence, and
   destructive Desk mutations;
-- zero-prompt YOLO execution for every eligible registered operation, including
-  Coder session authority without weakening pane identity or key/payload checks;
+- zero-prompt YOLO execution for the eligible operation families still outside
+  the two implemented slices;
 - Secure/Normal bounded grant issue/use/revoke presentation and source-linked
   use Receipts;
-- shared Qlippy, Mission Control, Coder, Cadence, History, Desk, and native Queue
-  treatment with no consequential fallback verb;
+- shared Qlippy, Mission Control, Cadence, History, Desk, and native Queue
+  treatment with no consequential fallback verb, plus production/device proof
+  for the implemented Coder treatment;
 - control/treatment production walks, exact prompt counts, owner prediction and
   Receipt-findability verdicts;
 - physical Web/iPhone/iPad evidence with exact build, device, destination, and
   operation provenance.
 
-The next autonomous development slice should carry registered Coder steering
-through policy v2: YOLO must require no HoldSpeak arm prompt while pane identity,
-registered capability, changed-target refusal, bounded execution, and the
-source-linked Receipt remain mandatory. Secure and Normal keep their deliberate,
-bounded authority paths.
+The next autonomous development slice should classify Coder factory and
+destructive operations through policy v2. Spawn's optional command, rename, and
+kill have materially different consequences; each must state its exact effect
+and destination, preserve name/argument and pane-identity invariants, and avoid
+inheriting text-steering posture authority by accident.

--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/story-07-decisions-explain-themselves.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/story-07-decisions-explain-themselves.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 93
-- **Status:** backlog
+- **Status:** in progress
 - **Depends on:** HS-93-02, HS-93-03, HS-93-04
 - **Unblocks:** HS-93-08, HS-93-09
 - **Owner:** unassigned

--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/story-07-decisions-explain-themselves.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/story-07-decisions-explain-themselves.md
@@ -82,6 +82,13 @@ OS-owned permissions are not HoldSpeak approval prompts. New arbitrary
 destinations or capabilities remain ineligible until configured/registered;
 YOLO is frictionless authority, not ambient remote-code execution.
 
+The 2026-07-11 Coder slice applies that boundary to text and allowed keys:
+Secure/Normal retain exact-pane grants; YOLO uses a registered session or exact
+`pane:%N` without an arm prompt; the typing node re-resolves the read-side pane
+identity and records the operation-policy snapshot and source-linked Receipt.
+The Desk keeps rename/kill controls separate pending factory/destructive
+classification; this slice does not claim posture authority for them.
+
 Bundling note: this initial Phase-93 scaffold is intentionally committed with
 the HS-93-01 through HS-93-05 in-progress implementation slices because the
 owner directed that the complete shared working tree ship together. No story is

--- a/tests/fixtures/db_schema_canonical.txt
+++ b/tests/fixtures/db_schema_canonical.txt
@@ -808,7 +808,9 @@ table steering_audit: CREATE TABLE steering_audit (
     grounding_json TEXT NOT NULL DEFAULT '[]',
     submit INTEGER NOT NULL DEFAULT 1,
     outcome TEXT NOT NULL,
-    detail TEXT
+    detail TEXT,
+    operation_json TEXT NOT NULL DEFAULT '{}',
+    policy_snapshot_json TEXT NOT NULL DEFAULT '{}'
 )
 table topics: CREATE TABLE topics (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/integration/test_history_slack_surfaces.py
+++ b/tests/integration/test_history_slack_surfaces.py
@@ -1,11 +1,11 @@
-"""HS-61-02 — the Send-to-Slack surfaces: gating, wiring, honest copy.
+"""Send-to-Slack surfaces: capability gating, policy, and wiring.
 
 The conditions under test: the aftercare response carries the capability
 flag (a bool, never the URL); the history page's buttons are gated on that
 flag, so an unconfigured install renders no Slack affordance at all; the
-buttons wire to the export route through `proposeSlack`; the settings field
-ships with the honest copy (what is sent, only after approval, only to this
-URL's host, stored locally).
+buttons wire to the export route through `proposeSlack`; and the result uses
+the central operation-policy snapshot rather than assuming every posture asks
+for approval.
 """
 from __future__ import annotations
 
@@ -127,17 +127,20 @@ def test_history_buttons_are_gated_on_the_flag():
     assert "Send digest to Slack" in page and "Send follow-up to Slack" in page
     assert "aftercare.slack_configured" in page
     assert 'proposeSlack("digest")' in page and 'proposeSlack("followup")' in page
-    assert "Each creates an exact-message proposed action" in page
-    assert "configured Slack destination" in page
+    assert 'apiFetch<JsonRecord>("/api/authority/policy")' in page
+    assert "controlModeDescription" in page
 
 
-def test_proposal_guard_copy_tells_the_per_target_truth():
-    # The guard copy tells the per-target truth, in one short line each
-    # (HS-62-02 swept the "Nothing runs without your approval" preamble).
+def test_proposal_rows_render_the_central_policy_and_refusal_truth():
     page = " ".join(
         (_REPO / "web/src/pages/HistoryPage.tsx").read_text().split()
     )
-    assert "Approval sends it to the configured Slack destination" in page
+    assert "row.policy_snapshot" in page and "row.operation" in page
+    assert 'policy.outcome === "refused"' in page
+    assert 'row.status === "proposed" && !refused' in page
+    assert "operation.effect_class" in page
+    assert "operation.destination" in page
+    assert "policy.authority_basis" in page
     assert "Proposed external actions appear here before execution" in page
 
 

--- a/tests/integration/test_web_companion_github.py
+++ b/tests/integration/test_web_companion_github.py
@@ -25,11 +25,11 @@ from fastapi.testclient import TestClient
 
 pytestmark = [pytest.mark.requires_meeting]
 
-import holdspeak.config as config_module
-import holdspeak.web.routes.actuator_shared as actuator_shared
-from holdspeak.config import Config
-from holdspeak.db import Database, get_database, reset_database
-from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
+import holdspeak.config as config_module  # noqa: E402
+import holdspeak.web.routes.actuator_shared as actuator_shared  # noqa: E402
+from holdspeak.config import Config  # noqa: E402
+from holdspeak.db import get_database, reset_database  # noqa: E402
+from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks  # noqa: E402
 
 REPO = "acme/app"
 ISSUE_URL = "https://github.com/acme/app/issues/42"
@@ -73,6 +73,12 @@ def settings_path(tmp_path, monkeypatch):
 def _configure(settings_path, repo=REPO):
     config = Config.load()
     config.meeting.companion_github_repo = repo
+    config.save(path=settings_path)
+
+
+def _set_control_mode(settings_path, mode):
+    config = Config.load()
+    config.control_mode = mode
     config.save(path=settings_path)
 
 
@@ -175,6 +181,41 @@ def test_approval_files_the_issue_and_returns_the_url(client, db, settings_path,
     argv = gh.calls[0]
     assert argv[:3] == ["gh", "issue", "create"]
     assert REPO in argv and "Wire onboarding" in argv and "the body" in argv
+
+
+@pytest.mark.integration
+def test_yolo_files_to_the_registered_repo_without_a_decision(
+    client, db, settings_path, gh
+):
+    _configure(settings_path)
+    _set_control_mode(settings_path, "yolo")
+    proposal = client.post(
+        PROPOSE,
+        json={"text": "the body", "title": "Wire onboarding"},
+    ).json()["proposal"]
+    assert proposal["status"] == "executed"
+    assert proposal["policy_snapshot"]["authority_basis"] == "control_posture"
+    assert len(gh.calls) == 1
+
+
+@pytest.mark.integration
+def test_yolo_refuses_an_unregistered_repo_without_filing_or_prompting(
+    client, db, settings_path, gh
+):
+    _configure(settings_path, repo="host/default")
+    _set_control_mode(settings_path, "yolo")
+    proposal = client.post(
+        PROPOSE,
+        json={"text": "the body", "title": "Ship", "repo": "other/repo"},
+    ).json()["proposal"]
+    assert proposal["status"] == "proposed"
+    assert proposal["policy_snapshot"]["outcome"] == "refused"
+    assert proposal["policy_snapshot"]["reason_code"] == "registered_destination_required"
+    assert gh.calls == []
+    assert client.get("/api/mesh/inbox").json()["counts"]["pending_approvals"] == 0
+    decision = _decide(client, proposal["id"], "approved")
+    assert decision.status_code == 400
+    assert "refuses" in decision.json()["error"]
 
 
 @pytest.mark.integration

--- a/tests/integration/test_web_companion_slack.py
+++ b/tests/integration/test_web_companion_slack.py
@@ -70,6 +70,12 @@ def _configure_slack(settings_path, url=URL):
     config.save(path=settings_path)
 
 
+def _set_control_mode(settings_path, mode):
+    config = Config.load()
+    config.control_mode = mode
+    config.save(path=settings_path)
+
+
 class _BroadcastSpy:
     def __init__(self):
         self.events: list[tuple[str, dict]] = []
@@ -278,6 +284,106 @@ def test_approval_posts_the_preview_byte_equal(client, db, settings_path, posts,
 
     audit = db.actuators.list_audit(proposal["id"])
     assert [a.to_status for a in audit] == ["proposed", "approved", "executed"]
+
+
+@pytest.mark.integration
+def test_yolo_executes_configured_slack_without_a_prompt_and_returns_receipt(
+    client, db, settings_path, posts, broadcasts
+):
+    _configure_slack(settings_path)
+    _set_control_mode(settings_path, "yolo")
+    db.notes.upsert(
+        note_id="n-yolo",
+        title="Release checklist",
+        body_markdown="release is ready",
+    )
+
+    response = client.post(
+        PROPOSE,
+        json={
+            "text": "release is ready",
+            "title": "Release checklist",
+            "source_ref": "note:n-yolo",
+        },
+    )
+    assert response.status_code == 200, response.text
+    proposal = response.json()["proposal"]
+    assert proposal["status"] == "executed"
+    policy = proposal["policy_snapshot"]
+    assert {
+        key: policy[key]
+        for key in (
+            "mode",
+            "policy_version",
+            "outcome",
+            "reason_code",
+            "authority_basis",
+            "next_state",
+            "eligible",
+            "requires_authorization",
+            "requires_grant",
+        )
+    } == {
+        "mode": "yolo",
+        "policy_version": "operation-policy/v2",
+        "outcome": "allowed",
+        "reason_code": "configured_destination_posture_allowed",
+        "authority_basis": "control_posture",
+        "next_state": "execute_now",
+        "eligible": True,
+        "requires_authorization": False,
+        "requires_grant": False,
+    }
+    assert len(posts) == 1
+    assert posts[0][1] == {"text": proposal["preview"]}
+    assert client.get("/api/mesh/inbox").json()["counts"]["pending_approvals"] == 0
+
+    receipt = db.projections.list(subject_ref="note:n-yolo")["projections"][0]
+    assert receipt["projection_kind"] == "receipt"
+    assert receipt["authority_basis"] == "control_posture"
+    assert receipt["control_mode"] == "yolo"
+    assert receipt["policy_version"] == "operation-policy/v2"
+    assert receipt["effect_class"] == "slack/post_message"
+    audit = db.actuators.list_audit(proposal["id"])
+    assert [row.to_status for row in audit] == ["proposed", "approved", "executed"]
+    assert audit[1].actor == "control-posture:yolo"
+
+    repeated = client.post(
+        PROPOSE,
+        json={
+            "text": "release is ready",
+            "title": "Release checklist",
+            "source_ref": "note:n-yolo",
+        },
+    ).json()["proposal"]
+    assert repeated["id"] == proposal["id"]
+    assert repeated["status"] == "executed"
+    assert len(posts) == 1
+
+
+@pytest.mark.integration
+def test_posture_change_never_widens_an_existing_proposal(
+    client, db, settings_path, posts, broadcasts
+):
+    _configure_slack(settings_path)
+    proposal = client.post(PROPOSE, json={"text": "captured normal"}).json()[
+        "proposal"
+    ]
+    assert proposal["policy_snapshot"]["mode"] == "neutral"
+    _set_control_mode(settings_path, "yolo")
+
+    repeated = client.post(PROPOSE, json={"text": "captured normal"}).json()[
+        "proposal"
+    ]
+    assert repeated["id"] == proposal["id"]
+    assert repeated["status"] == "proposed"
+    assert repeated["policy_snapshot"]["mode"] == "neutral"
+    assert posts == []
+
+    final = _decide(client, proposal["id"], "approved").json()["proposal"]
+    assert final["status"] == "executed"
+    assert final["policy_snapshot"]["mode"] == "neutral"
+    assert final["policy_snapshot"]["authority_basis"] == "per_action_decision"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_web_companion_webhook.py
+++ b/tests/integration/test_web_companion_webhook.py
@@ -24,11 +24,11 @@ from fastapi.testclient import TestClient
 
 pytestmark = [pytest.mark.requires_meeting]
 
-import holdspeak.config as config_module
-import holdspeak.plugins.builtin.webhook_post_actuator as webhook_module
-from holdspeak.config import Config
-from holdspeak.db import Database, get_database, reset_database
-from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
+import holdspeak.config as config_module  # noqa: E402
+import holdspeak.plugins.builtin.webhook_post_actuator as webhook_module  # noqa: E402
+from holdspeak.config import Config  # noqa: E402
+from holdspeak.db import get_database, reset_database  # noqa: E402
+from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks  # noqa: E402
 
 URL = "https://hooks.example.com/services/secret-hook"
 PROPOSE = "/api/desk/actuators/webhook/propose"
@@ -59,6 +59,12 @@ def settings_path(tmp_path, monkeypatch):
 def _configure(settings_path, url=URL):
     config = Config.load()
     config.meeting.companion_webhook_url = url
+    config.save(path=settings_path)
+
+
+def _set_control_mode(settings_path, mode):
+    config = Config.load()
+    config.control_mode = mode
     config.save(path=settings_path)
 
 
@@ -143,6 +149,20 @@ def test_approval_posts_the_preview_byte_equal(client, db, settings_path, posts,
     url, body = posts[0]
     assert url == URL
     assert body == {"text": proposal["preview"]}
+
+
+@pytest.mark.integration
+def test_yolo_executes_the_configured_webhook_without_a_decision(
+    client, db, settings_path, posts, broadcasts
+):
+    _configure(settings_path)
+    _set_control_mode(settings_path, "yolo")
+    proposal = client.post(PROPOSE, json={"text": "the brief"}).json()["proposal"]
+    assert proposal["status"] == "executed"
+    assert proposal["policy_snapshot"]["authority_basis"] == "control_posture"
+    assert proposal["policy_snapshot"]["mode"] == "yolo"
+    assert len(posts) == 1
+    assert posts[0][1] == {"text": proposal["preview"]}
 
 
 @pytest.mark.integration

--- a/tests/integration/test_web_history_archive.py
+++ b/tests/integration/test_web_history_archive.py
@@ -16,8 +16,9 @@ def test_history_uses_bounded_archive_and_detail_sections() -> None:
 def test_history_keeps_approval_and_export_governance() -> None:
     page = (_REPO / "web/src/pages/HistoryPage.tsx").read_text()
     assert '"approved"' in page and '"rejected"' in page
-    assert 'row.status !== "proposed"' in page
+    assert 'row.status === "proposed" && !refused' in page
+    assert 'policy.outcome === "refused"' in page
+    assert "row.policy_snapshot" in page and "row.operation" in page
     assert "apiBlob" in page
-    assert "Each creates an exact-message proposed action" in page
-    assert "Approval sends" in page
+    assert "commitment" in page and "authority_basis" in page
     assert "ConfirmAction" in page

--- a/tests/integration/test_web_slack_export.py
+++ b/tests/integration/test_web_slack_export.py
@@ -27,14 +27,17 @@ from fastapi.testclient import TestClient
 
 pytestmark = [pytest.mark.requires_meeting]
 
-import holdspeak.config as config_module
-import holdspeak.plugins.builtin.webhook_post_actuator as webhook_module
-from holdspeak.config import Config
-from holdspeak.db import Database, get_database, reset_database
-from holdspeak.meeting_session import IntelSnapshot, MeetingState
-from holdspeak.plugins.actuator_executor import ActuatorExecutionError, ActuatorExecutor
-from holdspeak.slack_export import build_slack_connector
-from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
+import holdspeak.config as config_module  # noqa: E402
+import holdspeak.plugins.builtin.webhook_post_actuator as webhook_module  # noqa: E402
+from holdspeak.config import Config  # noqa: E402
+from holdspeak.db import Database, get_database, reset_database  # noqa: E402
+from holdspeak.meeting_session import IntelSnapshot, MeetingState  # noqa: E402
+from holdspeak.plugins.actuator_executor import (  # noqa: E402
+    ActuatorExecutionError,
+    ActuatorExecutor,
+)
+from holdspeak.slack_export import build_slack_connector  # noqa: E402
+from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks  # noqa: E402
 
 URL = "https://hooks.slack.com/services/T0/B0/secret-credential"
 
@@ -64,6 +67,12 @@ def settings_path(tmp_path, monkeypatch):
 def _configure_slack(settings_path, url=URL):
     config = Config.load()
     config.meeting.slack_webhook_url = url
+    config.save(path=settings_path)
+
+
+def _set_control_mode(settings_path, mode):
+    config = Config.load()
+    config.control_mode = mode
     config.save(path=settings_path)
 
 
@@ -273,6 +282,22 @@ def test_approval_posts_the_preview_byte_equal(
     # The audit trail is the full lifecycle.
     audit = db.actuators.list_audit(proposal["id"])
     assert [a.to_status for a in audit] == ["proposed", "approved", "executed"]
+
+
+@pytest.mark.integration
+def test_yolo_sends_configured_meeting_export_without_a_decision(
+    client, db, settings_path, seeded, posts, broadcasts
+):
+    _configure_slack(settings_path)
+    _set_control_mode(settings_path, "yolo")
+    proposal = client.post(
+        "/api/meetings/m1/export/slack", json={"what": "digest"}
+    ).json()["proposal"]
+    assert proposal["status"] == "executed"
+    assert proposal["policy_snapshot"]["authority_basis"] == "control_posture"
+    assert proposal["policy_snapshot"]["mode"] == "yolo"
+    assert len(posts) == 1
+    assert posts[0][1] == {"text": proposal["preview"]}
 
 
 @pytest.mark.integration

--- a/tests/uat/test_conductor_api.py
+++ b/tests/uat/test_conductor_api.py
@@ -92,8 +92,8 @@ def test_features_route(client):
     assert r.status_code == 200
     body = r.json()
     assert body["feature_count"] > 200
-    # Phase numbers are zero-based in the record: 0 through 92 is 93 phases.
-    assert body["phases_total"] == 93
+    # Phase numbers are zero-based in the record: 0 through 93 is 94 phases.
+    assert body["phases_total"] == 94
 
 
 def test_packs_and_pack_detail(client):

--- a/tests/unit/test_authority_grants.py
+++ b/tests/unit/test_authority_grants.py
@@ -97,3 +97,41 @@ def test_proposal_axes_are_separate_and_queryable(tmp_path) -> None:
     running = db.actuators.mark_execution_state(approved.id, "running")
     assert running.status == "approved"
     assert running.execution_state == "running"
+
+
+def test_proposal_captures_policy_once_for_future_operations(tmp_path) -> None:
+    db = Database(tmp_path / "authority.db")
+    first = db.actuators.record_proposal(
+        meeting_id=None,
+        origin="desk",
+        window_id="desk:1",
+        plugin_id="slack_export",
+        plugin_version="1",
+        idempotency_key="captured-posture",
+        target="slack",
+        action="post_message",
+        preview="Send the digest",
+        payload={"body": {"text": "digest"}},
+        control_mode="yolo",
+        fixed_destination=True,
+    )
+    assert first.policy_snapshot["mode"] == "yolo"
+    assert first.policy_snapshot["policy_version"] == "operation-policy/v2"
+    assert first.policy_snapshot["authority_basis"] == "control_posture"
+
+    repeated = db.actuators.record_proposal(
+        meeting_id=None,
+        origin="desk",
+        window_id="desk:1",
+        plugin_id="slack_export",
+        plugin_version="1",
+        idempotency_key="captured-posture",
+        target="slack",
+        action="post_message",
+        preview="Send the digest",
+        payload={"body": {"text": "digest"}},
+        control_mode="safe",
+        fixed_destination=True,
+    )
+    assert repeated.id == first.id
+    assert repeated.policy_snapshot == first.policy_snapshot

--- a/tests/unit/test_authority_routes.py
+++ b/tests/unit/test_authority_routes.py
@@ -29,6 +29,9 @@ def test_policy_and_control_mode_are_one_future_operation_contract(rig) -> None:
     assert policy.status_code == 200
     assert policy.json()["control_mode"] == "neutral"
     assert policy.json()["control_mode_label"] == "Normal"
+    assert policy.json()["policy_version"] == "operation-policy/v2"
+    assert policy.json()["unsupported_family_behavior"] == "refused"
+    assert policy.json()["applies_to"] == "future_operations_only"
     assert policy.json()["precedence"][0] == "hard_invariants"
     assert "schema_safety" in policy.json()["hard_invariants"]
 
@@ -59,9 +62,11 @@ def test_grants_issue_only_from_fixed_proposal_and_expose_use_receipts(rig) -> N
         preview="Create issue",
         payload={"repo": "acme/app", "title": "Follow up"},
     )
-    neutral = client.post("/api/authority/grants", json={"proposal_id": proposal.id})
-    assert neutral.status_code == 409
     client.put("/api/authority/control-mode", json={"control_mode": "yolo"})
+    yolo = client.post("/api/authority/grants", json={"proposal_id": proposal.id})
+    assert yolo.status_code == 409
+    assert "captured posture" in yolo.json()["error"]
+    client.put("/api/authority/control-mode", json={"control_mode": "Normal"})
     issued = client.post(
         "/api/authority/grants",
         json={

--- a/tests/unit/test_authority_routes.py
+++ b/tests/unit/test_authority_routes.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 import holdspeak.config as config_module
 import holdspeak.db as hsdb
+from holdspeak import coder_steering
 from holdspeak.db import Database, reset_database
 from holdspeak.web.context import WebContext
 from holdspeak.web.routes import build_authority_router
@@ -14,12 +15,14 @@ from holdspeak.web.routes import build_authority_router
 @pytest.fixture
 def rig(tmp_path, monkeypatch):
     reset_database()
+    coder_steering.clear_grants()
     db = Database(tmp_path / "authority-routes.db")
     monkeypatch.setattr(hsdb, "get_database", lambda *args, **kwargs: db)
     monkeypatch.setattr(config_module, "CONFIG_FILE", tmp_path / "config.json")
     app = FastAPI()
     app.include_router(build_authority_router(WebContext(get_state=lambda: {})))
     yield db, TestClient(app)
+    coder_steering.clear_grants()
     reset_database()
 
 
@@ -35,9 +38,19 @@ def test_policy_and_control_mode_are_one_future_operation_contract(rig) -> None:
     assert policy.json()["precedence"][0] == "hard_invariants"
     assert "schema_safety" in policy.json()["hard_invariants"]
 
+    coder_steering.arm(
+        "claude:s1",
+        "%5",
+        runner=lambda argv, cwd=None: type(
+            "Result", (), {"returncode": 0, "stdout": "%5\n", "stderr": ""}
+        )(),
+    )
+
     changed = client.put("/api/authority/control-mode", json={"control_mode": "Secure"})
     assert changed.status_code == 200
     assert changed.json()["control_mode_label"] == "Secure"
+    assert changed.json()["revoked_coder_grants"] == 1
+    assert coder_steering.active_grants() == {}
     assert changed.json()["applies_to"] == "future_operations_only"
     assert client.get("/api/authority/policy").json()["control_mode"] == "safe"
     assert (

--- a/tests/unit/test_coder_steering_deliver.py
+++ b/tests/unit/test_coder_steering_deliver.py
@@ -162,6 +162,65 @@ def test_grounding_refs_ride_the_audit_row() -> None:
     assert rec.rows[0]["grounding"] == ["meeting:m1", "artifact:a2"]
 
 
+def test_yolo_posture_delivers_without_a_grant_to_the_expected_pane() -> None:
+    rec = _Recorder()
+    operation = {
+        "family": "coder_steering",
+        "effect_class": "terminal/type_text_and_keys",
+        "destination": "%9",
+    }
+    policy = {
+        "mode": "yolo",
+        "outcome": "allowed",
+        "authority_basis": "control_posture",
+        "reason_code": "registered_steering_posture_allowed",
+        "policy_version": "operation-policy/v2",
+    }
+    result = deliver(
+        "claude:a",
+        "ship it",
+        current_target="hs:0.0",
+        expected_pane_id="%9",
+        operation=operation,
+        policy_snapshot=policy,
+        runner=_identity_runner("%9"),
+        transport=rec.transport,
+        audit=rec.audit,
+    )
+    assert result["status"] == "delivered"
+    assert rec.sent == [{"pane": "%9", "text": "ship it", "submit": True}]
+    assert result["receipt"]["authority_basis"] == "control_posture"
+    assert rec.rows[0]["operation"] == operation
+    assert rec.rows[0]["policy_snapshot"] == policy
+
+
+def test_yolo_posture_refuses_a_changed_or_missing_expected_pane() -> None:
+    rec = _Recorder()
+    policy = {"outcome": "allowed", "authority_basis": "control_posture"}
+    changed = deliver(
+        "claude:a",
+        "old target",
+        current_target="hs:0.0",
+        expected_pane_id="%9",
+        policy_snapshot=policy,
+        runner=_identity_runner("%13"),
+        transport=rec.transport,
+        audit=rec.audit,
+    )
+    assert changed["status"] == "pane_mismatch"
+    missing = deliver(
+        "claude:a",
+        "no target",
+        current_target="hs:0.0",
+        policy_snapshot=policy,
+        runner=_identity_runner("%9"),
+        transport=rec.transport,
+        audit=rec.audit,
+    )
+    assert missing["status"] == "pane_identity_required"
+    assert rec.sent == []
+
+
 def test_a_broken_audit_sink_never_blocks_the_refusal() -> None:
     def exploding_audit(**kw):
         raise RuntimeError("db is gone")

--- a/tests/unit/test_coder_steering_keys.py
+++ b/tests/unit/test_coder_steering_keys.py
@@ -147,3 +147,25 @@ def test_recycled_pane_refuses_and_revokes_for_keys_too() -> None:
     assert result["status"] == "pane_mismatch"
     assert result.get("revoked") is True
     assert rec.sent == []  # nothing typed into the wrong pane
+
+
+def test_yolo_posture_keeps_the_key_allow_list_and_skips_the_grant() -> None:
+    rec = _Recorder()
+    policy = {"outcome": "allowed", "authority_basis": "control_posture"}
+    result = deliver_keys(
+        "claude:a", ["C-c"],
+        current_target="hs:0.0", expected_pane_id="%9",
+        policy_snapshot=policy, runner=_identity_runner("%9"),
+        transport=rec.transport, audit=rec.audit,
+    )
+    assert result["status"] == "delivered"
+    assert rec.sent == [{"pane": "%9", "keys": [("named", "C-c")]}]
+
+    refused = deliver_keys(
+        "claude:a", ["sudo reboot"],
+        current_target="hs:0.0", expected_pane_id="%9",
+        policy_snapshot=policy, runner=_identity_runner("%9"),
+        transport=rec.transport, audit=rec.audit,
+    )
+    assert refused["status"] == "unknown_key"
+    assert len(rec.sent) == 1

--- a/tests/unit/test_db_steering_audit.py
+++ b/tests/unit/test_db_steering_audit.py
@@ -27,6 +27,11 @@ def test_record_and_list_roundtrip_newest_first(db) -> None:
         grounding=["meeting:m1"],
         submit=True,
         outcome="delivered",
+        operation={"effect_class": "terminal/type_text_and_keys", "destination": "%5"},
+        policy_snapshot={
+            "mode": "yolo", "authority_basis": "control_posture",
+            "policy_version": "operation-policy/v2",
+        },
     )
     second = db.steering.record(
         session_key="claude:a",
@@ -45,6 +50,8 @@ def test_record_and_list_roundtrip_newest_first(db) -> None:
     oldest = entries[1]
     assert oldest.grounding == ["meeting:m1"]
     assert oldest.submit is True
+    assert oldest.operation["destination"] == "%5"
+    assert oldest.policy_snapshot["authority_basis"] == "control_posture"
     assert oldest.text_sha256 == hashlib.sha256(b"ship it").hexdigest()
 
 
@@ -70,8 +77,8 @@ def test_list_filters_by_session_and_clamps_limit(db) -> None:
     assert len(db.steering.list(limit=2)) == 2
 
 
-def test_v11_database_upgrades_to_v12_with_the_table(tmp_path) -> None:
-    # A stamped v11 file (no steering_audit) must land the table on open.
+def test_v11_database_upgrades_to_current_steering_receipt_shape(tmp_path) -> None:
+    # A stamped v11 file (no steering_audit) lands the table and policy columns.
     import sqlite3
 
     path = tmp_path / "old.db"
@@ -84,4 +91,46 @@ def test_v11_database_upgrades_to_v12_with_the_table(tmp_path) -> None:
     reset_database()
     db = Database(path)
     assert db.steering.list() == []
+    with db._connection() as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(steering_audit)")
+        }
+    assert {"operation_json", "policy_snapshot_json"}.issubset(columns)
+    reset_database()
+
+
+def test_v21_steering_rows_gain_empty_policy_snapshots_without_data_loss(
+    tmp_path,
+) -> None:
+    import sqlite3
+
+    path = tmp_path / "v21.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, "
+            "applied_at TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        conn.execute("INSERT INTO schema_version (version) VALUES (21)")
+        conn.execute(
+            """CREATE TABLE steering_audit (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               ts TEXT NOT NULL DEFAULT (datetime('now')),
+               session_key TEXT NOT NULL, agent TEXT NOT NULL DEFAULT '',
+               pane_id TEXT, text_sha256 TEXT NOT NULL,
+               text_head TEXT NOT NULL DEFAULT '',
+               grounding_json TEXT NOT NULL DEFAULT '[]',
+               submit INTEGER NOT NULL DEFAULT 1,
+               outcome TEXT NOT NULL, detail TEXT)"""
+        )
+        conn.execute(
+            """INSERT INTO steering_audit
+               (session_key,text_sha256,text_head,outcome)
+               VALUES ('claude:kept','hash','kept','delivered')"""
+        )
+    reset_database()
+    db = Database(path)
+    entry = db.steering.list()[0]
+    assert entry.session_key == "claude:kept"
+    assert entry.operation == {}
+    assert entry.policy_snapshot == {}
     reset_database()

--- a/tests/unit/test_mesh_inbox.py
+++ b/tests/unit/test_mesh_inbox.py
@@ -95,6 +95,10 @@ def test_inbox_aggregates_jobs_and_pending_proposals(env) -> None:
     assert desk_row["preview"] == "Digest → #eng-updates"
     assert desk_row["commitment"]["approve"] == "Approve and send to Slack"
     assert desk_row["authorization_state"] == "proposed"
+    assert desk_row["operation"]["effect_class"] == "slack/send_message"
+    assert desk_row["policy_snapshot"]["mode"] == "neutral"
+    assert desk_row["policy_snapshot"]["policy_version"] == "operation-policy/v2"
+    assert desk_row["policy_snapshot"]["next_state"] == "awaiting_authorization"
     for p in body["proposals"]:
         assert "payload" not in p
 

--- a/tests/unit/test_operation_policy.py
+++ b/tests/unit/test_operation_policy.py
@@ -65,14 +65,29 @@ def test_dictation_matrix() -> None:
     )
 
 
-@pytest.mark.parametrize("mode", ["safe", "neutral", "yolo"])
-def test_steering_always_requires_an_exact_grant(mode: str) -> None:
+@pytest.mark.parametrize("mode", ["safe", "neutral"])
+def test_secure_and_normal_steering_require_an_exact_grant(mode: str) -> None:
     operation = _operation("coder_steering")
     assert resolve_policy(operation, mode=mode).outcome == "grant_required"
     assert (
         resolve_policy(operation, mode=mode, grant=_grant(operation)).outcome
         == "allowed"
     )
+
+
+def test_yolo_steering_uses_registered_pane_posture_authority() -> None:
+    registered = _operation("coder_steering", fixed_destination=True)
+    decision = resolve_policy(registered, mode="yolo")
+    assert decision.outcome == "allowed"
+    assert decision.reason_code == "registered_steering_posture_allowed"
+    assert decision.authority_basis == "control_posture"
+    assert decision.requires_grant is False
+
+    unregistered = resolve_policy(
+        _operation("coder_steering", fixed_destination=False), mode="yolo"
+    )
+    assert unregistered.outcome == "refused"
+    assert unregistered.reason_code == "registered_steering_destination_required"
 
 
 def test_external_write_matrix_and_explicit_authorization() -> None:
@@ -100,6 +115,14 @@ def test_grant_scope_mismatch_refuses() -> None:
         resolve_policy(operation, mode="neutral", grant=grant).outcome
         == "authorization_required"
     )
+
+
+def test_grant_from_a_different_control_mode_does_not_authorize() -> None:
+    operation = _operation("coder_steering", fixed_destination=True)
+    grant = _grant(operation)
+    grant["control_mode"] = "safe"
+    decision = resolve_policy(operation, mode="neutral", grant=grant)
+    assert decision.outcome == "grant_required"
 
 
 def test_sync_matrix_and_unsupported_fail_closed() -> None:

--- a/tests/unit/test_operation_policy.py
+++ b/tests/unit/test_operation_policy.py
@@ -79,9 +79,14 @@ def test_external_write_matrix_and_explicit_authorization() -> None:
     operation = _operation("external_write")
     assert resolve_policy(operation, mode="safe").outcome == "authorization_required"
     assert resolve_policy(operation, mode="neutral").outcome == "authorization_required"
-    assert resolve_policy(operation, mode="yolo").outcome == "grant_required"
-    reusable = resolve_policy(operation, mode="yolo", grant=_grant(operation))
-    assert reusable.reason_code == "fixed_destination_grant_active"
+    automatic = resolve_policy(operation, mode="yolo")
+    assert automatic.outcome == "allowed"
+    assert automatic.reason_code == "configured_destination_posture_allowed"
+    assert automatic.authority_basis == "control_posture"
+    assert automatic.next_state == "execute_now"
+    reusable = resolve_policy(operation, mode="neutral", grant=_grant(operation))
+    assert reusable.reason_code == "scoped_grant_active"
+    assert reusable.authority_basis == "scoped_grant"
     for mode in ("safe", "neutral", "yolo"):
         decision = resolve_policy(operation, mode=mode, explicit_authorization=True)
         assert decision.outcome == "allowed"
@@ -92,19 +97,30 @@ def test_grant_scope_mismatch_refuses() -> None:
     grant = _grant(operation)
     grant["project_scope"] = "acme/other"
     assert (
-        resolve_policy(operation, mode="yolo", grant=grant).outcome == "grant_required"
+        resolve_policy(operation, mode="neutral", grant=grant).outcome
+        == "authorization_required"
     )
 
 
-def test_sync_matrix_and_unsupported_fail_to_current_behavior() -> None:
+def test_sync_matrix_and_unsupported_fail_closed() -> None:
     sync = _operation("sync_cadence")
     assert resolve_policy(sync, mode="safe").outcome == "authorization_required"
     assert resolve_policy(sync, mode="neutral").outcome == "allowed"
     assert resolve_policy(sync, mode="yolo").outcome == "allowed"
     unknown = _operation("future_arbitrary_shell")
     decision = resolve_policy(unknown, mode="yolo")
-    assert decision.outcome == "current_behavior"
-    assert decision.reason_code == "unsupported_family_current_behavior"
+    assert decision.outcome == "refused"
+    assert decision.reason_code == "unsupported_operation_family"
+    assert decision.eligible is False
+
+
+def test_yolo_refuses_an_unregistered_external_destination() -> None:
+    operation = _operation("external_write", fixed_destination=False)
+    decision = resolve_policy(operation, mode="yolo")
+    assert decision.outcome == "refused"
+    assert decision.reason_code == "registered_destination_required"
+    assert decision.authority_basis == "none"
+    assert decision.next_state == "refused"
 
 
 def test_steering_ttl_presets_cap_future_arms() -> None:

--- a/tests/unit/test_steering_chokepoint.py
+++ b/tests/unit/test_steering_chokepoint.py
@@ -83,21 +83,20 @@ def test_send_keys_to_pane_call_sites_are_pinned() -> None:
     )
 
 
-def test_the_chokepoint_itself_checks_the_grant_before_the_transport() -> None:
-    # Mechanical shape check: inside deliver(), require_grant appears
-    # before the send_text_to_pane import/call.
+def test_the_chokepoint_resolves_authority_before_the_transport() -> None:
+    # The central decision selects exact grant or registered-pane posture;
+    # either invariant check must happen before the text transport.
     body = (REPO / "holdspeak" / "coder_steering.py").read_text(encoding="utf-8")
     deliver_src = body.split("def deliver(", 1)[1]
-    assert deliver_src.index("require_grant") < deliver_src.index(
+    assert deliver_src.index("_require_delivery_authority") < deliver_src.index(
         "send_text_to_pane"
     )
 
 
-def test_the_key_chokepoint_checks_the_grant_before_the_transport() -> None:
-    # The same shape for deliver_keys: require_grant before send_keys_to_pane.
+def test_the_key_chokepoint_resolves_authority_before_the_transport() -> None:
     body = (REPO / "holdspeak" / "coder_steering.py").read_text(encoding="utf-8")
     deliver_src = body.split("def deliver_keys(", 1)[1]
-    assert deliver_src.index("require_grant") < deliver_src.index(
+    assert deliver_src.index("_require_delivery_authority") < deliver_src.index(
         "send_keys_to_pane"
     )
 

--- a/tests/unit/test_web_routes_coders_arm.py
+++ b/tests/unit/test_web_routes_coders_arm.py
@@ -199,6 +199,53 @@ def test_peek_envelope_carries_the_grant_state(monkeypatch, client) -> None:
     after = client.get("/api/coders/claude:abc/peek").json()
     assert after["grant"]["armed"] is True
     assert after["grant"]["expires_in_seconds"] > 0
+    assert after["pane_id"] == "%3"
+    assert after["policy"]["authority_basis"] == "scoped_grant"
+
+
+def test_yolo_peek_exposes_direct_registered_pane_policy(monkeypatch, client) -> None:
+    monkeypatch.setattr(
+        Config, "load", classmethod(lambda cls: SimpleNamespace(control_mode="yolo"))
+    )
+    _register(monkeypatch, _session())
+    monkeypatch.setattr(
+        coder_steering,
+        "peek_pane",
+        lambda target, *, lines, last_hash: {
+            "status": "live",
+            "hash": "h",
+            "lines": [],
+        },
+    )
+    body = client.get("/api/coders/claude:abc/peek").json()
+    assert body["grant"]["armed"] is False
+    assert body["pane_id"] == "%3"
+    assert body["policy"]["outcome"] == "allowed"
+    assert body["policy"]["authority_basis"] == "control_posture"
+    assert body["commitment"]["destination"] == "pane %3"
+
+
+def test_peek_arm_commitment_names_the_canonical_pane_not_a_tmux_alias(
+    monkeypatch, client
+) -> None:
+    _register(
+        monkeypatch,
+        _session(
+            tmux_pane=None,
+            tmux_session="work",
+            tmux_window="2",
+            tmux_pane_index="1",
+        ),
+    )
+    _pin_identity(monkeypatch, "%8")
+    monkeypatch.setattr(
+        coder_steering,
+        "peek_pane",
+        lambda target, *, lines, last_hash: {"status": "live", "lines": []},
+    )
+    body = client.get("/api/coders/claude:abc/peek").json()
+    assert body["pane_id"] == "%8"
+    assert body["arm_commitment"] == "Arm pane %8 for 15 minutes"
 
 
 def test_grants_route_lists_live_grants(monkeypatch, client) -> None:

--- a/tests/unit/test_web_routes_coders_steer.py
+++ b/tests/unit/test_web_routes_coders_steer.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 import holdspeak.agent_context as agent_context
 import holdspeak.tmux_transport as tmux_transport
 from holdspeak import coder_steering
+from holdspeak.config import Config
 from holdspeak.db import core as dbcore
 from holdspeak.web.context import WebContext
 from holdspeak.web.routes.system.coder_steering_routes import (
@@ -52,6 +53,10 @@ def env(tmp_path, monkeypatch):
     coder_steering.clear_grants()
     dbcore.reset_database()
     db = dbcore.Database(tmp_path / "holdspeak.db")
+    monkeypatch.setattr(
+        Config, "load",
+        classmethod(lambda cls: SimpleNamespace(control_mode="neutral")),
+    )
     monkeypatch.setattr("holdspeak.db.get_database", lambda *a, **k: db)
     frames: list = []
     app = FastAPI()
@@ -127,6 +132,67 @@ def test_armed_steer_delivers_exactly_as_composed(env) -> None:
     assert trail[0].pane_id == "%3"
 
 
+def test_yolo_steers_registered_pane_without_an_arm_and_returns_receipt(env) -> None:
+    env.monkeypatch.setattr(
+        Config, "load", classmethod(lambda cls: SimpleNamespace(control_mode="yolo"))
+    )
+    _register(env.monkeypatch, _session())
+    _pin_identity(env.monkeypatch, "%3")
+    res = env.client.post(
+        "/api/coders/claude:abc/steer",
+        json={"text": "ship it", "expected_pane_id": "%3"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "delivered"
+    assert body["policy"]["authority_basis"] == "control_posture"
+    assert body["policy"]["reason_code"] == "registered_steering_posture_allowed"
+    assert body["receipt"] == {
+        "id": f"steering:{body['audit_id']}",
+        "source_ref": "coder_session:claude:abc",
+        "actual_destination": "%3",
+        "authority_basis": "control_posture",
+        "control_mode": "yolo",
+        "policy_version": "operation-policy/v2",
+        "effect_class": "terminal/type_text_and_keys",
+        "outcome": "delivered",
+    }
+    assert coder_steering.active_grants() == {}
+    trail = env.db.steering.list()
+    assert trail[0].policy_snapshot["mode"] == "yolo"
+    assert trail[0].operation["destination"] == "%3"
+    projection = next(
+        row for row in env.db.projections.list(limit=20)["projections"]
+        if row["source_kind"] == "steering_audit"
+    )
+    assert projection["subject_ref"] == "coder_session:claude:abc"
+    assert projection["authority_basis"] == "control_posture"
+    assert projection["control_mode"] == "yolo"
+    assert projection["policy_version"] == "operation-policy/v2"
+
+
+def test_yolo_refuses_missing_or_changed_pane_identity_before_typing(env) -> None:
+    env.monkeypatch.setattr(
+        Config, "load", classmethod(lambda cls: SimpleNamespace(control_mode="yolo"))
+    )
+    _register(env.monkeypatch, _session())
+    _pin_identity(env.monkeypatch, "%3")
+    missing = env.client.post(
+        "/api/coders/claude:abc/steer", json={"text": "no snapshot"}
+    )
+    assert missing.status_code == 409
+    assert missing.json()["status"] == "pane_identity_required"
+    _pin_identity(env.monkeypatch, "%99")
+    changed = env.client.post(
+        "/api/coders/claude:abc/steer",
+        json={"text": "old pane", "expected_pane_id": "%3"},
+    )
+    assert changed.status_code == 409
+    assert changed.json()["status"] == "pane_mismatch"
+    assert changed.json().get("revoked") is not True
+    assert env.sent == []
+
+
 def test_no_submit_steer_leaves_enter_unpressed(env) -> None:
     _register(env.monkeypatch, _session())
     _pin_identity(env.monkeypatch)
@@ -153,6 +219,23 @@ def test_recycled_pane_steer_refuses_disarms_and_frames(env) -> None:
     assert len(env.frames) == 1  # the disarm is visible everywhere
     trail = env.db.steering.list()
     assert trail[0].outcome == "pane_mismatch"
+
+
+def test_expired_grant_keeps_its_typed_refusal_and_receipt(env) -> None:
+    _register(env.monkeypatch, _session())
+    _pin_identity(env.monkeypatch, "%3")
+    env.client.post("/api/coders/claude:abc/arm", json={})
+    with coder_steering._GRANTS_LOCK:
+        coder_steering._GRANTS["claude:abc"]["expires_at"] = 0.0
+    env.frames.clear()
+    res = env.client.post(
+        "/api/coders/claude:abc/steer", json={"text": "too late"}
+    )
+    assert res.status_code == 409
+    assert res.json()["status"] == "expired"
+    assert res.json()["receipt"]["outcome"] == "expired"
+    assert coder_steering.active_grants() == {}
+    assert len(env.frames) == 1
 
 
 def test_empty_text_is_a_400(env) -> None:
@@ -411,6 +494,23 @@ def test_armed_keys_interrupt_reaches_the_verified_pane(env) -> None:
     assert trail[0].outcome == "delivered" and trail[0].text_head == "C-c"
 
 
+def test_yolo_keys_reach_the_expected_registered_pane_without_an_arm(env) -> None:
+    env.monkeypatch.setattr(
+        Config, "load", classmethod(lambda cls: SimpleNamespace(control_mode="yolo"))
+    )
+    _register(env.monkeypatch, _session())
+    _pin_identity(env.monkeypatch, "%3")
+    keyed = _capture_keys(env)
+    res = env.client.post(
+        "/api/coders/claude:abc/keys",
+        json={"keys": ["C-c"], "expected_pane_id": "%3"},
+    )
+    assert res.status_code == 200
+    assert res.json()["policy"]["authority_basis"] == "control_posture"
+    assert keyed == [{"pane": "%3", "keys": [("named", "C-c")]}]
+    assert coder_steering.active_grants() == {}
+
+
 def test_unknown_key_is_refused_by_name_and_types_nothing(env) -> None:
     _register(env.monkeypatch, _session())
     _pin_identity(env.monkeypatch, "%3")
@@ -482,9 +582,24 @@ def test_arm_and_key_control_any_pane_under_a_grant(env) -> None:
     assert trail[0].session_key == "pane:%7" and trail[0].text_head == "C-c"
 
 
+def test_yolo_controls_an_exact_raw_pane_without_an_arm(env) -> None:
+    env.monkeypatch.setattr(
+        Config, "load", classmethod(lambda cls: SimpleNamespace(control_mode="yolo"))
+    )
+    _pin_identity(env.monkeypatch, "%7")
+    keyed = _capture_keys(env)
+    res = env.client.post("/api/coders/pane:%7/keys", json={"keys": ["C-c"]})
+    assert res.status_code == 200
+    assert res.json()["pane_id"] == "%7"
+    assert res.json()["policy"]["authority_basis"] == "control_posture"
+    assert keyed == [{"pane": "%7", "keys": [("named", "C-c")]}]
+
+
 def test_a_bad_pane_key_is_a_400(env) -> None:
-    res = env.client.post("/api/coders/pane:/arm", json={})
-    assert res.status_code == 400
+    for key in ("pane:", "pane:7", "pane:work", "pane:%7:0"):
+        res = env.client.post(f"/api/coders/{key}/arm", json={})
+        assert res.status_code == 400
+        assert res.json()["error"] == "key must be pane:%N"
 
 
 def test_registry_path_still_works_unchanged(env) -> None:
@@ -516,11 +631,15 @@ def _capture_relay(env):
 
 def test_relay_keys_forwards_node_key_and_sequence(env) -> None:
     calls = _capture_relay(env)
-    res = env.client.post("/api/coders/relay/beta/keys", json={"key": "pane:%5", "keys": ["C-c"]})
+    res = env.client.post(
+        "/api/coders/relay/beta/keys",
+        json={"key": "pane:%5", "keys": ["C-c"], "expected_pane_id": "%5"},
+    )
     assert res.status_code == 200
     assert res.json()["node"] == "beta"
     assert calls == [{"node": "beta", "verb": "keys", "key": "pane:%5",
-                      "method": "POST", "body": {"keys": ["C-c"]}}]
+                      "method": "POST", "body": {
+                          "keys": ["C-c"], "expected_pane_id": "%5"}}]
 
 
 def test_relay_steer_drops_key_from_the_forwarded_body(env) -> None:

--- a/web/src/desk/__tests__/steering.test.ts
+++ b/web/src/desk/__tests__/steering.test.ts
@@ -109,6 +109,34 @@ describe("the steering slice (attach)", () => {
     expect(st.paneDetail).toBe("can't find pane %3");
   });
 
+  it("consumes the Hub's YOLO pane policy without manufacturing a grant", async () => {
+    const hits: string[] = [];
+    stubPeek(hits, {
+      ...LIVE_BODY,
+      pane_id: "%5",
+      grant: { armed: false, expires_in_seconds: null },
+      operation: {
+        effect_class: "terminal/type_text_and_keys",
+        destination: "%5",
+      },
+      policy: {
+        mode: "yolo",
+        outcome: "allowed",
+        authority_basis: "control_posture",
+        reason_code: "registered_steering_posture_allowed",
+      },
+    });
+    useSteering.getState().openSession("claude:abc123");
+    await vi.advanceTimersByTimeAsync(0);
+    const st = useSteering.getState();
+    expect(st.armed).toBe(false);
+    expect(st.postureAuthorized).toBe(true);
+    expect(st.paneId).toBe("%5");
+    expect(st.policy?.reason_code).toBe(
+      "registered_steering_posture_allowed",
+    );
+  });
+
   it("a 404 is the registry speaking: unknown_session", async () => {
     const hits: string[] = [];
     stubPeek(hits, { status: "unknown_session", key: "claude:abc123" }, 404);
@@ -262,6 +290,93 @@ describe("the steer action (HS-87-03)", () => {
     expect(posts[0].url).toContain("/api/coders/claude%3Aabc123/steer");
     expect(posts[0].body).toEqual({ text: "do the thing", submit: false });
     expect(useSteering.getState().steerState).toBe("sent");
+  });
+
+  it("YOLO sends the peeked pane identity with no arm request and keeps the Receipt", async () => {
+    const posts: any[] = [];
+    vi.stubGlobal("fetch", (url: string, opts?: any) => {
+      posts.push({ url: String(url), body: JSON.parse(opts?.body || "{}") });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            status: "delivered",
+            pane_id: "%5",
+            receipt: {
+              id: "steering:9",
+              actual_destination: "%5",
+            },
+          }),
+      });
+    });
+    useSteering.setState({
+      openKey: "claude:abc123",
+      paneId: "%5",
+      postureAuthorized: true,
+      armed: false,
+    });
+    expect(await useSteering.getState().steer("ship it", true)).toBe(true);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toContain("/steer");
+    expect(posts[0].body).toEqual({
+      text: "ship it",
+      submit: true,
+      expected_pane_id: "%5",
+    });
+    expect(useSteering.getState().steerDetail).toBe(
+      "Receipt steering:9 · %5",
+    );
+  });
+
+  it("a posture identity refusal disables steering until peek rebinds", async () => {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({
+        ok: false,
+        status: 409,
+        json: () =>
+          Promise.resolve({
+            status: "pane_mismatch",
+            detail: "pane changed — nothing was typed",
+          }),
+      }),
+    );
+    useSteering.setState({
+      openKey: "claude:abc123",
+      paneId: "%5",
+      postureAuthorized: true,
+      armed: false,
+    });
+    expect(await useSteering.getState().steer("wrong pane", true)).toBe(false);
+    expect(useSteering.getState().paneId).toBeNull();
+    expect(useSteering.getState().postureAuthorized).toBe(false);
+  });
+
+  it("YOLO key control sends the same expected pane identity", async () => {
+    let posted: any = null;
+    vi.stubGlobal("fetch", (_url: string, opts?: any) => {
+      posted = JSON.parse(opts?.body || "{}");
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            status: "delivered",
+            receipt: { id: "steering:10", actual_destination: "%5" },
+          }),
+      });
+    });
+    useSteering.setState({
+      openKey: "claude:abc123",
+      paneId: "%5",
+      postureAuthorized: true,
+      armed: false,
+    });
+    expect(await useSteering.getState().sendKeys(["C-c"], "^C")).toBe(true);
+    expect(posted).toEqual({ keys: ["C-c"], expected_pane_id: "%5" });
+    expect(useSteering.getState().keyDetail).toBe(
+      "Receipt steering:10 · %5",
+    );
   });
 
   it("a revoking refusal drops the armed flag — ARM re-offered, not a toast", async () => {

--- a/web/src/desk/components/AttentionDrawer.tsx
+++ b/web/src/desk/components/AttentionDrawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { controlModeLabel } from "../../lib/productLanguage";
 import { useProjections } from "../projections";
 
 function when(raw: string) {
@@ -33,7 +34,9 @@ export function AttentionDrawer() {
       >
         <span aria-hidden="true">◎</span>
         Desk memory
-        {needs > 0 ? <strong aria-label={`${needs} need attention`}>{needs}</strong> : null}
+        {needs > 0 ? (
+          <strong aria-label={`${needs} need attention`}>{needs}</strong>
+        ) : null}
       </button>
       {store.open ? (
         <aside
@@ -47,26 +50,48 @@ export function AttentionDrawer() {
               <small>DESK ACTIVITY</small>
               <h2>Attention and Receipts</h2>
             </div>
-            <button type="button" onClick={() => store.setOpen(false)} aria-label="Close Desk memory">×</button>
+            <button
+              type="button"
+              onClick={() => store.setOpen(false)}
+              aria-label="Close Desk memory"
+            >
+              ×
+            </button>
           </header>
           <div className="desk-attention-counts" aria-live="polite">
-            <span><b>{needs}</b> need attention</span>
-            <span><b>{store.counts.receipts || 0}</b> Receipts</span>
-            <span><b>{store.page.total}</b> matching</span>
+            <span>
+              <b>{needs}</b> need attention
+            </span>
+            <span>
+              <b>{store.counts.receipts || 0}</b> Receipts
+            </span>
+            <span>
+              <b>{store.page.total}</b> matching
+            </span>
           </div>
           <form
             className="desk-attention-filters"
-            onSubmit={(event) => { event.preventDefault(); void store.refresh(true); }}
+            onSubmit={(event) => {
+              event.preventDefault();
+              void store.refresh(true);
+            }}
           >
             <label>
               <span>Search</span>
-              <input value={store.query} onChange={(event) => store.setQuery(event.target.value)} />
+              <input
+                value={store.query}
+                onChange={(event) => store.setQuery(event.target.value)}
+              />
             </label>
             <label>
               <span>Show</span>
               <select
                 value={store.kind}
-                onChange={(event) => store.setKind(event.target.value as "" | "attention" | "receipt")}
+                onChange={(event) =>
+                  store.setKind(
+                    event.target.value as "" | "attention" | "receipt",
+                  )
+                }
               >
                 <option value="">Everything</option>
                 <option value="attention">Needs / running</option>
@@ -78,30 +103,91 @@ export function AttentionDrawer() {
           {store.error ? (
             <div className="desk-attention-error" role="alert">
               <span>{store.error}</span>
-              <button type="button" onClick={() => void store.refresh(true)}>Retry</button>
+              <button type="button" onClick={() => void store.refresh(true)}>
+                Retry
+              </button>
             </div>
           ) : null}
           {selected ? (
-            <section className="desk-receipt-detail" aria-label={`${selected.title} detail`}>
-              <button type="button" onClick={() => store.select(null)}>← Back to list</button>
+            <section
+              className="desk-receipt-detail"
+              aria-label={`${selected.title} detail`}
+            >
+              <button type="button" onClick={() => store.select(null)}>
+                ← Back to list
+              </button>
               <small>{selected.subject_label}</small>
               <h3>{selected.title}</h3>
               <p>{selected.summary}</p>
               <dl>
-                <div><dt>Reason</dt><dd>{selected.reason_code}</dd></div>
-                <div><dt>Decision</dt><dd>{selected.decision_kind}</dd></div>
-                <div><dt>Destination</dt><dd>{selected.actual_destination || "not reached"}</dd></div>
-                <div><dt>Authority</dt><dd>{selected.authority_basis || "not required"}</dd></div>
-                <div><dt>Attempt / outcome</dt><dd>{selected.attempt ?? "—"} · {selected.outcome}</dd></div>
-                <div><dt>When</dt><dd>{when(selected.timestamp)}</dd></div>
-                <div><dt>Source</dt><dd>{selected.source_kind} · {selected.source_id}</dd></div>
+                <div>
+                  <dt>Reason</dt>
+                  <dd>{selected.reason_code}</dd>
+                </div>
+                <div>
+                  <dt>Decision</dt>
+                  <dd>{selected.decision_kind}</dd>
+                </div>
+                <div>
+                  <dt>Destination</dt>
+                  <dd>{selected.actual_destination || "not reached"}</dd>
+                </div>
+                <div>
+                  <dt>Authority</dt>
+                  <dd>{selected.authority_basis || "not required"}</dd>
+                </div>
+                {selected.control_mode ? (
+                  <div>
+                    <dt>Control posture</dt>
+                    <dd>
+                      {controlModeLabel(selected.control_mode)}
+                      {selected.policy_version
+                        ? ` · ${selected.policy_version}`
+                        : ""}
+                    </dd>
+                  </div>
+                ) : null}
+                {selected.effect_class ? (
+                  <div>
+                    <dt>Effect</dt>
+                    <dd>{selected.effect_class}</dd>
+                  </div>
+                ) : null}
+                <div>
+                  <dt>Attempt / outcome</dt>
+                  <dd>
+                    {selected.attempt ?? "—"} · {selected.outcome}
+                  </dd>
+                </div>
+                <div>
+                  <dt>When</dt>
+                  <dd>{when(selected.timestamp)}</dd>
+                </div>
+                <div>
+                  <dt>Source</dt>
+                  <dd>
+                    {selected.source_kind} · {selected.source_id}
+                  </dd>
+                </div>
               </dl>
               <div className="desk-receipt-actions">
                 <a href={selected.detail_url}>Open source</a>
                 {selected.attention_state === "needs_attention" ? (
-                  <button type="button" onClick={() => void store.present(selected.id, "acknowledge")}>Acknowledge</button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void store.present(selected.id, "acknowledge")
+                    }
+                  >
+                    Acknowledge
+                  </button>
                 ) : null}
-                <button type="button" onClick={() => void store.present(selected.id, "dismiss")}>Dismiss card</button>
+                <button
+                  type="button"
+                  onClick={() => void store.present(selected.id, "dismiss")}
+                >
+                  Dismiss card
+                </button>
               </div>
             </section>
           ) : (
@@ -110,9 +196,14 @@ export function AttentionDrawer() {
                 {store.projections.map((row) => (
                   <li key={row.id}>
                     <button type="button" onClick={() => store.select(row.id)}>
-                      <span className={`desk-projection-mark is-${row.severity}`} aria-hidden="true" />
+                      <span
+                        className={`desk-projection-mark is-${row.severity}`}
+                        aria-hidden="true"
+                      />
                       <span>
-                        <small>{row.subject_label} · {when(row.timestamp)}</small>
+                        <small>
+                          {row.subject_label} · {when(row.timestamp)}
+                        </small>
                         <strong>{row.title}</strong>
                         <em>{row.actual_destination || row.outcome}</em>
                       </span>
@@ -121,11 +212,20 @@ export function AttentionDrawer() {
                 ))}
               </ol>
               {!store.loading && store.projections.length === 0 ? (
-                <p className="desk-attention-empty">Nothing matches. Receipts remain in their source journals.</p>
+                <p className="desk-attention-empty">
+                  Nothing matches. Receipts remain in their source journals.
+                </p>
               ) : null}
               {store.page.has_more ? (
-                <button className="desk-attention-more" type="button" disabled={store.loading} onClick={() => void store.loadMore()}>
-                  {store.loading ? "Loading…" : `Load older (${store.page.total - store.projections.length} remain)`}
+                <button
+                  className="desk-attention-more"
+                  type="button"
+                  disabled={store.loading}
+                  onClick={() => void store.loadMore()}
+                >
+                  {store.loading
+                    ? "Loading…"
+                    : `Load older (${store.page.total - store.projections.length} remain)`}
                 </button>
               ) : null}
             </>

--- a/web/src/desk/components/DeskToolInspector.test.tsx
+++ b/web/src/desk/components/DeskToolInspector.test.tsx
@@ -56,6 +56,16 @@ describe("HS-93-04 Desk tool inspector", () => {
   it("binds an Integration proposal and Receipt to the exact selected source", async () => {
     const fetcher = vi.fn(async (input: string, init?: RequestInit) => {
       const url = String(input);
+      if (url.endsWith("/api/authority/policy")) {
+        return json({
+          control_mode: "neutral",
+          control_mode_label: "Normal",
+          control_mode_description:
+            "Runs routine configured work and asks at consequential boundaries.",
+          policy_version: "operation-policy/v2",
+          source: "config",
+        });
+      }
       if (url.endsWith("/api/desk/actuators/slack/propose")) {
         return json({
           proposal: {
@@ -64,6 +74,19 @@ describe("HS-93-04 Desk tool inspector", () => {
             target: "slack",
             preview: "Send Release checklist to Launch workspace",
             commitment: { approve: "Approve and send to Slack" },
+            operation: {
+              effect_class: "slack/post_message",
+              destination: "slack:sha256:fixed",
+              consequence: "execute_now",
+            },
+            policy_snapshot: {
+              mode: "neutral",
+              policy_version: "operation-policy/v2",
+              outcome: "authorization_required",
+              reason_code: "per_action_authorization_required",
+              authority_basis: "per_action_required",
+              next_state: "awaiting_authorization",
+            },
             payload: {
               _source: {
                 ref: "note:release",
@@ -125,9 +148,10 @@ describe("HS-93-04 Desk tool inspector", () => {
     expect(
       await screen.findByRole("button", { name: "Approve and send to Slack" }),
     ).toBeInTheDocument();
-    const proposed = JSON.parse(
-      String((fetcher.mock.calls[0][1] as RequestInit).body),
+    const proposeCall = fetcher.mock.calls.find(([url]) =>
+      String(url).endsWith("/api/desk/actuators/slack/propose"),
     );
+    const proposed = JSON.parse(String((proposeCall?.[1] as RequestInit).body));
     expect(proposed).toMatchObject({
       text: "Ship after checks pass.",
       source_ref: "note:release",
@@ -143,6 +167,85 @@ describe("HS-93-04 Desk tool inspector", () => {
       screen.getByRole("button", { name: "Return to Release checklist" }),
     );
     expect(useDesk.getState().openPullout).toHaveBeenCalledWith("note:release");
+  });
+
+  it("renders YOLO posture authority and the immediate Receipt without an approval prompt", async () => {
+    const fetcher = vi.fn(async (input: string) => {
+      const url = String(input);
+      if (url.endsWith("/api/authority/policy")) {
+        return json({
+          control_mode: "yolo",
+          control_mode_label: "YOLO",
+          control_mode_description:
+            "Runs eligible configured work without HoldSpeak approval prompts.",
+          policy_version: "operation-policy/v2",
+          source: "config",
+        });
+      }
+      if (url.endsWith("/api/desk/actuators/slack/propose")) {
+        return json({
+          proposal: {
+            id: "p-yolo",
+            status: "executed",
+            target: "slack",
+            preview: "Send Release checklist to Launch workspace",
+            operation: {
+              effect_class: "slack/post_message",
+              destination: "slack:sha256:fixed",
+              consequence: "execute_now",
+            },
+            policy_snapshot: {
+              mode: "yolo",
+              policy_version: "operation-policy/v2",
+              outcome: "allowed",
+              reason_code: "configured_destination_posture_allowed",
+              authority_basis: "control_posture",
+              next_state: "execute_now",
+            },
+            payload: {
+              _source: {
+                ref: "note:release",
+                label: "Release checklist",
+              },
+            },
+          },
+        });
+      }
+      if (url.startsWith("/api/desk/projections?")) {
+        return json({
+          projections: [],
+          counts: {},
+          subject_counts: {},
+          page: { offset: 0, limit: 50, total: 0, has_more: false },
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetcher);
+    useDesk.setState({
+      toolInspector: { kind: "integration", id: "slack" },
+    });
+
+    render(
+      <MemoryRouter>
+        <DeskToolInspector />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("YOLO")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Send Release checklist to Slack",
+      }),
+    );
+    expect(await screen.findByText("Receipt · executed")).toBeInTheDocument();
+    expect(screen.getByText("control_posture")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Approve and send to Slack" }),
+    ).not.toBeInTheDocument();
+    expect(
+      fetcher.mock.calls.some(([url]) => String(url).includes("/decision")),
+    ).toBe(false);
   });
 
   it("opens related Project material with its qualified identity", async () => {

--- a/web/src/desk/components/DeskToolInspector.tsx
+++ b/web/src/desk/components/DeskToolInspector.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { apiFetch, readableError } from "../../lib/api";
+import {
+  controlModeDescription,
+  controlModeLabel,
+} from "../../lib/productLanguage";
 import { workroomHref } from "../../workrooms/context";
 import { modelChatId } from "../chat";
 import { contextualIntegrationActions } from "../contextual";
@@ -17,9 +21,33 @@ interface Proposal {
   error?: string | null;
   result?: Record<string, unknown> | null;
   commitment?: { approve?: string; reject?: string };
+  operation?: {
+    effect_class?: string;
+    destination?: string;
+    consequence?: string;
+  };
+  policy_snapshot?: {
+    mode?: string;
+    source?: string;
+    policy_version?: string;
+    outcome?: string;
+    reason_code?: string;
+    authority_basis?: string;
+    next_state?: string;
+    eligible?: boolean;
+  };
   payload?: {
     _source?: { ref?: string; label?: string };
   };
+}
+
+interface AuthorityPolicy {
+  control_mode?: string;
+  control_mode_label?: string;
+  control_mode_description?: string;
+  policy_version?: string;
+  source?: string;
+  applies_to?: string;
 }
 
 const INTEGRATION_TARGET: Record<string, "slack" | "webhook" | "github"> = {
@@ -57,6 +85,7 @@ export function DeskToolInspector() {
   >([]);
   const [loadingProject, setLoadingProject] = useState(false);
   const [proposal, setProposal] = useState<Proposal | null>(null);
+  const [authority, setAuthority] = useState<AuthorityPolicy | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
@@ -108,8 +137,16 @@ export function DeskToolInspector() {
 
   useEffect(() => {
     setProposal(null);
+    setAuthority(null);
     setError("");
   }, [inspector?.kind, inspector?.id]);
+
+  useEffect(() => {
+    if (!integration) return;
+    void apiFetch<AuthorityPolicy>("/api/authority/policy")
+      .then(setAuthority)
+      .catch((reason) => setError(readableError(reason)));
+  }, [integration?.id]);
 
   useEffect(() => {
     if (!project) {
@@ -154,6 +191,15 @@ export function DeskToolInspector() {
         },
       );
       setProposal(response.proposal);
+      if (
+        response.proposal.status !== "proposed" ||
+        response.proposal.policy_snapshot?.outcome === "refused"
+      ) {
+        await Promise.all([
+          useProjections.getState().refresh(true),
+          useProjections.getState().refreshAmbient(),
+        ]);
+      }
     } catch (reason) {
       setError(readableError(reason));
     } finally {
@@ -314,7 +360,23 @@ export function DeskToolInspector() {
             <Fact label="Destination" value={integration.destination} />
             <Fact label="Boundary" value={integration.boundary} />
             <Fact label="Data" value={integration.data_class} />
-            <Fact label="Authority" value={integration.authority_basis} />
+            <Fact
+              label="Control posture"
+              value={
+                authority?.control_mode_label ||
+                (authority?.control_mode
+                  ? controlModeLabel(authority.control_mode)
+                  : undefined)
+              }
+            />
+            <Fact
+              label="Authority"
+              value={
+                authority?.control_mode
+                  ? controlModeDescription(authority.control_mode)
+                  : integration.authority_basis
+              }
+            />
             <Fact label="Background" value={integration.background_ability} />
           </dl>
           {integrationAction ? (
@@ -344,9 +406,39 @@ export function DeskToolInspector() {
           )}
           {proposal ? (
             <section className="desk-integration-proposal" aria-live="polite">
-              <h3>Proposed action</h3>
+              <h3>
+                {proposal.policy_snapshot?.outcome === "refused"
+                  ? "Operation refused"
+                  : proposal.status === "proposed"
+                    ? "Proposed action"
+                    : "Operation Receipt"}
+              </h3>
               <p>{proposal.preview}</p>
-              {proposal.status === "proposed" ? (
+              <dl className="desk-tool-facts">
+                <Fact label="Effect" value={proposal.operation?.effect_class} />
+                <Fact
+                  label="Destination"
+                  value={proposal.operation?.destination}
+                />
+                <Fact
+                  label="Control posture"
+                  value={
+                    proposal.policy_snapshot?.mode
+                      ? controlModeLabel(proposal.policy_snapshot.mode)
+                      : undefined
+                  }
+                />
+                <Fact
+                  label="Authority basis"
+                  value={proposal.policy_snapshot?.authority_basis}
+                />
+                <Fact
+                  label="Next state"
+                  value={proposal.policy_snapshot?.next_state}
+                />
+              </dl>
+              {proposal.status === "proposed" &&
+              proposal.policy_snapshot?.outcome !== "refused" ? (
                 <div className="desk-tool-actions">
                   <button
                     type="button"
@@ -377,9 +469,15 @@ export function DeskToolInspector() {
                   Retry {proposal.commitment?.approve || integration.operation}
                 </button>
               ) : null}
-              {["executed", "rejected", "failed"].includes(proposal.status) ? (
+              {["executed", "rejected", "failed"].includes(proposal.status) ||
+              proposal.policy_snapshot?.outcome === "refused" ? (
                 <div className="desk-integration-receipt">
-                  <strong>Receipt · {proposal.status}</strong>
+                  <strong>
+                    Receipt ·{" "}
+                    {proposal.policy_snapshot?.outcome === "refused"
+                      ? "refused"
+                      : proposal.status}
+                  </strong>
                   <p>
                     Source retained ·{" "}
                     {boundSource?.label || "selected material"}

--- a/web/src/desk/components/MissionControlConveyor.tsx
+++ b/web/src/desk/components/MissionControlConveyor.tsx
@@ -405,7 +405,10 @@ export function MissionControlConveyor() {
     const onFrame = (e: Event) => {
       const frame = (e as CustomEvent).detail;
       if (isBeltFrame(frame)) void refresh();
-      if (isCoderFrame(frame)) tick();
+      if (isCoderFrame(frame)) {
+        tick();
+        void useProjections.getState().refresh(true);
+      }
     };
     document.addEventListener("hs-broadcast", onFrame);
     return () => {

--- a/web/src/desk/components/SessionPullout.tsx
+++ b/web/src/desk/components/SessionPullout.tsx
@@ -1,8 +1,6 @@
 // The session pull-out (HS-87-01/02) — attach + arm, in the desk
-// grammar. Watching is free; steering is armed: the ARM chip is a
-// press-and-hold (the desk's consent gesture, the record-orb family),
-// armed becomes the countdown, one tap disarms. Enforcement lives
-// hub-side — this surface can only ask.
+// grammar. Watching is free. Secure/Normal use an exact pane grant; a Hub
+// policy decision can make a registered pane directly steerable in YOLO.
 import { useEffect, useRef, useState } from "react";
 import { motion } from "motion/react";
 import { MicButton } from "./MicButton";
@@ -19,6 +17,7 @@ import {
 import { flipTargetForStory, useMissionControl } from "../missioncontrol";
 import { mmss, useSteering } from "../steering";
 import { useDurableDraft } from "../../lib/durableDraft";
+import { controlModeLabel } from "../../lib/productLanguage";
 
 // The steer's context budget mirrors the hub's 8 KB cap (≈2000 tokens
 // at 4 chars/token); the gauge refuses past it before any send.
@@ -34,17 +33,16 @@ const PANE_STATE_LABEL: Record<string, string> = {
   idle: "…",
 };
 
-const HOLD_TO_ARM_MS = 600;
-
 function ArmChip() {
   const armed = useSteering((s) => s.armed);
   const armedUntil = useSteering((s) => s.armedUntil);
   const armError = useSteering((s) => s.armError);
   const armCommitment = useSteering((s) => s.armCommitment);
   const stale = useSteering((s) => Boolean(s.session?.stale));
+  const postureAuthorized = useSteering((s) => s.postureAuthorized);
+  const policy = useSteering((s) => s.policy);
+  const paneId = useSteering((s) => s.paneId);
   const [remaining, setRemaining] = useState(0);
-  const [holding, setHolding] = useState(false);
-  const holdTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!armed || armedUntil === null) return;
@@ -54,13 +52,28 @@ function ArmChip() {
     return () => clearInterval(t);
   }, [armed, armedUntil]);
 
-  const cancelHold = () => {
-    setHolding(false);
-    if (holdTimer.current !== null) {
-      clearTimeout(holdTimer.current);
-      holdTimer.current = null;
-    }
-  };
+  if (postureAuthorized) {
+    return (
+      <span className="desk-arm-wrap">
+        <span
+          className="desk-chip desk-arm-chip is-armed"
+          title={`Registered ${paneId || "pane"}; steering runs directly and leaves a Receipt`}
+        >
+          {controlModeLabel(policy?.mode || "yolo")} · direct
+        </span>
+        {armed ? (
+          <button
+            type="button"
+            className="desk-chip quiet"
+            title="Disarm the separate session-control grant"
+            onClick={() => void useSteering.getState().disarm()}
+          >
+            Session controls {mmss(remaining)}
+          </button>
+        ) : null}
+      </span>
+    );
+  }
 
   if (armed) {
     return (
@@ -78,21 +91,13 @@ function ArmChip() {
     <span className="desk-arm-wrap">
       <button
         type="button"
-        className={"desk-chip desk-arm-chip" + (holding ? " is-holding" : "")}
+        className="desk-chip desk-arm-chip"
         title={
           stale
-            ? "stale — arming will refuse"
-            : `Hold to ${armCommitment.toLowerCase()}`
+            ? "Stale session; arming will refuse"
+            : armCommitment
         }
-        onPointerDown={() => {
-          setHolding(true);
-          holdTimer.current = setTimeout(() => {
-            cancelHold();
-            void useSteering.getState().arm();
-          }, HOLD_TO_ARM_MS);
-        }}
-        onPointerUp={cancelHold}
-        onPointerLeave={cancelHold}
+        onClick={() => void useSteering.getState().arm()}
       >
         {armCommitment}
       </button>
@@ -102,8 +107,8 @@ function ArmChip() {
 }
 
 // The key palette (HS-90-02) — full key control on glass. Each button is
-// ONE real key through `/keys`, shown only in the armed window. `^C` is the
-// loud one (interrupt a runaway); the rest drive a TUI.
+// ONE real key through `/keys`, shown under resolved grant/posture authority.
+// `^C` is the loud one (interrupt a runaway); the rest drive a TUI.
 const KEY_BUTTONS: Array<{
   label: string;
   key: string;
@@ -142,7 +147,9 @@ function KeyPalette() {
           </button>
         ))}
         {keyState === "sent" && (
-          <span className="desk-key-fate desk-steer-sent">✓ {lastKey}</span>
+          <span className="desk-key-fate desk-steer-sent">
+            ✓ {keyDetail || lastKey}
+          </span>
         )}
         {keyState === "refused" && (
           <span className="desk-key-fate desk-arm-refusal">✕ {keyDetail}</span>
@@ -153,7 +160,7 @@ function KeyPalette() {
 }
 
 // The node chip (HS-90-02) — which machine the steering targets. Tap to
-// cycle this Mac → each configured node; a node routes arm/steer/keys
+// cycle this Mac → each configured node; a node routes watch/authority/delivery
 // through the relay. Absent config reads the honest "this Mac".
 function NodeChip() {
   const nodes = useSteering((s) => s.nodes);
@@ -186,8 +193,8 @@ function NodeChip() {
 }
 
 /** The pane picker (HS-90-02) — attach to ANY tmux pane on the machine,
- * not only a tracked session. Watching is free; arm to steer. A launcher
- * mounted on the desk beside the session surface. */
+ * not only a tracked session. Watching is free; policy resolves steering
+ * authority. A launcher mounted on the desk beside the session surface. */
 export function PanePicker() {
   const panes = useSteering((s) => s.panes);
   const panesState = useSteering((s) => s.panesState);
@@ -283,8 +290,8 @@ export function PanePicker() {
 }
 
 // The factory controls (HS-90-03) — rename + kill the open session, on glass.
-// Rendered only while armed: kill is gated like a steer, and rename rides the
-// same deliberate window. Kill is a two-step confirm (it is irreversible).
+// Rendered only with the separate session-control grant: factory authority is
+// deliberately not inherited from direct YOLO steering. Kill is two-step.
 function FactoryControls() {
   const attachedSession = useSteering((s) => s.attachedSession);
   const factoryState = useSteering((s) => s.factoryState);
@@ -376,9 +383,7 @@ function FactoryControls() {
   );
 }
 
-/** The voice-first composer (HS-87-03) — spoken first, typed if you
- * like, Enter its own deliberate chip. Rendered only while armed: the
- * ARM chip in the header IS the unarmed affordance. */
+/** The voice-first composer (HS-87-03), available under resolved authority. */
 function SteerComposer() {
   const steerState = useSteering((s) => s.steerState);
   const steerDetail = useSteering((s) => s.steerDetail);
@@ -463,8 +468,27 @@ function SteerComposer() {
       {steerState === "refused" && (
         <span className="desk-arm-refusal">✕ {steerDetail}</span>
       )}
-      {steerState === "sent" && <span className="desk-steer-sent">✓ sent</span>}
+      {steerState === "sent" && (
+        <span className="desk-steer-sent">✓ {steerDetail || "sent"}</span>
+      )}
     </div>
+  );
+}
+
+function SteeringPolicySummary() {
+  const operation = useSteering((s) => s.operation);
+  const policy = useSteering((s) => s.policy);
+  if (!operation || !policy) return null;
+  const authority =
+    policy.authority_basis === "control_posture"
+      ? `${controlModeLabel(policy.mode || "yolo")} control posture`
+      : "armed pane grant";
+  return (
+    <p className="quiet desk-steering-policy">
+      Send text or allowed keys to pane {operation.destination || "unresolved"}
+      {" · "}
+      {authority} · Receipt after every attempt
+    </p>
   );
 }
 
@@ -569,6 +593,8 @@ export function SessionPullout() {
   const paneDetail = useSteering((s) => s.paneDetail);
   const paneLines = useSteering((s) => s.paneLines);
   const armed = useSteering((s) => s.armed);
+  const postureAuthorized = useSteering((s) => s.postureAuthorized);
+  const paneId = useSteering((s) => s.paneId);
   const { closeSession } = useSteering.getState();
   const ref = useRef<HTMLDivElement | null>(null);
   const preRef = useRef<HTMLPreElement | null>(null);
@@ -655,11 +681,22 @@ export function SessionPullout() {
         )}
       </div>
 
-      {armed && (
+      {(armed || postureAuthorized) && (
         <footer className="desk-pullout-foot">
+          <SteeringPolicySummary />
           <KeyPalette />
           <SteerComposer />
-          <FactoryControls />
+          {armed ? (
+            <FactoryControls />
+          ) : (
+            <button
+              type="button"
+              className="desk-chip quiet"
+              onClick={() => void useSteering.getState().arm()}
+            >
+              Arm pane {paneId || "unresolved"} for rename and kill
+            </button>
+          )}
         </footer>
       )}
       <footer className="desk-pullout-foot">

--- a/web/src/desk/projections.ts
+++ b/web/src/desk/projections.ts
@@ -22,6 +22,9 @@ export interface DeskProjection {
   source_id: string;
   source_api: string;
   detail_url: string;
+  control_mode?: string | null;
+  policy_version?: string | null;
+  effect_class?: string | null;
   severity: "normal" | "warning" | "error";
   dismissed: boolean;
 }
@@ -49,7 +52,10 @@ interface ProjectionState extends ProjectionEnvelope {
   refresh(reset?: boolean): Promise<void>;
   refreshAmbient(): Promise<void>;
   loadMore(): Promise<void>;
-  present(id: string, action: "acknowledge" | "dismiss" | "restore"): Promise<void>;
+  present(
+    id: string,
+    action: "acknowledge" | "dismiss" | "restore",
+  ): Promise<void>;
 }
 
 const EMPTY_PAGE = { offset: 0, limit: 50, total: 0, has_more: false };
@@ -92,7 +98,9 @@ export const useProjections = create<ProjectionState>((set, get) => ({
         `/api/desk/projections?${params.toString()}`,
       );
       set({
-        projections: reset ? body.projections : [...get().projections, ...body.projections],
+        projections: reset
+          ? body.projections
+          : [...get().projections, ...body.projections],
         counts: body.counts,
         subject_counts: body.subject_counts,
         page: body.page,
@@ -114,15 +122,20 @@ export const useProjections = create<ProjectionState>((set, get) => ({
   },
   async loadMore() {
     if (!get().page.has_more || get().loading) return;
-    set({ page: { ...get().page, offset: get().page.offset + get().page.limit } });
+    set({
+      page: { ...get().page, offset: get().page.offset + get().page.limit },
+    });
     await get().refresh(false);
   },
   async present(id, action) {
     try {
-      await apiFetch(`/api/desk/projections/${encodeURIComponent(id)}/presentation`, {
-        method: "PUT",
-        json: { action },
-      });
+      await apiFetch(
+        `/api/desk/projections/${encodeURIComponent(id)}/presentation`,
+        {
+          method: "PUT",
+          json: { action },
+        },
+      );
       set({ selectedId: action === "dismiss" ? null : get().selectedId });
       await Promise.all([get().refresh(true), get().refreshAmbient()]);
     } catch (error) {

--- a/web/src/desk/steering.ts
+++ b/web/src/desk/steering.ts
@@ -10,6 +10,23 @@
 import { create } from "zustand";
 import { apiRequest } from "../lib/api";
 
+export interface SteeringOperation {
+  effect_class?: string;
+  destination?: string;
+  consequence?: string;
+}
+
+export interface SteeringPolicy {
+  mode?: string;
+  source?: string;
+  policy_version?: string;
+  outcome?: string;
+  reason_code?: string;
+  authority_basis?: string;
+  next_state?: string;
+  requires_grant?: boolean;
+}
+
 export type PaneStatus =
   | "live"
   | "not_modified"
@@ -100,6 +117,11 @@ interface SteeringState {
   paneDetail: string;
   paneLines: string[];
   paneHash: string | null;
+  paneId: string | null;
+  operation: SteeringOperation | null;
+  policy: SteeringPolicy | null;
+  /** True only when the Hub's decision names posture authority. */
+  postureAuthorized: boolean;
   inflight: boolean;
   /** The OPEN session's grant (HS-87-02): armed + a client-side
    * countdown anchor (epoch ms), re-synced by every peek. */
@@ -135,8 +157,7 @@ interface SteeringState {
   keepAsNote(title?: string): Promise<boolean>;
   pinToStory(key: string, storyId: string): void;
   clearPin(key: string): void;
-  /** HS-90-02 — full key control on glass: send a real key sequence
-   * (`C-c`, arrows, `Escape`) through `/keys`, armed only. */
+  /** Full key control through the Hub's resolved grant/posture authority. */
   keyState: "idle" | "sending" | "sent" | "refused";
   keyDetail: string;
   lastKey: string;
@@ -200,6 +221,25 @@ function grantPatch(
   };
 }
 
+function policyPatch(body: any) {
+  const policy = (body?.policy || null) as SteeringPolicy | null;
+  return {
+    paneId: body?.pane_id || null,
+    operation: (body?.operation || null) as SteeringOperation | null,
+    policy,
+    postureAuthorized: Boolean(
+      policy?.outcome === "allowed" &&
+        policy?.authority_basis === "control_posture",
+    ),
+  };
+}
+
+function receiptDetail(body: any): string {
+  const receipt = body?.receipt;
+  if (!receipt?.id) return "sent";
+  return `Receipt ${receipt.id} · ${receipt.actual_destination || "pane"}`;
+}
+
 export const useSteering = create<SteeringState>((set, get) => ({
   openKey: null,
   session: null,
@@ -207,6 +247,10 @@ export const useSteering = create<SteeringState>((set, get) => ({
   paneDetail: "",
   paneLines: [],
   paneHash: null,
+  paneId: null,
+  operation: null,
+  policy: null,
+  postureAuthorized: false,
   inflight: false,
   armed: false,
   armedUntil: null,
@@ -237,6 +281,10 @@ export const useSteering = create<SteeringState>((set, get) => ({
       paneDetail: "",
       paneLines: [],
       paneHash: null,
+      paneId: null,
+      operation: null,
+      policy: null,
+      postureAuthorized: false,
       armed: false,
       armedUntil: null,
       armError: "",
@@ -261,6 +309,10 @@ export const useSteering = create<SteeringState>((set, get) => ({
       paneDetail: "",
       paneLines: [],
       paneHash: null,
+      paneId: null,
+      operation: null,
+      policy: null,
+      postureAuthorized: false,
       armed: false,
       armedUntil: null,
       armError: "",
@@ -325,17 +377,23 @@ export const useSteering = create<SteeringState>((set, get) => ({
     set({ steerState: "sending", steerDetail: "" });
     try {
       const { url, wrap } = verbEndpoint(get().targetNode, key, "steer");
+      const expected = get().paneId;
+      const request = grounding ? { text, submit, grounding } : { text, submit };
       const res = await apiRequest(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(
-          wrap(grounding ? { text, submit, grounding } : { text, submit }),
+          wrap(
+            expected
+              ? { ...request, expected_pane_id: expected }
+              : request,
+          ),
         ),
       });
       const body = await res.json().catch(() => ({}));
       if (get().openKey !== key) return false;
       if (res.ok && body.status === "delivered") {
-        set({ steerState: "sent", steerDetail: "" });
+        set({ steerState: "sent", steerDetail: receiptDetail(body) });
         return true;
       }
       // A refusal that revoked (expiry, recycled pane) re-offers ARM:
@@ -350,10 +408,18 @@ export const useSteering = create<SteeringState>((set, get) => ({
         "pane_mismatch",
         "pane_gone",
       ].includes(body.status);
+      const identityInvalid = [
+        "pane_identity_required",
+        "pane_mismatch",
+        "pane_gone",
+      ].includes(body.status);
       set({
         steerState: "refused",
         steerDetail: body.detail || refusal,
         ...(revoking ? grantPatch(key, { armed: false }, get().armedKeys) : {}),
+        ...(identityInvalid
+          ? { paneId: null, postureAuthorized: false }
+          : {}),
       });
       return false;
     } catch {
@@ -402,15 +468,22 @@ export const useSteering = create<SteeringState>((set, get) => ({
     set({ keyState: "sending", keyDetail: "", lastKey: label });
     try {
       const { url, wrap } = verbEndpoint(get().targetNode, key, "keys");
+      const expected = get().paneId;
       const res = await apiRequest(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(wrap({ keys: seq })),
+        body: JSON.stringify(
+          wrap(
+            expected
+              ? { keys: seq, expected_pane_id: expected }
+              : { keys: seq },
+          ),
+        ),
       });
       const body = await res.json().catch(() => ({}));
       if (get().openKey !== key) return false;
       if (res.ok && body.status === "delivered") {
-        set({ keyState: "sent", keyDetail: "" });
+        set({ keyState: "sent", keyDetail: receiptDetail(body) });
         return true;
       }
       // A revoking refusal (recycled pane, expiry) drops the grant, exactly
@@ -421,10 +494,18 @@ export const useSteering = create<SteeringState>((set, get) => ({
         "pane_mismatch",
         "pane_gone",
       ].includes(body.status);
+      const identityInvalid = [
+        "pane_identity_required",
+        "pane_mismatch",
+        "pane_gone",
+      ].includes(body.status);
       set({
         keyState: "refused",
         keyDetail: body.detail || body.status || `HTTP ${res.status}`,
         ...(revoking ? grantPatch(key, { armed: false }, get().armedKeys) : {}),
+        ...(identityInvalid
+          ? { paneId: null, postureAuthorized: false }
+          : {}),
       });
       return false;
     } catch {
@@ -473,7 +554,16 @@ export const useSteering = create<SteeringState>((set, get) => ({
   },
 
   setTargetNode(node) {
-    set({ targetNode: node });
+    set({
+      targetNode: node,
+      paneHash: null,
+      paneId: null,
+      operation: null,
+      policy: null,
+      postureAuthorized: false,
+      armed: false,
+      armedUntil: null,
+    });
   },
 
   async spawnSession(name, command) {
@@ -608,8 +698,9 @@ export const useSteering = create<SteeringState>((set, get) => ({
       const peek = body.peek || {};
       const session = fromWireSteeringSession(body);
       const grant = grantPatch(key, body.grant, get().armedKeys);
+      const policy = policyPatch(body);
       if (peek.status === "not_modified") {
-        set({ session, paneStatus: "live", armCommitment: body.arm_commitment || "Arm this pane", ...grant }); // the view stays; the gate held
+        set({ session, paneStatus: "live", armCommitment: body.arm_commitment || "Arm this pane", ...grant, ...policy }); // the view stays; the gate held
         return;
       }
       if (peek.status === "live") {
@@ -621,6 +712,7 @@ export const useSteering = create<SteeringState>((set, get) => ({
           paneDetail: "",
           armCommitment: body.arm_commitment || "Arm this pane",
           ...grant,
+          ...policy,
         });
         return;
       }
@@ -632,6 +724,7 @@ export const useSteering = create<SteeringState>((set, get) => ({
         paneHash: null,
         armCommitment: body.arm_commitment || "Arm this pane",
         ...grant,
+        ...policy,
       });
     } catch {
       if (get().openKey === key)

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -15,6 +15,10 @@ import {
   Toolbar,
 } from "../components/signal/Signal";
 import { apiBlob, apiFetch, readableError, type JsonRecord } from "../lib/api";
+import {
+  controlModeDescription,
+  controlModeLabel,
+} from "../lib/productLanguage";
 import { MeetingConflictRecovery } from "../meetings/MeetingConflictRecovery";
 import { MeetingIntelRecovery } from "../meetings/MeetingIntelRecovery";
 import {
@@ -199,6 +203,7 @@ function MeetingDetail({
   const [aftercare, setAftercare] = useState<JsonRecord>({});
   const [timeline, setTimeline] = useState<JsonRecord>({});
   const [proposals, setProposals] = useState<JsonRecord>({});
+  const [authority, setAuthority] = useState<JsonRecord>({});
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -224,6 +229,9 @@ function MeetingDetail({
       apiFetch<JsonRecord>(`/api/meetings/${encodeURIComponent(id)}/proposals`)
         .then(setProposals)
         .catch(() => setProposals({})),
+      apiFetch<JsonRecord>("/api/authority/policy")
+        .then(setAuthority)
+        .catch(() => setAuthority({})),
     ]).catch((reason) => setError(readableError(reason)));
   }, [id, meeting]);
   const decide = async (
@@ -416,8 +424,13 @@ function MeetingDetail({
                   Send follow-up to Slack
                 </Button>
                 <small>
-                  Each creates an exact-message proposed action. Approval sends
-                  it to the configured Slack destination.
+                  {controlModeLabel(
+                    String(authority.control_mode ?? "neutral"),
+                  )}
+                  :{" "}
+                  {controlModeDescription(
+                    String(authority.control_mode ?? "neutral"),
+                  )}
                 </small>
               </div>
             ) : null}
@@ -431,42 +444,68 @@ function MeetingDetail({
         {active === "proposals" ? (
           proposalRows.length ? (
             <ul className="data-list">
-              {proposalRows.map((row, index) => (
-                <li className="data-row" key={rowId(row, index)}>
-                  <div>
-                    <strong>
-                      {String(row.title ?? row.kind ?? "Proposed action")}
-                    </strong>
-                    <small>
-                      {String(row.preview ?? row.body ?? row.status ?? "")}
-                    </small>
-                  </div>
-                  <div className="button-row">
-                    <Button
-                      dense
-                      loading={busy}
-                      disabled={row.status !== "proposed"}
-                      onClick={() => void decide(row, "approved")}
-                    >
-                      {String(
-                        (row.commitment as JsonRecord | undefined)?.approve ??
-                          `Approve for ${String(row.target ?? "executor")}`,
-                      )}
-                    </Button>
-                    <Button
-                      dense
-                      variant="ghost"
-                      disabled={row.status !== "proposed"}
-                      onClick={() => void decide(row, "rejected")}
-                    >
-                      {String(
-                        (row.commitment as JsonRecord | undefined)?.reject ??
-                          "Reject proposed action",
-                      )}
-                    </Button>
-                  </div>
-                </li>
-              ))}
+              {proposalRows.map((row, index) => {
+                const policy = (row.policy_snapshot ?? {}) as JsonRecord;
+                const operation = (row.operation ?? {}) as JsonRecord;
+                const refused = policy.outcome === "refused";
+                return (
+                  <li className="data-row" key={rowId(row, index)}>
+                    <div>
+                      <strong>
+                        {refused
+                          ? "Operation refused"
+                          : String(row.title ?? row.kind ?? "Proposed action")}
+                      </strong>
+                      <small>
+                        {String(row.preview ?? row.body ?? row.status ?? "")}
+                      </small>
+                      <small>
+                        {controlModeLabel(String(policy.mode ?? "neutral"))} ·{" "}
+                        {String(
+                          operation.effect_class ?? row.action ?? "effect",
+                        )}{" "}
+                        ·{" "}
+                        {String(
+                          operation.destination ?? row.target ?? "destination",
+                        )}{" "}
+                        ·{" "}
+                        {String(
+                          policy.authority_basis ?? "per_action_required",
+                        )}
+                      </small>
+                    </div>
+                    {row.status === "proposed" && !refused ? (
+                      <div className="button-row">
+                        <Button
+                          dense
+                          loading={busy}
+                          onClick={() => void decide(row, "approved")}
+                        >
+                          {String(
+                            (row.commitment as JsonRecord | undefined)
+                              ?.approve ??
+                              `Approve for ${String(row.target ?? "executor")}`,
+                          )}
+                        </Button>
+                        <Button
+                          dense
+                          variant="ghost"
+                          onClick={() => void decide(row, "rejected")}
+                        >
+                          {String(
+                            (row.commitment as JsonRecord | undefined)
+                              ?.reject ?? "Reject proposed action",
+                          )}
+                        </Button>
+                      </div>
+                    ) : (
+                      <StatusPill tone={refused ? "error" : "neutral"}>
+                        {refused ? "Refused" : String(row.status)}
+                      </StatusPill>
+                    )}
+                  </li>
+                );
+              })}
             </ul>
           ) : (
             <EmptyState title="No proposals">

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -350,8 +350,9 @@ export default function SettingsPage() {
         json: { control_mode: controlMode },
       });
       authority.setData({ ...authority.data, ...result });
+      const revoked = Number(result.revoked_grants ?? 0);
       setMessage({
-        text: `Control mode is now ${controlModeLabel(controlMode)}. Existing operations and grants did not change.`,
+        text: `Control posture is now ${controlModeLabel(controlMode)} for future operations. Existing proposals keep their captured posture.${revoked ? ` ${revoked} active ${revoked === 1 ? "grant was" : "grants were"} revoked.` : ""}`,
       });
     } catch (error) {
       setMessage({ error: true, text: readableError(error) });
@@ -381,13 +382,15 @@ export default function SettingsPage() {
         error={resource.error}
         onRetry={() => void resource.reload()}
       >
-        <Panel title="Control mode" eyebrow="Future operations">
+        <Panel title="Control posture" eyebrow="Future operations">
           <Field
             label="Preset"
             description={`${CONTROL_MODES.map(
               (mode) =>
                 `${controlModeLabel(mode)}: ${controlModeDescription(mode)}`,
-            ).join(" ")} Authentication, secret custody, destination and payload binding, pane identity, receipts, configuration, and schema checks never change.`}
+            ).join(
+              " ",
+            )} Authentication, secret custody, destination and payload binding, pane identity, receipts, configuration, and schema checks never change.`}
           >
             {({ id, describedBy }) => (
               <Select
@@ -406,7 +409,9 @@ export default function SettingsPage() {
             )}
           </Field>
           <p>
-            Source: {String(authority.data.source ?? "config")} · precedence:{" "}
+            Source: {String(authority.data.source ?? "config")} ·{" "}
+            {String(authority.data.policy_version ?? "operation policy")} ·
+            precedence:{" "}
             {Array.isArray(authority.data.precedence)
               ? authority.data.precedence.join(" → ")
               : "hard invariants → grants → mode → feature default"}


### PR DESCRIPTION
## What changed

- Snapshot `operation-policy/v2` decisions for configured Integration actions and Coder steering.
- Let YOLO execute eligible fixed Slack, Webhook, and GitHub destinations without a HoldSpeak approval or reusable-grant prompt.
- Let YOLO send text and allowed keys to an exact registered Coder pane without an arm prompt, while preserving canonical pane re-verification, changed-target refusal, the key allow-list, and node-owned relay authority.
- Keep Secure and Normal on bounded, destination-specific decisions and pane grants; posture changes revoke stale grants.
- Record source-linked Receipts with operation, destination, authority basis, posture, effect, and outcome across Hub, React, and flagship Swift.
- Update the shared mobile schemas, product documentation, and Phase 93 progress record without marking HS-93-07 complete.

## Why

Phase 93 defines YOLO as configured authority with zero extra HoldSpeak prompts, not as a correctness bypass. The prior paths still asked for reusable grants or Coder arm gestures even when the destination and capability were already registered.

## User impact

Configured Integration actions and registered Coder text/allowed-key steering now flow directly in YOLO. Unknown destinations, unsupported operations, missing or changed panes, invalid keys, and destructive factory operations remain refused or separately controlled.

## Verification

- Canonical Python suite: 3,802 passed, 37 intentionally skipped (`test_metal.py` excluded per repository contract).
- Full Python unit suite: 2,911 passed.
- Focused Coder policy/identity/audit lane: 108 passed.
- Web: architecture guard passed for 113 sources; 166 tests passed; typecheck and production build passed.
- Swift package: 545 passed, 9 skipped; generated flagship iOS simulator build passed.
- Mobile JSON Schema fixtures, product-copy/API/docs/density guards, roadmap validation, and the PMO commit gate passed.

Two non-failing transcript-import teardown warnings were recorded by the canonical Python run.
