### PR TITLE
HS-101-04 (round 9): the reflex round — the desk answers the hand

### DIFF
--- a/scripts/desk_gl_walk.py
+++ b/scripts/desk_gl_walk.py
@@ -72,6 +72,52 @@ def free_object(page, prefix: str | None = None):
     )
 
 
+def launch_tool(page, label):
+    """HS-100-11 — drawers launch from the BELL (Desk memory) or the
+    search shelf, never the dock (the dock carries the applications)."""
+    if label == "Desk memory":
+        # The bell opens the system shade (HS-101 B6); the full Desk
+        # memory browser is one verb inside it.
+        page.click(".desk-bell")
+        page.wait_for_selector(".desk-shade", timeout=3000)
+        page.click(".desk-shade-memory")
+        return
+    # ⌘K — the search shelf reaches every tool even when a window
+    # covers the bar chip.
+    page.keyboard.press("Meta+k")
+    page.wait_for_selector(".desk-tool-shelf", timeout=3000)
+    page.fill("#desk-tool-shelf input[type=search]", label)
+    page.wait_for_timeout(300)
+    page.click(f".desk-tool-link:has-text('{label}')")
+
+
+def open_object(page, target):
+    """Open an object's card with the OS click grammar (HS-101 round 9):
+    a mouse DOUBLE-click opens; a single click only selects. The open
+    motion (the card flies out of its object) settles before physics."""
+    page.mouse.dblclick(target["x"], target["y"])
+    page.wait_for_timeout(450)
+
+
+def settled_box(locator, page):
+    """A window box AFTER its motion settles (two identical reads) —
+    hands grab settled windows; headless measures mid-flight."""
+    prev = None
+    for _ in range(25):
+        cur = locator.bounding_box()
+        if (
+            prev
+            and cur
+            and abs(cur["x"] - prev["x"]) < 0.5
+            and abs(cur["y"] - prev["y"]) < 0.5
+            and abs(cur["width"] - prev["width"]) < 0.5
+        ):
+            return cur
+        prev = cur
+        page.wait_for_timeout(100)
+    return prev
+
+
 def open_shelf(page):
     """Open the tool shelf if it is not already open (the launch chip
     TOGGLES; a leg must never close the shelf it means to use)."""
@@ -113,12 +159,27 @@ def smoke() -> None:
         objs = page.evaluate("() => window.__hsWorldProbe()")
         assert objs, "no objects on the seeded desk"
         target = objs[0]
-        # 1. Tap-to-open THROUGH the canvas at the rendered position.
+        # 1. The OS click grammar THROUGH the canvas (round 9): a single
+        # click SELECTS (the Ask bar answers the selection, no card); a
+        # double-click OPENS the card.
         page.mouse.click(target["x"], target["y"])
         page.wait_for_timeout(500)
-        assert page.locator(".desk-pullout").count() > 0, "tap did not open"
+        assert page.locator(".desk-pullout").count() == 0, (
+            "a single click must select, not open"
+        )
+        assert page.locator(".desk-askbar").count() > 0, (
+            "a single click did not select (no ask bar)"
+        )
+        page.mouse.dblclick(target["x"], target["y"])
+        page.wait_for_timeout(500)
+        assert page.locator(".desk-pullout").count() > 0, (
+            "double-click did not open"
+        )
         page.keyboard.press("Escape")
-        page.wait_for_timeout(300)
+        page.wait_for_timeout(600)
+        assert page.locator(".desk-pullout").count() == 0, (
+            "Escape did not close the card"
+        )
         # 2. Drag: press on the object, move far, release on background.
         page.mouse.move(target["x"], target["y"])
         page.mouse.down()
@@ -279,21 +340,22 @@ def windows() -> None:
         # geometry since HS-97-02).
         target = free_object(page)
         assert target, "no tappable object on the desk"
-        page.mouse.click(target["x"], target["y"])
+        open_object(page, target)
         page.wait_for_selector(".desk-pullout", timeout=5000)
-        # Window 2: Desk memory (attention drawer).
-        page.click(".desk-dock-launch:has-text('Desk memory')")
-        page.wait_for_selector(".desk-attention-drawer", timeout=5000)
-        # Window 3: the Delivery board.
-        page.click(".desk-dock-launch:has-text('Delivery')")
+        # Window 2: the Delivery board (search shelf, while nothing
+        # covers the shelf).
+        launch_tool(page, "Delivery")
         page.wait_for_selector(".desk-dlv-board", timeout=5000)
+        # Window 3: Desk memory (the bell's shade carries the verb).
+        launch_tool(page, "Desk memory")
+        page.wait_for_selector(".desk-attention-drawer", timeout=5000)
         assert page.locator(".desk-window-shell").count() >= 3
         # Drag the pull-out by its head to a deliberate spot.
         head = page.locator(".desk-pullout.desk-window-shell").first.locator(
             ".desk-window-handle"
         )
-        hb = head.bounding_box()
-        page.mouse.move(hb["x"] + 40, hb["y"] + 10)
+        hb = settled_box(head, page)
+        page.mouse.move(hb["x"] + 120, hb["y"] + 10)
         page.mouse.down()
         page.mouse.move(300, 200, steps=8)
         page.mouse.up()
@@ -334,17 +396,17 @@ def windows() -> None:
             "() => JSON.parse(localStorage.getItem('hs.desk.panels'))"
         )
         assert layout["max"] == ["delivery-board"], layout
-        assert "pullout" in layout["rects"], layout
+        assert any(k.startswith("pullout") for k in layout["rects"]), layout
         assert "min" not in layout, layout
         assert isinstance(layout.get("order"), list), layout
-        page.click(".desk-dock-launch:has-text('Desk memory')")
+        launch_tool(page, "Desk memory")
         page.wait_for_selector(".desk-attention-drawer:visible", timeout=3000)
         min_now = page.evaluate(
             "() => JSON.parse(localStorage.getItem('hs.desk.panels')).min"
         )
         assert min_now is None, min_now
         # The delivery board reopens maximized (persisted lifecycle).
-        page.click(".desk-dock-launch:has-text('Delivery')")
+        launch_tool(page, "Delivery")
         page.wait_for_selector(".desk-dlv-board", timeout=5000)
         assert "is-max" in (
             page.locator(".desk-dlv-board").get_attribute("class") or ""
@@ -360,7 +422,7 @@ def windows() -> None:
         wait_world(page)
         target = free_object(page)
         assert target, "no tappable object on the desk"
-        page.mouse.click(target["x"], target["y"])
+        open_object(page, target)
         page.wait_for_selector(".desk-pullout", timeout=5000)
         cls = page.locator(".desk-pullout.desk-window-shell").first.get_attribute(
             "class"
@@ -385,11 +447,11 @@ def shell() -> None:
         page.goto(arrive_url(), wait_until="networkidle")
         wait_world(page)
         # Open two windows.
-        page.click(".desk-dock-launch:has-text('Desk memory')")
+        launch_tool(page, "Desk memory")
         page.wait_for_selector(".desk-attention-drawer", timeout=5000)
         target = free_object(page)
         assert target, "no tappable object on the desk"
-        page.mouse.click(target["x"], target["y"])
+        open_object(page, target)
         page.wait_for_selector(".desk-pullout", timeout=5000)
         # The dock shows both chips.
         page.wait_for_selector(".desk-dock", timeout=3000)
@@ -398,8 +460,8 @@ def shell() -> None:
         head = page.locator(".desk-pullout.desk-window-shell").first.locator(
             ".desk-window-handle"
         )
-        hb = head.bounding_box()
-        page.mouse.move(hb["x"] + 40, hb["y"] + 10)
+        hb = settled_box(head, page)
+        page.mouse.move(hb["x"] + 120, hb["y"] + 10)
         page.mouse.down()
         page.mouse.move(6, 450, steps=10)
         page.mouse.up()
@@ -612,7 +674,7 @@ def dictation() -> None:
         page.click('[aria-label="Close Speak"]')
         target = free_object(page)
         assert target, "no tappable object on the desk"
-        page.mouse.click(target["x"], target["y"])
+        open_object(page, target)
         page.wait_for_selector(".desk-pullout", timeout=5000)
         page.click(".desk-pullout button:has-text(\'Dictate about this\')")
         page.wait_for_selector(".desk-surface-window .desk-scope-chip",
@@ -968,7 +1030,7 @@ def lastexits() -> None:
             )
             page.screenshot(path=str(OUT / "lastexits-debug.png"))
             raise AssertionError(f"no tappable workflow object: {dump}")
-        page.mouse.click(wf["x"], wf["y"])
+        open_object(page, wf)
         page.wait_for_selector(".desk-pullout", timeout=8000)
         page.click(".desk-pullout button:has-text(\'Edit Workflow\')")
         wb = page.locator("[aria-label=\'Workbench\'].desk-surface-window")
@@ -1082,7 +1144,7 @@ def arrangement() -> None:
         head = page.locator(
             "[aria-label='Settings'].desk-surface-window .desk-window-handle"
         )
-        hb = head.bounding_box()
+        hb = settled_box(head, page)
         page.mouse.move(hb["x"] + 60, hb["y"] + 10)
         page.mouse.down()
         page.mouse.move(hb["x"] + 220, hb["y"] + 160, steps=8)
@@ -1151,7 +1213,7 @@ def arrangement() -> None:
         page.wait_for_timeout(500)
         objs = page.evaluate("() => window.__hsWorldProbe()")
         assert objs, "no object on the phone desk"
-        page.mouse.click(objs[0]["x"], objs[0]["y"])
+        open_object(page, objs[0])
         page.wait_for_selector(".desk-pullout", timeout=8000)
         page.wait_for_timeout(400)
         hit = page.evaluate(
@@ -1549,7 +1611,7 @@ def geometry() -> None:
                 continue
             page.wait_for_timeout(900)
             head = page.locator(f"{sel} header.desk-pullout-head")
-            hb = head.bounding_box()
+            hb = settled_box(head, page)
             if not hb or not (36 <= hb["height"] <= 46):
                 failures.append(f"{label}: head band {hb}")
             lights = page.locator(f"{sel} .desk-light").count()
@@ -1669,7 +1731,7 @@ def chrome() -> None:
               return [cs.backgroundColor, tok];
             }""")
         assert head_token and head_token in ("", head_token), head_token
-        hb = head.bounding_box()
+        hb = settled_box(head, page)
         assert 38 <= hb["height"] <= 42, hb
         # Materials spike (owner-approved): the window verbs are traffic
         # LIGHTS — small round discs, colored on the front window.
@@ -1862,7 +1924,7 @@ def shelf() -> None:
         assert page.locator("text=Select an item for actions").count() == 0
         page.screenshot(path=str(OUT / "shelf-idle-1440.png"))
         # A launcher opens its surface; the launcher folds into the chip.
-        page.click(".desk-dock-launch:has-text('Desk memory')")
+        launch_tool(page, "Desk memory")
         page.wait_for_selector(".desk-attention-drawer", timeout=5000)
         page.wait_for_timeout(400)
         assert page.locator(".desk-dock-launch:has-text('Desk memory')").count() == 0
@@ -1932,7 +1994,7 @@ def focus() -> None:
         page = browser.new_page(viewport={"width": 1440, "height": 900})
         page.goto(arrive_url(), wait_until="networkidle")
         wait_world(page)
-        page.click(".desk-dock-launch:has-text('Desk memory')")
+        launch_tool(page, "Desk memory")
         page.wait_for_selector(".desk-attention-drawer", timeout=5000)
         seen = []
         for _ in range(14):

--- a/web/src/desk/__tests__/scale.test.tsx
+++ b/web/src/desk/__tests__/scale.test.tsx
@@ -41,7 +41,7 @@ beforeEach(() => {
     divedZone: null,
     positions: {},
     selectedIds: [],
-    pulloutId: null,
+    pullouts: [],
     editingId: null,
     askOpen: false,
   });

--- a/web/src/desk/__tests__/window.test.ts
+++ b/web/src/desk/__tests__/window.test.ts
@@ -11,8 +11,7 @@ describe("desk windows", () => {
       panelRects: {},
       panelSaved: [],
       panelOrder: [],
-      pulloutId: null,
-      pulloutBackId: null,
+      pullouts: [],
       editingId: null,
       askOpen: false,
       chatPersonaId: null,
@@ -100,16 +99,54 @@ describe("desk windows", () => {
   it("windows coexist: opening the composer keeps the pull-out open", () => {
     useDesk.getState().openPullout("note:n1");
     useDesk.getState().openAsk();
-    expect(useDesk.getState().pulloutId).toBe("note:n1");
+    expect(useDesk.getState().pullouts.map((p) => p.id)).toEqual(["note:n1"]);
     expect(useDesk.getState().askOpen).toBe(true);
 
     useDesk.getState().openToolInspector("project", "orion");
     expect(useDesk.getState().askOpen).toBe(true);
-    expect(useDesk.getState().pulloutId).toBe("note:n1");
+    expect(useDesk.getState().pullouts.map((p) => p.id)).toEqual(["note:n1"]);
     expect(useDesk.getState().toolInspector).toEqual({
       kind: "project",
       id: "orion",
     });
+  });
+
+  it("object cards coexist; reopening focuses; close targets one card", () => {
+    useDesk.getState().openPullout("note:n1", { x: 100, y: 200 });
+    useDesk.getState().openPullout("meeting:m1", { x: 500, y: 300 });
+    expect(useDesk.getState().pullouts.map((p) => p.id)).toEqual([
+      "note:n1",
+      "meeting:m1",
+    ]);
+    expect(useDesk.getState().panelOrder).toEqual([
+      "pullout:note:n1",
+      "pullout:meeting:m1",
+    ]);
+
+    // Reopening an open object focuses its card — never a duplicate.
+    useDesk.getState().openPullout("note:n1");
+    expect(useDesk.getState().pullouts).toHaveLength(2);
+    expect(useDesk.getState().panelOrder).toEqual([
+      "pullout:meeting:m1",
+      "pullout:note:n1",
+    ]);
+
+    // An id-less close takes the FRONT card (note:n1 after the refocus).
+    useDesk.getState().closePullout();
+    expect(useDesk.getState().pullouts.map((p) => p.id)).toEqual([
+      "meeting:m1",
+    ]);
+    useDesk.getState().closePullout("meeting:m1");
+    expect(useDesk.getState().pullouts).toEqual([]);
+  });
+
+  it("the origin rides the card; the editor takes only its own card", () => {
+    useDesk.getState().openPullout("note:n1", { x: 42, y: 43 });
+    useDesk.getState().openPullout("kb:k1");
+    expect(useDesk.getState().pullouts[0].origin).toEqual({ x: 42, y: 43 });
+    expect(useDesk.getState().pullouts[1].origin).toBeNull();
+    useDesk.getState().openEditor("kb:k1");
+    expect(useDesk.getState().pullouts.map((p) => p.id)).toEqual(["note:n1"]);
   });
 });
 

--- a/web/src/desk/components/ContextualPullout.test.tsx
+++ b/web/src/desk/components/ContextualPullout.test.tsx
@@ -34,7 +34,7 @@ describe("HS-93-04 contextual pull-out actions", () => {
       profiles: [],
       inferenceTargets: [],
       selectedIds: ["note:release"],
-      pulloutBackId: null,
+      pullouts: [],
       closePullout: vi.fn(),
       openPullout: vi.fn(),
       openEditor: vi.fn(),

--- a/web/src/desk/components/DeskListView.test.tsx
+++ b/web/src/desk/components/DeskListView.test.tsx
@@ -37,8 +37,7 @@ function resetStore(seed: Items) {
     items: seed,
     selectedIds: [],
     divedZone: null,
-    pulloutId: null,
-    pulloutBackId: null,
+    pullouts: [],
     editingId: null,
     askOpen: false,
     panelRects: {},
@@ -105,7 +104,7 @@ describe("HS-93-08 semantic list mode: same records", () => {
   it("opens the SAME pull-out record a floater click opens", () => {
     const { container } = renderList();
     fireEvent.click(screen.getByRole("button", { name: "Release checklist" }));
-    const pulloutId = useDesk.getState().pulloutId;
+    const pulloutId = useDesk.getState().pullouts.at(-1)?.id;
     expect(pulloutId).toBe(qualifiedRef("note", "n1"));
     // The spatial DeskObject opens with the bare id; both refs resolve to
     // the identical record through the one lookup.
@@ -235,7 +234,9 @@ describe("HS-93-08 pagination at 1,000 items", () => {
       name: /Meridian launch brief/,
     });
     fireEvent.click(hit);
-    expect(useDesk.getState().pulloutId).toBe(qualifiedRef("kb", "needle"));
+    expect(useDesk.getState().pullouts.at(-1)?.id).toBe(
+      qualifiedRef("kb", "needle"),
+    );
   });
 });
 

--- a/web/src/desk/components/DeskListView.tsx
+++ b/web/src/desk/components/DeskListView.tsx
@@ -23,7 +23,7 @@ export function DeskListView() {
   const items = useDesk((s) => s.items);
   const divedZone = useDesk((s) => s.divedZone);
   const selectedIds = useDesk((s) => s.selectedIds);
-  const pulloutId = useDesk((s) => s.pulloutId);
+  const pullouts = useDesk((s) => s.pullouts);
   const editingId = useDesk((s) => s.editingId);
   const askOpen = useDesk((s) => s.askOpen);
   const subjectCounts = useProjections((s) => s.subject_counts);
@@ -60,7 +60,9 @@ export function DeskListView() {
       )
     : null;
 
-  const pullout = pulloutId ? objectByRef(items, pulloutId) : null;
+  const openCards = pullouts
+    .map((p) => ({ ...p, obj: objectByRef(items, p.id) }))
+    .filter((p) => Boolean(p.obj));
   const editing = editingId ? objectByRef(items, editingId) : null;
 
   const showMore = () => {
@@ -186,7 +188,9 @@ export function DeskListView() {
       {editing && (
         <InlineEditor key={editing.id} o={editing} u={{ x: 0.5, y: 0.4 }} />
       )}
-      {pullout && <Pullout key={pullout.id} o={pullout} />}
+      {openCards.map((p) => (
+        <Pullout key={p.id} o={p.obj!} origin={p.origin} />
+      ))}
       <AskBar />
       {askOpen && <AskPanel />}
     </div>

--- a/web/src/desk/components/DeskToolShelf.tsx
+++ b/web/src/desk/components/DeskToolShelf.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { openSurface } from "../shell";
 import { qualifiedRef } from "../api";
 import { modelChatId } from "../chat";
@@ -286,7 +287,12 @@ export function DeskToolShelf() {
       >
         <span aria-hidden="true">⌕</span> Search <kbd>⌘K</kbd>
       </button>
+      {/* Round 9 — the shelf PORTALS to the desk root: rendered inside
+          the chrome bar it inherited the bar's z-30 stacking context and
+          every desk window (z 42+) covered the ⌘K results — a palette
+          must sit above the window band, always. */}
       {open ? (
+        createPortal(
         <aside
           ref={rootRef}
           id="desk-tool-shelf"
@@ -581,7 +587,9 @@ export function DeskToolShelf() {
               )}
             </section>
           ) : null}
-        </aside>
+        </aside>,
+        launchRef.current?.closest(".desk-next") ?? document.body,
+        )
       ) : null}
     </>
   );

--- a/web/src/desk/components/DeskWindow.tsx
+++ b/web/src/desk/components/DeskWindow.tsx
@@ -9,6 +9,7 @@
 // The hook is module-private on purpose: windows do not hand-wire physics.
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -274,6 +275,10 @@ export interface DeskWindowOptions {
    * material decides) until the user arranges the window; the HS-97-09
    * max-height seed inflation is skipped. */
   fitContent?: boolean;
+  /** Round 9 — the client point this window opened FROM (the tapped
+   * desk object). The window seats itself beside it and the open/close
+   * motion flies out of and back into it — spatial, not a side dock. */
+  origin?: { x: number; y: number } | null;
 }
 
 /** The desk-window physics (Phase 93). Module-private since HS-95-02:
@@ -318,7 +323,10 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
   // bars, always whole inside the working band); a persisted rect is
   // clamped into the band and otherwise untouched (the arrangement is
   // sacred). Sheets (compact viewports) own their own form.
-  useEffect(() => {
+  // Round 9: a LAYOUT effect — the window never paints a frame at its
+  // CSS home before the engine seats it (the teleport flash), and an
+  // origin window's entrance motion starts before first paint.
+  useLayoutEffect(() => {
     if (!open) return;
     // Present, don't blindly raise: a window rehydrating on reload keeps
     // its remembered plane in the stacking order (HS-97-03).
@@ -365,7 +373,43 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
         if (Number.isFinite(mh) && mh > seed.h)
           seed.h = Math.min(mh, cap);
       }
-      s.setPanelRect(id, placeWindow(seed, others, vw, vh, minW, minH));
+      const origin = opts.origin;
+      if (origin) {
+        // The spatial seat: beside the object it opened from — the
+        // right flank when it fits, the left otherwise; placeWindow
+        // still nudges it off other title bars and into the band.
+        const rightX = origin.x + 28;
+        const leftX = origin.x - seed.w - 28;
+        seed.x =
+          rightX + seed.w <= vw - MARGIN ? rightX : Math.max(MARGIN, leftX);
+        seed.y = origin.y - 56;
+      }
+      const placed = placeWindow(seed, others, vw, vh, minW, minH);
+      s.setPanelRect(id, placed);
+      if (
+        origin &&
+        el &&
+        typeof el.animate === "function" &&
+        !(
+          typeof window.matchMedia === "function" &&
+          window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        )
+      ) {
+        // The open flies OUT of the object (the minimize grammar,
+        // pointed at the world instead of the dock).
+        const dx = origin.x - (placed.x + placed.w / 2);
+        const dy = origin.y - (placed.y + Math.min(placed.h, 320) / 2);
+        el.animate(
+          [
+            {
+              transform: `translate(${dx}px, ${dy}px) scale(0.05)`,
+              opacity: 0,
+            },
+            { transform: "translate(0, 0) scale(1)", opacity: 1 },
+          ],
+          { duration: 240, easing: "cubic-bezier(.2, .8, .2, 1)" },
+        );
+      }
     }
     return () => {
       // An unarranged (never persisted) rect is ephemeral: forget it so
@@ -378,6 +422,52 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, open]);
+
+  // Round 9 — growth settles with motion: a content-sized card whose
+  // material arrives async (a meeting detail, a relationships fetch)
+  // GROWS smoothly instead of popping. Only while the height is still
+  // CSS-driven (unarranged, not mid-resize: those set style.height).
+  useEffect(() => {
+    if (!opts.fitContent || arranged || !open) return;
+    const el = elRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    if (
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    )
+      return;
+    let last = el.getBoundingClientRect().height;
+    let animating = false;
+    const ro = new ResizeObserver(() => {
+      if (animating) return;
+      // An explicit height (arranged pin, live resize, maximize) is the
+      // user's geometry — never animated under them.
+      if (el.style.height) {
+        last = el.getBoundingClientRect().height;
+        return;
+      }
+      const h = el.getBoundingClientRect().height;
+      if (!last || Math.abs(h - last) < 3) {
+        last = h;
+        return;
+      }
+      const from = last;
+      last = h;
+      if (typeof el.animate !== "function") return;
+      animating = true;
+      const anim = el.animate(
+        [{ height: `${from}px` }, { height: `${h}px` }],
+        { duration: 200, easing: "cubic-bezier(.2, .8, .2, 1)" },
+      );
+      anim.onfinish = anim.oncancel = () => {
+        animating = false;
+        last = el.getBoundingClientRect().height;
+      };
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opts.fitContent, arranged, open]);
 
   const dragBind = useDrag(
     ({ event, first, last, movement: [mx, my], memo }) => {
@@ -864,6 +954,8 @@ export interface DeskWindowFrameProps {
   minH?: number;
   /** Content-sized card: see DeskWindowOptions.fitContent. */
   fitContent?: boolean;
+  /** The client point this window opened from: see DeskWindowOptions. */
+  origin?: { x: number; y: number } | null;
   open: boolean;
   onClose: () => void;
   /** Heavy content may unmount while minimized (default: stays mounted). */
@@ -920,6 +1012,7 @@ export function DeskWindowFrame(props: DeskWindowFrameProps) {
     minW,
     minH,
     fitContent,
+    origin,
     open,
     onClose,
     unmountOnMinimize,
@@ -946,6 +1039,7 @@ export function DeskWindowFrame(props: DeskWindowFrameProps) {
     minW,
     minH,
     fitContent,
+    origin,
     open: open && !minimized,
   });
   const glyph = glyphProp ?? (typeof icon === "string" ? icon : "▢");
@@ -1000,12 +1094,29 @@ export function DeskWindowFrame(props: DeskWindowFrameProps) {
       return;
     }
     leavingRef.current = true;
+    // Round 9 — a window born from a desk object returns INTO it; the
+    // rest keep the quiet scale-fade.
+    const r = origin && !compact ? el.getBoundingClientRect() : null;
     const anim = el.animate(
-      [
-        { opacity: 1, transform: "scale(1)" },
-        { opacity: 0, transform: "scale(0.96)" },
-      ],
-      { duration: 140, easing: "ease-in", fill: "forwards" },
+      origin && r
+        ? [
+            { opacity: 1, transform: "translate(0, 0) scale(1)" },
+            {
+              opacity: 0,
+              transform: `translate(${origin.x - (r.x + r.width / 2)}px, ${
+                origin.y - (r.y + r.height / 2)
+              }px) scale(0.05)`,
+            },
+          ]
+        : [
+            { opacity: 1, transform: "scale(1)" },
+            { opacity: 0, transform: "scale(0.96)" },
+          ],
+      {
+        duration: origin && r ? 200 : 140,
+        easing: origin && r ? "cubic-bezier(.4, 0, .8, .4)" : "ease-in",
+        fill: "forwards",
+      },
     );
     anim.onfinish = () => {
       leavingRef.current = false;
@@ -1128,7 +1239,13 @@ export function DeskWindowFrame(props: DeskWindowFrameProps) {
         (isFront ? " is-front" : "")
       }
       style={style}
-      initial={reducedMotion || !entrance ? false : { x: 60, opacity: 0 }}
+      // An origin window's entrance is the fly-out-of-the-object WAAPI
+      // (pre-paint, in the placement effect) — never the side slide.
+      initial={
+        reducedMotion || !entrance || (origin && !compact)
+          ? false
+          : { x: 60, opacity: 0 }
+      }
       animate={{ x: 0, opacity: 1 }}
       transition={{ type: "spring", stiffness: 320, damping: 30 }}
       onPointerDown={(e) => {

--- a/web/src/desk/components/Pullout.tsx
+++ b/web/src/desk/components/Pullout.tsx
@@ -3,8 +3,7 @@
 // world stays alive behind it; "Open full" is the ONE navigation on the
 // desk; Escape or ✕ closes (it is a desk window — it survives clicks
 // elsewhere and can be moved, resized, and raised).
-import { useEffect, useRef, useState } from "react";
-import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 // @ts-ignore — shared ESM module (see ../sprites.d.ts)
 import { spriteUrl } from "../sprites";
 import { apiRequest } from "../../lib/api";
@@ -62,17 +61,23 @@ function intelligenceState(value: string): string {
   return labels[value] || value.replace(/_/g, " ");
 }
 
-export function Pullout({ o }: { o: WorldObject }) {
-  const reducedMotion = useReducedMotion();
+export function Pullout({
+  o,
+  origin,
+}: {
+  o: WorldObject;
+  /** The client point the open gesture happened at (spatial motion). */
+  origin?: { x: number; y: number } | null;
+}) {
   const items = useDesk((s) => s.items);
   const profiles = useDesk((s) => s.profiles);
   const inferenceTargets = useDesk((s) => s.inferenceTargets);
   const selectedIds = useDesk((s) => s.selectedIds);
-  const backId = useDesk((s) => s.pulloutBackId);
   const {
     closePullout,
     openPullout,
     openEditor,
+    updatePrimitive,
     fileIntoDir,
     removeFromDir,
     answerCoder,
@@ -102,6 +107,18 @@ export function Pullout({ o }: { o: WorldObject }) {
   const [answered, setAnswered] = useState<
     "selected" | "sent" | "failed" | null
   >(null);
+  // Round 9 — canon rule 1: the note's material edits IN PLACE on the
+  // card. Escape reverts; Done (or ⌘Enter) commits through the real PUT.
+  const [editingBody, setEditingBody] = useState(false);
+  const [bodyDraft, setBodyDraft] = useState("");
+  const startBodyEdit = () => {
+    setBodyDraft(String((o.ref as any).bodyMarkdown || ""));
+    setEditingBody(true);
+  };
+  const commitBodyEdit = () => {
+    void updatePrimitive("note", o.id, { body_markdown: bodyDraft });
+    setEditingBody(false);
+  };
   const contextualAction = contextualCapabilityActions(items, selectedIds).find(
     (action) => action.id === o.id && action.kind === o.kind,
   );
@@ -124,17 +141,9 @@ export function Pullout({ o }: { o: WorldObject }) {
     recovered: coderDraftRecovered,
   } = useDurableDraft(`coder-reply:${coderSessionId}`);
 
-  useEffect(() => {
-    // A desk window closes deliberately (✕ or Escape) — never from a stray
-    // click elsewhere on the desk; arranged windows coexist.
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closePullout();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("keydown", onKey);
-    };
-  }, []);
+  // Escape scope: the focused card closes itself (DeskWindowFrame); a
+  // desk-scoped Escape closes the FRONT card (the WorldStage listener).
+  // Cards never close from a stray click elsewhere — windows coexist.
 
   useEffect(() => {
     if (o.kind !== "meeting") return;
@@ -300,28 +309,17 @@ export function Pullout({ o }: { o: WorldObject }) {
 
   return (
     <DeskWindowFrame
-      id="pullout"
+      id={`pullout:${o.id}`}
       glyph="▤"
       label={o.title}
       className="desk-pullout is-card"
       fitContent
+      origin={origin}
       rootStyle={{ "--k": objGlow(o.kind) } as React.CSSProperties}
       icon={<img src={spriteUrl(o.kind, o.id)} alt="" width={30} height={30} />}
       title={o.title}
       open
-      onClose={closePullout}
-      leading={
-        backId ? (
-          <button
-            type="button"
-            className="desk-chip quiet"
-            onClick={() => openPullout(backId)}
-            aria-label="Back"
-          >
-            ←
-          </button>
-        ) : null
-      }
+      onClose={() => closePullout(o.id)}
       actions={
         <>
           {egress && (
@@ -374,7 +372,7 @@ export function Pullout({ o }: { o: WorldObject }) {
               meetingId={o.id}
               onResolved={async (result) => {
                 if (result.deleted) {
-                  closePullout();
+                  closePullout(o.id);
                 } else if (result.meeting) {
                   setDetail(result.meeting as MeetingDetail);
                 }
@@ -463,6 +461,29 @@ export function Pullout({ o }: { o: WorldObject }) {
             const members = ((ir.memberIds as string[]) || [])
               .map((m) => ({ ref: m, member: objectByRef(items, m) }))
               .filter(({ member }) => member);
+            if (o.kind === "note" && editingBody)
+              return (
+                <section>
+                  <textarea
+                    className="desk-pullout-editbox"
+                    aria-label={`${o.title} content`}
+                    value={bodyDraft}
+                    autoFocus
+                    rows={Math.max(6, bodyDraft.split("\n").length + 1)}
+                    placeholder="Write"
+                    onChange={(e) => setBodyDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        e.stopPropagation();
+                        setEditingBody(false);
+                      } else if (e.key === "Enter" && e.metaKey) {
+                        e.preventDefault();
+                        commitBodyEdit();
+                      }
+                    }}
+                  />
+                </section>
+              );
             if (body)
               return (
                 <section>
@@ -652,7 +673,7 @@ export function Pullout({ o }: { o: WorldObject }) {
                 type="button"
                 className="desk-chip quiet"
                 onClick={() => {
-                  closePullout();
+                  closePullout(o.id);
                   useSteering
                     .getState()
                     .openSession(
@@ -944,7 +965,7 @@ export function Pullout({ o }: { o: WorldObject }) {
       </div>
 
       <footer className="desk-pullout-foot">
-        {FILABLE.has(o.kind) && (
+        {FILABLE.has(o.kind) && !editingBody && (
           <button
             type="button"
             className="desk-chip quiet"
@@ -964,14 +985,50 @@ export function Pullout({ o }: { o: WorldObject }) {
             Record follow-up
           </button>
         )}
-        {EDITABLE.has(o.kind) && (
-          <button
-            type="button"
-            className="desk-chip is-primary"
-            onClick={() => openEditor(o.id)}
-          >
-            Edit
-          </button>
+        {o.kind === "note" ? (
+          editingBody ? (
+            <>
+              <MicButton
+                label="Hold to fill"
+                draftScope={`card-edit:${o.id}`}
+                onText={(t) =>
+                  setBodyDraft((current) => (current ? `${current} ${t}` : t))
+                }
+              />
+              <button
+                type="button"
+                className="desk-chip quiet"
+                onClick={() => setEditingBody(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="desk-chip is-primary"
+                onClick={commitBodyEdit}
+              >
+                Done
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              className="desk-chip is-primary"
+              onClick={startBodyEdit}
+            >
+              Edit
+            </button>
+          )
+        ) : (
+          EDITABLE.has(o.kind) && (
+            <button
+              type="button"
+              className="desk-chip is-primary"
+              onClick={() => openEditor(o.id)}
+            >
+              Edit
+            </button>
+          )
         )}
       </footer>
     </DeskWindowFrame>

--- a/web/src/desk/desk.css
+++ b/web/src/desk/desk.css
@@ -775,12 +775,32 @@
   bottom: auto;
   max-height: calc(100dvh - 96px);
 }
-.desk-next .desk-pullout .surface-material,
-.desk-next .desk-pullout .surface-say,
-.desk-next .desk-pullout .desk-pullout-md,
+/* Round 9 — the MATERIAL is copyable text (facts lines, receipts,
+   rendered bodies, transcripts); only the chrome (chips, disclosure
+   summaries, eyebrows) stays un-selectable like any OS control. */
+.desk-next .desk-pullout .desk-pullout-body,
 .desk-next .desk-pullout input,
 .desk-next .desk-pullout textarea {
   user-select: text;
+}
+.desk-next .desk-pullout .desk-pullout-body .desk-chip,
+.desk-next .desk-pullout .desk-pullout-body summary,
+.desk-next .desk-pullout .desk-pullout-body .surface-eyebrow {
+  user-select: none;
+}
+/* Round 9 — canon rule 1: the note's text edits in place, in the same
+   reading geometry the material renders in. No box, no third chrome. */
+.desk-next .desk-pullout-editbox {
+  width: 100%;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-family: inherit;
+  font-size: var(--desk-surface-body-size);
+  line-height: 1.55;
+  resize: vertical;
 }
 .desk-next .desk-pullout .desk-pullout-body {
   min-height: 0;
@@ -4629,6 +4649,8 @@
 
 /* HS-101 sitting round 2 — the ambient card yields to an open right
    sheet instead of burying its composer. */
-body:has(.desk-next .desk-pullout) .ambient-qlippy {
+/* Object cards (.is-card) float anywhere since round 9 — only the
+   right-docked working sheets still displace the ambient card. */
+body:has(.desk-next .desk-pullout:not(.is-card)) .ambient-qlippy {
   right: 452px;
 }

--- a/web/src/desk/gl/WorldStage.tsx
+++ b/web/src/desk/gl/WorldStage.tsx
@@ -7,13 +7,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useDesk } from "../store";
 import { useProjections } from "../projections";
-import { objectByRef, objUnit } from "../world";
+import { objectByRef, objUnit, type WorldObject } from "../world";
 import { InlineEditor } from "../components/InlineEditor";
 import { Pullout } from "../components/Pullout";
 import { AskBar, AskPanel } from "../components/AskPanel";
 import { MicButton } from "../components/MicButton";
-import { WorldEngine } from "./engine";
+import { DeskMenuItem, DeskMenuList } from "../components/DeskMenu";
+import { WorldEngine, type WorldMenuTarget } from "./engine";
 import { buildScene, type WorldScene } from "./sceneModel";
+
+/** Kinds whose material can be edited (mirrors the Pullout's set). */
+const WORLD_EDITABLE = new Set(["note", "kb", "recipe", "workflow"]);
 
 export { MAX_FLOATERS } from "./sceneModel";
 
@@ -25,7 +29,7 @@ export function WorldStage() {
   const items = useDesk((s) => s.items);
   const divedZone = useDesk((s) => s.divedZone);
   const editingId = useDesk((s) => s.editingId);
-  const pulloutId = useDesk((s) => s.pulloutId);
+  const pullouts = useDesk((s) => s.pullouts);
   const askOpen = useDesk((s) => s.askOpen);
   const renamingZoneId = useDesk((s) => s.renamingZoneId);
   const editorPos = useDesk((s) =>
@@ -47,6 +51,13 @@ export function WorldStage() {
     top: number;
     w: number;
     h: number;
+  } | null>(null);
+  // §6.3 — right-click is universal: the world's objects and zones
+  // answer with the ONE menu vocabulary.
+  const [worldMenu, setWorldMenu] = useState<{
+    target: WorldMenuTarget;
+    x: number;
+    y: number;
   } | null>(null);
 
   // The a11y/chip scene: the same pure projection the engine draws from,
@@ -93,6 +104,7 @@ export function WorldStage() {
     const engine = new WorldEngine(canvas, host, {
       onLasso: setLasso,
       onRenameZone: (zoneId) => useDesk.getState().setRenamingZone(zoneId),
+      onContextMenu: (target, x, y) => setWorldMenu({ target, x, y }),
     });
     engineRef.current = engine;
     void engine.init();
@@ -101,6 +113,42 @@ export function WorldStage() {
       engine.destroy();
     };
   }, []);
+
+  // Escape on the desk (no window focused — focused windows own their
+  // own Escape and stop it) closes the FRONT-MOST object card. Capture
+  // phase so an open in-world editor keeps its Escape to itself.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      // A focused window (or field) owns its own Escape.
+      const t = e.target as HTMLElement | null;
+      if (t?.closest?.(".desk-window-shell, .desk-editor, input, textarea"))
+        return;
+      const s = useDesk.getState();
+      if (s.editingId || s.renamingZoneId || s.askOpen) return;
+      if (s.pullouts.length) s.closePullout();
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, []);
+
+  // The world menu dismisses like every desk menu: outside press, Escape.
+  useEffect(() => {
+    if (!worldMenu) return;
+    const close = () => setWorldMenu(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener("pointerdown", close);
+    window.addEventListener("keydown", onKey, true);
+    return () => {
+      window.removeEventListener("pointerdown", close);
+      window.removeEventListener("keydown", onKey, true);
+    };
+  }, [worldMenu]);
 
   const { surface } = useDesk.getState();
   const editingIdx = scene.objects.findIndex((o) => o.id === editingId);
@@ -115,7 +163,9 @@ export function WorldStage() {
           editorPos ? { [editingId]: editorPos } : {},
         )
       : null;
-  const pullout = pulloutId ? objectByRef(items, pulloutId) : null;
+  const openCards = pullouts
+    .map((p) => ({ ...p, obj: objectByRef(items, p.id) }))
+    .filter((p): p is typeof p & { obj: WorldObject } => Boolean(p.obj));
   const renameZone =
     scene.zones.find((z) => z.id === renamingZoneId) || null;
 
@@ -154,7 +204,80 @@ export function WorldStage() {
       {editingObj && editorU && (
         <InlineEditor key={editingObj.id} o={editingObj} u={editorU} />
       )}
-      {pullout && <Pullout key={pullout.id} o={pullout} />}
+      {openCards.map((p) => (
+        <Pullout key={p.id} o={p.obj} origin={p.origin} />
+      ))}
+      {worldMenu && (
+        <DeskMenuList
+          className="desk-world-menu"
+          label={
+            worldMenu.target.type === "object"
+              ? `${worldMenu.target.title} menu`
+              : `${worldMenu.target.title} zone menu`
+          }
+          anchor="below"
+          style={{
+            position: "fixed",
+            left: Math.min(worldMenu.x, window.innerWidth - 184),
+            top: Math.min(worldMenu.y, window.innerHeight - 132),
+          }}
+          onClose={() => setWorldMenu(null)}
+        >
+          {worldMenu.target.type === "object" ? (
+            <>
+              <DeskMenuItem
+                onSelect={() => {
+                  const t = worldMenu.target as Extract<
+                    WorldMenuTarget,
+                    { type: "object" }
+                  >;
+                  setWorldMenu(null);
+                  useDesk
+                    .getState()
+                    .openPullout(t.id, { x: worldMenu.x, y: worldMenu.y });
+                }}
+              >
+                Open
+              </DeskMenuItem>
+              {WORLD_EDITABLE.has(worldMenu.target.kind) && (
+                <DeskMenuItem
+                  onSelect={() => {
+                    const t = worldMenu.target as Extract<
+                      WorldMenuTarget,
+                      { type: "object" }
+                    >;
+                    setWorldMenu(null);
+                    useDesk.getState().openEditor(t.id);
+                  }}
+                >
+                  Edit
+                </DeskMenuItem>
+              )}
+            </>
+          ) : (
+            <>
+              <DeskMenuItem
+                onSelect={() => {
+                  const t = worldMenu.target;
+                  setWorldMenu(null);
+                  useDesk.getState().diveInto(t.id);
+                }}
+              >
+                Open
+              </DeskMenuItem>
+              <DeskMenuItem
+                onSelect={() => {
+                  const t = worldMenu.target;
+                  setWorldMenu(null);
+                  useDesk.getState().setRenamingZone(t.id);
+                }}
+              >
+                Rename
+              </DeskMenuItem>
+            </>
+          )}
+        </DeskMenuList>
+      )}
       {lasso && (
         <div
           className="desk-lasso"

--- a/web/src/desk/gl/engine.ts
+++ b/web/src/desk/gl/engine.ts
@@ -126,11 +126,18 @@ type DragState =
     }
   | { type: "scroll"; pointerId: number; lastY: number };
 
+/** §6.3 — what a right-click on the world hit. */
+export type WorldMenuTarget =
+  | { type: "object"; id: string; ref: string; kind: string; title: string }
+  | { type: "zone"; id: string; title: string };
+
 export interface EngineCallbacks {
   /** DOM overlays follow the GL lasso (kept as the proven .desk-lasso div). */
   onLasso(box: { left: number; top: number; w: number; h: number } | null): void;
   /** Tapping a zone title opens the DOM rename overlay. */
   onRenameZone(zoneId: string): void;
+  /** Right-click answered: the DOM renders the ONE menu vocabulary. */
+  onContextMenu?(target: WorldMenuTarget, x: number, y: number): void;
 }
 
 export class WorldEngine {
@@ -153,6 +160,10 @@ export class WorldEngine {
   private scene: WorldScene | null = null;
   private drag: DragState = { type: "idle" };
   private hoverKey: string | null = null;
+  /** The OS click grammar (round 9): a mouse tap SELECTS; a second tap
+   * on the same object within the double-click window OPENS. */
+  private lastTap: { key: string; t: number; x: number; y: number } | null =
+    null;
   private unsubscribers: (() => void)[] = [];
   private reduceMotion = false;
   private destroyed = false;
@@ -744,18 +755,61 @@ export class WorldEngine {
     const move = (e: PointerEvent) => this.onMove(e);
     const up = (e: PointerEvent) => this.onUp(e);
     const hover = (e: PointerEvent) => this.onHover(e);
+    const menu = (e: MouseEvent) => this.onContextMenu(e);
     c.addEventListener("pointerdown", down);
     c.addEventListener("pointermove", move);
     c.addEventListener("pointermove", hover);
     c.addEventListener("pointerup", up);
     c.addEventListener("pointercancel", up);
+    c.addEventListener("contextmenu", menu);
     this.unsubscribers.push(() => {
       c.removeEventListener("pointerdown", down);
       c.removeEventListener("pointermove", move);
       c.removeEventListener("pointermove", hover);
       c.removeEventListener("pointerup", up);
       c.removeEventListener("pointercancel", up);
+      c.removeEventListener("contextmenu", menu);
     });
+  }
+
+  /** §6.3 — right-click is universal: objects and zones answer with the
+   * desk's menu; the empty desk keeps the browser's own. */
+  private onContextMenu(e: MouseEvent): void {
+    if (!this.scene || !this.callbacks.onContextMenu) return;
+    const rect = this.worldRect();
+    const hit = hitTest(
+      this.scene,
+      rect,
+      e.clientX - rect.left,
+      e.clientY - rect.top,
+    );
+    if (hit.type === "object") {
+      e.preventDefault();
+      this.drag = { type: "idle" };
+      this.callbacks.onContextMenu(
+        {
+          type: "object",
+          id: hit.object.id,
+          ref: hit.object.selectionRef,
+          kind: hit.object.kind,
+          title: hit.object.title,
+        },
+        e.clientX,
+        e.clientY,
+      );
+    } else if (
+      hit.type === "zone" ||
+      hit.type === "zone-title" ||
+      hit.type === "zone-grip"
+    ) {
+      e.preventDefault();
+      this.drag = { type: "idle" };
+      this.callbacks.onContextMenu(
+        { type: "zone", id: hit.zone.id, title: hit.zone.title },
+        e.clientX,
+        e.clientY,
+      );
+    }
   }
 
   private local(e: PointerEvent): { x: number; y: number; rect: WorldRect } {
@@ -893,6 +947,7 @@ export class WorldEngine {
       if (right - left < 8 && bottom - top < 8) {
         // A bare tap on the desk settles the selection — unless the Ask
         // composer holds the rope (HSM-16-04).
+        this.lastTap = null;
         if (!state.askOpen) state.clearSelection();
         return;
       }
@@ -912,13 +967,40 @@ export class WorldEngine {
       if (hit.type === "object") {
         if (e.shiftKey || e.metaKey || e.ctrlKey) {
           state.toggleSelected(hit.object.selectionRef);
-        } else {
+          this.lastTap = null;
+        } else if (e.pointerType === "touch" || e.pointerType === "pen") {
+          // Touch keeps tap-to-open (the iPad's grammar: no hover, no
+          // double-click reflex on glass).
           state.setDragging(null);
-          state.openPullout(hit.object.id);
+          state.openPullout(hit.object.id, { x: e.clientX, y: e.clientY });
+        } else {
+          // The desktop reflex: click selects, double-click opens.
+          const now = performance.now();
+          const prior = this.lastTap;
+          const again =
+            prior &&
+            prior.key === hit.object.key &&
+            now - prior.t < 400 &&
+            Math.hypot(e.clientX - prior.x, e.clientY - prior.y) < 8;
+          if (again) {
+            this.lastTap = null;
+            state.setDragging(null);
+            state.openPullout(hit.object.id, { x: e.clientX, y: e.clientY });
+          } else {
+            this.lastTap = {
+              key: hit.object.key,
+              t: now,
+              x: e.clientX,
+              y: e.clientY,
+            };
+            state.setSelected([hit.object.selectionRef]);
+          }
         }
       } else if (hit.type === "zone") {
+        this.lastTap = null;
         state.diveInto(hit.zone.id);
       } else if (hit.type === "zone-title") {
+        this.lastTap = null;
         this.callbacks.onRenameZone(hit.zone.id);
       } else if (hit.type === "zone-grip") {
         // A grip tap does nothing (DOM parity: click stopped propagation).

--- a/web/src/desk/store.ts
+++ b/web/src/desk/store.ts
@@ -181,9 +181,11 @@ interface DeskState {
   newIds: string[];
   /** The world object id whose in-world editor is open (one at a time). */
   editingId: string | null;
-  /** The object whose pull-out is open, + one level of back (HS-73-04). */
-  pulloutId: string | null;
-  pulloutBackId: string | null;
+  /** Open object cards (HS-101 round 9): real windows — they COEXIST,
+   * each remembering the tap point it opened from (the origin its
+   * open/close motion flies to). Order is open order; the panel order
+   * decides stacking. */
+  pullouts: { id: string; origin: { x: number; y: number } | null }[];
   /** The zone a live drag is hovering (the drop affordance, HS-73-05). */
   hoverZoneId: string | null;
   /** The freshly-created zone whose rename is focused. */
@@ -238,8 +240,13 @@ interface DeskState {
     patch: Record<string, unknown>,
   ): Promise<void>;
   renameZone(id: string, name: string): Promise<void>;
-  openPullout(id: string): void;
-  closePullout(): void;
+  /** Open an object card. A second object opens a SECOND card (windows
+   * coexist); reopening an open object focuses its card. `origin` is
+   * the client point the open gesture happened at (the card flies out
+   * of it and back into it on close). */
+  openPullout(id: string, origin?: { x: number; y: number }): void;
+  /** Close one card by object id; with no id, the front-most card. */
+  closePullout(id?: string): void;
   setHoverZone(id: string | null): void;
   setRenamingZone(id: string | null): void;
   diveInto(zoneId: string): void;
@@ -342,8 +349,7 @@ export const useDesk = create<DeskState>((set, get) => ({
   setup: null,
   newIds: [],
   editingId: null,
-  pulloutId: null,
-  pulloutBackId: null,
+  pullouts: [],
   hoverZoneId: null,
   renamingZoneId: null,
   selectedIds: [],
@@ -436,10 +442,11 @@ export const useDesk = create<DeskState>((set, get) => ({
   },
 
   openEditor(id) {
+    // The object's own card yields to its editor; other cards keep
+    // their seats (windows coexist).
     set({
       editingId: id,
-      pulloutId: null,
-      pulloutBackId: null,
+      pullouts: get().pullouts.filter((p) => p.id !== id),
       toolInspector: null,
     });
   },
@@ -510,8 +517,7 @@ export const useDesk = create<DeskState>((set, get) => ({
   diveInto(zoneId) {
     set({
       divedZone: zoneId,
-      pulloutId: null,
-      pulloutBackId: null,
+      pullouts: [],
       editingId: null,
       toolInspector: null,
     });
@@ -520,19 +526,28 @@ export const useDesk = create<DeskState>((set, get) => ({
     set({ divedZone: null });
   },
 
-  openPullout(id) {
-    const current = get().pulloutId;
-    set({
-      pulloutId: id,
-      // One-deep stack: opening from inside a pull-out remembers where to
-      // go back to (an artifact row inside a meeting's drawer).
-      pulloutBackId: current && current !== id ? current : null,
-      editingId: null,
-    });
-    get().focusPanel("pullout");
+  openPullout(id, origin) {
+    const open = get().pullouts;
+    if (!open.some((p) => p.id === id))
+      set({ pullouts: [...open, { id, origin: origin ?? null }] });
+    set({ editingId: null });
+    get().focusPanel(`pullout:${id}`);
   },
-  closePullout() {
-    set({ pulloutId: null, pulloutBackId: null });
+  closePullout(id) {
+    const open = get().pullouts;
+    if (open.length === 0) return;
+    const victim =
+      id ??
+      // Front-most card: the last pullout panel in the stacking order
+      // (cards never focused yet fall back to open order).
+      [...open]
+        .sort(
+          (a, b) =>
+            get().panelOrder.indexOf(`pullout:${a.id}`) -
+            get().panelOrder.indexOf(`pullout:${b.id}`),
+        )
+        .pop()?.id;
+    set({ pullouts: open.filter((p) => p.id !== victim) });
   },
 
   async fileIntoDir(pid, dirId, kind = "note") {

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -544,8 +544,10 @@ button.surface-edit-in-place:hover {
 }
 .desk-surface-body .signal-disclosure > summary::before {
   content: "▸";
-  font-size: 0.5625rem;
-  color: var(--text-faint);
+  /* Round 9 — the caret must READ as a caret (it rendered as a faint
+     dot at 9px): detail size, muted not faint. */
+  font-size: 0.6875rem;
+  color: var(--text-muted);
   transition: transform var(--duration-short) var(--ease-quart);
 }
 .desk-surface-body .signal-disclosure[open] > summary::before {


### PR DESCRIPTION
The sitting-loop round after the round-8 D- verdict on OS-primitive and experience behavior. Method inverted per the relief note: the desk was OPERATED first — headed browser, single/double click, drag, resize, Escape, ⌘W, two cards, right-click, Edit, 1440 AND 393, a real touch context — and every measured reflex failure was fixed at the cause.

## What changed
- **Click grammar**: mouse click selects (ring + ask bar), double-click opens; modifier-click toggles; touch/pen keep tap-to-open (iPad parity).
- **Spatial cards**: the open gesture carries its point; the card seats itself beside its object and flies out of it / back into it (the minimize grammar pointed at the world). The fixed top-right teleport is dead.
- **Coexistence**: object cards are real windows (`pullouts[]`, per-object ids + dock chips); the one-slot back-chip stack died. Escape closes the front card only.
- **Pre-paint placement**: the placement engine runs in a layout effect — no first-frame flash at the CSS home, and origin motion starts before paint.
- **Growth is motion**: async fit-content growth animates; pinned/live-resize heights are never animated under the user.
- **Right-click is universal on the world**: objects Open/Edit, zones Open/Rename, one menu vocabulary.
- **Edit in place**: the note's material becomes a same-geometry editor in the card (mic, Cancel, Done; Escape reverts, ⌘Enter commits). The overlay editor remains only for structured kinds (recorded remainder).
- **Copy + polish**: card body text selectable, chrome not; the disclosure caret is visible.
- **Found z defect**: the ⌘K shelf rendered under the window band (chrome-bar stacking context) — portaled to the desk root.
- **Walks**: smoke pins select-vs-open; `open_object`/`settled_box`/`launch_tool` helpers; latent HS-100-11 launcher breaks in windows/shell legs repointed through the bell shade and ⌘K.

## Proof
Staged hub :8792 (rebuilt bundle): headed verification walk at 1440 + 393 + touch, every screenshot read; vitest 312/312 (two new coexistence/origin tests); token gate clean; vocabulary + interior-canon guards 7/7; targeted desk/web pytest 438; smoke, geometry, keys, speakflow, meetingflow, windows, shell, chrome (headed), storm (headed, median 8.3 ms, p95 10.3 ms, 0 layout / 0 paint events) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)