### PR TITLE
Phase 101 (HS-101-04 round 2): the wall, traced to its causes

### DIFF
--- a/web/src/components/AmbientLayer.tsx
+++ b/web/src/components/AmbientLayer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { apiFetch, readableError, type JsonRecord } from "../lib/api";
 import { useRuntimeBus, useRuntimeFrame } from "../runtime/RuntimeBus";
 import { useProjections } from "../desk/projections";
+import { humanizeWireValue } from "../lib/productLanguage";
 import { Button, InlineMessage, StatusPill } from "./signal/Signal";
 
 type Preview = { token?: string; text?: string; kind?: "wake" | "preview" };
@@ -188,7 +189,7 @@ function Qlippy() {
       <div>
         <span className="signal-eyebrow">
           {projection
-            ? `${projection.projection_kind} · ${projection.subject_label}`
+            ? `${humanizeWireValue(String(projection.projection_kind))} · ${humanizeWireValue(String(projection.subject_label))}`
             : card!.frameType.replace(/_/g, " ")}
         </span>
         <strong>

--- a/web/src/desk/components/PersonaChat.tsx
+++ b/web/src/desk/components/PersonaChat.tsx
@@ -222,9 +222,17 @@ export function PersonaChat(props: { personaId: string }) {
 
       <div className="desk-pullout-body desk-chat-scroll">
         {turns.length === 0 && !thinking && (
-          <p className="desk-chat-empty">
-            Start a conversation with {String(persona.name || "this agent")}.
-          </p>
+          <div className="desk-chat-hello">
+            <span className="desk-chat-hello-avatar" aria-hidden="true">
+              {String(persona.avatar || "🤖")}
+            </span>
+            <strong className="surface-primary">
+              {String(persona.name || "This agent")}
+            </strong>
+            {persona.role ? (
+              <small>{String(persona.role)}</small>
+            ) : null}
+          </div>
         )}
         {turns.map((t) => (
           <div
@@ -273,12 +281,6 @@ export function PersonaChat(props: { personaId: string }) {
       </div>
 
       <footer className="desk-chat-foot">
-        <RunsOnPicker
-          targets={inferenceTargets}
-          selectedId={inferenceTargetId}
-          onChange={setInferenceTargetId}
-          disabled={thinking}
-        />
         <GroundingSection
           meetings={(items.meeting || []).map((m: any) => ({
             id: m.id,
@@ -289,33 +291,43 @@ export function PersonaChat(props: { personaId: string }) {
           onChange={setAndSaveGrounding}
           limitTokens={limitTokens}
         />
-        <div className="desk-chat-composer">
-          <MicButton
-            draftScope={`persona-chat:${personaId}`}
-            onText={(t) => setInput((v) => (v ? v + " " + t : t))}
-          />
-          <input
-            autoFocus
-            value={input}
-            placeholder={"Message " + String(persona.name || "")}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") void send();
-            }}
-          />
-          <button
-            type="button"
-            className="desk-chip"
-            disabled={!input.trim() || thinking || overBudget}
-            title={
-              overBudget
-                ? "Grounding exceeds the context limit. Remove material."
-                : undefined
-            }
-            onClick={() => void send()}
-          >
-            {thinking ? "…" : "Send"}
-          </button>
+        <div className="desk-chat-well">
+          <div className="desk-chat-composer">
+            <MicButton
+              draftScope={`persona-chat:${personaId}`}
+              onText={(t) => setInput((v) => (v ? v + " " + t : t))}
+            />
+            <input
+              autoFocus
+              value={input}
+              placeholder={"Message " + String(persona.name || "")}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void send();
+              }}
+            />
+            <button
+              type="button"
+              className="desk-chip"
+              disabled={!input.trim() || thinking || overBudget}
+              title={
+                overBudget
+                  ? "Grounding exceeds the context limit. Remove material."
+                  : undefined
+              }
+              onClick={() => void send()}
+            >
+              {thinking ? "…" : "Send"}
+            </button>
+          </div>
+          <div className="desk-chat-well-foot">
+            <RunsOnPicker
+              targets={inferenceTargets}
+              selectedId={inferenceTargetId}
+              onChange={setInferenceTargetId}
+              disabled={thinking}
+            />
+          </div>
         </div>
         {inputRecovered ? (
           <span className="quiet">Recovered local message draft.</span>

--- a/web/src/desk/components/RunsOnPicker.tsx
+++ b/web/src/desk/components/RunsOnPicker.tsx
@@ -32,7 +32,10 @@ export function RunsOnPicker(props: {
         >
           {props.targets.map((target) => (
             <option key={target.id} value={target.id} disabled={!target.readiness.available}>
-              {target.name} · {KIND_LABEL[target.kind] || target.kind}
+              {target.name}
+              {(KIND_LABEL[target.kind] || target.kind) !== target.name
+                ? ` · ${KIND_LABEL[target.kind] || target.kind}`
+                : ""}
               {!target.readiness.available ? ` · unavailable: ${target.readiness.reason}` : ""}
             </option>
           ))}

--- a/web/src/desk/desk.css
+++ b/web/src/desk/desk.css
@@ -4142,7 +4142,8 @@
   max-width: 34em;
 }
 .desk-next .speak-run-row {
-  align-items: flex-start;
+  align-items: center;
+  gap: 10px;
   flex-wrap: wrap;
 }
 .desk-next .speak-result {
@@ -4543,4 +4544,90 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+/* HS-101 sitting round 2 — the chat is a CONVERSATION, not a form
+   pile: a composed hello, one composer well, the route folded into
+   the well's foot. */
+.desk-next .desk-chat .desk-pullout-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+.desk-next .desk-chat-hello {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--text-muted);
+}
+.desk-next .desk-chat-hello-avatar {
+  font-size: var(--font-size-3xl);
+  filter: drop-shadow(0 6px 14px var(--shadow-ink-3));
+}
+.desk-next .desk-chat-hello small {
+  color: var(--text-faint);
+  font-size: var(--desk-surface-detail-size);
+}
+.desk-next .desk-chat-foot {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px 12px;
+}
+.desk-next .desk-chat-well {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  background: var(--desk-window-well);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+}
+.desk-next .desk-chat-well:focus-within {
+  box-shadow:
+    inset 0 0 0 1px var(--accent-soft),
+    0 0 0 3px var(--accent-tint);
+}
+.desk-next .desk-chat-well .desk-chat-composer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.desk-next .desk-chat-well .desk-chat-composer input {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: 0;
+  outline: none;
+  color: var(--text);
+  font-size: var(--desk-surface-body-size);
+}
+.desk-next .desk-chat-well-foot .runs-on-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.desk-next .desk-chat-well-foot .runs-on-picker > label > span {
+  display: none;
+}
+.desk-next .desk-chat-well-foot .runs-on-picker select {
+  height: 24px;
+  padding: 0 22px 0 8px;
+  font-size: var(--desk-surface-label-size);
+  color: var(--text-muted);
+  background-color: transparent;
+}
+.desk-next .desk-chat-well-foot .runs-on-picker p {
+  margin: 0;
+  font-size: var(--desk-surface-label-size);
+  color: var(--text-faint);
+}
+
+/* HS-101 sitting round 2 — the ambient card yields to an open right
+   sheet instead of burying its composer. */
+body:has(.desk-next .desk-pullout) .ambient-qlippy {
+  right: 452px;
 }

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -466,12 +466,50 @@ button.surface-edit-in-place:hover {
   border-radius: var(--radius-sm);
   background: transparent;
 }
+/* HS-101 sitting round 2 — a disclosure must READ as one: the desk
+   stripped the card (rule 1) but left bare bold text. The summary is
+   a quiet chip with a turning caret; the wash lives on the summary,
+   never the whole block. */
 .desk-surface-body .signal-disclosure > summary,
 .desk-surface-body .signal-disclosure > .signal-disclosure-summary {
-  font-size: var(--desk-surface-body-size);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  min-height: 26px;
+  margin: 2px 0;
+  padding: 2px 9px 2px 7px;
+  border-radius: var(--radius-sm);
+  list-style: none;
+  font-size: var(--desk-surface-detail-size);
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.desk-surface-body .signal-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+.desk-surface-body .signal-disclosure > summary::before {
+  content: "▸";
+  font-size: 0.5625rem;
+  color: var(--text-faint);
+  transition: transform var(--duration-short) var(--ease-quart);
+}
+.desk-surface-body .signal-disclosure[open] > summary::before {
+  transform: rotate(90deg);
+}
+.desk-surface-body .signal-disclosure > summary:hover {
+  background: var(--wash-1);
+  color: var(--text);
 }
 .desk-surface-body .signal-disclosure:hover {
-  background: var(--wash-1);
+  background: transparent;
+}
+.desk-surface-body .signal-disclosure > div {
+  padding: 4px 8px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 /* Rule 1 — inside a window the tab strip sits on the material: no
@@ -1220,4 +1258,15 @@ button.surface-edit-in-place:hover {
   .surface-bay {
     animation: none;
   }
+}
+
+/* HS-101 sitting round 2 — a verb under a centered empty state
+   centers with it; the search control in a section head stays
+   bounded. */
+.surface-actions.is-centered {
+  justify-content: center;
+}
+.surface-section-head input[type="search"] {
+  width: 150px;
+  min-width: 0;
 }

--- a/web/src/pages/cores/CommandsCore.tsx
+++ b/web/src/pages/cores/CommandsCore.tsx
@@ -118,7 +118,7 @@ export function CommandsCore({ hero }: CoreProps) {
       {hero ? (
         hero(verbs)
       ) : (
-        <SurfaceVerbs status={`${items.length} macros`}>{verbs}</SurfaceVerbs>
+        <SurfaceVerbs status={`${items.length} ${items.length === 1 ? "command" : "commands"}`}>{verbs}</SurfaceVerbs>
       )}
       {message ? (
         <InlineMessage tone={message.error ? "error" : "success"}>
@@ -138,7 +138,7 @@ export function CommandsCore({ hero }: CoreProps) {
                 emptyLabel="No voice commands"
                 emptyGlyph="❝"
               />
-              <div className="surface-actions">
+              <div className="surface-actions is-centered">
                 <Button
                   variant="primary"
                   dense

--- a/web/src/pages/cores/DictationCore.tsx
+++ b/web/src/pages/cores/DictationCore.tsx
@@ -287,10 +287,7 @@ function SpeakFace({ onOpenDoor }: { onOpenDoor: () => void }) {
           label="Hold to talk"
           onText={(text) => setUtterance(text)}
         />
-        <p className="speak-hint">
-          Hold to talk, or type below. Runs the real pipeline on paper,
-          without typing into another app.
-        </p>
+        <p className="speak-hint">Hold to talk, or type below — on paper</p>
       </div>
       <div className="desk-mic-row">
         <TextArea

--- a/web/src/pages/cores/HistoryCore.tsx
+++ b/web/src/pages/cores/HistoryCore.tsx
@@ -698,17 +698,18 @@ export function HistoryCore({ hero, scope }: CoreProps) {
   /* The rail: this week's meetings, search-first; the filter wall
      stays folded. */
   const rail = (
-    <SurfaceSection label="Meetings">
-      <Field label="Search meetings">
-        {({ id }) => (
-          <TextInput
-            id={id}
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-          />
-        )}
-      </Field>
+    <SurfaceSection
+      label="Meetings"
+      actions={
+        <TextInput
+          type="search"
+          aria-label="Search meetings"
+          placeholder="Search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      }
+    >
       <Disclosure title="Filters">
         <div className="surface-actions">
           <Field label="From">


### PR DESCRIPTION
The sitting's round-1 verdict ("buttons aren't margined correctly… still a wall of HTML — try ask an agent"), worked eyes-first: every registered face screenshotted and read. Four systematic causes, fixed at the source: the desk disclosure had lost its affordance (kit-wide chip + turning caret), the agent chat was a form pile (composed hello + one composer well, the RunsOnPicker duplication fixed, the ambient card yields to open sheets), raw wire enums in the glass (ACTIVE_APP humanized, one vocabulary in Commands), and button rows without rhythm (Speak, Commands). Guards 14/14, web 310/310, token gate clean, geometry + speakflow green on the staged hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)