### PR TITLE
UAT campaigns 10-12: the Phase 93/94 physical proof program + TestFlight build 12

### DIFF
--- a/apple/scripts/gen-meeting-capture.rb
+++ b/apple/scripts/gen-meeting-capture.rb
@@ -119,7 +119,7 @@ target.build_configurations.each do |config|
   s['PRODUCT_BUNDLE_IDENTIFIER'] = BUNDLE_ID
   s['PRODUCT_NAME'] = 'HoldSpeakMobile'
   s['MARKETING_VERSION'] = '0.1.0'
-  s['CURRENT_PROJECT_VERSION'] = '11'  # TestFlight build number — Phase 92 convergence + Phase 93 effortless slices through HS-93-07
+  s['CURRENT_PROJECT_VERSION'] = '12'  # TestFlight build number — Phase 93 close (round-2 UI remediation, HS-93-08/09) + Phase 94 Delivery Runtime native contracts
   s['GENERATE_INFOPLIST_FILE'] = 'NO'
   s['INFOPLIST_FILE'] = info_plist
   s['TARGETED_DEVICE_FAMILY'] = '1,2'

--- a/uat/FUNCTIONAL-PASS.md
+++ b/uat/FUNCTIONAL-PASS.md
@@ -5,12 +5,17 @@ the product feels like and whether its user journeys work. Database drift,
 packet-capture/no-telemetry proof, crafted-schema attacks, and token-gate attack
 work are not part of this pass by owner decision.
 
-The guided site exposes nine ordered campaigns assembled from the canonical
+The guided site exposes twelve ordered campaigns assembled from the canonical
 scenario files. Campaigns 1–5 are the core owner pass. Campaign 6 is the
 user-visible connectivity/integration extension. Campaign 7 is conditional on
 having the two non-flagship native builds installed. Campaigns 8 and 9 are the
 Phase 92 convergence close: the same ten journeys on production Web and the
-physical flagship Swift root, with required raw measurements.
+physical flagship Swift root, with required raw measurements. Campaigns 10–12
+are the Phase 93/94 physical proof program (BACKLOG candidate Y): 10 covers the
+Phase 93 owner residue on production desktop Web, 11 the same residue on
+physical iPhone/iPad with the flagship app (TestFlight build 12+), and 12 the
+Phase 94 Delivery Runtime legs that need real metal — a second machine over
+Tailscale, the physical iPad, and tailnet HTTPS.
 
 This protocol uses implementation target × form factor. Campaign 1 is the
 `web_react:desktop` Desk leg. Campaign 5 contains the separately executed

--- a/uat/README.md
+++ b/uat/README.md
@@ -35,9 +35,13 @@ uv run python -m uat.conductor           # opens the UAT site; note the URL it p
 
 Then, in the browser (it prints `http://localhost:8799`):
 
-1. Start **1 · React Web Desk foundation — desktop**. The nine numbered owner
+1. Start **1 · React Web Desk foundation — desktop**. The twelve numbered owner
    campaigns are the execution protocol; ordinary packs remain below them as
-   reference/diagnostic material.
+   reference/diagnostic material. Campaigns 10–12 are the Phase 93/94
+   physical-proof legs (BACKLOG candidate Y): 10 is production-Web owner
+   evidence, 11 is the flagship pass on physical devices (TestFlight build 12+),
+   12 is the Delivery Runtime on real metal (second machine, iPad, tailnet
+   HTTPS).
 2. Walk the beats: each says *do this*, *expect this*. Use **Open the product**
    to jump to the right screen. Cast a verdict only for the displayed
    **target/form-factor slot**. Campaign 1 is React desktop; Campaign 5 is the
@@ -55,11 +59,14 @@ Then, in the browser (it prints `http://localhost:8799`):
 If anything is broken or pending, it is named honestly under **Known state**
 below.
 
-The numbered pass currently contains 90 scenarios and 327 direct observations:
-54 are fully automatic, 27 are recipe-staged plus a real-world preflight, and 9
-begin at a genuinely hands-on boundary. Exact meeting/action/proposal fixtures
-remove model wording and manual setup from UI-mechanics tests; live inference
-stays in the scenarios that judge intelligence itself.
+Campaigns 1–9 contain 90 scenarios and 327 direct observations: 54 are fully
+automatic, 27 are recipe-staged plus a real-world preflight, and 9 begin at a
+genuinely hands-on boundary. Exact meeting/action/proposal fixtures remove
+model wording and manual setup from UI-mechanics tests; live inference stays
+in the scenarios that judge intelligence itself. Campaigns 10–12 add 20
+scenarios that are deliberately hands-on: they exist to capture the owner and
+physical-device evidence the Phase 93/94 closes parked, so most beats start at
+a human boundary (real microphones, real devices, a second machine).
 
 ---
 

--- a/uat/campaigns/owner-10-phase93-web-close.yaml
+++ b/uat/campaigns/owner-10-phase93-web-close.yaml
@@ -1,0 +1,25 @@
+title: "10 · Phase 93 physical proof — production Web"
+purpose: >
+  Burn down the Phase 93 owner residue (BACKLOG candidate Y) on production
+  desktop Web: first-glance and discovery, room returns, the copy read-through,
+  Desk-power measures, the real-microphone fault matrix, meeting survival, and
+  the ten-journey direct observation. Every verdict here is the owner evidence
+  the machine-verified story closes explicitly parked.
+sequence: 10
+tier: close
+estimated_minutes: 180
+prerequisites:
+  - Phase 93 closed at machine-verifiable scope on 2026-07-16; this campaign is its owner leg, not a re-run of the bounded suites.
+  - Use the exact production build; record commit and build provenance in the sitting notes.
+  - A real desktop microphone, a reachable model endpoint you can also kill, and a second paired device for the conflict/sync legs.
+exit_gate:
+  - Every scenario has a verdict on web_react:desktop with its measurements recorded; no lost work, false completion, or silent retargeting anywhere.
+  - Non-pass findings are triaged per TRIAGE.md into BACKLOG rows before the native campaign starts.
+scenarios:
+  - phase-93-web/phase93-web-first-glance
+  - phase-93-web/phase93-web-room-return
+  - phase-93-web/phase93-web-copy-read
+  - phase-93-web/phase93-web-desk-power
+  - phase-93-web/phase93-web-mic-faults
+  - phase-93-web/phase93-web-meeting-survival
+  - phase-93-web/phase93-web-ten-journeys

--- a/uat/campaigns/owner-11-phase93-native-close.yaml
+++ b/uat/campaigns/owner-11-phase93-native-close.yaml
@@ -1,0 +1,25 @@
+title: "11 · Phase 93 physical proof — flagship on glass"
+purpose: >
+  The same Phase 93 owner residue on physical iPhone and iPad with the flagship
+  Swift app: first glance, room returns, copy, Desk power, the microphone fault
+  matrix with real interruptions, sustained meeting capture with airplane-mode
+  exactly-once sync, and the full accessibility walks. Native verdicts stay
+  locked to pairing-verified device attestations.
+sequence: 11
+tier: close
+estimated_minutes: 300
+prerequisites:
+  - TestFlight build 12 or newer installed on both physical devices; register the device attestation (device, OS, bundle, build 12+, TestFlight) before any verdict.
+  - Start the conductor with UAT_HOST=0.0.0.0 and Device sitting enabled; pair the app to the isolated run.
+  - A second phone for real incoming calls, a Bluetooth audio route, and a 30-minute quiet block for the sustained capture.
+exit_gate:
+  - Every scenario has independent verdicts on ios_flagship_swift:iphone and :ipad with measurements and provenance recorded.
+  - VoiceOver screen-curtain, Dynamic Type, Reduce Motion, and orientation evidence is direct and unwaived.
+scenarios:
+  - phase-93-native/phase93-native-first-glance
+  - phase-93-native/phase93-native-room-return
+  - phase-93-native/phase93-native-copy-read
+  - phase-93-native/phase93-native-desk-power
+  - phase-93-native/phase93-native-mic-faults
+  - phase-93-native/phase93-native-meeting-survival
+  - phase-93-native/phase93-native-accessibility

--- a/uat/campaigns/owner-12-phase94-delivery-runtime.yaml
+++ b/uat/campaigns/owner-12-phase94-delivery-runtime.yaml
@@ -1,0 +1,25 @@
+title: "12 · Phase 94 delivery runtime — the platform on real metal"
+purpose: >
+  Prove the Delivery Runtime beyond the two-process proofs: delivery work
+  observed and steered from the Desk, evidence dossiers, Story-bound agent
+  launch, a second physical machine over Tailscale, the physical iPad native
+  legs with remote disarm, and iPad Safari over tailnet HTTPS with a
+  secure-context microphone.
+sequence: 12
+tier: close
+estimated_minutes: 240
+prerequisites:
+  - Phase 94 closed at machine-verifiable scope on 2026-07-16; this campaign is its physical leg (second machine, iPad, tailnet HTTPS).
+  - A second physical machine on the tailnet running `holdspeak node serve` with a node-scoped token and a real repository checkout.
+  - Tailscale Serve HTTPS configured for the hub; TestFlight build 12 or newer on the physical iPad.
+  - Use scratch branches or worktrees for launched agent work so a real repository is never at risk.
+exit_gate:
+  - Zero duplicate or wrong-target effects across every steer, launch, and reconnect leg, with complete Receipts.
+  - The remote-disarm and stale/offline clocks behave as specified; the tailnet HTTPS microphone works in Safari's secure context.
+scenarios:
+  - phase-94-delivery/phase94-desk-observe
+  - phase-94-delivery/phase94-evidence-dossier
+  - phase-94-delivery/phase94-story-launch
+  - phase-94-delivery/phase94-second-node
+  - phase-94-delivery/phase94-ipad-native
+  - phase-94-delivery/phase94-tailnet-https

--- a/uat/feature-additions.yaml
+++ b/uat/feature-additions.yaml
@@ -81,3 +81,119 @@ features:
     recipes: [seeded-desk]
     priority: must
     status: live
+  # Phase 93/94 physical proof program — BACKLOG candidate Y, moved here as
+  # scheduled owner work when the phases closed at machine-verifiable scope
+  # (2026-07-16). Each key names one residue family; the scenarios in
+  # uat/scenarios/phase-93-web, phase-93-native, and phase-94-delivery cite them.
+  - key: phase93.residue.first-glance
+    title: Owner first-glance explanation and moved-tool discovery on the production build
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'yes'}
+    recipes: [fresh-desk]
+    priority: must
+    status: live
+  - key: phase93.residue.room-return
+    title: Contextual entry and pasted direct links return to a Desk subject through cancel and failure
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'yes'}
+    recipes: [seeded-desk]
+    priority: must
+    status: live
+  - key: phase93.residue.copy-read
+    title: Owner copy read-through of the ten primary journeys with zero misunderstood noun or commitment
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'yes'}
+    recipes: [seeded-desk]
+    priority: must
+    status: live
+  - key: phase93.residue.desk-power
+    title: Owner discovery-time and irrelevant-control measures for Desk-composed power
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'yes'}
+    recipes: [seeded-desk]
+    priority: must
+    status: live
+  - key: phase93.residue.mic-faults
+    title: Real-microphone fault matrix with interruption during active capture and per-walk provenance
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'yes'}
+    recipes: [fresh-desk]
+    priority: must
+    status: live
+  - key: phase93.residue.meeting-survival
+    title: Physical meeting duration, fault, airplane-mode exactly-once sync, and owner conflict decisions
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'yes'}
+    recipes: [seeded-desk]
+    priority: must
+    status: live
+  - key: phase93.residue.accessibility
+    title: Physical VoiceOver screen-curtain, Dynamic Type, Reduce Motion, and orientation walks
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'no', ipad: 'yes', iphone: 'yes'}
+    recipes: []
+    priority: must
+    status: live
+  - key: phase93.residue.dogfood
+    title: Sustained owner dogfood with full provenance and the ten-journey direct observation
+    domain: Phase 93 physical proof
+    phases: [93]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'yes'}
+    recipes: []
+    priority: must
+    status: live
+  - key: phase94.delivery.desk-observe
+    title: Delivery projects, stories, sessions, and receipts observable from the Desk
+    domain: Phase 94 delivery runtime
+    phases: [94]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'no'}
+    recipes: []
+    priority: must
+    status: live
+  - key: phase94.delivery.evidence-dossier
+    title: A completed Story and Phase open as evidence dossiers with receipts and honest remote bytes
+    domain: Phase 94 delivery runtime
+    phases: [94]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'no'}
+    recipes: []
+    priority: must
+    status: live
+  - key: phase94.delivery.story-launch
+    title: Discover panes, choose a worktree, launch Story-bound agent work, steer and end it from the Desk
+    domain: Phase 94 delivery runtime
+    phases: [94]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'no'}
+    recipes: []
+    priority: must
+    status: live
+  - key: phase94.delivery.native-parity
+    title: iPad native observe, evidence, voice-steer, and remote-disarm legs with the same contracts
+    domain: Phase 94 delivery runtime
+    phases: [94]
+    surfaces: {web: 'no', ipad: 'yes', iphone: 'no'}
+    recipes: []
+    priority: must
+    status: live
+  - key: phase94.delivery.tailnet-https
+    title: iPad Safari over tailnet HTTPS completes the journeys with a secure-context microphone
+    domain: Phase 94 delivery runtime
+    phases: [94]
+    surfaces: {web: 'yes', ipad: 'yes', iphone: 'no'}
+    recipes: []
+    priority: must
+    status: live
+  - key: phase94.delivery.second-node
+    title: A second physical machine over Tailscale exercises real transport, clock skew, and latency budgets
+    domain: Phase 94 delivery runtime
+    phases: [94]
+    surfaces: {web: 'yes', ipad: 'no', iphone: 'no'}
+    recipes: []
+    priority: must
+    status: live

--- a/uat/feature-targets.yaml
+++ b/uat/feature-targets.yaml
@@ -91,3 +91,21 @@ features:
     ios_flagship_swift: [ipad, iphone]
   sync.content.cross_device:
     ios_flagship_swift: [ipad, iphone]
+  phase93.residue.first-glance:
+    ios_flagship_swift: [ipad, iphone]
+  phase93.residue.room-return:
+    ios_flagship_swift: [ipad, iphone]
+  phase93.residue.copy-read:
+    ios_flagship_swift: [ipad, iphone]
+  phase93.residue.desk-power:
+    ios_flagship_swift: [ipad, iphone]
+  phase93.residue.mic-faults:
+    ios_flagship_swift: [ipad, iphone]
+  phase93.residue.meeting-survival:
+    ios_flagship_swift: [ipad, iphone]
+  phase93.residue.accessibility:
+    ios_flagship_swift: [ipad, iphone]
+  phase93.residue.dogfood:
+    ios_flagship_swift: [ipad, iphone]
+  phase94.delivery.native-parity:
+    ios_flagship_swift: [ipad]

--- a/uat/features.yaml
+++ b/uat/features.yaml
@@ -2828,6 +2828,180 @@ features:
   - seeded-desk
   priority: must
   status: live
+- key: phase93.residue.accessibility
+  title: Physical VoiceOver screen-curtain, Dynamic Type, Reduce Motion, and orientation walks
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes: []
+  priority: must
+  status: live
+- key: phase93.residue.copy-read
+  title: Owner copy read-through of the ten primary journeys with zero misunderstood noun or commitment
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: phase93.residue.desk-power
+  title: Owner discovery-time and irrelevant-control measures for Desk-composed power
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: phase93.residue.dogfood
+  title: Sustained owner dogfood with full provenance and the ten-journey direct observation
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes: []
+  priority: must
+  status: live
+- key: phase93.residue.first-glance
+  title: Owner first-glance explanation and moved-tool discovery on the production build
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: phase93.residue.meeting-survival
+  title: Physical meeting duration, fault, airplane-mode exactly-once sync, and owner conflict decisions
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: phase93.residue.mic-faults
+  title: Real-microphone fault matrix with interruption during active capture and per-walk provenance
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - fresh-desk
+  priority: must
+  status: live
+- key: phase93.residue.room-return
+  title: Contextual entry and pasted direct links return to a Desk subject through cancel and failure
+  domain: Phase 93 physical proof
+  phases:
+  - 93
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'yes'
+  recipes:
+  - seeded-desk
+  priority: must
+  status: live
+- key: phase94.delivery.desk-observe
+  title: Delivery projects, stories, sessions, and receipts observable from the Desk
+  domain: Phase 94 delivery runtime
+  phases:
+  - 94
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'no'
+  recipes: []
+  priority: must
+  status: live
+- key: phase94.delivery.evidence-dossier
+  title: A completed Story and Phase open as evidence dossiers with receipts and honest remote bytes
+  domain: Phase 94 delivery runtime
+  phases:
+  - 94
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'no'
+  recipes: []
+  priority: must
+  status: live
+- key: phase94.delivery.native-parity
+  title: iPad native observe, evidence, voice-steer, and remote-disarm legs with the same contracts
+  domain: Phase 94 delivery runtime
+  phases:
+  - 94
+  surfaces:
+    web: 'no'
+    ipad: 'yes'
+    iphone: 'no'
+  recipes: []
+  priority: must
+  status: live
+- key: phase94.delivery.second-node
+  title: A second physical machine over Tailscale exercises real transport, clock skew, and latency budgets
+  domain: Phase 94 delivery runtime
+  phases:
+  - 94
+  surfaces:
+    web: 'yes'
+    ipad: 'no'
+    iphone: 'no'
+  recipes: []
+  priority: must
+  status: live
+- key: phase94.delivery.story-launch
+  title: Discover panes, choose a worktree, launch Story-bound agent work, steer and end it from the Desk
+  domain: Phase 94 delivery runtime
+  phases:
+  - 94
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'no'
+  recipes: []
+  priority: must
+  status: live
+- key: phase94.delivery.tailnet-https
+  title: iPad Safari over tailnet HTTPS completes the journeys with a secure-context microphone
+  domain: Phase 94 delivery runtime
+  phases:
+  - 94
+  surfaces:
+    web: 'yes'
+    ipad: 'yes'
+    iphone: 'no'
+  recipes: []
+  priority: must
+  status: live
 - key: plugins.authoring.write-your-own
   title: Write your own meeting plugin or connector against a documented contract
   domain: public-docs-claims
@@ -3992,4 +4166,11 @@ phase_map:
   - phase92.journey.next-day-memory
   - phase92.journey.pair-sync
   '93':
-  - internal/no-uat-surface
+  - phase93.residue.accessibility
+  - phase93.residue.copy-read
+  - phase93.residue.desk-power
+  - phase93.residue.dogfood
+  - phase93.residue.first-glance
+  - phase93.residue.meeting-survival
+  - phase93.residue.mic-faults
+  - phase93.residue.room-return

--- a/uat/scenarios/phase-93-native/01-first-glance.yaml
+++ b/uat/scenarios/phase-93-native/01-first-glance.yaml
@@ -1,0 +1,20 @@
+id: phase93-native-first-glance
+execution_target: ios_flagship_swift
+title: "Phase 93 · Native · First glance and moved-tool discovery on glass"
+features: [phase93.residue.first-glance]
+manual_setup:
+  - Install TestFlight build 12 or newer on the physical device; register the device attestation (device, OS, bundle, build, install source) before any verdict.
+recipes: []
+form_factors: [iphone, ipad]
+steps:
+  - do: Cold-launch the app, look for ten seconds without touching, then state what you can start from here.
+    expect: The stated understanding matches the three daily starts; nothing on the first screen needs vocabulary it did not supply.
+    verifies: [phase93.residue.first-glance]
+    measurements:
+      - {key: misread_starts, label: Starts whose purpose was misstated, unit: starts}
+  - do: Find the creation entry, the tool shelf, and Desk memory without documentation, on each device.
+    expect: Each is reached through visible affordances in at most three touches; no tool needs a guess.
+    verifies: [phase93.residue.first-glance]
+    measurements:
+      - {key: dead_ends, label: Wrong paths before finding a tool, unit: paths}
+teardown: []

--- a/uat/scenarios/phase-93-native/02-room-return.yaml
+++ b/uat/scenarios/phase-93-native/02-room-return.yaml
@@ -1,0 +1,21 @@
+id: phase93-native-room-return
+execution_target: ios_flagship_swift
+title: "Phase 93 · Native · Contextual entry and returns through cancel and failure"
+features: [phase93.residue.room-return]
+manual_setup:
+  - Pair the flagship app with a running hub; keep at least one Desk subject (a note or meeting) available to enter rooms from.
+recipes: []
+form_factors: [iphone, ipad]
+steps:
+  - do: Enter Dictation and the Meeting room contextually from a Desk subject, complete one and cancel the other, and return.
+    expect: Each room names its subject; complete returns to the subject; cancel retains the draft and returns without loss.
+    verifies: [phase93.residue.room-return]
+  - do: Force a failure inside a room (airplane mode mid-action), leave, and look for the retained work.
+    expect: The failure names what is retained and where; the Desk shows it after return; no journey ends orphaned.
+    verifies: [phase93.residue.room-return]
+    measurements:
+      - {key: orphaned_journeys, label: Journeys ending with no findable result, unit: journeys}
+  - do: Kill the app mid-room, relaunch, and look for the room's work.
+    expect: Relaunch lands somewhere honest; the room's retained draft or result is findable, and Studio does not read as a second home.
+    verifies: [phase93.residue.room-return]
+teardown: []

--- a/uat/scenarios/phase-93-native/03-copy-read.yaml
+++ b/uat/scenarios/phase-93-native/03-copy-read.yaml
@@ -1,0 +1,18 @@
+id: phase93-native-copy-read
+execution_target: ios_flagship_swift
+title: "Phase 93 · Native · Copy read-through of the primary journeys on glass"
+features: [phase93.residue.copy-read]
+manual_setup:
+  - Keep a notepad; every label, state, destination, or commitment you had to reread or guess at is a finding.
+recipes: []
+form_factors: [iphone, ipad]
+steps:
+  - do: Walk the primary journeys the flagship app owns (arrival, dictation, meeting capture, capability run, destination choice, pairing/sync, decision authority, coder steering, failure recovery) reading every noun, state, and button out loud.
+    expect: Zero misunderstood nouns, states, destinations, or commitments; Secure/Normal/YOLO and destination classes read identically to the Web.
+    verifies: [phase93.residue.copy-read]
+    measurements:
+      - {key: misunderstood_terms, label: Terms requiring a guess or reread, unit: terms}
+  - do: Force two failures (airplane mode, dead endpoint) and read the error copy on the device.
+    expect: Each error states failure, retained work, destination, and next action — no reassurance prose.
+    verifies: [phase93.residue.copy-read]
+teardown: []

--- a/uat/scenarios/phase-93-native/04-desk-power.yaml
+++ b/uat/scenarios/phase-93-native/04-desk-power.yaml
@@ -1,0 +1,18 @@
+id: phase93-native-desk-power
+execution_target: ios_flagship_swift
+title: "Phase 93 · Native · Inspector, connector, Coder, Runs-on, and relaunch walks"
+features: [phase93.residue.desk-power]
+manual_setup:
+  - Pair with a hub that has at least one configured Integration, one Runs-on target, and one live or waiting Coder session.
+recipes: []
+form_factors: [iphone, ipad]
+steps:
+  - do: From the device Desk, find and open the Project inspector, a configured Integration, the Runs-on choice, and the waiting Coder.
+    expect: Each is reachable through Desk affordances without matching Web chrome; each names its state and authority honestly.
+    verifies: [phase93.residue.desk-power]
+    measurements:
+      - {key: undiscoverable, label: Capabilities not found without documentation, unit: capabilities}
+  - do: Complete one Integration proposal to its Receipt, then force one to fail; kill and relaunch the app between the two.
+    expect: The Receipt projects back to its source subject; the failure names what refused and why; relaunch loses neither.
+    verifies: [phase93.residue.desk-power]
+teardown: []

--- a/uat/scenarios/phase-93-native/05-mic-faults.yaml
+++ b/uat/scenarios/phase-93-native/05-mic-faults.yaml
@@ -1,0 +1,23 @@
+id: phase93-native-mic-faults
+execution_target: ios_flagship_swift
+title: "Phase 93 · Native · Real-microphone fault matrix with capture interruption"
+features: [phase93.residue.mic-faults]
+manual_setup:
+  - Use the physical device microphone; record provenance per walk — device, OS, build, audio route (built-in, wired, Bluetooth), model, destination.
+  - Have a second phone ready to place a real incoming call.
+recipes: []
+form_factors: [iphone, ipad]
+steps:
+  - do: Dictate one clean utterance end to end on each device to confirm the happy path.
+    expect: Text lands once at the intended destination; paired delivery produces one Receipt.
+    verifies: [phase93.residue.mic-faults]
+  - do: Induce each fault during real dictation — deny then revoke mic permission, switch to Bluetooth mid-capture, take an incoming call mid-capture, enable airplane mode before delivery, and point at a dead model endpoint.
+    expect: Every fault retains audio or editable text, names itself factually, and offers only applicable recovery; delivery after recovery happens exactly once.
+    verifies: [phase93.residue.mic-faults]
+    measurements:
+      - {key: lost_captures, label: Captures lost across the fault matrix, unit: captures}
+      - {key: duplicate_deliveries, label: Paired deliveries that landed twice, unit: deliveries}
+  - do: Background the app mid-capture, lock the device, then return.
+    expect: The capture checkpoint survives; the app states what was kept; no silent empty result.
+    verifies: [phase93.residue.mic-faults]
+teardown: []

--- a/uat/scenarios/phase-93-native/06-meeting-survival.yaml
+++ b/uat/scenarios/phase-93-native/06-meeting-survival.yaml
@@ -1,0 +1,24 @@
+id: phase93-native-meeting-survival
+execution_target: ios_flagship_swift
+title: "Phase 93 · Native · Long capture, faults, airplane-mode sync, and conflict decisions"
+features: [phase93.residue.meeting-survival]
+manual_setup:
+  - Reserve a 30-minute block for the sustained capture leg (the 60-minute trace may be a separate sitting); note device memory pressure if visible.
+  - Keep the paired hub reachable for the sync legs, then genuinely offline for the airplane leg.
+recipes: []
+form_factors: [iphone, ipad]
+steps:
+  - do: Record a real 5-minute meeting, then a sustained 30-minute one; watch for memory-pressure warnings and check the transcript afterward.
+    expect: Capture stays bounded and responsive; the transcript and base analysis land; any deferred intelligence leaves the Meeting honestly partial with Retry remaining.
+    verifies: [phase93.residue.meeting-survival]
+    measurements:
+      - {key: sustained_minutes, label: Longest completed capture, unit: minutes}
+  - do: Kill the app mid-capture and relaunch; separately, record a full meeting in airplane mode, then reconnect and sync.
+    expect: The killed capture recovers its checkpoint with an honest statement of loss; the airplane-mode meeting syncs exactly once with no duplicate on either side.
+    verifies: [phase93.residue.meeting-survival]
+    measurements:
+      - {key: duplicate_sync_effects, label: Sync effects applied more than once, unit: effects}
+  - do: Create a conflict (edit the same Meeting on the desktop while the device is offline, then reconnect) and decide it on the device.
+    expect: Both exact versions display at the Meeting subject; Keep current, Use synced, or a named deletion is required; the decision applies atomically.
+    verifies: [phase93.residue.meeting-survival]
+teardown: []

--- a/uat/scenarios/phase-93-native/07-accessibility.yaml
+++ b/uat/scenarios/phase-93-native/07-accessibility.yaml
@@ -1,0 +1,23 @@
+id: phase93-native-accessibility
+execution_target: ios_flagship_swift
+title: "Phase 93 · Native · VoiceOver, Dynamic Type, Reduce Motion, and orientation"
+features: [phase93.residue.accessibility]
+manual_setup:
+  - Enable VoiceOver with screen curtain for the first step; know the triple-click accessibility shortcut to switch modes between steps.
+recipes: []
+form_factors: [iphone, ipad]
+steps:
+  - do: With screen curtain and VoiceOver only, complete one dictation and one meeting start-stop, and open one Desk object.
+    expect: Every primary action has a VoiceOver path; focus order is coherent; results are announced, not just drawn.
+    verifies: [phase93.residue.accessibility]
+    measurements:
+      - {key: gesture_only_actions, label: Primary actions with no VoiceOver equivalent, unit: actions}
+  - do: Set the largest accessibility text size and revisit the Desk, a Meeting, and Settings; then enable Reduce Motion and watch the Desk idle.
+    expect: Layouts remain operable without clipped controls; continuous decorative motion stops under Reduce Motion.
+    verifies: [phase93.residue.accessibility]
+    measurements:
+      - {key: clipped_controls, label: Controls clipped or unreachable at max text, unit: controls}
+  - do: Rotate through both orientations mid-dictation and mid-meeting on the iPad; lock and unlock mid-action.
+    expect: No capture, draft, or room context is lost to a rotation or lock.
+    verifies: [phase93.residue.accessibility]
+teardown: []

--- a/uat/scenarios/phase-93-web/01-first-glance.yaml
+++ b/uat/scenarios/phase-93-web/01-first-glance.yaml
@@ -1,0 +1,26 @@
+id: phase93-web-first-glance
+execution_target: web_react
+title: "Phase 93 · Web · First glance explains itself; moved tools are findable"
+features: [phase93.residue.first-glance]
+recipes: [fresh-desk]
+manual_setup:
+  - Use the exact production build (record commit and bundle hash) in a desktop browser at a normal window size.
+form_factors: [desktop]
+steps:
+  - do: Look at the fresh Desk for ten seconds without clicking, then say aloud what you can start from here and what each of the three starts will do.
+    expect: The stated understanding matches Dictate, Record, and Create; no start requires a vocabulary the screen did not supply.
+    where: /
+    verifies: [phase93.residue.first-glance]
+    measurements:
+      - {key: misread_starts, label: Starts whose purpose was misstated, unit: starts}
+  - do: Without documentation, find three tools that moved during the Phase 93 subtraction — the creation entry, the Tools shelf, and Desk memory — and open each.
+    expect: Each is reached through visible Desk affordances; no tool needs a URL, a guess, or more than three actions.
+    where: /
+    verifies: [phase93.residue.first-glance]
+    measurements:
+      - {key: discovery_seconds_worst, label: Slowest tool discovery, unit: seconds}
+      - {key: dead_ends, label: Wrong paths taken before finding a tool, unit: paths}
+  - do: Ask for something that does not exist — look for a "dashboard" or "control center" view.
+    expect: No such destination exists; the Desk itself remains the only home and nothing on screen promises one.
+    where: /
+teardown: []

--- a/uat/scenarios/phase-93-web/02-room-return.yaml
+++ b/uat/scenarios/phase-93-web/02-room-return.yaml
@@ -1,0 +1,20 @@
+id: phase93-web-room-return
+execution_target: web_react
+title: "Phase 93 · Web · Every room returns to its Desk subject through cancel and failure"
+features: [phase93.residue.room-return]
+recipes: [seeded-desk]
+form_factors: [desktop]
+steps:
+  - do: Confirm the seeded Desk shows its objects, then enter Dictation, Meetings, and Workbench contextually from a Desk subject, complete or cancel each, and come back.
+    expect: Each room names the subject it was opened with; completing returns to that subject; cancel returns without losing the room's draft.
+    where: /
+    verifies: [phase93.residue.room-return]
+  - do: Paste a direct room link into a fresh tab (no Desk subject), work in it, and return.
+    expect: The room states its explicit Desk fallback rather than fabricating a subject; the return lands somewhere findable, not an orphaned screen.
+    verifies: [phase93.residue.room-return]
+  - do: Force a failure inside a room (kill the network mid-action or use an invalid input), then leave the room.
+    expect: The failure names what is retained and where; leaving does not discard the retained work; the Desk shows it afterward.
+    verifies: [phase93.residue.room-return]
+    measurements:
+      - {key: orphaned_journeys, label: Journeys that ended with no findable result, unit: journeys}
+teardown: []

--- a/uat/scenarios/phase-93-web/03-copy-read.yaml
+++ b/uat/scenarios/phase-93-web/03-copy-read.yaml
@@ -1,0 +1,20 @@
+id: phase93-web-copy-read
+execution_target: web_react
+title: "Phase 93 · Web · The ten-journey copy read-through"
+features: [phase93.residue.copy-read]
+recipes: [seeded-desk]
+manual_setup:
+  - Keep a notepad; every label, state, destination, or commitment you had to reread or guess at is a finding.
+form_factors: [desktop]
+steps:
+  - do: Walk the ten primary journeys (arrival, dictation, meeting, capability run, destination choice, pairing/sync, integration, decision authority, coder steering, failure recovery) reading every noun, state, and button out loud.
+    expect: Zero misunderstood nouns, states, destinations, or commitments; Secure/Normal/YOLO, Persona, Coder session, and Runs on read as distinct things.
+    where: /
+    verifies: [phase93.residue.copy-read]
+    measurements:
+      - {key: misunderstood_terms, label: Terms requiring a guess or reread, unit: terms}
+      - {key: marketing_lines, label: Lines that sell instead of state, unit: lines}
+  - do: Trigger at least two forced failures (dead endpoint, refused action) and read the error copy.
+    expect: Each error states what failed, what is retained, where it lives, and the next action — no reassurance prose, no anthropomorphic filler.
+    verifies: [phase93.residue.copy-read]
+teardown: []

--- a/uat/scenarios/phase-93-web/04-desk-power.yaml
+++ b/uat/scenarios/phase-93-web/04-desk-power.yaml
@@ -1,0 +1,23 @@
+id: phase93-web-desk-power
+execution_target: web_react
+title: "Phase 93 · Web · Power is discoverable on the Desk without chrome"
+features: [phase93.residue.desk-power]
+recipes: [seeded-desk]
+form_factors: [desktop]
+steps:
+  - do: Starting from the seeded Desk, time how long it takes to find each of — a Project, a configured Integration, a Runs-on target, a live process, and a Receipt — using only Desk affordances (Tools, search, selection, inspector).
+    expect: Every one is reachable without permanent top-level navigation; nothing requires the Studio to merely be found.
+    where: /
+    verifies: [phase93.residue.desk-power]
+    measurements:
+      - {key: discovery_seconds_total, label: Total discovery time across the five, unit: seconds}
+      - {key: undiscoverable, label: Capabilities not found without documentation, unit: capabilities}
+  - do: Count the controls visible on the initial Desk that you did not use for any of the above.
+    expect: The count is honest and small; no control exists whose purpose you cannot state.
+    verifies: [phase93.residue.desk-power]
+    measurements:
+      - {key: irrelevant_controls, label: Visible controls with no stated purpose, unit: controls}
+  - do: Open the desk windows you used, drag, resize, and reload the page.
+    expect: Windows move, resize, keep position across reload, and focus-to-front works — the desk-window contract, not glued panels.
+    verifies: [phase93.residue.desk-power]
+teardown: []

--- a/uat/scenarios/phase-93-web/05-mic-faults.yaml
+++ b/uat/scenarios/phase-93-web/05-mic-faults.yaml
@@ -1,0 +1,23 @@
+id: phase93-web-mic-faults
+execution_target: web_react
+title: "Phase 93 · Web · Real-microphone fault matrix on production Web"
+features: [phase93.residue.mic-faults]
+recipes: [fresh-desk]
+manual_setup:
+  - Use a real microphone on the production desktop browser; record provenance for every walk — device, build, browser, audio route, model, destination.
+form_factors: [desktop]
+steps:
+  - do: Dictate one clean utterance end to end to confirm the happy path before inducing faults.
+    expect: Text lands once in the intended target and a first-value event records without a model-placement decision.
+    where: /
+    verifies: [phase93.residue.mic-faults]
+  - do: Induce each fault in turn during a real dictation — revoke mic permission mid-session, unplug or switch the audio route during active capture, kill the network before delivery, and stop the model endpoint before transcription.
+    expect: Every fault retains the captured audio or editable text, names the fault factually, and offers only applicable recovery actions; nothing claims success falsely.
+    verifies: [phase93.residue.mic-faults]
+    measurements:
+      - {key: lost_captures, label: Captures lost across the fault matrix, unit: captures}
+      - {key: false_successes, label: Faults reported as success, unit: faults}
+  - do: Interrupt a dictation mid-capture by closing the tab, reopen the production URL, and look for the work.
+    expect: The checkpointed capture or draft is findable and editable after relaunch; delivery, when retried, happens exactly once.
+    verifies: [phase93.residue.mic-faults]
+teardown: []

--- a/uat/scenarios/phase-93-web/06-meeting-survival.yaml
+++ b/uat/scenarios/phase-93-web/06-meeting-survival.yaml
@@ -1,0 +1,24 @@
+id: phase93-web-meeting-survival
+execution_target: web_react
+title: "Phase 93 · Web · A desktop meeting survives duration, faults, and conflicts"
+features: [phase93.residue.meeting-survival]
+recipes: [seeded-desk]
+manual_setup:
+  - Reserve one uninterrupted desktop block; have a process monitor open to read the runtime's RSS at capture start, five minutes, and thirty minutes.
+  - Prepare a second paired device (or the flagship app) for the conflict and exactly-once sync legs.
+form_factors: [desktop]
+steps:
+  - do: Record a real five-minute meeting with live audio, noting RSS at start and end, then let intelligence run.
+    expect: Memory stays bounded (no unbounded growth across the capture), the transcript lands, and a partial intelligence failure — if one occurs — retains the Meeting as partial with Retry remaining and Skip remaining offered.
+    verifies: [phase93.residue.meeting-survival]
+    measurements:
+      - {key: rss_growth_mb, label: RSS growth over the capture, unit: MB}
+  - do: Start another capture and kill the runtime process mid-recording, then relaunch and open the Meeting.
+    expect: The checkpointed audio and transcript-so-far are retained and named; recovery states what was kept and what was lost; no silent empty Meeting.
+    verifies: [phase93.residue.meeting-survival]
+  - do: Create a sync conflict — edit the same Meeting on the second device while offline, then reconnect — and decide it from the Meeting's Desk pull-out.
+    expect: Both exact versions display; Keep current, Use synced, or a named deletion is required; the applied choice resolves atomically and syncs exactly once.
+    verifies: [phase93.residue.meeting-survival]
+    measurements:
+      - {key: duplicate_sync_effects, label: Sync effects applied more than once, unit: effects}
+teardown: []

--- a/uat/scenarios/phase-93-web/07-ten-journeys.yaml
+++ b/uat/scenarios/phase-93-web/07-ten-journeys.yaml
@@ -1,0 +1,21 @@
+id: phase93-web-ten-journeys
+execution_target: web_react
+title: "Phase 93 · Web · The ten-journey direct observation on production Web"
+features: [phase93.residue.dogfood]
+recipes: [seeded-desk]
+manual_setup:
+  - Run this as a real work session, not a demo — bring one genuine task per journey; record build and commit provenance.
+form_factors: [desktop]
+steps:
+  - do: Complete all ten primary journeys as real work — arrival, dictation, meeting, capability run, destination choice, pairing/sync, integration, decision authority, coder steering, and failure recovery — counting HoldSpeak approval prompts in your configured posture.
+    expect: No lost work, no false completion, no silent retargeting, and no unexplained external effect across the ten; in YOLO, zero HoldSpeak approval prompts for eligible configured actions.
+    where: /
+    verifies: [phase93.residue.dogfood]
+    measurements:
+      - {key: journeys_completed, label: Journeys completed without a blocking finding, unit: journeys}
+      - {key: approval_prompts_yolo, label: Approval prompts on eligible YOLO actions, unit: prompts}
+      - {key: blocking_findings, label: Findings that blocked a journey, unit: findings}
+  - do: At session end, try to reconstruct from the product alone what happened today — what ran, what landed where, what still needs you.
+    expect: Receipts, attention, and Desk state answer it without memory or external notes.
+    verifies: [phase93.residue.dogfood]
+teardown: []

--- a/uat/scenarios/phase-94-delivery/01-desk-observe.yaml
+++ b/uat/scenarios/phase-94-delivery/01-desk-observe.yaml
@@ -1,0 +1,21 @@
+id: phase94-desk-observe
+execution_target: web_react
+title: "Phase 94 · Web · Delivery work is observable from the Desk"
+features: [phase94.delivery.desk-observe]
+manual_setup:
+  - Run the hub against this repository as a configured delivery source (the HoldSpeak clone with its Delivery Workbench rails); start the local node adapter if it is not embedded.
+recipes: []
+form_factors: [desktop]
+steps:
+  - do: From the Desk, find the delivery source, its current phase, its stories, and any live Coder session without using a URL.
+    expect: Project, Story, session, and Receipt views open through existing Desk affordances; no separate dashboard exists; raw filesystem paths never render.
+    verifies: [phase94.delivery.desk-observe]
+    measurements:
+      - {key: raw_paths_shown, label: Raw repository paths rendered, unit: paths}
+  - do: Check the read model's honesty — note the snapshot freshness, then stop the node or collector and watch the source's state.
+    expect: The source turns stale or offline on the specified clock with its last-known data marked as such; nothing invents absence or freshness.
+    verifies: [phase94.delivery.desk-observe]
+  - do: At a compact width, repeat the discovery.
+    expect: Past work and evidence remain reachable without the current-phase belt.
+    verifies: [phase94.delivery.desk-observe]
+teardown: []

--- a/uat/scenarios/phase-94-delivery/02-evidence-dossier.yaml
+++ b/uat/scenarios/phase-94-delivery/02-evidence-dossier.yaml
@@ -1,0 +1,18 @@
+id: phase94-evidence-dossier
+execution_target: web_react
+title: "Phase 94 · Web · A closed Story opens as an evidence dossier"
+features: [phase94.delivery.evidence-dossier]
+manual_setup:
+  - Use a delivery source with at least one closed story carrying real evidence assets (this repository's Phase 93/94 stories qualify).
+recipes: []
+form_factors: [desktop]
+steps:
+  - do: Open a completed Story's dossier and read its rendered Markdown, captured runs, and any PNG, JSON, or log assets; then open the Phase-level dossier.
+    expect: Evidence renders in place with commit, gate, and PR/CI receipts where present; membership comes from the rails, not guesses.
+    verifies: [phase94.delivery.evidence-dossier]
+  - do: Find an asset that is not locally present (a remote or offline node's bytes) and try to open it.
+    expect: The dossier lists it honestly as unavailable rather than erroring blindly or fabricating content.
+    verifies: [phase94.delivery.evidence-dossier]
+    measurements:
+      - {key: dishonest_assets, label: Assets shown as present that were not, unit: assets}
+teardown: []

--- a/uat/scenarios/phase-94-delivery/03-story-launch.yaml
+++ b/uat/scenarios/phase-94-delivery/03-story-launch.yaml
@@ -1,0 +1,22 @@
+id: phase94-story-launch
+execution_target: web_react
+title: "Phase 94 · Web · Launch, steer, and end Story-bound agent work from the Desk"
+features: [phase94.delivery.story-launch]
+manual_setup:
+  - Have a delivery source with an actionable story, a configured agent profile on the node, and tmux available; use a scratch branch or worktree so real work stays safe.
+recipes: []
+form_factors: [desktop]
+steps:
+  - do: From the Desk, discover the node's panes, create or choose a worktree, and launch configured agent work bound to a Story.
+    expect: The launch runs the atomic sequence (worktree, spawn, target, attempt, receipt); the Work attempt joins node, source, worktree, Story, session, and terminal exactly.
+    verifies: [phase94.delivery.story-launch]
+  - do: Watch the live terminal, deliver one steer through the typed command envelope, rename the session, then end it.
+    expect: Output streams or falls back to snapshots; the steer lands once on the exact pane with a source-linked Receipt; rename and kill honor the same authority gates.
+    verifies: [phase94.delivery.story-launch]
+    measurements:
+      - {key: wrong_target_effects, label: Effects on a pane other than the target, unit: effects}
+      - {key: duplicate_commands, label: Commands applied more than once, unit: commands}
+  - do: Break a launch mid-way (kill the spawn target before it starts) and recover from the Desk.
+    expect: The partial launch is named with what completed and what did not; recovery does not require arbitrary shell input.
+    verifies: [phase94.delivery.story-launch]
+teardown: []

--- a/uat/scenarios/phase-94-delivery/04-second-node.yaml
+++ b/uat/scenarios/phase-94-delivery/04-second-node.yaml
@@ -1,0 +1,20 @@
+id: phase94-second-node
+execution_target: web_react
+title: "Phase 94 · Web · A second physical machine serves delivery over Tailscale"
+features: [phase94.delivery.second-node]
+manual_setup:
+  - On a second physical machine over Tailscale, run `holdspeak node serve` against the hub with a node-scoped token and a real repository checkout.
+recipes: []
+form_factors: [desktop]
+steps:
+  - do: Watch the remote node connect, advertise capabilities, and expose its sources; then observe and steer a session running on it.
+    expect: The remote node's work behaves like the local one under real transport latency; target identity, receipts, and authority survive the network hop.
+    verifies: [phase94.delivery.second-node]
+    measurements:
+      - {key: steer_latency_ms, label: Observed steer round-trip, unit: ms}
+  - do: Cut the node's network for a minute, restore it, and check the event stream and liveness clock.
+    expect: The node goes stale then offline on the specified clock, resumes its cursor on reconnect, and no events are invented or doubled.
+    verifies: [phase94.delivery.second-node]
+    measurements:
+      - {key: duplicated_events, label: Events replayed as new after reconnect, unit: events}
+teardown: []

--- a/uat/scenarios/phase-94-delivery/05-ipad-native.yaml
+++ b/uat/scenarios/phase-94-delivery/05-ipad-native.yaml
@@ -1,0 +1,19 @@
+id: phase94-ipad-native
+execution_target: ios_flagship_swift
+title: "Phase 94 · Native · iPad observe, evidence, voice-steer, and remote disarm"
+features: [phase94.delivery.native-parity]
+manual_setup:
+  - Install TestFlight build 12 or newer on the physical iPad and pair it with the hub that has a live delivery source and session.
+recipes: []
+form_factors: [ipad]
+steps:
+  - do: From the iPad, observe the delivery source, open a Story's evidence, and watch the live session.
+    expect: The native views consume the same contracts as the Web — same states, reason codes, and receipts; nothing is a Swift-only invention.
+    verifies: [phase94.delivery.native-parity]
+  - do: Voice-steer the session (hold to talk, review, send once), then disarm the remote target from the iPad.
+    expect: The steer lands exactly once on the exact pane with a Receipt; remote disarm takes effect on the owning node and further input refuses by name.
+    verifies: [phase94.delivery.native-parity]
+    measurements:
+      - {key: wrong_target_effects, label: Effects on a pane other than the target, unit: effects}
+      - {key: disarm_failures, label: Inputs accepted after remote disarm, unit: inputs}
+teardown: []

--- a/uat/scenarios/phase-94-delivery/06-tailnet-https.yaml
+++ b/uat/scenarios/phase-94-delivery/06-tailnet-https.yaml
@@ -1,0 +1,18 @@
+id: phase94-tailnet-https
+execution_target: web_react
+title: "Phase 94 · Web · iPad Safari over tailnet HTTPS with a secure-context microphone"
+features: [phase94.delivery.tailnet-https]
+manual_setup:
+  - Serve the hub over Tailscale Serve (HTTPS) and open it in iPad Safari on the tailnet; sign in with the HoldSpeak bearer flow.
+recipes: []
+form_factors: [ipad_browser]
+steps:
+  - do: Complete the observe and evidence journeys from iPad Safari over the tailnet HTTPS URL.
+    expect: The Web Desk works at tablet width over HTTPS; no mixed-content or insecure-context failures; authentication is the bearer flow, not an open port.
+    verifies: [phase94.delivery.tailnet-https]
+  - do: Use the microphone from the HTTPS page — dictate one steer or note.
+    expect: Safari grants the microphone in the secure context and the dictation lands with the same delivery guarantees as the desktop.
+    verifies: [phase94.delivery.tailnet-https]
+    measurements:
+      - {key: insecure_context_blocks, label: Features blocked by context or certificate, unit: features}
+teardown: []


### PR DESCRIPTION
Phases 93 and 94 closed at machine-verifiable scope (2026-07-16) with every owner/physical criterion parked as BACKLOG candidate Y. This PR makes that residue schedulable work in the UAT rig and ships the matching device build.

## What's here

- **Scenario packs** `phase-93-web` (7), `phase-93-native` (7), `phase-94-delivery` (6): the per-story candidate-Y residue as guided beats — first-glance/discovery, room returns, the copy read-through, Desk-power measures, the real-microphone fault matrix, meeting survival with airplane-mode exactly-once sync, the accessibility walks, delivery observe/dossier/launch, the second tailnet node, iPad native + tailnet-HTTPS legs.
- **Owner campaigns 10/11/12** sequence them after the Phase 92 closes: 10 = production Web, 11 = flagship on physical iPhone/iPad (requires TestFlight build 12+ attestation), 12 = Delivery Runtime on real metal.
- **Feature ledger**: `phase93.residue.*` / `phase94.delivery.*` keys in `feature-additions.yaml`, native ownership in `feature-targets.yaml`, `features.yaml` regenerated in sync.
- **Docs**: `uat/README.md` + `uat/FUNCTIONAL-PASS.md` name the new campaigns truthfully.
- **apple**: `CURRENT_PROJECT_VERSION` 12 — TestFlight build 12 archived, uploaded (VALID) and attached to the internal group; it carries the Phase 93 close (round-2 UI remediation, HS-93-08/09) and the Phase 94 Swift Delivery Runtime contracts.

## Verification

- `uv run pytest -q tests/uat/` — **156 passed** (includes pack/scenario/campaign validation and ledger sync).
- All five new packs/campaigns load with zero `validation_errors` via the live conductor API.
- Build 12 verified before upload: ARCHIVE SUCCEEDED, gemma4 strings present in the llama framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)