### PR TITLE
Phase 95 scaffold: The Desk OS + the Constitution of HoldSpeak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,9 @@ git config core.hooksPath .githooks
 These are the docs phases must be grounded in. If any phase document
 disagrees with one of these, canon wins:
 
+- `docs/internal/CONSTITUTION.md` — **the supreme canon**: the ratified
+  articles every phase, story, and design decision is measured against.
+  Where any doc below disagrees with it, the Constitution wins.
 - `README.md` — public install + usage surface.
 - `docs/internal/POSITIONING.md` — the positioning canon: the story, the
   pillars, the named competitive frame, canonical feature names, and the

--- a/docs/internal/CONSTITUTION.md
+++ b/docs/internal/CONSTITUTION.md
@@ -1,0 +1,115 @@
+# The Constitution of HoldSpeak
+
+Ratified by the owner's charter of 2026-07-17, born from the first live UAT
+sitting. This is the north star: the supreme canon of the product. Every
+phase, story, design decision, and doc is measured against these articles.
+Where any other document disagrees with this one, this one wins and the
+other must be amended (or this one must be, by the owner, in Article X's
+process). Positioning, plans, and phase charters elaborate these articles;
+they do not override them.
+
+## Preamble
+
+HoldSpeak is one local copilot with a place to live: the Desk. Your voice
+types anywhere and learns how you work; your meetings end with their loops
+closed; your agents, terminals, and delivery work sit on the same surface
+you do. All of it local, all of it yours, all of it through the Desk.
+
+## Article I — The Desk is the operating surface
+
+1. The Desk is not a feature, a view, or a tier. It is the product's
+   operating surface: the place where everything is seen, opened, and done.
+2. Features do not own surfaces. The OS owns surfaces (objects, windows,
+   the dock, the stage) and features plug into them.
+3. No interaction that starts on the Desk may eject the user to a
+   feature-owned screen. Routes exist only as deep links that open the Desk
+   in the right state.
+4. This article supersedes the page-based information architecture in
+   `POSITIONING.md` (Phase 70). That section is to be amended, not obeyed.
+
+## Article II — Everything is a primitive
+
+1. Every capability the product offers is a system primitive: dictation,
+   meetings, intelligence, steering, terminals, delivery, configuration,
+   profiles, the mesh.
+2. A primitive exposes a contract (API, schema, events) and a core surface.
+   The OS decides where and how that surface appears.
+3. Every thing the user touches is a DeskPrimitive with derived UI. New
+   capability means a new primitive or a new affordance on one, never a new
+   world.
+
+## Article III — Local first, honest egress
+
+1. Nothing leaves the machine by default. Intelligence runs where the user
+   put it: in process, on their metal, or at an endpoint they named.
+2. Egress is disclosed by the badge (local / local+cloud / cloud) at the
+   point of decision. Never by prose, never by reassurance.
+3. No account, no telemetry, no silent cloud dependency. Ever.
+
+## Article IV — Voice is a first-class input
+
+1. Every text input can be spoken into. The mic is an affordance of the OS,
+   not of any one feature.
+2. Voice arms; it does not fire. Wake and command surfaces prepare actions
+   for a human to confirm, in line with Article V.
+3. One mic authority at a time: surfaces never compete for capture, and the
+   owner of the mic is always visible.
+
+## Article V — Consent is the spine of action
+
+1. Watching is free; acting is armed. Anything that types, sends, files,
+   spawns, or kills passes propose, approve, execute.
+2. Every attempt leaves a receipt: who, what, where, outcome. The audit is
+   part of the act, not an accessory.
+3. Refusal is by name. When the product will not act, it says which rule
+   refused and what would satisfy it.
+4. Reach never outruns consent: more machines, more panes, more connectors
+   always ride the same chokepoints.
+
+## Article VI — Honest by construction
+
+1. The product states its own limits where the user meets them: the doctor
+   reports what is broken, counts are honest at zero, approximations are
+   labeled.
+2. No demo state, no seeded flattery, no fallback that hides a failure. A
+   broken dependency produces a named failure, not a quiet degradation.
+3. Copy never promises what the code does not do. The test suite locks the
+   honest claims.
+
+## Article VII — The interface serves, it does not speak
+
+1. No prose in the UI. Labels state what, in the fewest words. No how-to,
+   no reassurance, no selling.
+2. No modals. Everything is created and edited in-world, in place, on the
+   Desk.
+3. Chrome is quiet: one window grammar, one z ladder, one dock. The user's
+   arrangement is sacred and persists.
+
+## Article VIII — Native-grade craft
+
+1. The Desk must feel like an OS, not a website: GPU-rendered world,
+   compositor-only motion, 60fps interaction budget on the production
+   bundle.
+2. Physics are contracts: drag, resize, raise, persist, coexist, snap. Once
+   shipped, they are a floor no change may regress.
+3. Every glass is first-class: the workstation window, the phone's bottom
+   sheet, the iPad's diorama. Craft is not a desktop-only property.
+
+## Article IX — Proof over claim
+
+1. Nothing is done because its code merged. It is done when it ran: real
+   hub, real mic, real model, real device, real viewport.
+2. UI ships only after it was seen: production screenshot walks at real
+   sizes, and the owner's eyes for anything that changes the feel.
+3. Evidence rides with the change through the delivery rails. A claim
+   without a receipt is a defect.
+4. The owner's live verdict outranks every green suite.
+
+## Article X — Amendment
+
+1. Only the owner amends this constitution. Agents propose; the owner
+   ratifies.
+2. A phase that touches an article cites it in its charter. A story that
+   cannot satisfy an article says so before it starts, not after it ships.
+3. When practice and constitution drift, one of them is wrong on purpose.
+   The drift is named and resolved; it is never ignored.

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -4,7 +4,19 @@
 > pick up, and the repo conventions that bite (PMO commit gate, write-once
 > evidence, no `Co-Authored-By`, metal-test exclusion).
 
-**Last updated:** 2026-07-16 — **Phase 93 CLOSED (9/9) and Phase 94, The Delivery Runtime, CLOSED (10/10) the same day under the owner's standing
+**Last updated:** 2026-07-17 — **Phase 95, The Desk OS, SCAFFOLDED** from the
+owner's first live UAT sitting (conductor Campaign 1 territory): the verdict
+was that the desk experience is clunky and fragmented — desk actions eject to
+sixteen flat routes under an alien shell, and the world renders DOM/CSS. The
+phase carries the owner's charter (**features do not own surfaces; the OS owns
+surfaces and features plug into them**) across ten stories: the WebGL stage,
+OS-grade windows over the Phase 93 physics, the dock/shell, embeddable page
+cores, dictation/meetings/configuration/studio re-homed as desk windows, the
+escape hatches retired with flat routes demoted to deep links, docs, and a
+closeout gated on the frame budget, the production screenshot walk, and a live
+owner walk. See
+[phase-95-the-desk-os](./phase-95-the-desk-os/current-phase-status.md).
+Previously (2026-07-16): **Phase 93 CLOSED (9/9) and Phase 94, The Delivery Runtime, CLOSED (10/10) the same day under the owner's standing
 close directive: HS-93-01 through HS-93-08 are done at their owner-rescoped
 machine-verifiable scopes (bounded route preflight, every-room walks, the
 failure-facts census over 4,173 candidates, contextual power, the Web
@@ -190,7 +202,9 @@ canon, canon wins.
 | 90 | The Factory: spawn, rename, drive, and kill terminal sessions from glass on the one consent spine | done | [phase-90-the-factory](./phase-90-the-factory/) |
 | 91 | One React Surface: one Vite/React application carrying DeskOS craft across every Web route; owner/Swift parity close gate remains | in-progress | [phase-91-one-react-surface](./phase-91-one-react-surface/) |
 | 92 | Make HoldSpeak feel like one powerful, understandable product by converging Web and native journeys on the Desk's shared objects, destinations, attention, authority, and retained results without rewriting the underlying systems. | planning | [phase-92-the-coalescence](./phase-92-the-coalescence/) |
-| 93 | Effortless HoldSpeak: make the Desk a rich, learnable AI operating system through visible subtraction, coherent OS affordances, contextual power, real failure recovery, accessibility, and sustained owner use across Web and flagship Swift. | in-progress | [phase-93-effortless-holdspeak](./phase-93-effortless-holdspeak/) |
+| 93 | Effortless HoldSpeak: make the Desk a rich, learnable AI operating system through visible subtraction, coherent OS affordances, contextual power, real failure recovery, accessibility, and sustained owner use across Web and flagship Swift. | done | [phase-93-effortless-holdspeak](./phase-93-effortless-holdspeak/) |
+| 94 | The Delivery Runtime: Delivery Workbench projects, Story progress, remote/local Coder sessions, terminals, evidence, and receipts as one robust platform primitive across workstation, iPad, and tailnet Web | done | [phase-94-delivery-runtime](./phase-94-delivery-runtime/) |
+| 95 | The Desk OS: the desk becomes the one operating surface — WebGL stage, OS-grade windows and dock, every service surfaced through OS primitives, flat routes demoted to deep links | planning | [phase-95-the-desk-os](./phase-95-the-desk-os/) |
 
 (Status values: `planning`, `in-progress`, `done`, `paused`, `cancelled`.)
 

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/current-phase-status.md
@@ -1,0 +1,135 @@
+# Phase 95 — The Desk OS
+
+**Status:** PLANNED (scaffolded 2026-07-17 from the owner's live UAT verdict;
+HS-95-01 ready).
+
+**Last updated:** 2026-07-17 (scaffolded).
+
+## Why this phase exists
+
+The owner ran the first live UAT sitting (2026-07-17, Campaign 1 territory)
+and the verdict was blunt: the desk experience is confusing and convoluted,
+because the desk is a front door that keeps throwing you out of it. Actions
+like "Dictate" leave the desk for `/dictation` — a flat page under a
+completely different shell, look, and feel — and the same is true for
+meetings, settings, studio, workbench, profiles, commands, cadence, and
+activity. On top of that, the world itself is DOM/CSS: every sprite, zone,
+and drag is layout-engine work, and it feels clunky rather than native.
+
+Phase 93 shipped the desk-window *contract* (floating panels drag, resize,
+persist, raise, coexist; one chrome; a documented z ladder). What it did not
+ship is the *content*: the windows host nine hand-wired panels while the
+product's real surfaces still live on sixteen flat routes. This phase closes
+that gap and gives the desk a real engine. The outcome the owner named: a
+native-like OS desk where you interact with everything **through the desk**,
+WebGL-accelerated, with OS-grade behavior, design, and features.
+
+## The thesis (owner's charter, 2026-07-17)
+
+The services were built to system-primitive quality — the dictation runtime,
+meeting intelligence, steering and the factory, profiles and the mesh, the
+delivery runtime, configuration. The DeskOS philosophy was always that those
+services get *integrated through OS primitives*: desk objects, windows, the
+dock — never through screens of their own. Instead, each service accreted a
+page-shaped UI, and the product became a desk-flavored lobby in front of
+sixteen other lobbies. This phase is the inversion, and it is the rule every
+story enforces: **features do not own surfaces; the OS owns surfaces and
+features plug into them.** A service exposes a core; the OS decides where
+and how it appears. Any future surface that ships as a route instead of a
+primitive is a regression against this charter (the HS-95-08 guard makes
+that mechanical).
+
+The charter is ratified as the
+[Constitution of HoldSpeak](../../../docs/internal/CONSTITUTION.md), the
+supreme canon this and every future phase is measured against. This phase
+executes Articles I (the Desk is the operating surface), II (everything is a
+primitive), VII (the interface serves), VIII (native-grade craft), and IX
+(proof over claim); Articles III–VI are standing law it must not regress.
+
+## The measured starting point (survey 2026-07-17)
+
+- One React 19 SPA, react-router, two shells selected by an `immersive` flag
+  (`web/src/App.tsx`, `web/src/components/AppShell.tsx`): the desk is
+  immersive; sixteen routes render under the flat `AppShell` top-nav chrome
+  with `styles/react-app.css`, visually alien to `desk/desk.css`.
+- Nineteen desk→page escape hatches: the DeskChrome room menu (Dictation /
+  Meetings / Studio / Settings), DeskStartActions "Dictate", seven
+  DeskToolShelf tools, three DeskToolInspector edit links, six Pullout links,
+  and FirstWords onboarding links. All are `<Link>`s out of the world.
+- The window system is `useDeskWindow` (`desk/components/DeskWindow.tsx`) — a
+  hook each panel hand-wires; there is no `<DeskWindow>` container with a
+  content slot, so arbitrary content cannot be hosted in a window today.
+- Rendering is DOM/CSS end to end. `Stage.tsx` is a 78-line 2D-canvas mote
+  background; no WebGL anywhere; `motion` and `@use-gesture/react` are
+  already dependencies.
+- Pages own their data via `useResource`/`apiFetch` over the one shared
+  `lib/api.ts` client and the one `RuntimeBus`; they do not depend on
+  `AppShell` for data. Mounting a page core in a window is a chrome/style
+  refactor, not a rewrite. Precedent exists: the meeting recovery panels and
+  `RunsOnPicker` already render on both sides of the boundary.
+
+## Goal
+
+The desk is the product's operating surface. The world (room, zones, objects,
+ambient) renders on a WebGL scene graph at a 60fps interaction budget. Every
+daily surface — dictation, meetings and live recording, settings, profiles,
+integrations, commands, cadence, studio, workbench, personas and coder
+sessions, activity — opens as an OS-grade desk window in place, with a dock,
+minimize/restore, focus order, and layout persistence. Flat routes survive
+only as deep links that open the desk with the right window. No desk action
+navigates away from the desk.
+
+## Scope
+
+### In
+
+- A WebGL-accelerated stage for the world layer; DOM retained for text-heavy
+  windows composited above it.
+- A generic `<DeskWindow>` container (content slot, one chrome, lifecycle:
+  open / focus / minimize / restore / close) over the Phase 93 physics, and
+  migration of the nine existing hand-wired panels onto it.
+- OS shell furniture: dock/taskbar of open and minimized windows, window
+  switching, snap targets, per-desk layout persistence, the phone bottom-sheet
+  window grammar.
+- Chrome-optional page cores extracted from the flat pages, then re-homed
+  into desk windows domain by domain (dictation; meetings/live; configuration;
+  studio/workbench/sessions).
+- Retirement of every desk→page escape hatch; flat routes become deep-link
+  openers into the desk.
+- Docs and a closeout with a machine-verified performance proof, a production
+  screenshot walk (1440 and 393 viewports), and an owner walk on the UAT rig.
+
+### Out
+
+- Native Swift Desk parity (tracked by the HSM belt; contracts only ride
+  along where free).
+- New backend routes or hub behavior (the phase re-homes existing surfaces;
+  it does not add product capabilities).
+- The control-posture remainder (BACKLOG candidate X) and the physical proof
+  program (BACKLOG candidate Y).
+- Qlippy/theater behavior changes beyond what the stage migration requires.
+
+## Story status
+
+| ID | Story | Status | Story file | Evidence |
+|---|---|---|---|---|
+| HS-95-01 | The WebGL stage | ready | [story-01-the-webgl-stage](./story-01-the-webgl-stage.md) | — |
+| HS-95-02 | OS-grade windows | backlog | [story-02-os-grade-windows](./story-02-os-grade-windows.md) | — |
+| HS-95-03 | The shell: dock, switching, layouts | backlog | [story-03-the-shell](./story-03-the-shell.md) | — |
+| HS-95-04 | Embeddable page cores | backlog | [story-04-embeddable-page-cores](./story-04-embeddable-page-cores.md) | — |
+| HS-95-05 | Dictation through the desk | backlog | [story-05-dictation-through-the-desk](./story-05-dictation-through-the-desk.md) | — |
+| HS-95-06 | Meetings and recording through the desk | backlog | [story-06-meetings-through-the-desk](./story-06-meetings-through-the-desk.md) | — |
+| HS-95-07 | Configuration through the desk | backlog | [story-07-configuration-through-the-desk](./story-07-configuration-through-the-desk.md) | — |
+| HS-95-08 | Studio, sessions, and the last exits | backlog | [story-08-studio-sessions-last-exits](./story-08-studio-sessions-last-exits.md) | — |
+| HS-95-09 | Docs: the Desk OS is the documented product | backlog | [story-09-docs](./story-09-docs.md) | — |
+| HS-95-10 | Closeout: performance proof, screenshot walk, owner walk | backlog | [story-10-closeout-owner-walk](./story-10-closeout-owner-walk.md) | — |
+
+## Where we are
+
+Scaffolded from the owner's live 2026-07-17 UAT verdict and a same-day code
+survey. No implementation has started. HS-95-01 (the engine) and HS-95-04
+(the page-core mechanism) are independent tracks; HS-95-02/03 build the
+window shell; HS-95-05..08 re-home the surfaces and retire the escape
+hatches; HS-95-09/10 document and close. The desk-window physics contract
+from Phase 93 is the floor, not the ceiling: nothing in this phase may
+regress drag, resize, persist, raise, or coexist.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-01-the-webgl-stage.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-01-the-webgl-stage.md
@@ -1,0 +1,88 @@
+# HS-95-01 — The WebGL stage
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** ready
+- **Depends on:** —
+- **Unblocks:** HS-95-03 (dock composites over the stage), HS-95-10
+
+## Problem
+
+The desk world is DOM/CSS: zones, object sprites, drag ghosts, ambient
+effects are all absolutely-positioned elements, so every pan, drag, and
+hover is layout/paint work on the main thread. The only canvas in the desk
+is `Stage.tsx`, a 78-line 2D-context mote background. The owner's verdict
+from the live sitting: the experience is clunky and must be WebGL
+accelerated with native-like feel.
+
+## Scope
+
+- In:
+  - a WebGL-backed scene graph (PixiJS v8 or equivalent; WebGL2 required,
+    WebGPU welcome where available) rendering the world layer: room
+    backdrop, zones, object sprites and their states, selection/hover
+    affordances, drag ghosts, ambient motes/glow;
+  - a single coordinate system shared between the GPU world and the DOM
+    overlay (windows, text editors) so a window can anchor to an object;
+  - pointer input unified through the existing `@use-gesture` handlers
+    driving the scene graph instead of element styles;
+  - sprite atlas/asset pipeline for the existing `_built` desk art;
+  - the DOM world renderer deleted once parity is proven (no dual
+    maintenance; this product is pre-release).
+- Out:
+  - window content rendering (windows stay DOM, composited above);
+  - new art or world semantics (same primitives, same store, same
+    projections — `desk/store.ts` and `desk/projections.ts` are the truth
+    the renderer draws);
+  - Swift/native renderers.
+
+## Acceptance criteria
+
+- [ ] The world layer renders through WebGL; DevTools shows no per-frame
+      layout/paint attributable to world pan, object drag, or ambient
+      motion.
+- [ ] Everything a desk primitive shows today (kind sprite, label, state,
+      selection, zone membership, filing) renders identically from the same
+      store; the desk store and projection tests pass unmodified.
+- [ ] Object drag, zone drag, pan, hover, tap-to-open behave as today
+      (including the 3px tap threshold contract) through the scene graph.
+- [ ] A window can anchor to a world object and stay glued through pan and
+      resize (shared coordinate transform proven by test).
+- [ ] Sustained 60fps (median frame ≤ 16.7ms, p95 ≤ 33ms) during a scripted
+      drag-and-pan storm on a desk seeded with the UAT `seeded-desk` recipe,
+      measured on the production bundle via CDP tracing.
+- [ ] The DOM world renderer is gone; the bundle carries one renderer.
+- [ ] Phone viewport (393px) renders and interacts correctly with
+      devicePixelRatio handling (no blurry sprites, no offset taps).
+
+## Test plan
+
+- `npm --prefix web test` — store/projection suites unmodified and green.
+- New renderer unit tests: coordinate transform round-trips, scene-graph
+  diffing from store snapshots, DPR handling.
+- Playwright production walk driving drag/pan/open against the real hub with
+  CDP tracing capturing frame timings (the performance criterion's proof).
+- `uv run pytest -q tests/ -k web` — hub-served bundle smoke unaffected.
+
+## Implementation direction
+
+- The store stays the single source of truth; the renderer is a projection.
+  Do not move state into the scene graph.
+- Prefer PixiJS v8 (mature WebGL2/WebGPU, sprite batching, React interop via
+  a thin custom reconciler-free mount — one canvas, imperatively synced from
+  zustand subscriptions). Avoid react-three-fiber; this is 2D compositing.
+- Keep the mote/glow ambience but move it into the same scene graph;
+  `Stage.tsx` retires.
+- Text-heavy affordances (editors, pullout content) remain DOM; only the
+  world becomes GPU. The z ladder gains one documented rule: canvas at the
+  bottom, windows above, chrome above windows.
+- Measure with the production build only (`npm --prefix web run build`); dev
+  overlays lie about frame cost.
+
+## Evidence required
+
+- captured test runs (web suites + new renderer tests);
+- CDP frame-timing capture from the seeded-desk storm walk, with the median
+  and p95 stated;
+- before/after screenshots at 1440 and 393 showing parity;
+- the commit removing the DOM world renderer.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-02-os-grade-windows.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-02-os-grade-windows.md
@@ -1,0 +1,91 @@
+# HS-95-02 — OS-grade windows
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** —
+- **Unblocks:** HS-95-03, HS-95-04, HS-95-05, HS-95-06, HS-95-07, HS-95-08
+
+## Problem
+
+Phase 93's `useDeskWindow` hook gives panels drag, resize, persist, raise,
+and coexist — but it is a hook each panel hand-wires (`setEl`,
+`handleProps`, `style`, `grip`, its own open gate). There is no
+`<DeskWindow>` container with a content slot, so hosting arbitrary content
+in a window is not possible, and the nine existing consumers each carry
+their own copy of the wiring. There is also no window lifecycle beyond
+open/closed: no minimize, no restore, no maximize, no consistent close
+affordance — table stakes for the OS feel the owner demands.
+
+## Scope
+
+- In:
+  - a `<DeskWindow id title icon …>{children}</DeskWindow>` container over
+    the existing hook: one chrome (head, close, minimize, maximize/restore),
+    one focus/z behavior, one persisted-rect behavior, a content slot that
+    accepts arbitrary React children;
+  - window lifecycle in the desk store: open, focus, minimize, restore,
+    maximize, close; `panelRects`/`panelSaved`/`panelOrder` extended, all
+    persisted in the existing `hs.desk.panels` slot;
+  - motion-driven open/close/minimize transitions (the `motion` dependency
+    is already present) within the interaction budget;
+  - migration of all nine hand-wired panels (ask, attention, delivery-board,
+    delivery-terminal, delivery-dossier, inspector, chat, pullout, session)
+    onto the container — no panel keeps private wiring;
+  - the phone form: on narrow viewports a window presents as the Phase 93
+    round-2 bottom sheet, from the same component and state.
+- Out:
+  - the dock/taskbar and window switching (HS-95-03);
+  - page-core content (HS-95-04 onward);
+  - any weakening of the Phase 93 physics contract — drag, resize, persist,
+    raise, coexist, tap-transparent chrome band, the 72px grabbable clamp
+    strip, and the cascade are the regression floor.
+
+## Acceptance criteria
+
+- [ ] `<DeskWindow>` hosts arbitrary children with one shared chrome; a new
+      window is added with no wiring beyond `id`, `title`, and children.
+- [ ] Minimize, restore, maximize, and close work on every window; state
+      survives reload via the existing persistence slot.
+- [ ] All nine existing panels render through the container; the hook is no
+      longer exported for hand-wiring; behavior parity is proven by the
+      existing desk interaction tests passing unmodified or with
+      mechanical-only updates.
+- [ ] Drag/resize/persist/raise/coexist/cascade/clamp behave exactly per the
+      Phase 93 contract (regression suite green).
+- [ ] Open/minimize/close transitions run compositor-only (transform/opacity;
+      no layout thrash in DevTools).
+- [ ] At 393px every window presents as a bottom sheet with the same content
+      and lifecycle.
+- [ ] No modal anywhere: windows coexist and never trap focus globally
+      (standing rule: edit in-world, no modals).
+
+## Test plan
+
+- `npm --prefix web test` — desk window/store suites (extended for
+  lifecycle transitions and persistence round-trips).
+- Playwright: open three windows, minimize one, maximize one, reload,
+  assert restored geometry and states; run at 1440 and 393.
+- Visual: screenshot pass on the shared chrome across all nine migrated
+  panels.
+
+## Implementation direction
+
+- Build the container on top of `useDeskWindow`, then fold the hook private.
+  Do not fork the physics; extend the store actions
+  (`setPanelRect`/`focusPanel`) with lifecycle state rather than adding a
+  parallel mechanism.
+- Chrome verbs are icons with accessible labels, not prose (standing rule:
+  labels state WHAT in fewest words).
+- Minimized windows park their state, not their mount, unless the content
+  opts into unmount (heavy cores from HS-95-04 will want unmount-on-minimize
+  — design the slot API for both).
+- Keep the z ladder documented in `desk.css` current as the single place the
+  ladder is written down.
+
+## Evidence required
+
+- captured web test run including new lifecycle suites;
+- Playwright lifecycle walk output at both viewports;
+- screenshots of the one chrome across all nine panels;
+- the diff showing the nine panels' private wiring deleted.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-03-the-shell.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-03-the-shell.md
@@ -1,0 +1,81 @@
+# HS-95-03 — The shell: dock, switching, layouts
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-01, HS-95-02
+- **Unblocks:** HS-95-08 (deep links open through the shell)
+
+## Problem
+
+An OS is not just windows — it is knowing what is open, getting back to it,
+and trusting the room to stay arranged. Today nothing shows which desk
+panels are open, a minimized window (new in HS-95-02) has nowhere to live,
+and there is no way to move between windows except hunting for them. The
+DeskChrome room menu currently fills this role by *leaving the desk* — the
+opposite of a shell.
+
+## Scope
+
+- In:
+  - a dock: one bar showing open and minimized windows with kind icons and
+    truncated titles; tap focuses/restores; long-press or context affordance
+    closes; lives above the stage, below nothing (top of the z ladder with
+    the chrome band);
+  - window switching: keyboard cycling on desktop (and the dock as the
+    touch path); most-recently-used order from the existing `panelOrder`;
+  - snap targets: drag-to-edge half/quarter tiling on desktop viewports,
+    within the persisted-rect system;
+  - named layout persistence: the current arrangement (windows, rects,
+    minimized set) survives reload per desk, replacing ad-hoc
+    `panelRects`-only persistence; a "reset layout" verb;
+  - DeskChrome's room menu reworked to open desk windows (wiring lands per
+    surface in HS-95-05..08; this story ships the shell affordance and
+    converts the menu's mechanism from `<Link>` to window-open actions).
+- Out:
+  - multiple virtual desks/spaces (note as a rider if trivially close,
+    otherwise BACKLOG);
+  - notification surfaces (AttentionDrawer already exists and simply docks);
+  - any new page.
+
+## Acceptance criteria
+
+- [ ] The dock shows every open and minimized window; tap focuses or
+      restores; the affordance to close works; empty dock is invisible.
+- [ ] Keyboard cycling moves focus through windows in MRU order on desktop;
+      the dock provides the same on touch.
+- [ ] Dragging a window to screen edges snaps to half/quarter tiles; snapped
+      rects persist and un-snap by drag.
+- [ ] The full arrangement (open set, rects, minimized set, focus order)
+      survives reload; "reset layout" returns the documented defaults.
+- [ ] The DeskChrome menu no longer navigates by `<Link>`; it dispatches
+      window-open actions (destinations may temporarily open the legacy
+      routes' windows as they land in later stories, but the mechanism is
+      the shell's).
+- [ ] All shell furniture is chrome-band tap-transparent per the Phase 93
+      round-2 contract; default layouts never sit under the chrome.
+- [ ] The 393px viewport gets the dock as a compact strip compatible with
+      the bottom-sheet window form.
+
+## Test plan
+
+- `npm --prefix web test` — shell store suites: MRU order, snap math,
+  layout persistence round-trips, reset.
+- Playwright: open/minimize/cycle/snap/reload walk at 1440; dock strip and
+  sheet interplay at 393.
+- Screenshot pass of dock states (empty, three open, one minimized).
+
+## Implementation direction
+
+- The dock derives entirely from store state; no separate registry
+  (standing rule: everything is a projection of the store).
+- Snap is geometry in the store's rect vocabulary — no new positioning
+  system.
+- Keep labels terse; icons carry the weight (no prose in the UI).
+- Compositor-only motion for dock hover/restore transitions.
+
+## Evidence required
+
+- captured web test run;
+- Playwright shell walk output at both viewports;
+- screenshots: dock states, a snapped layout, the reloaded arrangement.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-04-embeddable-page-cores.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-04-embeddable-page-cores.md
@@ -1,0 +1,85 @@
+# HS-95-04 — Embeddable page cores
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-02
+- **Unblocks:** HS-95-05, HS-95-06, HS-95-07, HS-95-08
+
+## Problem
+
+The flat pages fetch their own data through the shared `lib/api.ts` client
+and `useResource`, so their cores are portable — but their chrome is not.
+`PageHero`/`WorkroomBar` assume a flat page (they read routing state and
+render document chrome), and `styles/react-app.css` page styling collides
+with `desk.css` inside a window. Without a clean extraction pattern, each
+re-homing story would improvise its own, and the desk would inherit sixteen
+inconsistent embeddings.
+
+## Scope
+
+- In:
+  - the pattern: each page splits into a chrome-free core component
+    (props-driven, no `useLocation`, no `PageHero`/`WorkroomBar`, no
+    `.page-wrap` classes) and a thin flat-route wrapper that keeps today's
+    page working;
+  - the style seam: core styles that render correctly under both shells —
+    scoped classes (or the desk-window scope) so `react-app.css` document
+    chrome never leaks into windows;
+  - the workroom-context bridge inverted: cores accept an optional context
+    prop; the desk passes it directly instead of encoding `?room=` into a
+    URL; flat wrappers keep decoding it for deep links;
+  - the pattern proven end to end on two pages of different weight:
+    ActivityPage (read-mostly) and CommandsPage (form-bearing), each
+    rendering in a desk window and on its flat route from one core;
+  - a short authoring note in `web/README.md`: how to extract a core, the
+    style rules, the context prop.
+- Out:
+  - the remaining pages (their stories re-home them);
+  - deleting flat routes (HS-95-08 decides their end state);
+  - visual redesign of page content beyond what the seam requires.
+
+## Acceptance criteria
+
+- [ ] The core/wrapper pattern exists with a typed contract (context prop,
+      no router coupling in cores) and is written down in `web/README.md`.
+- [ ] ActivityPage and CommandsPage each render from one core in both
+      hosts; the flat routes are pixel-equivalent to before (screenshot
+      diff) and the desk windows carry no document chrome.
+- [ ] No `react-app.css` page-chrome selector applies inside a desk window
+      (verified by a style-leak test or targeted assertion).
+- [ ] Cores never read `useLocation`; grep-level guard or lint rule
+      enforces it for `web/src/pages/cores/` (or the chosen home).
+- [ ] Data behavior is unchanged: same requests, same `useResource`
+      semantics, proven by existing page tests passing against the wrappers.
+- [ ] A window hosting a core unmounts cleanly on close and on
+      minimize-with-unmount (the HS-95-02 slot API) with no leaked
+      subscriptions (RuntimeBus listeners released).
+
+## Test plan
+
+- `npm --prefix web test` — new core-mount tests (both hosts) for the two
+  proof pages; existing page suites green.
+- Playwright: open each proof page as a window and as a flat route;
+  screenshot both; drive one interaction in each host.
+- A style-leak assertion: mount a core in a window and assert the computed
+  style of a marker element matches the desk scope.
+
+## Implementation direction
+
+- Prefer moving files: `pages/XPage.tsx` becomes a 20-line wrapper around
+  `pages/cores/X.tsx` (naming per the survey; adjust to repo taste once).
+- The context prop mirrors `workrooms/context.ts` types — reuse the codec,
+  do not fork it.
+- Do not migrate state into `useDesk` in this story; cores keep
+  `useResource`. Coordination moves store-ward only where a later story
+  needs it (e.g. dictation subject handoff).
+- Resist improving pages while extracting; mechanical extraction keeps the
+  screenshot-equivalence criterion honest.
+
+## Evidence required
+
+- captured web test run;
+- side-by-side screenshots (flat vs window) for both proof pages at 1440;
+- the `web/README.md` authoring note in the diff;
+- the style-leak assertion output.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-05-dictation-through-the-desk.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-05-dictation-through-the-desk.md
@@ -1,0 +1,82 @@
+# HS-95-05 — Dictation through the desk
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-02, HS-95-04
+- **Unblocks:** HS-95-08 (its exits count toward the final sweep)
+
+## Problem
+
+Dictation is the product's founding act, and it is the desk's loudest
+escape hatch: DeskStartActions "Dictate", the DeskChrome room, the Pullout's
+"dictate about subject", and the DeskToolInspector's project-context link
+all throw the user onto `/dictation` — a flat page under alien chrome. The
+desk's own `MicButton` speak-to-fill proves the runtime works in-world; the
+full surface (session, corrections, journal, project context, runs-on) is
+what's missing.
+
+## Scope
+
+- In:
+  - the DictationPage core (per the HS-95-04 pattern) hosted in a desk
+    window: live session, preview-before-type where enabled, corrections,
+    journal/review, project-context picker, `RunsOnPicker` — full parity
+    with the flat page;
+  - subject handoff in-world: "dictate about this" on a Pullout passes the
+    subject as the context prop — the window opens pre-scoped to the object,
+    no URL encoding;
+  - every dictation escape hatch rewired to open the window in place:
+    DeskStartActions, the DeskChrome room, Pullout, DeskToolInspector;
+  - the flat `/dictation` route kept working through the thin wrapper (its
+    end state is HS-95-08's call);
+  - mic state honesty: the window and the in-world `MicButton` share one
+    recording/permission state — two surfaces never both claim the mic.
+- Out:
+  - dictation runtime/pipeline changes (DIR-01 territory);
+  - the wake-word and voice-command layers (untouched);
+  - LivePage/meeting recording (HS-95-06).
+
+## Acceptance criteria
+
+- [ ] The dictation window carries the full flat-page capability from the
+      shared core; a real dictation lands text end to end from inside the
+      window against the real hub.
+- [ ] "Dictate about this" from a Pullout opens the window scoped to that
+      subject with the grounding visibly attached, without leaving the desk
+      or touching the URL.
+- [ ] No desk surface links to `/dictation` anymore (grep-verified across
+      `web/src/desk/`); each former exit opens the window.
+- [ ] `/dictation` still renders for deep links via the wrapper.
+- [ ] Mic arbitration: starting dictation in the window while a speak-to-fill
+      is armed (or vice versa) resolves to one owner with an honest refusal
+      or handoff — no double capture.
+- [ ] The window behaves as a full shell citizen: dock presence, minimize
+      (session-preserving), bottom-sheet form at 393px.
+
+## Test plan
+
+- `npm --prefix web test` — core-mount tests, subject-handoff prop tests,
+  mic-arbitration unit tests.
+- Live proof against the real hub with the real Whisper runtime: a spoken
+  sentence lands from the window (the standing bar: real metal, not
+  seeded simulation).
+- Playwright walk: open from each former exit point, assert scope, at 1440
+  and 393.
+
+## Implementation direction
+
+- The core keeps `useResource`; only the subject scope rides the context
+  prop. If the journal needs desk-store coordination, add a minimal
+  selector, not a second store.
+- Reuse `lib/speakToFill`/`lib/dictationRecovery` state as the single mic
+  authority; do not duplicate recorder state in the window.
+- Minimize must not kill an armed session silently — parked-but-armed shows
+  in the dock (icon state), consistent with runtime presence rules.
+
+## Evidence required
+
+- captured test runs;
+- the live real-mic proof (command + output via evidence capture);
+- before/after: the four former exits, each opening the window (screenshots);
+- the grep sweep output showing zero `/dictation` links in `web/src/desk/`.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-06-meetings-through-the-desk.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-06-meetings-through-the-desk.md
@@ -1,0 +1,88 @@
+# HS-95-06 — Meetings and recording through the desk
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-02, HS-95-04
+- **Unblocks:** HS-95-08
+
+## Problem
+
+The desk already starts and stops the recorder (RecordOrb drives the same
+`/api/meeting/start|stop` as LivePage), but everything after the first
+second leaves the world: the live meeting view exists only on `/live`, and
+review — history, intelligence cards, aftercare, "show me the moment" —
+only on `/history`. The Pullout links out for both ("review-meeting",
+"record-follow-up"), and the meeting recovery panels are the one precedent
+already rendering on both sides of the boundary.
+
+## Scope
+
+- In:
+  - the live meeting window: the LivePage core in a desk window — live
+    state, markers, stop/finish — opened automatically by the desk's Record
+    verb, so recording never navigates away;
+  - the meeting review window: the HistoryPage core (meeting detail,
+    intelligence cards, artifacts, aftercare, moment jump, facets) hosted in
+    a window; a meeting object's Pullout opens it scoped to that meeting;
+  - recovery panels (conflict/intel) render only through the shared
+    components in both hosts — no divergence;
+  - all meeting escape hatches rewired: DeskChrome "Meetings", Pullout
+    "review-meeting" and "record-follow-up";
+  - flat `/history`, `/meetings`, `/live` kept as wrappers for deep links.
+- Out:
+  - capture pipeline, plugin chain, artifact types (untouched);
+  - meeting import/transcript import flows beyond their existing entry
+    points surviving in the core;
+  - aftercare/actuator semantics (render-only re-homing).
+
+## Acceptance criteria
+
+- [ ] Pressing Record on the desk opens the live window; a real recorded
+      meeting runs start-to-intelligence entirely in-world, against the real
+      hub (live proof, `.43` for intelligence).
+- [ ] A meeting object's Pullout opens the review window scoped to that
+      meeting: cards, artifacts, aftercare, and moment jump all work inside
+      the window (moment jump scrolls the in-window transcript).
+- [ ] No desk surface links to `/history`, `/meetings`, or `/live`
+      (grep-verified across `web/src/desk/`); each former exit opens the
+      right window at the right scope.
+- [ ] Deep links to the three flat routes still render via wrappers.
+- [ ] The review window at 393px presents the bottom-sheet form with cards
+      and transcript usable (the phone meeting-review path the flagship
+      pass compares against).
+- [ ] Recording state is honest across surfaces: RecordOrb, the live
+      window, and the dock icon agree at all times; stopping from any one
+      of them settles all.
+
+## Test plan
+
+- `npm --prefix web test` — core-mount and scope-prop tests for both
+  windows; recorder state-sharing tests.
+- Live proof: one real short meeting through mic → stop → intelligence on
+  `.43` → aftercare, all in-world (evidence-captured).
+- Playwright walk at 1440 and 393: record-open, review-open from Pullout,
+  moment jump inside the window.
+
+## Implementation direction
+
+- One recorder authority: the desk store's existing
+  `startRecording`/`stopRecording` remain the only callers; the live core
+  subscribes, it does not own.
+- Scope rides the context prop from HS-95-04 (meeting id), mirroring the
+  Pullout's existing object identity; no `?room=`/`?open=` encoding for
+  in-world opens.
+- The history core is the heaviest extraction in the phase — extract
+  mechanically first (HS-95-04 rule), resist redesigning cards while
+  moving them.
+- Moment jump must target the in-window transcript container, not
+  `window.scrollTo`.
+
+## Evidence required
+
+- captured test runs;
+- the live meeting proof (commands + outputs, control-vs-treatment where
+  intelligence is judged);
+- screenshots: record → live window, Pullout → scoped review window, 393px
+  sheet;
+- the grep sweep output for the three routes across `web/src/desk/`.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-07-configuration-through-the-desk.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-07-configuration-through-the-desk.md
@@ -1,0 +1,88 @@
+# HS-95-07 — Configuration through the desk
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-02, HS-95-04
+- **Unblocks:** HS-95-08
+
+## Problem
+
+Every act of configuring HoldSpeak ejects the user: Settings, Profiles
+("Runs on"), Integrations, Commands, and Cadence are five flat pages, and
+the desk's own inspector — the surface that *shows* a tool's state
+in-world — links out the moment you want to change anything
+(DeskToolInspector → `/settings`, `/profiles`, `/dictation`). The
+tool shelf is a launcher for leaving the desk. The standing rule is
+edit-in-world; configuration is where it is most broken.
+
+## Scope
+
+- In:
+  - cores per the HS-95-04 pattern for SettingsPage, ProfilesPage,
+    CommandsPage (proof core from HS-95-04 re-used), CadencePage, and the
+    settings-integrations section, each hosted in a desk window;
+  - the DeskToolShelf rewired: every tool opens its window in place
+    (workflow editor and personas land in HS-95-08; this story converts the
+    shelf mechanism plus the five configuration destinations);
+  - DeskToolInspector completes: its edit affordances open the scoped
+    window section (e.g. one integration's settings) instead of linking
+    out — inspect and edit become one in-world flow;
+  - FirstWords onboarding links (`/setup`, `/profiles`) open windows;
+  - flat routes kept as wrappers for deep links.
+- Out:
+  - settings semantics, schema, or hub config routes (render-only);
+  - the guided `/welcome` wizard (immersive already, untouched);
+  - StudioPage, WorkbenchPage, CompanionPage, ActivityPage shelf entries
+    beyond mechanism conversion (content lands in HS-95-08).
+
+## Acceptance criteria
+
+- [ ] Settings, Runs on, Integrations, Commands, and Cadence each open as
+      desk windows with full flat-page capability; a real setting change
+      round-trips to the hub from inside a window.
+- [ ] DeskToolInspector edit affordances open the scoped window (the
+      integration case lands on that integration, not the settings root);
+      the inspector itself never navigates.
+- [ ] The tool shelf opens windows for all five configuration
+      destinations; its remaining entries dispatch through the same
+      mechanism even where the destination window arrives in HS-95-08.
+- [ ] FirstWords opens setup and profiles in-world.
+- [ ] No desk surface links to `/settings`, `/profiles`, `/commands`,
+      `/cadence`, or `/setup` (grep-verified across `web/src/desk/`).
+- [ ] Egress badges and trust affordances render identically in-window
+      (the badge, never prose — standing rule).
+- [ ] Every text input in the re-homed cores keeps its speak-to-fill mic
+      (standing rule), and the windows behave as shell citizens at 1440
+      and 393.
+
+## Test plan
+
+- `npm --prefix web test` — core-mount tests per surface; inspector
+  scoped-open tests.
+- Playwright: change a setting, switch a profile, and edit an integration
+  entirely in-world against the real hub; assert persistence after reload;
+  both viewports.
+- Screenshot pass: each configuration window, plus the inspector-to-window
+  flow.
+
+## Implementation direction
+
+- Scoped opens ride the HS-95-04 context prop (section/subject), reusing
+  the `subject` vocabulary the shelf already encodes
+  (`integration:destinations`).
+- Do not build a settings tree inside the desk store; cores keep their
+  fetch-render autonomy.
+- The shelf becomes a pure dispatcher: one table, action → window id +
+  scope. Its search stays.
+- Where a form is small (a single toggle the inspector exposes), prefer
+  inline in-inspector editing over opening the full window — fewest-moves
+  rule; the window is for the full surface.
+
+## Evidence required
+
+- captured test runs;
+- Playwright in-world configuration walk output (with the hub round-trip
+  shown);
+- screenshots of the five windows and the inspector scoped-open flow;
+- the grep sweep output for the five routes across `web/src/desk/`.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-08-studio-sessions-last-exits.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-08-studio-sessions-last-exits.md
@@ -1,0 +1,97 @@
+# HS-95-08 — Studio, sessions, and the last exits
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-03, HS-95-05, HS-95-06, HS-95-07
+- **Unblocks:** HS-95-09, HS-95-10
+
+## Problem
+
+After the domain stories land, the heavy studio surfaces still live
+outside: the Workbench (the node-canvas workflow editor), Studio, the
+Companion page (personas and coder sessions — conceptually overlapping the
+in-desk PersonaChat and SessionPullout windows), and Activity. And the
+product still carries two navigation worlds: the desk shell and the flat
+`AppShell` with its own `PRIMARY_NAV`. The phase's promise — no desk action
+navigates away — is only real when the last exits are gone and the flat
+shell is demoted to a deep-link door.
+
+## Scope
+
+- In:
+  - Workbench hosted in-world: the canvas core in a desk window that
+    supports maximize (the canvas wants the full stage); "edit-workflow"
+    Pullout links open it scoped to the workflow object;
+  - Studio and Activity cores in desk windows via the shelf;
+  - Companion reconciled, not duplicated: the Companion core hosted
+    in-world and the existing PersonaChat/SessionPullout windows become the
+    single sessions surface (one list, one chat, one session detail — decide
+    the merge direction in-story and record it);
+  - the final sweep: zero `<Link>` out of `web/src/desk/` to any product
+    route, enforced by a lint/test guard so regressions cannot land
+    silently;
+  - flat-route demotion: every wrapped route renders the desk with the
+    matching window opened (the existing `?open=` arrival mechanism,
+    generalized) instead of the flat `AppShell` page; `AppShell` and
+    `PRIMARY_NAV` are deleted along with `react-app.css` page chrome that
+    nothing uses anymore (pre-release product: no compatibility ceremony);
+  - external links (receipt sources, PR URLs, asset downloads) stay honest
+    `<a>`s — leaving the product is allowed; leaving the desk for the
+    product's own surface is not.
+- Out:
+  - workflow/persona/session semantics or hub routes;
+  - the theater/presence immersive routes (`/welcome`, `/presence`);
+  - Swift parity.
+
+## Acceptance criteria
+
+- [ ] Workbench opens in-world, maximizes to the full stage, and edits a
+      real workflow end to end; the Pullout's "edit-workflow" opens it
+      scoped.
+- [ ] Studio and Activity open as windows from the shelf with full
+      capability.
+- [ ] One sessions surface: opening personas/coder sessions from the shelf
+      and opening a session from the world land in the same reconciled
+      windows; no duplicated list/chat implementations remain.
+- [ ] The guard is live: a `<Link>` from `web/src/desk/` to a product route
+      fails the web test suite; the sweep shows zero occurrences.
+- [ ] Every former flat route (`/dictation`, `/history`, `/meetings`,
+      `/live`, `/settings`, `/profiles`, `/commands`, `/cadence`,
+      `/activity`, `/studio`, `/workbench`, `/companion`, `/setup`,
+      `/docs/dictation-runtime`, `/design/components`) resolves to the desk
+      with the right window open at the right scope; `AppShell`,
+      `PRIMARY_NAV`, and dead page chrome are deleted from the bundle.
+- [ ] The `?room=` workroom "Back to Desk" bridge is retired (nothing
+      renders outside the desk to come back from); the codec survives only
+      where deep links still need scope decoding.
+- [ ] Bundle check: the flat-shell chunk disappears from the build output;
+      no route regression at 1440 or 393.
+
+## Test plan
+
+- `npm --prefix web test` — reconciliation suites, the no-exit guard, the
+  route-demotion table test (each route → expected window + scope).
+- Playwright: hit every demoted route cold, assert the desk arrives with
+  the right window; drive one real workflow edit in-world.
+- Full sweep: `uv run pytest -q` (excluding the standing metal exclusion)
+  for hub-served route smoke.
+
+## Implementation direction
+
+- Demotion is a routing-table change: `PRODUCT_ROUTES` entries map to
+  `{window, scope}` descriptors handled by the desk arrival path — one
+  mechanism, sixteen table rows.
+- Prefer keeping SessionPullout as the session-detail body and letting the
+  Companion core provide the roster; kill whichever chat duplicate loses.
+- Delete boldly and let the guard hold the line; this story is where the
+  two-worlds architecture actually dies.
+
+## Evidence required
+
+- captured test runs including the guard failing on a planted violation
+  (then removed);
+- Playwright demotion walk output covering every route;
+- build output showing the flat-shell chunk gone;
+- screenshots: Workbench maximized in-world, the reconciled sessions
+  surface.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-09-docs.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-09-docs.md
@@ -1,0 +1,87 @@
+# HS-95-09 — Docs: the Desk OS is the documented product
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-08
+- **Unblocks:** HS-95-10
+
+## Problem
+
+After HS-95-08 the product's shape changes fundamentally: there are no
+pages, there is an OS. Every doc that teaches "go to the Dictation page" or
+screenshots the flat shell is now wrong, and the architecture docs still
+describe a two-shell frontend. Worse, the model that makes the system
+legible — services surfaced through OS primitives, never through their own
+screens — exists only in this phase's files. Docs stories must touch entry
+points (standing rule), and this one lands the model where users and
+contributors actually enter.
+
+## Scope
+
+- In:
+  - `README.md` (public surface): the desk-first story updated — what you
+    see on arrival, how windows/dock work, how deep links behave;
+  - `docs/ARCHITECTURE.md` + diagrams: the frontend section redrawn — one
+    shell, the WebGL stage, the window system, the route-demotion table;
+    the render guard stays green;
+  - `docs/internal/POSITIONING.md` amended under the Constitution: the
+    Phase 70 page-based information architecture section (four
+    destinations, Desk in the Studio tier) is rewritten to Article I —
+    the Desk is the operating surface; services (dictation, meetings,
+    steering, delivery, configuration) are system primitives; windows,
+    desk objects, and the dock are the OS primitives they surface
+    through; feature UIs never own navigation;
+  - every touched doc checked against
+    `docs/internal/CONSTITUTION.md`; any remaining drift is named in the
+    story's evidence rather than papered over (Article X);
+  - USER_GUIDE: every "page" walkthrough rewritten as a window/desk
+    walkthrough with fresh screenshots from the shipped build;
+  - `web/README.md`: the contributor path — how to add a surface (core +
+    window registration + route-table row), the no-exit guard, the style
+    seam;
+  - the voice guard passes on everything touched (no AI vocabulary, dash
+    rules, no privacy prose — the badge carries trust).
+- Out:
+  - HSM/native docs (the Swift belt documents its own catch-up);
+  - marketing/site work beyond the README surface;
+  - roadmap archaeology (final-summary belongs to HS-95-10).
+
+## Acceptance criteria
+
+- [ ] No shipped doc instructs navigating to a flat product page; every
+      walkthrough moves through desk windows (sweep-verified over docs/
+      and README.md for the demoted route paths).
+- [ ] ARCHITECTURE frontend section and its Mermaid diagrams match the
+      shipped code (one shell, stage, windows, demotion table); the render
+      guard passes.
+- [ ] POSITIONING carries the Desk OS canon paragraph: system primitives
+      surfaced through OS primitives, with the named services listed.
+- [ ] USER_GUIDE screenshots are from the shipped build at real viewports
+      (1440 desktop, 393 phone) — no stale flat-shell captures anywhere in
+      docs assets.
+- [ ] `web/README.md` documents the add-a-surface path including the
+      HS-95-04 core pattern and the HS-95-08 guard.
+- [ ] Voice guard and doc lints pass on the full touched set.
+
+## Test plan
+
+- `uv run pytest -q tests/ -k doctor` plus the docs/voice/render guards.
+- The demoted-route sweep over docs (grep list from HS-95-08's table).
+- Manual read-through of the USER_GUIDE desk walkthrough against the live
+  product (the doc IS the walkthrough script).
+
+## Implementation direction
+
+- Screenshots come from the HS-95-10 walk tooling where possible — one
+  capture pipeline, two consumers.
+- Write the POSITIONING canon tight: one section, the frame, the named
+  primitives, the rule. It governs future phases; it is not an essay.
+- Entry points first: README and USER_GUIDE arrival flow before internals.
+
+## Evidence required
+
+- captured guard/lint runs;
+- the docs sweep output (zero demoted-route instructions);
+- the diff summary showing entry-point files touched;
+- one before/after doc screenshot pair.

--- a/pm/roadmap/holdspeak/phase-95-the-desk-os/story-10-closeout-owner-walk.md
+++ b/pm/roadmap/holdspeak/phase-95-the-desk-os/story-10-closeout-owner-walk.md
@@ -1,0 +1,87 @@
+# HS-95-10 — Closeout: performance proof, screenshot walk, owner walk
+
+- **Project:** holdspeak
+- **Phase:** 95
+- **Status:** backlog
+- **Depends on:** HS-95-01, HS-95-09
+- **Unblocks:** phase close
+
+## Problem
+
+This phase was born from a live owner sitting that found the desk clunky
+and fragmented. It can only close the same way it opened: the owner at the
+desk, on the production build, judging feel — backed by machine proof that
+the engine hits its budget and that no journey leaves the world. Phase 93's
+lesson is standing law: a code-reviewed UI is not a proven UI; the
+screenshot walk and the owner's eyes come before any done-claim.
+
+## Scope
+
+- In:
+  - the performance proof: the HS-95-01 CDP frame-timing storm re-run on
+    the final assembled build (stage + windows + dock + heaviest core
+    open), budgets met with numbers stated;
+  - the production screenshot walk: a Playwright drive of the full Desk OS
+    against the real hub at 1440 and 393 — arrival, every window opened via
+    its real entry point, dock states, snap, minimize/restore, reload
+    persistence, every demoted route — zero failed API responses, shots
+    archived;
+  - the no-exit audit: the HS-95-08 guard plus a recorded interaction sweep
+    showing no product-route navigation events from desk interactions;
+  - the UAT rider: a Desk OS campaign (or Campaign 1 revision) authored in
+    `uat/` so the rig that produced the opening verdict can measure the
+    closing one;
+  - the owner walk: a live sitting on the production bundle — dictate,
+    record and review a meeting, change a setting, edit a workflow, steer a
+    session, all through the desk; the owner's verdict recorded verbatim;
+  - final-summary.md with honest deferals: anything descoped goes to
+    BACKLOG by name.
+- Out:
+  - fixing findings beyond walk-blocking defects (new findings triage to
+    BACKLOG per the standing ritual);
+  - native/physical-device legs (candidate Y's program).
+
+## Acceptance criteria
+
+- [ ] Frame budget met on the assembled build: median ≤ 16.7ms, p95 ≤ 33ms
+      through the storm scenario, numbers recorded in evidence.
+- [ ] The screenshot walk passes at both viewports with zero failed API
+      responses; the archive lands with the evidence.
+- [ ] The no-exit audit is clean: guard green, zero desk-initiated
+      product-route navigations in the recorded sweep.
+- [ ] The UAT campaign for the Desk OS exists and runs on the rig
+      (conductor stages it; a full pass is executable end to end).
+- [ ] The owner completed the walk on the production bundle and the verdict
+      is recorded; walk-blocking defects fixed and re-walked, or the phase
+      does not close.
+- [ ] Full suite green (standing exclusions honored) and the final summary
+      names every deferral with its BACKLOG destination.
+
+## Test plan
+
+- `uv run pytest -q` (with the standing metal-test exclusion) — suite
+  output read before any flip.
+- `npm --prefix web test` — full web suite.
+- The Playwright walk script (archived with the evidence, rerunnable).
+- The live owner sitting through the UAT conductor.
+
+## Implementation direction
+
+- Assemble the walk script from the per-story Playwright walks; one
+  entry-point-driven script, not a route list — the walk must travel the
+  way a user does.
+- Run the storm with the meeting review window open on a real seeded
+  history; an empty desk flatters the renderer.
+- Stage the UAT campaign with the existing recipe/deck vocabulary; no new
+  conductor machinery unless a beat is impossible without it.
+- The owner's words go in the evidence unedited — that is the bar the
+  phase answers to.
+
+## Evidence required
+
+- frame-timing capture with stated percentiles;
+- the screenshot-walk archive and its zero-failure API log;
+- the no-exit sweep recording;
+- the UAT campaign files and a staged-run receipt;
+- the owner walk verdict, verbatim;
+- the full-suite and web-suite outputs.


### PR DESCRIPTION
Born from the owner's first live UAT sitting (2026-07-17). The verdict: the desk experience is clunky and fragmented — desk actions eject to sixteen flat routes under an alien shell, and the world renders DOM/CSS.

**What this ships**
- `docs/internal/CONSTITUTION.md` — the ratified north star (ten articles; the charter line: features do not own surfaces, the OS owns surfaces and features plug into them), registered as supreme canon in CLAUDE.md.
- `pm/roadmap/holdspeak/phase-95-the-desk-os/` — the phase charter + ten stories:
  1. The WebGL stage (GPU scene graph for the world, 60fps budget, DOM renderer deleted)
  2. OS-grade windows (a generic DeskWindow container + lifecycle over the Phase 93 physics)
  3. The shell (dock, switching, snap, layout persistence)
  4. Embeddable page cores (the chrome-free extraction pattern, proven on two pages)
  5. Dictation through the desk
  6. Meetings and recording through the desk
  7. Configuration through the desk
  8. Studio, sessions, and the last exits (no-exit guard; flat routes demoted to deep links; AppShell deleted)
  9. Docs (POSITIONING amended under Article I)
  10. Closeout (frame-budget proof, production screenshot walk at 1440/393, UAT campaign rider, live owner walk)
- Roadmap README: last-updated narrative, index rows for Phases 94/95, stale Phase 93 row corrected to done.

Scaffold only — no story flips, no product code. Grounded in a same-day code survey (19 desk→page escape hatches, no window content slot, no WebGL anywhere). `dw check: ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)