### PR TITLE
Phase 93 round 2: zones get physics + the owner's live-spin fixes

### DIFF
--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/progress-story-04.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/progress-story-04.md
@@ -206,3 +206,22 @@ slice and remain open.
 The raw captures were taken via the evidence tool and folded here because an
 `evidence-story-04.md` file is a done-claim in `dw check` and this story
 remains in progress.
+
+## Round 2 — the owner's spin (2026-07-15, same evening)
+
+The owner walked the merged desk on desktop and iPhone (LAN + token) and
+found it still not right: zones immovable, several surfaces visually broken.
+Ten findings (R2-01..R2-10 in the inventory) were reproduced with live
+screenshots against the running hub before fixing. The heart of it: zones had
+been treated as fixed furniture while objects and panels got physics — they
+now drag, resize, and persist exactly like objects; the chrome band no longer
+eats taps; default layouts respect the chrome on both breakpoints; paper
+sprites read as documents; the in-world editor is a bottom sheet on phones
+with a proper header; frosted panels no longer ghost; the egress badge
+truncates.
+
+Verification: full Web gate green (guard 115 sources, typecheck, 32 files /
+173 tests, production build), full Python unit suite `2911 passed in 96.28s`,
+desk source-lock/copy/doc-drift guards `30 passed`, and before/after live
+captures on desktop (1440) and iPhone (393) viewports plus the seeded-rig
+create-Persona editor sheets.

--- a/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/ui-consistency-inventory.md
+++ b/pm/roadmap/holdspeak/phase-93-effortless-holdspeak/ui-consistency-inventory.md
@@ -164,6 +164,25 @@ AttentionDrawer; the hardcoded corner geometry leaves
 With per-panel rects the destroy-on-open exclusivity relaxes to
 focus-not-destroy.
 
+### Round 2 — owner spin findings (2026-07-15, live Web + iPhone)
+
+The owner took the merged desk for a spin (desktop + iPhone over LAN) and
+found it still bad. Every finding below was reproduced with live screenshots
+before fixing; all four Round-1 review passes had missed them.
+
+| ID | Sev | Where | Defect | Status |
+|---|---|---|---|---|
+| R2-01 | crit | `World.tsx` ZoneTray, `desk.css` `.desk-zone` | Zones were never given the object/window physics: pinned to a fixed top-row grid, not movable, not resizable, no persistence — now they drag like objects (tap dives, drag moves, position persists as `zone:<id>` beside the object layout) and resize by a width grip | fixed |
+| R2-02 | crit | `desk.css` `.desk-chrome` | The chrome clusters' empty flex boxes intercepted taps meant for the world beneath (on iPhone whole objects were unreachable); the band is now `pointer-events: none` with interactive children only | fixed |
+| R2-03 | high | `world.ts` objUnit, `World.tsx` zone slots | Default homes placed objects and zones under the chrome band (worse on phones where the chrome wraps two rows); defaults now respect a chrome-safe band per breakpoint, zones one band above the object grid | fixed |
+| R2-04 | high | `desk.css` sprites | Note/artifact paper sprites render as blank beige squares that read as missing textures; a ruled-lines + ink-margin + corner-fold treatment (CSS only, assets untouched) makes them read as documents, slightly downsized | fixed |
+| R2-05 | high | `InlineEditor.tsx`, `desk.css` | The in-world create/edit card anchors beside its object and runs off-screen on phones (Done unreachable); on compact it is now a fixed bottom sheet, and it gained a kind eyebrow + close header on all sizes | fixed |
+| R2-06 | med | `desk.css` window fills | Desk objects ghosted through the 0.93-alpha frosted panels as blurry blocks (read as broken rendering); fills raised to 0.985 | fixed |
+| R2-07 | med | `desk.css` chrome | The egress badge renders unbounded content (full endpoint URLs) and overflowed the viewport; now truncates with ellipsis | fixed |
+| R2-08 | low | `desk.css` compact | Edge objects' labels clipped at both screen edges on phones; compact grid insets widened and label width capped | fixed |
+| R2-09 | low | `desk.css` compact chrome | The start-action row could overflow the phone viewport (Create clipped); the cluster now wraps | fixed |
+| R2-10 | med | `Pullout.tsx` sections, `desk.css` | Pull-out body sections were floating bare text with no rhythm; sections are now quiet cards (border, radius, consistent gap) | fixed |
+
 ### Noted, not scheduled here
 
 - `AmbientLayer.tsx` 277–279 copy ("Making meeting intelligence", "The hub is

--- a/web/src/desk/components/DeskObject.tsx
+++ b/web/src/desk/components/DeskObject.tsx
@@ -127,6 +127,7 @@ export function DeskObject({
       tabIndex={0}
       aria-label={`${o.title}${projectionCounts?.needs_attention ? `, ${projectionCounts.needs_attention} need attention` : ""}`}
       data-obj-id={selectionRef}
+      data-kind={o.kind}
       className={
         "desk-obj" +
         (dragging ? " dragging" : "") +

--- a/web/src/desk/components/InlineEditor.tsx
+++ b/web/src/desk/components/InlineEditor.tsx
@@ -126,6 +126,26 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
         style={style}
         onPointerDown={(e) => e.stopPropagation()}
       >
+        <header className="desk-editor-head">
+          <span className="desk-panel-eyebrow">
+            {(
+              {
+                note: "Note",
+                kb: "Knowledge",
+                recipe: "Persona",
+                workflow: "Workflow",
+              } as Record<string, string>
+            )[o.kind] || o.kind}
+          </span>
+          <button
+            type="button"
+            className="desk-pullout-close"
+            onClick={closeEditor}
+            aria-label="Close editor"
+          >
+            ✕
+          </button>
+        </header>
         {o.kind === "note" && (
           <>
             <input

--- a/web/src/desk/components/World.tsx
+++ b/web/src/desk/components/World.tsx
@@ -3,6 +3,7 @@
 // the lasso surface (HSM-16-04): drag on the background to rope objects into
 // the Ask atom's context.
 import { useRef, useState } from "react";
+import { useDrag } from "@use-gesture/react";
 import { useDesk } from "../store";
 import {
   objectByRef,
@@ -123,8 +124,10 @@ export function World() {
         </button>
       )}
       {zones.map((z, i) => {
-        const cols = Math.max(1, Math.min(4, zones.length));
-        const wPct = Math.min(30, 84 / cols);
+        const compact =
+          typeof window !== "undefined" && window.innerWidth <= 720;
+        const cols = Math.max(1, Math.min(compact ? 2 : 4, zones.length));
+        const wPct = Math.min(compact ? 42 : 30, 84 / cols);
         return (
           <ZoneTray
             key={z.id}
@@ -132,7 +135,10 @@ export function World() {
             style={
               {
                 left: `${((((i % cols) + 0.5) / cols) * 100).toFixed(2)}%`,
-                top: "12%",
+                // Default homes clear the chrome band and sit one band
+                // above the object grid (objUnit yMin); a dragged zone
+                // keeps whatever home the owner gave it.
+                top: `${(compact ? 0.2 : 0.13) * 100 + Math.floor(i / cols) * 12}%`,
                 width: `${wPct}%`,
                 "--zk": objGlow("directory"),
               } as React.CSSProperties
@@ -173,7 +179,10 @@ export function World() {
 }
 
 /** A landmark zone tray (HS-73-05): stable tint, member mini-sprites,
- * drop affordance, dive on click, rename-in-place, an empty hint. */
+ * drop affordance, dive on click, rename-in-place, an empty hint. A zone is
+ * desk material like any object: drag it anywhere (the position persists
+ * beside the object layout, keyed `zone:<id>`), resize its width by the
+ * corner grip, tap to dive. */
 function ZoneTray({
   z,
   style,
@@ -181,13 +190,72 @@ function ZoneTray({
   z: ReturnType<typeof worldZones>[number];
   style: React.CSSProperties;
 }) {
+  const zoneKey = `zone:${z.id}`;
   const items = useDesk((s) => s.items);
   const hoverZoneId = useDesk((s) => s.hoverZoneId);
   const renamingZoneId = useDesk((s) => s.renamingZoneId);
+  const savedPos = useDesk((s) => s.positions[zoneKey]);
+  const savedWidth = useDesk((s) => s.zoneWidths[z.id]);
+  const dragging = useDesk((s) => s.draggingId === zoneKey);
   const { renameZone, diveInto, setRenamingZone } = useDesk.getState();
   const [renaming, setRenaming] = useState(false);
   const [name, setName] = useState(z.title);
   const focusRename = renamingZoneId === z.id;
+
+  const bind = useDrag(
+    ({ event, first, last, movement: [mx, my], memo }) => {
+      // The rename input and mic keep their own gestures.
+      if (first) {
+        const t = event?.target as HTMLElement | null;
+        if (t?.closest("input, button, [role='textbox']"))
+          return { skip: true };
+      }
+      if (memo?.skip) return memo;
+      const el = event?.target as HTMLElement | null;
+      const world = memo?.world ?? el?.closest(".desk-world");
+      if (!world) return memo;
+      const moved = memo?.moved || Math.abs(mx) + Math.abs(my) > 4;
+      const { setDragging, setPosition, persistPositions } = useDesk.getState();
+      if (first) setDragging(zoneKey);
+      if (moved && event && "clientX" in event) {
+        // A FRESH world rect each move (the HS-71-05 robustness rule).
+        const px = (event as PointerEvent).clientX;
+        const py = (event as PointerEvent).clientY;
+        const r = (world as HTMLElement).getBoundingClientRect();
+        setPosition(zoneKey, {
+          x: Math.min(0.96, Math.max(0.04, (px - r.left) / r.width)),
+          y: Math.min(0.94, Math.max(0.03, (py - r.top) / r.height)),
+        });
+      }
+      if (last) {
+        if (moved) {
+          persistPositions();
+          // Cleared next tick so the click reads the drag and does not dive.
+          setTimeout(() => setDragging(null), 0);
+        } else {
+          setDragging(null);
+        }
+      }
+      return { world, moved, skip: false };
+    },
+    { pointer: { buttons: 1 } },
+  );
+
+  const resizeBind = useDrag(
+    ({ event, movement: [mx], last, memo }) => {
+      event?.stopPropagation();
+      const base: number =
+        memo?.base ??
+        (event?.target as HTMLElement | null)?.closest<HTMLElement>(
+          ".desk-zone",
+        )?.offsetWidth ??
+        200;
+      const next = Math.min(560, Math.max(148, base + mx));
+      useDesk.getState().setZoneWidth(z.id, next, last);
+      return { base };
+    },
+    { pointer: { buttons: 1 } },
+  );
   const memberIds = ((z.ref as any).memberIds as string[]) || [];
   const thumbs = memberIds.slice(0, 4).map((mid) => {
     const r = resolveRef(items, mid);
@@ -200,15 +268,34 @@ function ZoneTray({
     if (clean && clean !== z.title) void renameZone(z.id, clean);
   };
   const tint = ZONE_TINTS[variantIndex(z.id, ZONE_TINTS.length)];
+  const placed: React.CSSProperties = savedPos
+    ? {
+        ...style,
+        left: `${(savedPos.x * 100).toFixed(2)}%`,
+        top: `${(savedPos.y * 100).toFixed(2)}%`,
+      }
+    : style;
+  if (savedWidth) {
+    placed.width = savedWidth;
+    placed.maxWidth = "none";
+  }
+
   return (
     <div
-      className={"desk-zone" + (hoverZoneId === z.id ? " drop-ready" : "")}
+      {...bind()}
+      className={
+        "desk-zone" +
+        (hoverZoneId === z.id ? " drop-ready" : "") +
+        (dragging ? " dragging" : "")
+      }
       data-zone-id={z.id}
       role="button"
       tabIndex={0}
       aria-label={`${z.title} zone, ${memberIds.length} ${memberIds.length === 1 ? "item" : "items"}`}
-      style={{ ...style, "--zk": tint } as React.CSSProperties}
+      style={{ ...placed, "--zk": tint } as React.CSSProperties}
       onClick={() => {
+        // A completed drag never dives (the HS-71-06 discrimination).
+        if (useDesk.getState().draggingId === zoneKey) return;
         if (!renaming && !focusRename) diveInto(z.id);
       }}
       onKeyDown={(event) => {
@@ -281,6 +368,12 @@ function ZoneTray({
       ) : (
         <span className="desk-zone-count">drop things here</span>
       )}
+      <span
+        className="desk-zone-grip"
+        {...resizeBind()}
+        aria-hidden="true"
+        onClick={(e) => e.stopPropagation()}
+      />
     </div>
   );
 }

--- a/web/src/desk/desk.css
+++ b/web/src/desk/desk.css
@@ -147,6 +147,46 @@
 .desk-next .desk-obj:hover .desk-obj-sprite {
   filter: drop-shadow(0 12px 16px rgba(0, 0, 0, 0.6)) brightness(1.08);
 }
+/* Notes: the paper sprite is a near-blank sheet, which reads as a missing
+   texture at 88px. Ruled lines, an ink margin, and a corner fold make it
+   read as a note without touching the sprite assets. */
+.desk-next .desk-obj[data-kind="note"] .desk-obj-sprite,
+.desk-next .desk-obj[data-kind="artifact"] .desk-obj-sprite {
+  width: 74px;
+  height: 74px;
+  margin: 7px;
+}
+.desk-next .desk-obj[data-kind="note"] .desk-obj-lift,
+.desk-next .desk-obj[data-kind="artifact"] .desk-obj-lift {
+  position: relative;
+}
+.desk-next .desk-obj[data-kind="note"] .desk-obj-lift::after,
+.desk-next .desk-obj[data-kind="artifact"] .desk-obj-lift::after {
+  content: "";
+  position: absolute;
+  inset: 16px 15px 15px 16px;
+  z-index: 2;
+  pointer-events: none;
+  background:
+    linear-gradient(
+        225deg,
+        rgba(0, 0, 0, 0.22) 0 9px,
+        rgba(255, 255, 255, 0.28) 9px 10px,
+        transparent 10px
+      )
+      no-repeat,
+    repeating-linear-gradient(
+      180deg,
+      transparent 0 11px,
+      rgba(72, 62, 46, 0.28) 11px 12px
+    );
+  background-size:
+    100% 100%,
+    100% calc(100% - 14px);
+  background-position:
+    0 0,
+    0 12px;
+}
 .desk-next .desk-obj:hover .desk-obj-glow {
   opacity: 0.82;
 }
@@ -194,11 +234,48 @@
     0 12px 30px rgba(0, 0, 0, 0.42),
     inset 0 1px 0 color-mix(in srgb, var(--zk, #e0a458) 30%, transparent);
   color: var(--text);
-  cursor: pointer;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
   transition:
-    transform var(--duration-short) var(--ease-standard),
     box-shadow var(--duration-short) var(--ease-standard),
     border-color var(--duration-short) var(--ease-standard);
+}
+.desk-next .desk-zone.dragging {
+  cursor: grabbing;
+  z-index: 20;
+  transition: none;
+}
+.desk-next .desk-zone-grip {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 16px;
+  height: 16px;
+  cursor: ew-resize;
+  touch-action: none;
+  opacity: 0;
+  background: linear-gradient(
+      135deg,
+      transparent 0 50%,
+      color-mix(in srgb, var(--zk, #e0a458) 70%, var(--text-faint)) 50% 58%,
+      transparent 58% 72%,
+      color-mix(in srgb, var(--zk, #e0a458) 70%, var(--text-faint)) 72% 80%,
+      transparent 80%
+    )
+    no-repeat;
+  transition: opacity var(--duration-short) var(--ease-standard);
+}
+.desk-next .desk-zone:hover .desk-zone-grip,
+.desk-next .desk-zone.dragging .desk-zone-grip {
+  opacity: 0.9;
+}
+@media (pointer: coarse) {
+  .desk-next .desk-zone-grip {
+    opacity: 0.6;
+    width: 22px;
+    height: 22px;
+  }
 }
 .desk-next .desk-zone:hover {
   transform: translateX(-50%) translateY(-2px);
@@ -230,10 +307,22 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  /* The chrome band must never eat taps meant for the world beneath it:
+     only its actual controls are interactive, the flex box is not. */
+  pointer-events: none;
+}
+.desk-next .desk-chrome > * {
+  pointer-events: auto;
 }
 .desk-next .desk-chrome-tl {
   top: 14px;
   left: 18px;
+}
+.desk-next .desk-chrome .egress-badge {
+  max-width: min(340px, 34vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .desk-next .desk-chrome-tr {
   top: 14px;
@@ -429,7 +518,7 @@
   border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border));
   border-left: 3px solid color-mix(in srgb, var(--accent) 70%, transparent);
   border-radius: 18px;
-  background: rgba(13, 11, 18, 0.93);
+  background: rgba(13, 11, 18, 0.985);
   color: var(--text);
   box-shadow: 0 26px 70px rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(10px);
@@ -532,7 +621,7 @@
   border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border));
   border-left: 3px solid color-mix(in srgb, var(--accent) 70%, transparent);
   border-radius: 18px;
-  background: rgba(13, 11, 18, 0.93);
+  background: rgba(13, 11, 18, 0.985);
   color: var(--text);
   box-shadow: 0 26px 70px rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(10px);
@@ -870,6 +959,14 @@
   outline: none;
   border-color: var(--accent, #ff6b35);
 }
+.desk-next .desk-editor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
 .desk-next .desk-editor-more {
   align-self: flex-start;
   padding: 4px 10px;
@@ -920,7 +1017,7 @@
   border-radius: 18px;
   border: 1px solid color-mix(in srgb, var(--k, #ff6b35) 34%, var(--border));
   border-left: 3px solid color-mix(in srgb, var(--k, #ff6b35) 70%, transparent);
-  background: rgba(13, 11, 18, 0.93);
+  background: rgba(13, 11, 18, 0.985);
   box-shadow: 0 26px 70px rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(10px);
 }
@@ -1015,6 +1112,15 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+}
+.desk-next .desk-pullout-body section,
+.desk-next .desk-relationship-axes {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.03);
 }
 .desk-next .desk-pullout-body h3 {
   margin: 0 0 6px;
@@ -2684,7 +2790,7 @@
   border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border));
   border-left: 3px solid color-mix(in srgb, var(--accent) 70%, transparent);
   border-radius: 18px;
-  background: rgba(13, 11, 18, 0.93);
+  background: rgba(13, 11, 18, 0.985);
   color: var(--text);
   box-shadow: 0 26px 70px rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(10px);
@@ -2876,6 +2982,20 @@
   }
   .desk-next .desk-start-actions {
     width: 100%;
+    flex-wrap: wrap;
+  }
+  /* The in-world editor becomes a bottom sheet on phones: an editor
+     anchored beside an object near the screen edge is unreachable. */
+  .desk-next .desk-editor {
+    position: fixed;
+    top: auto !important;
+    left: 10px !important;
+    right: 10px !important;
+    bottom: 84px;
+    width: auto;
+    max-height: 62vh;
+    overflow: auto;
+    z-index: 46;
   }
   .desk-next .desk-start-action,
   .desk-next .desk-create-button {
@@ -2925,6 +3045,15 @@
   .desk-next .desk-receipt-detail dl div {
     grid-template-columns: 1fr;
     gap: 3px;
+  }
+}
+@media (max-width: 720px) {
+  .desk-next .desk-obj-label {
+    max-width: 92px;
+    font-size: 11px;
+  }
+  .desk-next .desk-chrome .egress-badge {
+    max-width: 40vw;
   }
 }
 @media (max-width: 420px) {

--- a/web/src/desk/store.ts
+++ b/web/src/desk/store.ts
@@ -72,6 +72,26 @@ function savePanelRects(rects: Record<string, PanelRect>, keep: string[]) {
 
 const initialPanelRects = loadPanelRects();
 
+/** Zone tray widths in px (`hs.desk.zonew`) — zones move via the shared
+ * positions map (keyed `zone:<id>`) and resize via this sibling map. */
+const ZONE_W_KEY = "hs.desk.zonew";
+
+function loadZoneWidths(): Record<string, number> {
+  try {
+    return JSON.parse(localStorage.getItem(ZONE_W_KEY) || "{}") || {};
+  } catch {
+    return {};
+  }
+}
+
+function saveZoneWidths(widths: Record<string, number>) {
+  try {
+    localStorage.setItem(ZONE_W_KEY, JSON.stringify(widths));
+  } catch {
+    /* storage may be unavailable; arranging just won't persist */
+  }
+}
+
 /** Meetings on the desk when a local recording started (NEW-beat diff). */
 let meetingsBeforeRecording = new Set<string>();
 
@@ -122,6 +142,8 @@ interface DeskState {
   recording: "idle" | "recording" | "busy";
   recordingExternal: boolean;
   recordingStartedAt: number | null;
+  /** Zone tray widths in px (resized zones only). */
+  zoneWidths: Record<string, number>;
   /** Desk-window geometry per panel id (moved/resized panels only). */
   panelRects: Record<string, PanelRect>;
   /** Panel ids whose rect the user arranged — the persisted subset. */
@@ -204,6 +226,8 @@ interface DeskState {
   startRecording(): Promise<void>;
   /** Stop the hub recorder; the finished meeting materializes NEW. */
   stopRecording(): Promise<void>;
+  /** Resize a zone tray; persist=true saves the width. */
+  setZoneWidth(id: string, width: number, persist?: boolean): void;
   /** Move/resize a desk window; persist=true marks it user-arranged. */
   setPanelRect(id: string, rect: PanelRect, persist?: boolean): void;
   /** Forget a window's arranged rect (back to its CSS default corner). */
@@ -223,6 +247,7 @@ export const useDesk = create<DeskState>((set, get) => ({
   loading: false,
   updatedAt: null,
   positions: loadPositions(),
+  zoneWidths: loadZoneWidths(),
   recording: "idle",
   recordingExternal: false,
   recordingStartedAt: null,
@@ -677,6 +702,11 @@ export const useDesk = create<DeskState>((set, get) => ({
     const after = get().items.meeting.map((m: any) => String(m.id));
     const fresh = after.find((id: string) => !meetingsBeforeRecording.has(id));
     if (fresh) get().markNew(fresh);
+  },
+  setZoneWidth(id, width, persist = false) {
+    const zoneWidths = { ...get().zoneWidths, [id]: width };
+    set({ zoneWidths });
+    if (persist) saveZoneWidths(zoneWidths);
   },
   setPanelRect(id, rect, persist = false) {
     const panelRects = { ...get().panelRects, [id]: rect };

--- a/web/src/desk/world.ts
+++ b/web/src/desk/world.ts
@@ -136,9 +136,19 @@ export function objUnit(
   const row = Math.floor(i / cols);
   const jx = (oh(o.id + "x") - 0.5) * (0.7 / cols);
   const jy = (oh(o.id + "y") - 0.5) * (0.6 / rows);
+  // Default homes stay clear of the chrome band: the top clusters occupy
+  // one row on wide screens and wrap much deeper on phones. A user drag
+  // may still park anything anywhere; only defaults respect the band.
+  const compact = typeof window !== "undefined" && window.innerWidth <= 720;
+  // Zones default one band above (0.20 compact / 0.13 wide, see World).
+  const yMin = compact ? 0.32 : 0.18;
+  const xMin = compact ? 0.14 : 0.07;
   return {
-    x: Math.min(0.94, Math.max(0.06, (col + 0.5) / cols + jx)),
-    y: Math.min(0.94, Math.max(0.06, (row + 0.5) / rows + jy)),
+    x: Math.min(1 - xMin, Math.max(xMin, (col + 0.5) / cols + jx)),
+    y: Math.min(
+      0.92,
+      Math.max(yMin, yMin + (1 - yMin - 0.08) * ((row + 0.5) / rows) + jy),
+    ),
   };
 }
 


### PR DESCRIPTION
## Why

The owner walked the merged desk (desktop + iPhone over LAN) and found it still wrong: zones immovable and unresizable, several surfaces visually broken. Ten findings (R2-01..R2-10 in `ui-consistency-inventory.md`), each reproduced with live screenshots against the running hub before fixing — all missed by the round-1 review passes.

## What

- **Zones are desk material now**: drag anywhere (tap still dives in), resize by a width grip, position persists (`zone:<id>` beside the object layout, width under `hs.desk.zonew`) — the same @use-gesture machinery objects use, with the same tap/drag discrimination.
- **The chrome band no longer eats taps**: on iPhone, whole desk objects were unreachable under the top clusters' empty flex boxes; the band is now pointer-transparent with interactive children only.
- **Chrome-safe default layout** per breakpoint; zones default one band above the object grid instead of under the chrome.
- **Paper sprites read as documents** (ruled lines + ink margin + corner fold, CSS only) instead of blank beige squares that looked like missing textures.
- **The in-world create/edit card is a bottom sheet on phones** (it anchored beside the object and ran off-screen, Done unreachable) and gains a kind-eyebrow + close header everywhere.
- Frosted panels no longer ghost desk objects as blurry blocks (fill 0.985); the egress badge truncates instead of overflowing with a full URL; compact labels fit; the start-action row wraps; pull-out body sections are structured cards.

## Verification

Full Web gate (guard 115 sources, typecheck, 32 files / 173 tests, production build), full Python unit suite **2911 passed**, desk source-lock/copy/doc-drift guards 30 passed, live before/after captures at 1440 and 393 widths plus seeded-rig create-Persona editor sheets.