### PR TITLE
HS-101-04 (round 8): the object cards — double-click opens a designed thing

### DIFF
--- a/scripts/desk_gl_walk.py
+++ b/scripts/desk_gl_walk.py
@@ -656,9 +656,11 @@ def meetingflow() -> None:
         row.wait_for(timeout=10000)
         row.click()
         clicks += 1
-        page.wait_for_selector(
-            ".desk-surface-window >> text=Needs you", timeout=10000
-        )
+        # The face leads with needs-you — or, since HS-101 round 6, the
+        # HONEST line when intelligence is off and made no outcomes.
+        page.locator(".desk-surface-window >> text=Needs you").or_(
+            page.locator(".desk-surface-window >> text=Intelligence is off")
+        ).first.wait_for(timeout=10000)
         assert (
             page.locator(".desk-surface-body [role=tablist]").count() == 0
         ), "no tab wall in the window body"

--- a/tests/unit/test_web_vocabulary_guard.py
+++ b/tests/unit/test_web_vocabulary_guard.py
@@ -61,10 +61,16 @@ def _prose_segments(path: Path):
         if path.suffix == ".tsx":
             segments += [m.group(1).strip() for m in _JSX_TEXT_RE.finditer(line)]
         for seg in segments:
-            if seg.strip().startswith("/"):
+            text = seg.strip()
+            if text.startswith("/"):
                 continue  # URL/path, not copy
             if " " in seg and sum(c.isalpha() for c in seg) >= 3:
                 yield lineno, seg
+            elif text[:1].isupper() and text.isalpha():
+                # A lone Capitalized word is a display label ("Persona"
+                # on a chip) — the round-8 miss. Lowercase single words
+                # stay exempt: those are wire keys, not copy.
+                yield lineno, text
 
 
 def _scan() -> dict[str, set[str]]:
@@ -112,7 +118,7 @@ def test_refusals_never_leak_paths() -> None:
 def test_guard_patterns_catch_seeded_violations() -> None:
     """Proven both ways, like the voice guard."""
     for hit in ("Intel model not found", "the intel summary", "New Persona",
-                "Personas and coders"):
+                "Personas and coders", "Persona", "Intel"):
         assert any(rx.search(hit) for rx in _BANNED.values()), hit
     for keep in ("Meeting intelligence", "intelligent routing",
                  "personal notes stay local"):

--- a/web/src/desk/api.ts
+++ b/web/src/desk/api.ts
@@ -286,7 +286,7 @@ export async function loadAll(): Promise<LoadResult> {
           .map(fromWireRecipe);
         status.recipe = "live";
       })
-      .catch((e) => fail("recipe", "Personas", e)),
+      .catch((e) => fail("recipe", "Agents", e)),
     fetchJson("/api/kbs")
       .then((d) => {
         items.kb = (d.kbs || []).filter((k: any) => !k.deleted).map(fromWireKb);

--- a/web/src/desk/components/DeskListView.test.tsx
+++ b/web/src/desk/components/DeskListView.test.tsx
@@ -89,7 +89,7 @@ describe("HS-93-08 semantic list mode: same records", () => {
     expect(kickoff.closest("tr")).toHaveTextContent("Meeting");
     expect(
       screen.getByRole("button", { name: "Scout" }).closest("tr"),
-    ).toHaveTextContent("Persona");
+    ).toHaveTextContent("Agent");
 
     // The attention count rides the same projection subject the floater uses.
     expect(

--- a/web/src/desk/components/DeskToolShelf.tsx
+++ b/web/src/desk/components/DeskToolShelf.tsx
@@ -102,7 +102,7 @@ export const KIND_LABEL: Record<string, string> = {
   kb: "Knowledge",
   meeting: "Meeting",
   note: "Note",
-  recipe: "Persona",
+  recipe: "Agent",
   workflow: "Workflow",
 };
 

--- a/web/src/desk/components/DeskWindow.tsx
+++ b/web/src/desk/components/DeskWindow.tsx
@@ -270,6 +270,10 @@ export interface DeskWindowOptions {
   minH?: number;
   /** Pass false while the panel renders nothing (launcher-only mounts). */
   open?: boolean;
+  /** Round 8 — a content-sized card: height stays CSS-driven (the
+   * material decides) until the user arranges the window; the HS-97-09
+   * max-height seed inflation is skipped. */
+  fitContent?: boolean;
 }
 
 /** The desk-window physics (Phase 93). Module-private since HS-95-02:
@@ -280,6 +284,10 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
   const open = opts.open ?? true;
   const rect = useDesk((s) => s.panelRects[id]);
   const orderIndex = useDesk((s) => s.panelOrder.indexOf(id));
+  const arranged = useDesk((s) => s.panelSaved.includes(id));
+  // A fit-content card pins its height DURING the first resize drag,
+  // before the arrangement persists on pointer-up.
+  const [liveResize, setLiveResize] = useState(false);
   const elRef = useRef<HTMLElement | null>(null);
 
   const measure = (): PanelRect => {
@@ -346,7 +354,7 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
       // full-band window is a choice (resize/maximize), not a default
       // (HS-97-09).
       const el = elRef.current;
-      if (el) {
+      if (el && !opts.fitContent) {
         const mh = parseFloat(getComputedStyle(el).maxHeight);
         const cap = Math.max(
           minH,
@@ -419,6 +427,7 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
   const resizeBind = useDrag(
     ({ movement: [mx, my], last, memo }) => {
       const base: PanelRect = memo?.base ?? measure();
+      setLiveResize(!last);
       useDesk
         .getState()
         .setPanelRect(
@@ -436,6 +445,7 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
     ({ args, movement: [mx, my], last, memo }) => {
       const mode = String(args?.[0] ?? "br");
       const base: PanelRect = memo?.base ?? measure();
+      setLiveResize(!last);
       useDesk
         .getState()
         .setPanelRect(id, resizeEdge(mode, base, mx, my, minW, minH), last);
@@ -478,11 +488,14 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
         top: rect.y,
         left: rect.x,
         width: rect.w,
-        height: rect.h,
         right: "auto",
         bottom: "auto",
-        maxHeight: "none",
         zIndex: Z_BASE + Math.max(orderIndex, 0),
+        // A content-sized card keeps its CSS height (the material
+        // decides) until the user arranges it; arranged rects pin.
+        ...(opts.fitContent && !arranged && !liveResize
+          ? {}
+          : { height: rect.h, maxHeight: "none" }),
       }
     : { zIndex: Z_BASE + Math.max(orderIndex, 0) };
 
@@ -849,6 +862,8 @@ export interface DeskWindowFrameProps {
   className?: string;
   minW?: number;
   minH?: number;
+  /** Content-sized card: see DeskWindowOptions.fitContent. */
+  fitContent?: boolean;
   open: boolean;
   onClose: () => void;
   /** Heavy content may unmount while minimized (default: stays mounted). */
@@ -904,6 +919,7 @@ export function DeskWindowFrame(props: DeskWindowFrameProps) {
     className,
     minW,
     minH,
+    fitContent,
     open,
     onClose,
     unmountOnMinimize,
@@ -926,7 +942,12 @@ export function DeskWindowFrame(props: DeskWindowFrameProps) {
   });
   const compact = useCompactViewport();
   const reducedMotion = useReducedMotion();
-  const win = useDeskWindow(id, { minW, minH, open: open && !minimized });
+  const win = useDeskWindow(id, {
+    minW,
+    minH,
+    fitContent,
+    open: open && !minimized,
+  });
   const glyph = glyphProp ?? (typeof icon === "string" ? icon : "▢");
   const name = label ?? (typeof title === "string" ? title : id);
 

--- a/web/src/desk/components/InlineEditor.tsx
+++ b/web/src/desk/components/InlineEditor.tsx
@@ -132,7 +132,7 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
               {
                 note: "Note",
                 kb: "Knowledge",
-                recipe: "Persona",
+                recipe: "Agent",
                 workflow: "Workflow",
               } as Record<string, string>
             )[o.kind] || o.kind}

--- a/web/src/desk/components/Pullout.tsx
+++ b/web/src/desk/components/Pullout.tsx
@@ -15,10 +15,14 @@ import { parseLinearGraph, stepLabel } from "../graph";
 import { MicButton } from "./MicButton";
 import { lineage } from "../lineage";
 import { useSteering } from "../steering";
-import { objGlow, type WorldObject } from "../world";
+import { objectByRef, objGlow, type WorldObject } from "../world";
 import { qualifiedRef } from "../api";
 import { RunsOnPicker } from "./RunsOnPicker";
-import { humanizeWireValue } from "../../lib/productLanguage";
+import { humanizeWireValue, productLabel } from "../../lib/productLanguage";
+import { Disclosure } from "../../components/signal/Signal";
+import { Material } from "../surface/Material";
+import { SurfaceRow, SurfaceRows } from "../surface/Surface";
+import { humanTime } from "../surface/format";
 import { DeskWindowFrame } from "./DeskWindow";
 import { MeetingConflictRecovery } from "../../meetings/MeetingConflictRecovery";
 import { MeetingIntelRecovery } from "../../meetings/MeetingIntelRecovery";
@@ -91,7 +95,6 @@ export function Pullout({ o }: { o: WorldObject }) {
     string,
     unknown
   > | null>(null);
-  const [filing, setFiling] = useState(false);
   const [relationships, setRelationships] = useState<any>(null);
   const [knowledgeChoices, setKnowledgeChoices] = useState<any[]>([]);
   const [projectChoices, setProjectChoices] = useState<any[]>([]);
@@ -269,25 +272,39 @@ export function Pullout({ o }: { o: WorldObject }) {
     : null;
 
   const artifactRow = (a: any) => (
-    <button
+    <SurfaceRow
       key={a.id}
-      type="button"
-      className="desk-pullout-row"
-      onClick={() => openPullout(a.id)}
-    >
-      <span className="desk-pullout-row-type">
-        {a.artifact_type || a.artifactType}
-      </span>
-      <span className="desk-pullout-row-title">{a.title}</span>
-    </button>
+      title={a.title}
+      detail={humanizeWireValue(String(a.artifact_type || a.artifactType || ""))}
+      onOpen={() => openPullout(a.id)}
+    />
   );
+
+  // The meeting's one facts line (round 6 phrasing): when · length · size.
+  const meetingFacts =
+    o.kind === "meeting" && detail
+      ? [
+          humanTime(String(detail.started_at || "")),
+          Number(detail.duration) > 0
+            ? `${Math.max(1, Math.round(Number(detail.duration) / 60))} min`
+            : "",
+          Array.isArray(detail.segments) && detail.segments.length
+            ? `${detail.segments.length} segment${
+                detail.segments.length === 1 ? "" : "s"
+              }`
+            : "",
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      : "";
 
   return (
     <DeskWindowFrame
       id="pullout"
       glyph="▤"
       label={o.title}
-      className="desk-pullout"
+      className="desk-pullout is-card"
+      fitContent
       rootStyle={{ "--k": objGlow(o.kind) } as React.CSSProperties}
       icon={<img src={spriteUrl(o.kind, o.id)} alt="" width={30} height={30} />}
       title={o.title}
@@ -337,9 +354,12 @@ export function Pullout({ o }: { o: WorldObject }) {
         </>
       }
     >
-      <div className="desk-pullout-body">
+      <div className="desk-pullout-body desk-surface-body">
         {o.kind === "meeting" && (
           <>
+            {meetingFacts ? (
+              <p className="quiet desk-pullout-facts">{meetingFacts}</p>
+            ) : null}
             {detail?.capture_status && detail.capture_status !== "finalized" ? (
               <section>
                 <h3>Saved, incomplete</h3>
@@ -372,19 +392,15 @@ export function Pullout({ o }: { o: WorldObject }) {
               }}
             />
             {detail?.intel?.summary ? (
-              <section>
-                <h3>Summary</h3>
-                <p>{detail.intel.summary}</p>
-              </section>
+              <p className="surface-say">{detail.intel.summary}</p>
             ) : (
-              <section>
-                <h3>Intelligence</h3>
-                <p className="quiet">
-                  {detail?.intel_status?.state
+              <p className="quiet">
+                {detail?.intel_status?.state === "disabled"
+                  ? "Intelligence is off — no outcomes were made for this meeting."
+                  : detail?.intel_status?.state
                     ? `Intelligence ${intelligenceState(detail.intel_status.state)}`
                     : "Intelligence queued"}
-                </p>
-              </section>
+              </p>
             )}
             {detail?.intel?.action_items &&
               detail.intel.action_items.length > 0 && (
@@ -406,7 +422,7 @@ export function Pullout({ o }: { o: WorldObject }) {
             {artifacts.length > 0 && (
               <section>
                 <h3>Artifacts</h3>
-                {artifacts.map(artifactRow)}
+                <SurfaceRows>{artifacts.map(artifactRow)}</SurfaceRows>
               </section>
             )}
           </>
@@ -415,10 +431,8 @@ export function Pullout({ o }: { o: WorldObject }) {
         {o.kind === "artifact" && (
           <>
             <section>
-              <h3>{String(ir.artifactType || "artifact")}</h3>
-              <pre className="desk-pullout-md">
-                {String(ir.bodyMarkdown || "")}
-              </pre>
+              <h3>{humanizeWireValue(String(ir.artifactType || "artifact"))}</h3>
+              <Material>{String(ir.bodyMarkdown || "")}</Material>
             </section>
             {lin.any && (
               <section>
@@ -445,46 +459,76 @@ export function Pullout({ o }: { o: WorldObject }) {
 
         {(o.kind === "note" || o.kind === "kb") &&
           (() => {
-            const body = String(
-              ir.bodyMarkdown ||
-                (ir.memberIds || [])
-                  .map((m: string) => `· ${m}`)
-                  .join("\n") ||
-                "",
-            );
+            const body = String(ir.bodyMarkdown || "");
+            const members = ((ir.memberIds as string[]) || [])
+              .map((m) => ({ ref: m, member: objectByRef(items, m) }))
+              .filter(({ member }) => member);
+            if (body)
+              return (
+                <section>
+                  <Material>{body}</Material>
+                </section>
+              );
+            if (o.kind === "kb" && members.length)
+              return (
+                <section>
+                  <SurfaceRows>
+                    {members.map(({ ref, member }) => (
+                      <SurfaceRow
+                        key={ref}
+                        glyph={
+                          <img
+                            src={spriteUrl(member!.kind, member!.id)}
+                            width={22}
+                            height={22}
+                            alt=""
+                          />
+                        }
+                        title={member!.title}
+                        detail={productLabel(member!.kind)}
+                        onOpen={() => openPullout(member!.id)}
+                      />
+                    ))}
+                  </SurfaceRows>
+                </section>
+              );
             return (
               <section>
-                {body ? (
-                  <pre className="desk-pullout-md">{body}</pre>
-                ) : (
-                  <p className="quiet">
-                    Nothing written here yet — Edit adds content.
-                  </p>
-                )}
+                <p className="quiet">
+                  Nothing written here yet — Edit adds content.
+                </p>
               </section>
             );
           })()}
 
         {o.kind === "recipe" && (
-          <section>
-            <p className="quiet">{String(ir.role || "")}</p>
-            <pre className="desk-pullout-md">
-              {String(ir.systemPrompt || "")}
-            </pre>
+          <section className="desk-pullout-agent">
+            <div className="desk-chat-hello">
+              <span className="desk-chat-hello-avatar" aria-hidden="true">
+                {String(ir.avatar || "🤖")}
+              </span>
+              <strong className="surface-primary">{o.title}</strong>
+              {ir.role ? <small>{String(ir.role)}</small> : null}
+            </div>
             <button
               type="button"
-              className="desk-chip is-primary"
+              className="desk-chip is-primary desk-pullout-agent-chat"
               onClick={() => openChat(o.id)}
             >
               Chat with {o.title}
             </button>
+            {ir.systemPrompt ? (
+              <Disclosure title="Instructions">
+                <Material>{String(ir.systemPrompt)}</Material>
+              </Disclosure>
+            ) : null}
           </section>
         )}
 
         {(o.kind === "chain" || o.kind === "workflow") && (
           <section>
             <h3>Steps</h3>
-            <ul>
+            <ol className="desk-pullout-steps">
               {(
                 (o.kind === "workflow" && ir.graphJson
                   ? (parseLinearGraph(ir.graphJson)?.map(stepLabel) ?? [
@@ -496,7 +540,7 @@ export function Pullout({ o }: { o: WorldObject }) {
               ).map((st, i) => (
                 <li key={i}>{st}</li>
               ))}
-            </ul>
+            </ol>
           </section>
         )}
 
@@ -506,7 +550,9 @@ export function Pullout({ o }: { o: WorldObject }) {
               {String(ir.model || "")} · {String(ir.state || "")}
             </p>
             {ir.question ? (
-              <pre className="desk-pullout-md">{String(ir.question)}</pre>
+              <Material className="desk-coder-question">
+                {String(ir.question)}
+              </Material>
             ) : null}
             <div className="desk-coder-answer">
               {coderWaiting ? (
@@ -537,42 +583,46 @@ export function Pullout({ o }: { o: WorldObject }) {
                       </button>
                     </div>
                   ) : null}
-                  <MicButton
-                    label="Hold to answer"
-                    draftScope={`coder-reply:${coderSessionId}`}
-                    onText={(t) =>
-                      setCoderDraft((current) =>
-                        current ? `${current} ${t}` : t,
-                      )
-                    }
-                  />
-                  <textarea
-                    className="desk-coder-draft-input"
-                    aria-label="Coder reply draft"
-                    value={coderDraft}
-                    placeholder="Reply"
-                    rows={3}
-                    onChange={(event) => setCoderDraft(event.target.value)}
-                  />
-                  <button
-                    type="button"
-                    className="desk-chip"
-                    disabled={!coderDraft.trim()}
-                    onClick={() => {
-                      setAnswered(null);
-                      const retained = coderDraft.trim();
-                      void speakToCoder(
-                        String(ir.agent || "claude"),
-                        coderSessionId,
-                        retained,
-                      ).then((ok) => {
-                        setAnswered(ok ? "sent" : "failed");
-                        if (ok) setCoderDraft("");
-                      });
-                    }}
-                  >
-                    {answered === "failed" ? "Retry reply" : "Send reply"}
-                  </button>
+                  <div className="desk-chat-well">
+                    <div className="desk-chat-composer">
+                      <MicButton
+                        label="Hold to answer"
+                        draftScope={`coder-reply:${coderSessionId}`}
+                        onText={(t) =>
+                          setCoderDraft((current) =>
+                            current ? `${current} ${t}` : t,
+                          )
+                        }
+                      />
+                      <textarea
+                        className="desk-coder-draft-input"
+                        aria-label="Coder reply draft"
+                        value={coderDraft}
+                        placeholder="Reply"
+                        rows={2}
+                        onChange={(event) => setCoderDraft(event.target.value)}
+                      />
+                      <button
+                        type="button"
+                        className="desk-chip"
+                        disabled={!coderDraft.trim()}
+                        onClick={() => {
+                          setAnswered(null);
+                          const retained = coderDraft.trim();
+                          void speakToCoder(
+                            String(ir.agent || "claude"),
+                            coderSessionId,
+                            retained,
+                          ).then((ok) => {
+                            setAnswered(ok ? "sent" : "failed");
+                            if (ok) setCoderDraft("");
+                          });
+                        }}
+                      >
+                        {answered === "failed" ? "Retry reply" : "Send reply"}
+                      </button>
+                    </div>
+                  </div>
                   <span className="quiet desk-coder-answer-state" role="status">
                     {answered === "sent"
                       ? "Sent"
@@ -617,70 +667,14 @@ export function Pullout({ o }: { o: WorldObject }) {
         )}
 
         {["recipe", "chain", "workflow"].includes(o.kind) && (
-          <section>
-            <div className="desk-capability-contract">
-              <strong>
-                {o.kind === "recipe"
-                  ? "Persona"
-                  : o.kind === "chain"
-                    ? "Sequence"
-                    : "Workflow"}
-              </strong>
-              <span className={`desk-chip quiet is-${readiness.state}`}>
-                {readiness.state === "ready" ? "Ready" : "Unavailable here"}
-              </span>
-              <p className="quiet">
-                {capability.input_help ||
-                  "Choose the material this capability should work on."}
+          <section className="desk-pullout-capability">
+            {readiness.state !== "ready" && (
+              <p className="desk-run-warning">
+                {readiness.detail || "Unavailable here."}
               </p>
-              {readiness.detail && (
-                <p className="desk-run-warning">{readiness.detail}</p>
-              )}
-              <p className="quiet">
-                Runs on{" "}
-                {(capability.supported_placements || ["this_machine"])
-                  .map((value: string) => humanizeWireValue(value))
-                  .join(" · ")}
-                {capability.effect_classes?.length
-                  ? ` · ${capability.effect_classes
-                      .map((value: string) => humanizeWireValue(value))
-                      .join(" · ")}`
-                  : ""}
-              </p>
-              <button
-                type="button"
-                className="desk-chip quiet"
-                onClick={() =>
-                  openSurfaceOr("configure-runs-on", "/profiles", resourceRef)
-                }
-              >
-                Configure Runs on
-              </button>
-              {o.kind === "chain" && (
-                <p className="quiet">
-                  Sequence is the linear compatibility form.
-                </p>
-              )}
-              {o.kind === "workflow" && (
-                <button
-                  type="button"
-                  className="desk-chip quiet"
-                  onClick={() =>
-                    openSurfaceOr("build-workflow", "/workbench", resourceRef)
-                  }
-                >
-                  Edit this Workflow
-                </button>
-              )}
-            </div>
-            <div className="desk-pullout-run">
-              <RunsOnPicker
-                targets={inferenceTargets}
-                selectedId={runTargetId}
-                onChange={setRunTargetId}
-                disabled={runBusy}
-              />
-              <div className="desk-run-composer">
+            )}
+            <div className="desk-chat-well">
+              <div className="desk-chat-composer">
                 <MicButton
                   label={`Hold to fill ${runLabel.toLowerCase()} material`}
                   draftScope={`capability:${o.kind}:${o.id}`}
@@ -693,12 +687,15 @@ export function Pullout({ o }: { o: WorldObject }) {
                 <input
                   value={runInput}
                   placeholder="Material"
-                  aria-label="Run material"
+                  aria-label={runLabel}
+                  title={String(capability.input_help || "")}
                   onChange={(e) => setRunInput(e.target.value)}
                 />
                 <button
                   type="button"
-                  className="desk-chip is-primary"
+                  className={
+                    o.kind === "recipe" ? "desk-chip" : "desk-chip is-primary"
+                  }
                   onClick={() => void run()}
                   disabled={
                     runBusy ||
@@ -710,16 +707,52 @@ export function Pullout({ o }: { o: WorldObject }) {
                   {runBusy
                     ? "Running…"
                     : runState === "failed" || runState === "empty"
-                      ? `Retry ${runLabel}`
-                      : runLabel}
+                      ? "Retry"
+                      : o.kind === "recipe"
+                        ? "Ask"
+                        : "Run"}
                 </button>
               </div>
-              {runInputRecovered ? (
-                <span className="quiet">Recovered local run material.</span>
-              ) : null}
+              <div className="desk-chat-well-foot">
+                <RunsOnPicker
+                  targets={inferenceTargets}
+                  selectedId={runTargetId}
+                  onChange={setRunTargetId}
+                  disabled={runBusy}
+                />
+              </div>
+            </div>
+            {runInputRecovered ? (
+              <span className="quiet">Recovered local run material.</span>
+            ) : null}
+            <div className="desk-pullout-capability-foot">
+              <span className="quiet">
+                Runs on{" "}
+                {(capability.supported_placements || ["this_machine"])
+                  .map((value: string) => humanizeWireValue(value))
+                  .join(" · ")}
+                {capability.effect_classes?.length
+                  ? ` · ${capability.effect_classes
+                      .map((value: string) => humanizeWireValue(value))
+                      .join(" · ")}`
+                  : ""}
+              </span>
+              <button
+                type="button"
+                className="desk-chip quiet"
+                onClick={() =>
+                  openSurfaceOr("configure-runs-on", "/profiles", resourceRef)
+                }
+              >
+                Configure Runs on
+              </button>
             </div>
             {runWarning && <p className="desk-run-warning">⚠ {runWarning}</p>}
-            {runOut && <pre className="desk-pullout-md">{runOut}</pre>}
+            {runOut && (
+              <div className="surface-aerogel">
+                <Material>{runOut}</Material>
+              </div>
+            )}
             {runArtifactId && (
               <button
                 type="button"
@@ -755,83 +788,154 @@ export function Pullout({ o }: { o: WorldObject }) {
           </section>
         )}
 
-        {FILABLE.has(o.kind) && relationships && (
-          <section
-            className="desk-relationship-axes"
-            aria-label="Organization and context"
-          >
-            <h3>Where it belongs</h3>
-            <p>
-              {relationships.zone
-                ? `Zone: ${relationships.zone.directory_id}`
-                : "Desk root"}
-            </p>
-
-            <h3>Knowledge</h3>
-            <div className="desk-pullout-lineage">
-              {knowledgeChoices.map((knowledge) => {
-                const active = (relationships.knowledge || []).some(
-                  (row: any) => row.knowledge_id === knowledge.id,
-                );
-                return (
-                  <button
-                    key={knowledge.id}
-                    type="button"
-                    className={`desk-chip quiet${active ? " in-zone" : ""}`}
-                    aria-pressed={active}
-                    onClick={() =>
-                      void toggleRelationship("knowledge", knowledge.id, active)
-                    }
-                  >
-                    {active ? "✓ " : "+ "}
-                    {knowledge.name}
-                  </button>
-                );
-              })}
-              {!knowledgeChoices.length && (
-                <span className="quiet">No Knowledge yet</span>
-              )}
-            </div>
-
-            <h3>Projects</h3>
-            <div className="desk-pullout-lineage">
-              {projectChoices.map((project) => {
-                const active = (relationships.projects || []).some(
-                  (row: any) => row.project_id === project.id,
-                );
-                return (
-                  <span className="desk-project-choice" key={project.id}>
-                    <button
-                      type="button"
-                      className={`desk-chip quiet${active ? " in-zone" : ""}`}
-                      aria-label={`${active ? "Remove from" : "Assign to"} ${project.name} Project`}
-                      aria-pressed={active}
-                      onClick={() =>
-                        void toggleRelationship("projects", project.id, active)
-                      }
-                    >
-                      {active ? "✓ " : "+ "}
-                      {project.name}
-                    </button>
-                    <button
-                      type="button"
-                      className="desk-chip quiet"
-                      aria-label={`Inspect ${project.name} Project`}
-                      onClick={() =>
-                        openToolInspector("project", String(project.id))
-                      }
-                    >
-                      Inspect
-                    </button>
-                  </span>
-                );
-              })}
-              {!projectChoices.length && (
-                <span className="quiet">No Projects yet</span>
-              )}
-            </div>
-          </section>
-        )}
+        {FILABLE.has(o.kind) &&
+          relationships &&
+          (() => {
+            // The belonging strip (round 8): ONE disclosure whose summary
+            // states the truth; the label walls and the foot's separate
+            // "Move to…" both fold into it.
+            const homeZone = zones.find((z) => {
+              const members = ((z as any).memberIds as string[]) || [];
+              return members.includes(o.id) || members.includes(resourceRef);
+            });
+            const kCount = (relationships.knowledge || []).length;
+            const pCount = (relationships.projects || []).length;
+            // A Knowledge collection never offers itself as a home.
+            const knowledgeHomes = knowledgeChoices.filter(
+              (knowledge) => resourceRef !== qualifiedRef("kb", knowledge.id),
+            );
+            const filedSummary = [
+              homeZone ? String(homeZone.name || homeZone.id) : "Desk root",
+              kCount ? `${kCount} Knowledge` : "",
+              pCount
+                ? `${pCount} Project${pCount === 1 ? "" : "s"}`
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" · ");
+            return (
+              <Disclosure title={`Filed · ${filedSummary}`}>
+                <div className="desk-pullout-filed">
+                  {zones.length > 0 && (
+                    <div className="desk-pullout-filed-axis">
+                      <span className="surface-eyebrow">Zone</span>
+                      <div className="desk-pullout-lineage">
+                        {zones.map((z) => {
+                          const members =
+                            ((z as any).memberIds as string[]) || [];
+                          const inZone =
+                            members.includes(o.id) ||
+                            members.includes(resourceRef);
+                          return (
+                            <button
+                              key={String(z.id)}
+                              type="button"
+                              className={`desk-chip quiet${inZone ? " in-zone" : ""}`}
+                              aria-pressed={inZone}
+                              onClick={() =>
+                                void (inZone
+                                  ? removeFromDir(o.id, String(z.id), o.kind)
+                                  : fileIntoDir(o.id, String(z.id), o.kind))
+                              }
+                            >
+                              {inZone ? "✓ " : "+ "}
+                              {String(z.name || z.id)}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  {knowledgeHomes.length > 0 && (
+                    <div className="desk-pullout-filed-axis">
+                      <span className="surface-eyebrow">Knowledge</span>
+                      <div className="desk-pullout-lineage">
+                        {knowledgeHomes.map((knowledge) => {
+                            const active = (relationships.knowledge || []).some(
+                              (row: any) => row.knowledge_id === knowledge.id,
+                            );
+                            return (
+                              <button
+                                key={knowledge.id}
+                                type="button"
+                                className={`desk-chip quiet${active ? " in-zone" : ""}`}
+                                aria-pressed={active}
+                                onClick={() =>
+                                  void toggleRelationship(
+                                    "knowledge",
+                                    knowledge.id,
+                                    active,
+                                  )
+                                }
+                              >
+                                {active ? "✓ " : "+ "}
+                                {knowledge.name}
+                              </button>
+                            );
+                          })}
+                      </div>
+                    </div>
+                  )}
+                  {projectChoices.length > 0 && (
+                    <div className="desk-pullout-filed-axis">
+                      <span className="surface-eyebrow">Projects</span>
+                      <div className="desk-pullout-lineage">
+                        {projectChoices.map((project) => {
+                          const active = (relationships.projects || []).some(
+                            (row: any) => row.project_id === project.id,
+                          );
+                          return (
+                            <span
+                              className="desk-project-choice"
+                              key={project.id}
+                            >
+                              <button
+                                type="button"
+                                className={`desk-chip quiet${active ? " in-zone" : ""}`}
+                                aria-label={`${active ? "Remove from" : "Assign to"} ${project.name} Project`}
+                                aria-pressed={active}
+                                onClick={() =>
+                                  void toggleRelationship(
+                                    "projects",
+                                    project.id,
+                                    active,
+                                  )
+                                }
+                              >
+                                {active ? "✓ " : "+ "}
+                                {project.name}
+                              </button>
+                              <button
+                                type="button"
+                                className="desk-chip quiet"
+                                aria-label={`Inspect ${project.name} Project`}
+                                onClick={() =>
+                                  openToolInspector(
+                                    "project",
+                                    String(project.id),
+                                  )
+                                }
+                              >
+                                Inspect
+                              </button>
+                            </span>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  {!zones.length &&
+                    !knowledgeChoices.length &&
+                    !projectChoices.length && (
+                      <span className="quiet">
+                        Nothing to file into yet — Zones, Knowledge, and
+                        Projects appear here once they exist.
+                      </span>
+                    )}
+                </div>
+              </Disclosure>
+            );
+          })()}
         {relationshipError && (
           <p className="desk-run-warning" role="alert">
             {relationshipError}
@@ -868,39 +972,6 @@ export function Pullout({ o }: { o: WorldObject }) {
           >
             Edit
           </button>
-        )}
-        {FILABLE.has(o.kind) && zones.length > 0 && (
-          <div className="desk-pullout-file">
-            <button
-              type="button"
-              className="desk-chip quiet"
-              onClick={() => setFiling((v) => !v)}
-            >
-              Move to…
-            </button>
-            {filing &&
-              zones.map((z) => {
-                const members = ((z as any).memberIds as string[]) || [];
-                const inZone =
-                  members.includes(o.id) || members.includes(resourceRef);
-                return (
-                  <button
-                    key={String(z.id)}
-                    type="button"
-                    className={"desk-chip quiet" + (inZone ? " in-zone" : "")}
-                    onClick={() => {
-                      setFiling(false);
-                      void (inZone
-                        ? removeFromDir(o.id, String(z.id), o.kind)
-                        : fileIntoDir(o.id, String(z.id), o.kind));
-                    }}
-                  >
-                    {inZone ? "✓ " : ""}
-                    {String(z.name || z.id)}
-                  </button>
-                );
-              })}
-          </div>
         )}
       </footer>
     </DeskWindowFrame>

--- a/web/src/desk/desk.css
+++ b/web/src/desk/desk.css
@@ -765,6 +765,25 @@
   display: flex;
   flex-direction: column;
   border: 1px solid color-mix(in srgb, var(--k, #ff6b35) 34%, var(--border));
+  /* OS chrome is not selectable text; the MATERIAL below re-enables. */
+  user-select: none;
+}
+/* Round 8 — the OBJECT card fits its material: no fixed bottom, so a
+   short object never opens onto a two-thirds void. Working surfaces
+   (chat, sessions, terminals) keep the full-height sheet. */
+.desk-next .desk-pullout.is-card {
+  bottom: auto;
+  max-height: calc(100dvh - 96px);
+}
+.desk-next .desk-pullout .surface-material,
+.desk-next .desk-pullout .surface-say,
+.desk-next .desk-pullout .desk-pullout-md,
+.desk-next .desk-pullout input,
+.desk-next .desk-pullout textarea {
+  user-select: text;
+}
+.desk-next .desk-pullout .desk-pullout-body {
+  min-height: 0;
 }
 /* HS-99-02 — the title bar is a BAR (DESIGN_SYSTEM.md, the chrome
    ladder): the head tone sits one step above the body, separation is
@@ -1043,20 +1062,14 @@
   flex-direction: column;
   gap: var(--space-3);
 }
-.desk-next .desk-pullout-body section,
-.desk-next .desk-relationship-axes {
-  /* Materials round 3.2 — no card-in-window: the axes are sections on
-     the material, separated by hairlines. */
+.desk-next .desk-pullout-body section {
+  /* Materials round 3.2 — no card-in-window: sections sit on the
+     material, separated by hairlines. */
   display: grid;
   gap: 8px;
   padding: 0;
   border: 0;
   background: transparent;
-}
-.desk-next .desk-relationship-axes h3:not(:first-child) {
-  margin-top: 10px;
-  padding-top: 12px;
-  border-top: 1px solid var(--wash-1);
 }
 .desk-next .desk-pullout-body h3 {
   margin: 0 0 6px;
@@ -1096,30 +1109,6 @@
   max-height: 320px;
   overflow-y: auto;
 }
-.desk-next .desk-pullout-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 10px;
-  margin-bottom: 4px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: rgba(10, 9, 14, 0.5);
-  color: var(--text);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  text-align: left;
-}
-.desk-next .desk-pullout-row:hover {
-  border-color: color-mix(in srgb, var(--k, #ff6b35) 55%, var(--border));
-}
-.desk-next .desk-pullout-row-type {
-  font-size: var(--font-size-xs);
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
 .desk-next .desk-pullout-lineage {
   display: flex;
   flex-wrap: wrap;
@@ -1129,38 +1118,63 @@
   display: inline-flex;
   gap: 3px;
 }
-.desk-next .desk-pullout-run {
-  /* Materials round 3.4 — the run area STACKS: picker, then one
-     composer row (mic · material · verb). The one-row cram that
-     crushed the picker and stretched the mic is dead. */
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+/* HS-101 round 8 — the pull-out recomposed: the object's material
+   leads, the run lane is the ONE chat-well composer, belonging folds
+   into a single disclosure, and section walls are gone. */
+.desk-next .desk-pullout-facts {
+  font-size: var(--font-size-xs);
 }
-.desk-next .desk-run-composer {
+.desk-next .desk-pullout-agent {
+  justify-items: stretch;
+}
+.desk-next .desk-pullout-agent .desk-chat-hello {
+  padding: 10px 0 2px;
+}
+.desk-next .desk-pullout-agent-chat {
+  justify-self: center;
+  min-height: 34px;
+  padding: 0 18px;
+}
+.desk-next .desk-pullout-capability-foot {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px 10px;
 }
-.desk-next .desk-run-composer input {
+.desk-next .desk-pullout-capability-foot .quiet {
+  font-size: var(--font-size-xs);
+}
+.desk-next .desk-pullout-filed {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.desk-next .desk-pullout-filed-axis {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.desk-next .desk-pullout-steps {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.desk-next .desk-chat-composer textarea {
   flex: 1;
   min-width: 0;
-  height: 36px;
+  resize: none;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 8px 0;
 }
-.desk-next .desk-run-composer .desk-chip {
-  height: 36px;
-  flex: none;
-}
-.desk-next .desk-capability-contract {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: flex-start;
-}
-.desk-next .desk-capability-contract > strong {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+.desk-next .desk-chat-composer textarea:focus {
+  outline: none;
 }
 
 .desk-next .runs-on-picker {
@@ -1196,15 +1210,6 @@
   margin: 0;
   font-size: 11px;
 }
-.desk-next .desk-pullout-run input {
-  flex: 1;
-  padding: 8px 10px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: var(--desk-glass);
-  color: var(--text);
-  font-size: var(--font-size-sm);
-}
 .desk-next .desk-pullout-foot {
   display: flex;
   align-items: center;
@@ -1228,12 +1233,6 @@
 .desk-next .desk-chip.is-primary:hover {
   background: var(--accent-hover);
 }
-.desk-next .desk-pullout-file {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
 /* the dive camera: the world scales in as the zone's members take the stage */
 .desk-next .desk-world {
   transition:
@@ -4615,7 +4614,9 @@
 }
 .desk-next .desk-chat-well-foot .runs-on-picker select {
   height: 24px;
+  min-height: 24px;
   padding: 0 22px 0 8px;
+  border: 0;
   font-size: var(--desk-surface-label-size);
   color: var(--text-muted);
   background-color: transparent;

--- a/web/src/desk/surface/Material.tsx
+++ b/web/src/desk/surface/Material.tsx
@@ -1,0 +1,112 @@
+// HS-101 round 8 — written material (a note's body, an artifact, an
+// agent's instructions) presents as a DOCUMENT on the window material,
+// never as markdown source in a box. A deliberately small renderer:
+// headings, lists, paragraphs, bold/italic/code/links — built as React
+// nodes (no innerHTML), unknown syntax falls back to plain text.
+import type { ReactNode } from "react";
+
+const INLINE_RE =
+  /(\*\*[^*]+\*\*|\*[^*\s][^*]*\*|_[^_\s][^_]*_|`[^`]+`|\[[^\]]+\]\([^)\s]+\))/g;
+
+function inline(text: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  for (const m of text.matchAll(INLINE_RE)) {
+    const at = m.index ?? 0;
+    if (at > last) out.push(text.slice(last, at));
+    const tok = m[0];
+    if (tok.startsWith("**"))
+      out.push(<strong key={key++}>{tok.slice(2, -2)}</strong>);
+    else if (tok.startsWith("`"))
+      out.push(<code key={key++}>{tok.slice(1, -1)}</code>);
+    else if (tok.startsWith("[")) {
+      const text_ = tok.slice(1, tok.indexOf("]"));
+      const href = tok.slice(tok.indexOf("(") + 1, -1);
+      out.push(
+        /^https?:\/\//.test(href) ? (
+          <a key={key++} href={href} target="_blank" rel="noreferrer">
+            {text_}
+          </a>
+        ) : (
+          <strong key={key++}>{text_}</strong>
+        ),
+      );
+    } else out.push(<em key={key++}>{tok.slice(1, -1)}</em>);
+    last = at + tok.length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
+}
+
+type Block =
+  | { kind: "h"; text: string }
+  | { kind: "ul" | "ol"; items: string[] }
+  | { kind: "p"; text: string };
+
+function blocks(source: string): Block[] {
+  const out: Block[] = [];
+  let para: string[] = [];
+  const flush = () => {
+    if (para.length) out.push({ kind: "p", text: para.join(" ") });
+    para = [];
+  };
+  for (const raw of source.split("\n")) {
+    const line = raw.trim();
+    if (!line) {
+      flush();
+      continue;
+    }
+    const h = line.match(/^#{1,4}\s+(.*)$/);
+    if (h) {
+      flush();
+      out.push({ kind: "h", text: h[1] });
+      continue;
+    }
+    const li = line.match(/^[-*·]\s+(.*)$/);
+    const oli = line.match(/^\d+[.)]\s+(.*)$/);
+    if (li || oli) {
+      flush();
+      const kind = li ? "ul" : "ol";
+      const prev = out.at(-1);
+      if (prev && prev.kind === kind) prev.items.push((li || oli)![1]);
+      else out.push({ kind, items: [(li || oli)![1]] });
+      continue;
+    }
+    para.push(line);
+  }
+  flush();
+  return out;
+}
+
+export function Material({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
+  const parsed = blocks(children);
+  if (!parsed.length) return null;
+  return (
+    <div
+      className={className ? `surface-material ${className}` : "surface-material"}
+    >
+      {parsed.map((b, i) => {
+        if (b.kind === "h")
+          return (
+            <strong key={i} className="surface-material-h">
+              {inline(b.text)}
+            </strong>
+          );
+        if (b.kind === "p") return <p key={i}>{inline(b.text)}</p>;
+        const items = b.items.map((item, j) => <li key={j}>{inline(item)}</li>);
+        return b.kind === "ul" ? (
+          <ul key={i}>{items}</ul>
+        ) : (
+          <ol key={i}>{items}</ol>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -393,6 +393,54 @@
   line-height: var(--desk-type-primary-lh);
 }
 
+/* HS-101 round 8 — written material reads as a document on the window
+   material: reading leading, real emphasis, never source in a box. */
+.surface-material {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: var(--desk-surface-body-size);
+  line-height: 1.55;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+.surface-material p,
+.surface-material ul,
+.surface-material ol {
+  margin: 0;
+}
+.surface-material .surface-material-h {
+  font-size: var(--desk-type-primary-size);
+  font-weight: var(--desk-type-primary-weight);
+  line-height: var(--desk-type-primary-lh);
+  margin-top: 4px;
+}
+.surface-material .surface-material-h:first-child {
+  margin-top: 0;
+}
+.surface-material ul,
+.surface-material ol {
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.surface-material code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--wash-1);
+  padding: 1px 5px;
+  border-radius: 6px;
+}
+.surface-material a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.surface-material a:hover,
+.surface-material a:focus-visible {
+  text-decoration: underline;
+}
+
 /* HS-101 rule 1 — edit in place: the presented text is the editor.
    Same geometry presented and editing; the ring is the only tell. */
 .surface-edit-in-place {

--- a/web/src/pages/cores/CompanionCore.tsx
+++ b/web/src/pages/cores/CompanionCore.tsx
@@ -3,7 +3,7 @@
 // HS-100-09 — Agents (thesis §1.3): the application opens on WHO NEEDS
 // YOU — blocked sessions first with their question and an Answer verb
 // one step from the pane; then running. Delivery and Chat are the
-// wings. "Personas" leaves the glass; the canon word is agents.
+// wings. The persona noun leaves the glass; the canon word is agents.
 import { useMemo, useState } from "react";
 import { openCoderSession, openPersona } from "../../desk/shell";
 import type { CoreProps } from "./ActivityCore";

--- a/web/token-allowlist.json
+++ b/web/token-allowlist.json
@@ -108,11 +108,6 @@
     },
     {
       "file": "src/desk/desk.css",
-      "match": "rgba(10, 9, 14, 0.5)",
-      "reason": "hand-tuned one-off (glass/glow/ink shade) — consolidation is HS-96-04's material fold"
-    },
-    {
-      "file": "src/desk/desk.css",
       "match": "rgba(255, 255, 255, 0.055)",
       "reason": "hand-tuned one-off (glass/glow/ink shade) — consolidation is HS-96-04's material fold"
     },


### PR DESCRIPTION
Round 8 of the Phase-101 closeout sitting loop — the owner's double-click walk over every desk object.

**Eyes first:** all five object opens screenshotted and read on a staged hub. Every kind opened into one generic HS-73 template: raw markdown source in bordered boxes, three always-rendered label walls, two competing orange CTAs on the agent card, a "Persona" heading, and a two-thirds void under every card.

**Fixed at the source:**
- `Material.tsx` — a small dependency-free markdown→React renderer; notes/artifacts/instructions read as documents, never source in a box.
- Per-kind recomposition of the pullout: meeting facts line + honest intelligence line; KB members as openable rows; agent = composed identity card with ONE primary verb, run lane in the chat-well idiom.
- Belonging folds into ONE `Filed · <truth>` disclosure (Move to… included; a collection never offers itself as a home) — driven live over the wire.
- `fitContent` window physics: object cards size to their material until the user arranges them; working pull-outs keep the full-height sheet.
- Persona → Agent in three labels + a load error; the vocabulary guard now flags lone Capitalized words (the miss class), seeded both ways.
- Card chrome is unselectable (`user-select`), the material stays selectable.
- meetingflow accepts the round-6 honest intelligence-off face it had never been re-run against.

**Proof:** vitest 310/310 · token gate clean (allowlist shrank by one) · vocabulary + interior-canon guards 7/7 · desk/web pytest 443 · geometry/keys/speakflow/meetingflow green on the staged hub · all five opens re-walked and looked at at 1440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)