### PR TITLE
TestFlight build 11

### DIFF
--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -119,7 +119,7 @@ target.build_configurations.each do |config|
   s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
   s['PRODUCT_NAME'] = 'HoldSpeakMobile'
   s['MARKETING_VERSION'] = '0.1.0'
-  s['CURRENT_PROJECT_VERSION'] = '10'  # TestFlight build number — bump per upload (b10 = the terminal surface: attach/arm/keys/steer/spawn/kill on glass)
+  s['CURRENT_PROJECT_VERSION'] = '11'  # TestFlight build number — Phase 92 convergence + Phase 93 effortless slices through HS-93-07
   s['GENERATE_INFOPLIST_FILE'] = 'NO'
   s['INFOPLIST_FILE'] = info_plist
   s['TARGETED_DEVICE_FAMILY'] = '1,2'


### PR DESCRIPTION
## What changed

- Bumps the flagship iOS app build number from 10 to 11.
- Packages the merged Phase 92 convergence work and Phase 93 effortless-product slices through HS-93-07 for physical-device UAT.

## User impact

Build 11 becomes the TestFlight vehicle for owner walks on the current iPhone/iPad product instead of the July 8 build 10 baseline.

## Validation

- `swift test`: 545 passed, 9 skipped, 0 failures.
- Generated `HoldSpeakMeetingCapture.xcodeproj` reports build 11 and bundle `dev.holdspeak.mobile`.
- Flagship iOS Simulator target: `BUILD SUCCEEDED` after restoring the canonical gitignored Core ML diarization weight in the isolated build worktree.
- iPhone 17 Pro Max simulator launch and rendered connection/Desk inspection completed.
