### PR TITLE
HS-105-01 rider: zones ARE drawers on the glass

### DIFF
--- a/web/src/desk/gl/__tests__/sceneModel.test.ts
+++ b/web/src/desk/gl/__tests__/sceneModel.test.ts
@@ -12,6 +12,8 @@ import {
   ropeObjects,
   zoneRect,
   MAX_FLOATERS,
+  OBJ_H,
+  OBJ_W,
   type SceneInputs,
 } from "../sceneModel";
 import {
@@ -73,12 +75,14 @@ describe("buildScene", () => {
     expect(m.u).toEqual(objUnit(world[w], w, world.length, {}));
   });
 
-  it("keeps a filed object off the stage and inside its zone's thumbs", () => {
+  it("keeps a filed object off the stage; the drawer wears the count", () => {
+    // HS-105-01/03: the tray thumbs died with the tray — the drawer icon
+    // carries the live member count instead.
     const scene = buildScene(inputs({ items: someItems }));
     expect(scene.objects.some((o) => o.id === "n2")).toBe(false);
     expect(scene.zones).toHaveLength(1);
-    expect(scene.zones[0].thumbs.map((t) => t.id)).toEqual(["note:n2"]);
     expect(scene.zones[0].count).toBe(1);
+    expect(scene.zones[0].sprite).toContain("drawer");
   });
 
   it("caps at MAX_FLOATERS with the honest overflow", () => {
@@ -118,7 +122,9 @@ describe("buildScene", () => {
     expect(n.editing).toBe(true);
   });
 
-  it("gives zones saved positions/widths precedence over the default grid", () => {
+  it("gives zones saved positions precedence; the cell is fixed-size", () => {
+    // HS-105-01/03: the drawer cell has no resize — saved widths are
+    // ignored; the arrangement (position) stays sacred.
     const scene = buildScene(
       inputs({
         items: someItems,
@@ -127,14 +133,16 @@ describe("buildScene", () => {
       }),
     );
     expect(scene.zones[0].u).toEqual({ x: 0.7, y: 0.6 });
-    expect(scene.zones[0].width).toBe(420);
+    expect(scene.zones[0].width).toBe(OBJ_W);
+    expect(scene.zones[0].height).toBe(OBJ_H);
   });
 
-  it("clamps a saved zone width to the grip's own bounds", () => {
+  it("a drop-ready drawer wears the real second image", () => {
     const scene = buildScene(
-      inputs({ items: someItems, zoneWidths: { d1: 9999 } }),
+      inputs({ items: someItems, hoverZoneId: "d1" }),
     );
-    expect(scene.zones[0].width).toBe(560);
+    expect(scene.zones[0].dropReady).toBe(true);
+    expect(scene.zones[0].sprite).toContain("drawer_sel");
   });
 });
 
@@ -195,16 +203,18 @@ describe("hitTest (DOM stacking parity: zones above resting objects)", () => {
 
   it("prefers the overlapping zone over the object beneath", () => {
     const zr = zoneRect(scene.zones[0], RECT);
-    const hit = hitTest(scene, RECT, zr.cx, zr.top + zr.height - 8);
-    expect(["zone", "zone-grip"]).toContain(hit.type);
+    const hit = hitTest(scene, RECT, zr.cx, zr.top + 8);
+    expect(hit.type).toBe("zone");
   });
 
-  it("resolves the grip corner and the title row distinctly", () => {
+  it("resolves the drawer body and the label band distinctly", () => {
+    // HS-105-01/03: the grip died with the tray; rename rides the label
+    // band beneath the art.
     const zr = zoneRect(scene.zones[0], RECT);
-    const grip = hitTest(scene, RECT, zr.left + zr.width - 8, zr.top + zr.height - 8);
-    expect(grip.type).toBe("zone-grip");
-    const title = hitTest(scene, RECT, zr.cx, zr.top + 12);
-    expect(title.type).toBe("zone-title");
+    const body = hitTest(scene, RECT, zr.cx, zr.top + 12);
+    expect(body.type).toBe("zone");
+    const label = hitTest(scene, RECT, zr.cx, zr.top + zr.height - 8);
+    expect(label.type).toBe("zone-title");
   });
 
   it("ignores the dragged object for the drop hit-test", () => {

--- a/web/src/desk/gl/engine.ts
+++ b/web/src/desk/gl/engine.ts
@@ -84,16 +84,19 @@ interface ObjectNode {
   data: SceneObject;
 }
 
+/** HS-105-01/03 — a zone is a DRAWER ICON in the uniform cell (the tray,
+ * its thumbs strip, its resize grip, and its "drop things here" prose all
+ * died). The `_sel` drawer image lights when the zone is a drop target. */
 interface ZoneNode {
   root: Container;
-  shadow: NineSliceSprite;
-  panel: Sprite;
-  panelKey: string;
-  title: Text;
-  count: Text;
-  thumbs: Container;
-  thumbKeys: string;
-  grip: Sprite;
+  shadow: Sprite;
+  glow: Sprite;
+  sprite: Sprite;
+  spriteUrl: string;
+  label: Text;
+  labelText: string;
+  countBadge: Container | null;
+  countText: string;
   lift: number;
   liftTarget: number;
   scale: number;
@@ -576,44 +579,44 @@ export class WorldEngine {
 
   private createZoneNode(): ZoneNode {
     const root = new Container();
-    const shadow = new NineSliceSprite({
-      texture: zoneShadowTexture(),
-      leftWidth: 32,
-      topHeight: 32,
-      rightWidth: 32,
-      bottomHeight: 32,
-    });
-    shadow.alpha = 0.85;
-    const panel = new Sprite();
-    const title = new Text({
+    const shadow = new Sprite(shadowTexture());
+    shadow.anchor.set(0.5);
+    const glow = new Sprite();
+    glow.anchor.set(0.5);
+    glow.alpha = 0.5;
+    const sprite = new Sprite();
+    sprite.anchor.set(0.5);
+    const label = new Text({
       text: "",
       style: {
         fontFamily: bodyFont(),
-        fontSize: 13,
+        fontSize: 12,
+        lineHeight: 15,
         fontWeight: "600",
         fill: TEXT_COLOR,
+        align: "center",
+        dropShadow: {
+          alpha: 0.7,
+          angle: Math.PI / 2,
+          blur: 3,
+          color: 0x000000,
+          distance: 1,
+        },
       },
       resolution: Math.min((window.devicePixelRatio || 1) * 1.5, 3),
     });
-    const count = new Text({
-      text: "",
-      style: { fontFamily: bodyFont(), fontSize: 12, fill: TEXT_MUTED },
-      resolution: Math.min((window.devicePixelRatio || 1) * 1.5, 3),
-    });
-    const thumbs = new Container();
-    const grip = new Sprite();
-    grip.alpha = 0;
-    root.addChild(shadow, panel, title, count, thumbs, grip);
+    label.anchor.set(0.5, 0);
+    root.addChild(shadow, glow, sprite, label);
     return {
       root,
       shadow,
-      panel,
-      panelKey: "",
-      title,
-      count,
-      thumbs,
-      thumbKeys: "",
-      grip,
+      glow,
+      sprite,
+      spriteUrl: "",
+      label,
+      labelText: "",
+      countBadge: null,
+      countText: "",
       lift: 0,
       liftTarget: 0,
       scale: 1,
@@ -630,67 +633,55 @@ export class WorldEngine {
     this.zoneLayer.sortableChildren = true;
     node.root.pivot.set(0, 0);
     const emphasized = z.dropReady || this.hoverKey === `zone:${z.id}`;
-    const panelKey = `${z.tint}:${Math.round(z.width)}x${z.height}:${emphasized ? 1 : 0}`;
-    if (node.panelKey !== panelKey) {
-      node.panelKey = panelKey;
-      node.panel.texture = zonePanelTexture(
-        z.tint,
-        z.width,
-        z.height,
-        emphasized,
-      );
-    }
-    node.shadow.position.set(-14, -8);
-    node.shadow.width = z.width + 28;
-    node.shadow.height = z.height + 34;
-    node.title.text = z.title;
-    node.title.position.set(16, 11);
-    const countText =
-      z.count === 0
-        ? "drop things here"
-        : z.count === 1
-          ? "1 item"
-          : `${z.count} items`;
-    node.count.text = countText;
-    node.count.position.set(
-      z.thumbs.length > 0 ? 16 + z.thumbs.length * 26 + (z.more ? 26 : 0) : 16,
-      z.thumbs.length > 0 ? z.height - 27 : z.height - 29,
-    );
-    const thumbKeys =
-      z.thumbs.map((t) => t.id).join(",") + (z.more ? `+${z.more}` : "");
-    if (node.thumbKeys !== thumbKeys) {
-      node.thumbKeys = thumbKeys;
-      node.thumbs.removeChildren().forEach((c) => c.destroy({ children: true }));
-      z.thumbs.forEach((t, i) => {
-        const s = new Sprite();
-        const tex = loadSprite(t.sprite, (loaded) => {
-          s.texture = loaded;
-        });
-        if (tex) s.texture = tex;
-        s.width = 22;
-        s.height = 22;
-        s.position.set(16 + i * 26, z.height - 33);
-        node.thumbs.addChild(s);
+    // The cell's centerline (the root stays top-left anchored so the tick's
+    // y math is unchanged).
+    const cx = z.width / 2;
+    const cy = LIFT / 2;
+    if (node.spriteUrl !== z.sprite) {
+      node.spriteUrl = z.sprite;
+      const tex = loadSprite(z.sprite, (t) => {
+        if (node.spriteUrl === z.sprite) node.sprite.texture = t;
       });
-      if (z.more > 0) {
-        const more = new Text({
-          text: `+${z.more}`,
-          style: { fontFamily: bodyFont(), fontSize: 11, fill: TEXT_MUTED },
-          resolution: 2,
-        });
-        more.position.set(16 + z.thumbs.length * 26, z.height - 30);
-        node.thumbs.addChild(more);
-      }
+      if (tex) node.sprite.texture = tex;
     }
-    if (!node.grip.texture || node.grip.texture === Texture.EMPTY) {
-      node.grip.texture = gripTexture(z.tint);
+    node.sprite.width = SPRITE;
+    node.sprite.height = SPRITE;
+    node.sprite.position.set(cx, cy);
+    if (!node.glow.texture || node.glow.texture === Texture.EMPTY) {
+      node.glow.texture = glowTexture(z.tint);
     }
-    node.grip.position.set(z.width - GRIP - 3, z.height - GRIP - 3);
-    node.grip.alpha = emphasized || z.dragging ? 0.9 : 0.35;
+    node.glow.width = LIFT + 40;
+    node.glow.height = LIFT + 40;
+    node.glow.position.set(cx, cy);
+    node.glow.alpha = emphasized ? 0.85 : 0.5;
+    node.shadow.position.set(cx, cy + SPRITE / 2 + 8);
+    node.shadow.width = 54;
+    node.shadow.height = 12;
+    if (node.labelText !== z.title) {
+      node.labelText = z.title;
+      const measure = (s: string) => {
+        node.label.text = s;
+        return node.label.width;
+      };
+      node.label.text = clampLabel(z.title, measure, 98);
+    }
+    node.label.position.set(cx, cy + SPRITE / 2 + 8);
+    // Member count: the live badge (memberIds.length), bottom-right of the
+    // art — counts and marks only, never prose.
+    const countText = z.count > 0 ? String(z.count) : "";
+    if (countText !== node.countText) {
+      node.countText = countText;
+      node.countBadge?.destroy({ children: true });
+      node.countBadge = countText
+        ? makeBadge(countText, 0x242833, 0xf2f3f5, 9)
+        : null;
+      if (node.countBadge) node.root.addChild(node.countBadge);
+    }
+    node.countBadge?.position.set(cx + SPRITE / 2 - 4, cy + SPRITE / 2 - 4);
     node.liftTarget = z.dropReady ? -4 : emphasized ? -2 : 0;
     node.scaleTarget = z.dropReady ? 1.04 : 1;
-    // Rename hides the GL title (the DOM input overlays it).
-    node.title.visible = !z.renaming;
+    // Rename hides the GL label (the DOM input overlays it).
+    node.label.visible = !z.renaming;
   }
 
   // ── per-frame (transform-only) ──────────────────────────────────────────

--- a/web/src/desk/gl/sceneModel.ts
+++ b/web/src/desk/gl/sceneModel.ts
@@ -91,11 +91,16 @@ export interface SceneZone {
   id: string;
   title: string;
   u: UnitPos;
-  /** Resolved width in px for the given world width. */
+  /** HS-105-01/03 — a zone renders as a DRAWER ICON in the uniform cell
+   * (the tray + its "drop things here" prose died); width/height are the
+   * cell now. */
   width: number;
   height: number;
   tint: string;
   count: number;
+  /** The drawer sprite url; the `_sel` image when the zone is a lit
+   * drop target (the real second image, never a filter). */
+  sprite: string;
   thumbs: SceneZoneThumb[];
   more: number;
   dropReady: boolean;
@@ -215,30 +220,20 @@ export function buildScene(input: SceneInputs): WorldScene {
               (input.compact ? 0.2 : 0.13) +
               (Math.floor(i / cols) * 12) / 100,
           };
-    const savedWidth = input.zoneWidths[z.id];
-    const width = savedWidth
-      ? Math.min(ZONE_MAX_W, Math.max(ZONE_MIN_W, savedWidth))
-      : Math.min(
-          ZONE_DEFAULT_MAX_W,
-          Math.max(ZONE_MIN_W, (wPct / 100) * input.worldWidth),
-        );
     const memberIds = (((z.ref as any).memberIds as string[]) || []).slice();
-    const thumbs: SceneZoneThumb[] = memberIds.slice(0, 4).map((mid) => {
-      const r = resolveRef(input.items, mid);
-      const kind = r.kind || "note";
-      return { id: mid, kind, sprite: spriteUrl(kind, mid) };
-    });
+    const dropReady = input.hoverZoneId === z.id;
     return {
       id: z.id,
       title: z.title,
       u,
-      width,
-      height: thumbs.length > 0 ? ZONE_THUMBS_H : ZONE_H,
+      width: OBJ_W,
+      height: OBJ_H,
       tint: ZONE_TINTS[variantIndex(z.id, ZONE_TINTS.length)],
       count: memberIds.length,
-      thumbs,
-      more: Math.max(0, memberIds.length - 4),
-      dropReady: input.hoverZoneId === z.id,
+      sprite: spriteUrl("directory", z.id, dropReady ? "sel" : "rest"),
+      thumbs: [],
+      more: 0,
+      dropReady,
       dragging: input.draggingId === zoneKey,
       renaming: input.renamingZoneId === z.id,
     };
@@ -306,16 +301,10 @@ export function hitTest(
       localY >= r.top &&
       localY <= r.top + r.height;
     if (!inside) continue;
-    const gripPad = 6;
-    if (
-      localX >= r.left + r.width - GRIP - gripPad &&
-      localY >= r.top + r.height - GRIP - gripPad
-    ) {
-      return { type: "zone-grip", zone: z };
-    }
-    // The title row: tapping it starts rename (DOM parity — the title span
-    // stopped propagation and opened the rename input).
-    if (localY <= r.top + 30) return { type: "zone-title", zone: z };
+    // HS-105-01/03 — the drawer cell: tapping the LABEL band starts rename
+    // (the old tray's title row is gone with the tray; the resize grip died
+    // with it — an icon has no resize).
+    if (localY >= r.top + LIFT) return { type: "zone-title", zone: z };
     return { type: "zone", zone: z };
   }
   for (let i = scene.objects.length - 1; i >= 0; i--) {


### PR DESCRIPTION
The owner caught the shipped story claiming drawers the glass didn't show — zones rendered as tray panels outside the sprite system. Now a zone is a drawer icon in the uniform cell: 64px art, label beneath, live member count, `drawer_sel` lighting on drop-ready. Tray + thumbs + grip + "drop things here" prose deleted. Five tray pins deliberately rewritten. tsc clean · vitest 325/325 · build + tokens gate green · reshot on the staged hub at 1440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)