### PR TITLE
Phase 101 (HS-101-04 round 5): bespoke configuration components

### DIFF
--- a/tests/integration/test_history_slack_surfaces.py
+++ b/tests/integration/test_history_slack_surfaces.py
@@ -146,7 +146,7 @@ def test_proposal_rows_render_the_central_policy_and_refusal_truth():
     assert "operation.destination" in page
     assert "policy.authority_basis" in page
     # HS-100-08: an empty needs-you face says so honestly.
-    assert 'emptyLabel="Nothing waiting on you"' in page
+    assert "Nothing waiting on you" in page
 
 
 def test_history_app_wires_the_export_route():

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -1307,3 +1307,86 @@ button.surface-edit-in-place:hover {
   font-size: var(--desk-surface-detail-size);
   color: var(--text-faint);
 }
+
+/* HS-101 round 5 — bespoke configuration: choice bays + the keycap. */
+.settings-destination {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.settings-bays {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 8px;
+}
+.settings-bay {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--wash-1);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--duration-short) var(--ease-quart),
+    box-shadow var(--duration-short) var(--ease-quart);
+}
+.settings-bay:hover {
+  background: var(--wash-2);
+}
+.settings-bay.is-selected {
+  background: var(--accent-tint);
+  box-shadow: inset 0 0 0 1.5px var(--accent-soft);
+}
+.settings-bay-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: var(--radius-pill);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+.settings-bay.is-selected .settings-bay-dot {
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+.settings-bay-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.settings-bay-text strong {
+  font-size: var(--desk-surface-body-size);
+  font-weight: 600;
+}
+.settings-bay-text small {
+  color: var(--text-muted);
+  font-size: var(--desk-surface-label-size);
+}
+.settings-keycap {
+  min-width: 56px;
+  height: 30px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--desk-window-well);
+  box-shadow:
+    inset 0 0 0 1px var(--border-subtle),
+    inset 0 -2px 0 var(--shade-1);
+  color: var(--text);
+  font-size: var(--desk-surface-body-size);
+  font-weight: 650;
+  cursor: pointer;
+}
+.settings-keycap.is-listening {
+  box-shadow:
+    inset 0 0 0 1.5px var(--accent-soft),
+    0 0 0 3px var(--accent-tint);
+  animation: surface-state-pulse calc(var(--duration-long) * 3) ease-in-out infinite;
+}

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -1390,3 +1390,43 @@ button.surface-edit-in-place:hover {
     0 0 0 3px var(--accent-tint);
   animation: surface-state-pulse calc(var(--duration-long) * 3) ease-in-out infinite;
 }
+
+/* HS-101 round 6 — the opened record's head: the name is the
+   material, the facts are secondary, the foot separates export from
+   destruction. The transcript reads like a script. */
+.surface-detail-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.surface-detail-title {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.surface-detail-title small {
+  color: var(--text-muted);
+  font-size: var(--desk-surface-detail-size);
+  font-variant-numeric: tabular-nums;
+}
+.surface-detail-foot {
+  align-items: center;
+}
+.surface-detail-foot-gap {
+  flex: 1;
+}
+.desk-surface-body .transcript-list time {
+  flex: none;
+  width: 52px;
+  text-align: right;
+  color: var(--text-faint);
+  font-size: var(--desk-surface-detail-size);
+  font-variant-numeric: tabular-nums;
+  padding-top: 1px;
+}
+.desk-surface-body .transcript-list p {
+  margin: 0;
+  line-height: 1.55;
+}

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -1430,3 +1430,44 @@ button.surface-edit-in-place:hover {
   margin: 0;
   line-height: 1.55;
 }
+
+/* HS-101 round 7 — the import is a drop well, not a form: the same
+   verb the desk already answers, with browse folded in. */
+.surface-dropwell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 110px;
+  padding: 16px;
+  border: 1.5px dashed var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  cursor: pointer;
+  text-align: center;
+  transition:
+    border-color var(--duration-short) var(--ease-quart),
+    background var(--duration-short) var(--ease-quart);
+}
+.surface-dropwell:hover {
+  border-color: var(--accent-soft);
+  background: var(--accent-tint);
+}
+.surface-dropwell.has-file {
+  border-style: solid;
+  border-color: var(--accent-soft);
+  background: var(--accent-tint);
+  color: var(--text);
+}
+.surface-dropwell input[type="file"] {
+  display: none;
+}
+.surface-dropwell small {
+  color: var(--text-faint);
+  font-size: var(--desk-surface-label-size);
+}
+.surface-dropwell-glyph {
+  font-size: var(--font-size-xl);
+  line-height: 1;
+}

--- a/web/src/pages/cores/HistoryCore.tsx
+++ b/web/src/pages/cores/HistoryCore.tsx
@@ -138,49 +138,60 @@ function ImportSection({
         </Button>
       }
     >
-      <Field
-        label="File"
-        description="WAV works directly. Compressed audio needs ffmpeg. VTT, SRT and TXT keep transcript structure."
+      <label
+        className={"surface-dropwell" + (file ? " has-file" : "")}
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const dropped = event.dataTransfer?.files?.[0];
+          if (dropped) setFile(dropped);
+        }}
       >
-        {({ id, describedBy }) => (
-          <input
-            className="hs-control"
-            id={id}
-            aria-describedby={describedBy}
-            type="file"
-            accept="audio/*,.wav,.mp3,.m4a,.ogg,.flac,.vtt,.srt,.txt"
-            onChange={(event) => setFile(event.target.files?.[0] ?? null)}
-          />
+        <input
+          type="file"
+          accept="audio/*,.wav,.mp3,.m4a,.ogg,.flac,.vtt,.srt,.txt"
+          onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+        />
+        {file ? (
+          <>
+            <span className="surface-dropwell-name surface-primary">
+              {file.name}
+            </span>
+            <small>Drop another file to replace it</small>
+          </>
+        ) : (
+          <>
+            <span className="surface-dropwell-glyph" aria-hidden="true">
+              ⇣
+            </span>
+            <span className="surface-primary">Drop it here — or browse</span>
+            <small>.wav .mp3 .m4a .ogg .flac · .vtt .srt .txt</small>
+          </>
         )}
-      </Field>
-      <Field label="Title">
-        {({ id }) => (
+      </label>
+      {file ? (
+        <div className="surface-actions">
           <TextInput
-            id={id}
+            aria-label="Title"
+            placeholder="Title"
             value={title}
             onChange={(event) => setTitle(event.target.value)}
           />
-        )}
-      </Field>
-      <Field label="Speaker">
-        {({ id }) => (
           <TextInput
-            id={id}
+            aria-label="Speaker"
+            placeholder="Speaker"
             value={speaker}
             onChange={(event) => setSpeaker(event.target.value)}
           />
-        )}
-      </Field>
-      <Field label="Tags" description="Comma-separated.">
-        {({ id, describedBy }) => (
           <TextInput
-            id={id}
-            aria-describedby={describedBy}
+            aria-label="Tags, comma separated"
+            placeholder="Tags"
             value={tags}
             onChange={(event) => setTags(event.target.value)}
           />
-        )}
-      </Field>
+        </div>
+      ) : null}
       {error ? <InlineMessage tone="error">{error}</InlineMessage> : null}
       <div className="surface-actions">
         <Button

--- a/web/src/pages/cores/HistoryCore.tsx
+++ b/web/src/pages/cores/HistoryCore.tsx
@@ -166,7 +166,7 @@ function ImportSection({
               ⇣
             </span>
             <span className="surface-primary">Drop it here — or browse</span>
-            <small>.wav .mp3 .m4a .ogg .flac · .vtt .srt .txt</small>
+            <small>.wav direct · .mp3 .m4a .ogg .flac need ffmpeg · .vtt .srt .txt</small>
           </>
         )}
       </label>

--- a/web/src/pages/cores/HistoryCore.tsx
+++ b/web/src/pages/cores/HistoryCore.tsx
@@ -399,15 +399,40 @@ function MeetingDetail({
     />
   );
 
+  const startedAt = detail?.started_at ?? meeting.started_at;
+  const durationS = Number(detail?.duration_seconds ?? meeting.duration_seconds ?? 0);
+  const intelStatus = detail?.intel_status;
+  const intelOff =
+    (typeof intelStatus === "object" && intelStatus !== null
+      ? String((intelStatus as JsonRecord).state ?? "")
+      : String(intelStatus ?? "")) === "disabled";
+  const hasOutcomes =
+    proposalRows.length > 0 || openActions.length > 0 || settledActions.length > 0;
   return (
-    <SurfaceSection
-      label={String(detail?.title ?? meeting.title ?? "Meeting detail")}
-      actions={
+    <SurfaceSection>
+      <div className="surface-detail-head">
+        <div className="surface-detail-title">
+          <strong className="surface-primary">
+            {String(detail?.title ?? meeting.title ?? "Meeting")}
+          </strong>
+          <small>
+            {[
+              humanTime(startedAt),
+              durationS > 0
+                ? `${Math.max(1, Math.round(durationS / 60))} min`
+                : "",
+              segments.length
+                ? `${segments.length} segment${segments.length === 1 ? "" : "s"}`
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </small>
+        </div>
         <Button dense variant="ghost" onClick={onClose}>
           Close
         </Button>
-      }
-    >
+      </div>
       {error ? <InlineMessage tone="error">{error}</InlineMessage> : null}
       {detail?.capture_status && detail.capture_status !== "finalized" ? (
         <InlineMessage tone="warning">
@@ -455,21 +480,26 @@ function MeetingDetail({
         )
       ) : (
         <>
-          {/* 1 — what needs you: undecided proposals, then open actions. */}
+          {/* 1 — what needs you: undecided proposals, then open actions.
+              Intelligence OFF says so honestly instead of celebrating
+              an empty queue it never filled. */}
           <div className="surface-outcome-sec">
-            <span className="surface-eyebrow">
-              {`Needs you — ${proposalRows.filter((row) => row.status === "proposed").length + openActions.length}`}
-            </span>
+            {intelOff && !hasOutcomes ? (
+              <p className="surface-boundary-note">
+                Intelligence is off — no outcomes were made for this
+                meeting.
+              </p>
+            ) : (
+              <span className="surface-eyebrow">
+                {`Needs you — ${proposalRows.filter((row) => row.status === "proposed").length + openActions.length}`}
+              </span>
+            )}
             {proposalsBlock}
             {openActions.length ? (
               <SurfaceRows>{openActions.map(actionRow)}</SurfaceRows>
             ) : null}
-            {!proposalRows.length && !openActions.length ? (
-              <SurfaceState
-                empty
-                emptyLabel="Nothing waiting on you"
-                emptyGlyph="✓"
-              />
+            {!intelOff && !proposalRows.length && !openActions.length ? (
+              <p className="surface-boundary-note">✓ Nothing waiting on you</p>
             ) : null}
             {aftercare.slack_configured ? (
               <div className="surface-actions">
@@ -507,12 +537,23 @@ function MeetingDetail({
               vocabulary): behind disclosures, never a wall. */}
           <Disclosure
             title={`Transcript — the receipt (${segments.length} segments)`}
+            open={!hasOutcomes && segments.length > 0}
           >
             {segments.length ? (
               <ol className="transcript-list">
                 {segments.map((row, index) => (
                   <li key={rowId(row, index)}>
-                    <time>{String(row.timestamp ?? row.start ?? "")}</time>
+                    <time>
+                      {(() => {
+                        const s = Number(row.start_time ?? row.start ?? NaN);
+                        if (!Number.isFinite(s)) {
+                          return String(row.timestamp ?? "");
+                        }
+                        const m = Math.floor(s / 60);
+                        const sec = Math.floor(s % 60);
+                        return `${m}:${String(sec).padStart(2, "0")}`;
+                      })()}
+                    </time>
                     <p>{String(row.text ?? row.transcript ?? "")}</p>
                   </li>
                 ))}
@@ -526,17 +567,21 @@ function MeetingDetail({
               <SurfaceCode>{JSON.stringify(timelineRows, null, 2)}</SurfaceCode>
             </Disclosure>
           ) : null}
-          <div className="surface-actions">
-            <Select
-              aria-label="Export format"
-              defaultValue="markdown"
-              onChange={(event) => void exportMeeting(event.target.value)}
-            >
-              <option value="markdown">Export…</option>
-              <option value="txt">Plain text</option>
-              <option value="json">JSON</option>
-              <option value="srt">SRT</option>
-            </Select>
+          <div className="surface-actions surface-detail-foot">
+            <span className="surface-eyebrow">Export</span>
+            <Button dense variant="ghost" onClick={() => void exportMeeting("markdown")}>
+              Markdown
+            </Button>
+            <Button dense variant="ghost" onClick={() => void exportMeeting("txt")}>
+              Text
+            </Button>
+            <Button dense variant="ghost" onClick={() => void exportMeeting("json")}>
+              JSON
+            </Button>
+            <Button dense variant="ghost" onClick={() => void exportMeeting("srt")}>
+              SRT
+            </Button>
+            <span className="surface-detail-foot-gap" />
             <ConfirmVerb
               label="Delete meeting"
               confirmLabel="Delete meeting?"

--- a/web/src/pages/cores/SettingsCore.tsx
+++ b/web/src/pages/cores/SettingsCore.tsx
@@ -23,6 +23,7 @@ import {
   SurfaceToggle,
   SurfaceVerbs,
 } from "../../desk/surface/Surface";
+import { HotkeyCapture, RuntimeDestination } from "./settingsBespoke";
 import { SurfaceWings, useWindowWings } from "../../desk/surface/wings";
 import { RuntimeDocsCore } from "./RuntimeDocsCore";
 
@@ -129,17 +130,33 @@ function SettingsFields({
 }) {
   type Leaf = { key: string; item: unknown; path: string[] };
   type Group = { label: string; leaves: Leaf[] };
+  // HS-101 round 5 — bespoke components own their complex ideas.
+  if (path.length === 1 && path[0] === "hotkey") {
+    return (
+      <HotkeyCapture
+        value={value}
+        onCommit={(next) => onChange(path, { ...value, ...next })}
+      />
+    );
+  }
   const groups: Group[] = [];
   const walk = (node: JsonRecord, nodePath: string[], label: string) => {
     const leaves: Leaf[] = [];
     for (const [key, item] of Object.entries(node)) {
       const nextPath = [...nodePath, key];
       if (item !== null && typeof item === "object" && !Array.isArray(item)) {
-        walk(
-          item as JsonRecord,
-          nextPath,
-          `${label ? label + " · " : ""}${title(key)}`,
-        );
+        if (nextPath.join(".") === "dictation.runtime") {
+          groups.push({
+            label: "Runtime",
+            leaves: [{ key: "__runtime__", item, path: nextPath }],
+          });
+        } else {
+          walk(
+            item as JsonRecord,
+            nextPath,
+            `${label ? label + " · " : ""}${title(key)}`,
+          );
+        }
       } else if (
         !query ||
         `${nextPath.join(" ")}`.toLowerCase().includes(query.toLowerCase())
@@ -152,7 +169,20 @@ function SettingsFields({
   walk(value, path, "");
   return (
     <>
-      {groups.map((group) => (
+      {groups.map((group) => {
+        const runtime = group.leaves.find((leaf) => leaf.key === "__runtime__");
+        if (runtime) {
+          return (
+            <div key="runtime">
+              <h4 className="surface-panel-title">Runtime</h4>
+              <RuntimeDestination
+                value={runtime.item as JsonRecord}
+                onCommit={(next) => onChange(runtime.path, next)}
+              />
+            </div>
+          );
+        }
+        return (
         <SurfaceGroup
           key={group.label || "general"}
           label={group.label || undefined}
@@ -309,7 +339,8 @@ function SettingsFields({
             );
           })}
         </SurfaceGroup>
-      ))}
+        );
+      })}
     </>
   );
 }

--- a/web/src/pages/cores/SetupCore.tsx
+++ b/web/src/pages/cores/SetupCore.tsx
@@ -18,7 +18,7 @@ import {
   SurfaceState,
   SurfaceVerbs,
 } from "../../desk/surface/Surface";
-import { presentValue } from "../../desk/surface/format";
+import { deSnake, presentValue } from "../../desk/surface/format";
 
 type SetupStatus = {
   overall?: string;
@@ -81,7 +81,7 @@ export function SetupCore({ hero }: CoreProps) {
                     : "warning"
               }
             >
-              {presentValue(resource.data.overall) || "checking"}
+              {deSnake(String(resource.data.overall ?? "")) || "checking"}
             </StatusPill>
           }
         >

--- a/web/src/pages/cores/settingsBespoke.tsx
+++ b/web/src/pages/cores/settingsBespoke.tsx
@@ -1,0 +1,300 @@
+// HS-101 round 5 — bespoke configuration components (the owner's
+// bar: "these things are complicated enough that they can't just be
+// dumbed down to a bunch of input boxes"). A complex idea gets a
+// component shaped like the idea:
+//  - RuntimeDestination: "where does voice typing run" — one choice
+//    among bays, each revealing only ITS fields (13 boxes fold away).
+//  - HotkeyCapture: a key is pressed, not typed — mapped to exactly
+//    the key names the hub accepts (holdspeak/hotkey.py).
+import { useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Select,
+  TextInput,
+} from "../../components/signal/Signal";
+import { apiFetch, type JsonRecord } from "../../lib/api";
+import { openSurfaceOr } from "../../desk/shell";
+import {
+  Disclosure,
+} from "../../components/signal/Signal";
+import {
+  SurfaceGroup,
+  SurfaceSettingRow,
+  SurfaceToggle,
+} from "../../desk/surface/Surface";
+
+/* ── the hotkey: pressed, not typed ────────────────────────────── */
+
+// The hub's accepted set (holdspeak/hotkey.py _key_name_map) — the
+// capture can only ever write a name the listener understands.
+const CODE_TO_NAME: Record<string, string> = {
+  AltRight: "alt_r",
+  AltLeft: "alt_l",
+  ControlRight: "ctrl_r",
+  ControlLeft: "ctrl_l",
+  MetaRight: "cmd_r",
+  MetaLeft: "cmd_l",
+  ShiftRight: "shift_r",
+  ShiftLeft: "shift_l",
+  CapsLock: "caps_lock",
+};
+for (let n = 1; n <= 12; n += 1) CODE_TO_NAME[`F${n}`] = `f${n}`;
+
+const NAME_TO_DISPLAY: Record<string, string> = {
+  alt_r: "⌥R",
+  alt_l: "⌥L",
+  ctrl_r: "⌃R",
+  ctrl_l: "⌃L",
+  cmd_r: "⌘R",
+  cmd_l: "⌘L",
+  shift_r: "⇧R",
+  shift_l: "⇧L",
+  caps_lock: "⇪",
+};
+for (let n = 1; n <= 12; n += 1) NAME_TO_DISPLAY[`f${n}`] = `F${n}`;
+
+export function HotkeyCapture({
+  value,
+  onCommit,
+}: {
+  value: JsonRecord;
+  onCommit: (next: { key: string; display: string }) => void;
+}) {
+  const [listening, setListening] = useState(false);
+  const [refused, setRefused] = useState("");
+  useEffect(() => {
+    if (!listening) return;
+    const onKey = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "Escape") {
+        setListening(false);
+        return;
+      }
+      const name = CODE_TO_NAME[event.code];
+      if (!name) {
+        setRefused(
+          `${event.code} can't be a hold key — use a modifier (⌥ ⌃ ⌘ ⇧, left or right), ⇪, or F1–F12`,
+        );
+        return;
+      }
+      setRefused("");
+      setListening(false);
+      onCommit({ key: name, display: NAME_TO_DISPLAY[name] ?? name });
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [listening, onCommit]);
+  const current = String(value.display || value.key || "unset");
+  return (
+    <SurfaceGroup>
+      <SurfaceSettingRow
+        label="Push-to-talk key"
+        description={
+          listening
+            ? refused || "Press the key to hold — Esc cancels"
+            : "Hold it to talk, release to type"
+        }
+        control={
+          <button
+            type="button"
+            className={
+              "settings-keycap" + (listening ? " is-listening" : "")
+            }
+            onClick={() => {
+              setRefused("");
+              setListening((v) => !v);
+            }}
+          >
+            {listening ? "…" : current}
+          </button>
+        }
+      />
+    </SurfaceGroup>
+  );
+}
+
+/* ── the runtime: one destination, not thirteen boxes ──────────── */
+
+type RuntimeMode = "auto" | "mlx" | "llama_cpp" | "openai_compatible" | "profile";
+
+const MODE_LABEL: Record<RuntimeMode, [string, string]> = {
+  auto: ["Automatic", "picks the best local engine on this device"],
+  mlx: ["This device · MLX", "an Apple-silicon model file"],
+  llama_cpp: ["This device · llama.cpp", "a GGUF model file"],
+  openai_compatible: ["An endpoint", "any OpenAI-compatible server"],
+  profile: ["A saved destination", "one of your Runs on destinations"],
+};
+
+function runtimeMode(rt: JsonRecord): RuntimeMode {
+  if (rt.profile_id) return "profile";
+  const backend = String(rt.backend ?? "auto");
+  return (["mlx", "llama_cpp", "openai_compatible"] as const).includes(
+    backend as never,
+  )
+    ? (backend as RuntimeMode)
+    : "auto";
+}
+
+export function RuntimeDestination({
+  value,
+  onCommit,
+}: {
+  value: JsonRecord;
+  onCommit: (next: JsonRecord) => void;
+}) {
+  const mode = runtimeMode(value);
+  const [profiles, setProfiles] = useState<JsonRecord[]>([]);
+  const fetched = useRef(false);
+  useEffect(() => {
+    if (fetched.current) return;
+    fetched.current = true;
+    void apiFetch<{ profiles?: JsonRecord[] }>("/api/profiles")
+      .then((data) =>
+        setProfiles(
+          (data.profiles ?? []).filter((row) => !row.deleted),
+        ),
+      )
+      .catch(() => setProfiles([]));
+  }, []);
+  const patch = (next: JsonRecord) => onCommit({ ...value, ...next });
+  const choose = (next: RuntimeMode) => {
+    if (next === "profile") {
+      patch({ profile_id: String(profiles[0]?.id ?? "") || null });
+    } else {
+      patch({ backend: next, profile_id: null });
+    }
+  };
+  const field = (
+    label: string,
+    key: string,
+    placeholder?: string,
+  ) => (
+    <SurfaceSettingRow
+      label={label}
+      control={
+        <TextInput
+          aria-label={label}
+          value={String(value[key] ?? "")}
+          placeholder={placeholder}
+          onChange={(event) => patch({ [key]: event.target.value })}
+        />
+      }
+    />
+  );
+  return (
+    <div className="settings-destination">
+      <div className="settings-bays" role="radiogroup" aria-label="Runs on">
+        {(Object.keys(MODE_LABEL) as RuntimeMode[]).map((option) => {
+          const [name, caption] = MODE_LABEL[option];
+          const selected = option === mode;
+          return (
+            <button
+              key={option}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              className={
+                "settings-bay" + (selected ? " is-selected" : "")
+              }
+              onClick={() => choose(option)}
+            >
+              <span className="settings-bay-dot" aria-hidden="true" />
+              <span className="settings-bay-text">
+                <strong>{name}</strong>
+                <small>{caption}</small>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      <SurfaceGroup>
+        {mode === "mlx"
+          ? field("MLX model", "mlx_model", "~/Models/mlx/…")
+          : null}
+        {mode === "llama_cpp"
+          ? field("Model file", "llama_cpp_model_path", "~/Models/gguf/…")
+          : null}
+        {mode === "openai_compatible" ? (
+          <>
+            {field("Endpoint URL", "openai_compatible_base_url", "http://…/v1")}
+            {field("Model", "openai_compatible_model")}
+            {field("API key env var", "openai_compatible_api_key_env")}
+          </>
+        ) : null}
+        {mode === "profile" ? (
+          <SurfaceSettingRow
+            label="Destination"
+            control={
+              <span className="surface-actions">
+                <Select
+                  aria-label="Saved destination"
+                  value={String(value.profile_id ?? "")}
+                  onChange={(event) =>
+                    patch({ profile_id: event.target.value || null })
+                  }
+                >
+                  {profiles.length ? null : (
+                    <option value="">No saved destinations</option>
+                  )}
+                  {profiles.map((row) => (
+                    <option key={String(row.id)} value={String(row.id)}>
+                      {String(row.name ?? row.id)}
+                    </option>
+                  ))}
+                </Select>
+                <Button
+                  dense
+                  variant="ghost"
+                  onClick={() => openSurfaceOr("configure-runs-on", "/profiles")}
+                >
+                  Open Runs on
+                </Button>
+              </span>
+            }
+          />
+        ) : null}
+      </SurfaceGroup>
+      <Disclosure title="Engine details">
+        <SurfaceGroup>
+          <SurfaceSettingRow
+            label="Context window"
+            control={
+              <TextInput
+                aria-label="Context window"
+                type="number"
+                value={Number(value.n_ctx ?? 2048)}
+                onChange={(event) =>
+                  patch({ n_ctx: Number(event.target.value) })
+                }
+              />
+            }
+          />
+          <SurfaceSettingRow
+            label="Warm on start"
+            control={
+              <SurfaceToggle
+                label="Warm on start"
+                checked={Boolean(value.warm_on_start)}
+                onChange={(checked) => patch({ warm_on_start: checked })}
+              />
+            }
+          />
+          <SurfaceSettingRow
+            label="Idle eviction (s)"
+            control={
+              <TextInput
+                aria-label="Idle eviction seconds"
+                type="number"
+                value={Number(value.eviction_idle_seconds ?? 0)}
+                onChange={(event) =>
+                  patch({ eviction_idle_seconds: Number(event.target.value) })
+                }
+              />
+            }
+          />
+        </SurfaceGroup>
+      </Disclosure>
+    </div>
+  );
+}


### PR DESCRIPTION
Complex ideas get idea-shaped components: RuntimeDestination (the 13-box runtime group becomes five choice bays revealing only the chosen path's fields, engine details folded, linked to Runs on) and HotkeyCapture (the push-to-talk key is pressed, not typed — mapped to exactly the hub's accepted key set, refusing others by name). Both ride the settings auto-save and were driven live on the staged hub. Token gate clean; web 310/310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)