### PR TITLE
HS-104-01: the capability ledger — what each adapter actually knows

### DIFF
--- a/apple/Sources/Contracts/ProductLanguage.swift
+++ b/apple/Sources/Contracts/ProductLanguage.swift
@@ -116,7 +116,7 @@ public enum ProductLanguage {
         .result: ("Result", "Results"), .artifact: ("Artifact", "Artifacts"),
         .note: ("Note", "Notes"), .zone: ("Zone", "Zones"),
         .knowledge: ("Knowledge", "Knowledge collections"), .project: ("Project", "Projects"),
-        .persona: ("Persona", "Personas"), .coderSession: ("Coder session", "Coder sessions"),
+        .persona: ("Agent", "Agents"), .coderSession: ("Coder session", "Coder sessions"),
         .workflow: ("Workflow", "Workflows"), .sequence: ("Sequence", "Sequences"),
         .integration: ("Integration", "Integrations"), .runsOn: ("Runs on", "Runs on"),
         .proposedAction: ("Proposed action", "Proposed actions"), .review: ("Review", "Reviews"),

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -9,7 +9,7 @@ and the clients that call it (extracted from the real call sites in
 `web/src` and `apple/`). "server only" means no in-repo client calls
 it today.
 
-Routes: 333 (plus static mounts). iOS-consumed: 88. Web-consumed: 248.
+Routes: 334 (plus static mounts). iOS-consumed: 88. Web-consumed: 249.
 
 ## device_audio_ws
 
@@ -546,6 +546,12 @@ Routes: 333 (plus static mounts). iOS-consumed: 88. Web-consumed: 248.
 |---|---|---|
 | GET | `/api/sync/pull` | ios, web |
 | POST | `/api/sync/push` | ios, web |
+
+## web.routes.system.agent_capabilities
+
+| Method | Path | Consumers |
+|---|---|---|
+| GET | `/api/agents/capabilities` | web |
 
 ## web.routes.system.coder_steering_routes
 

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -389,6 +389,16 @@
       ]
     },
     {
+      "path": "/api/agents/capabilities",
+      "methods": [
+        "GET"
+      ],
+      "module": "web.routes.system.agent_capabilities",
+      "consumers": [
+        "web"
+      ]
+    },
+    {
       "path": "/api/all-action-items",
       "methods": [
         "GET"

--- a/holdspeak/agent_capabilities.py
+++ b/holdspeak/agent_capabilities.py
@@ -1,0 +1,200 @@
+"""The agent capability ledger (HS-104-01).
+
+Before any gate holds a call or any card prints a number, the system
+states — per agent adapter — whether each capability is
+``authoritative``, ``inferred``, or ``unavailable`` (Article VI:
+honest by construction). The ledger is DATA, hand-written and
+reviewed in the same commit as the code that changes a standing;
+nothing here is detected at runtime, because a computed table is
+just another inference.
+
+Three parts:
+
+- ``LEDGER`` — the frozen declaration table, adapter → capability →
+  standing, covering every adapter that exists today.
+- ``require_capability(adapter, capability)`` — the one enforcement
+  hook. Consumers that render or act on a capability MUST call it;
+  it raises :class:`CapabilityUnavailableError` (typed, naming the
+  adapter and the standing) when the ledger cannot vouch. The
+  chokepoint census pins its call sites.
+- ``LEDGER_CONSUMERS`` — the registered consumers list the doctor
+  check walks: a consumer registered against an ``unavailable``
+  capability turns the "Agent capabilities" doctor line red before
+  the lying surface ever ships.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+
+
+class Capability(str, Enum):
+    """The fixed capability vocabulary. Extending it is a reviewed edit."""
+
+    TOOL_HOOKS = "tool_hooks"
+    SESSION_IDENTITY = "session_identity"
+    USAGE_TOKENS = "usage_tokens"
+    REPO_HEAD = "repo_head"
+    BLOCKING = "blocking"  # can the adapter STOP a call, or only observe it
+
+
+class Standing(str, Enum):
+    AUTHORITATIVE = "authoritative"
+    INFERRED = "inferred"
+    UNAVAILABLE = "unavailable"
+
+
+ADAPTERS = ("tmux-pane", "delivery-node", "mesh-node", "claude-code-hooks")
+
+# The declaration table. Every cell is a reviewed claim:
+#
+# - tmux-pane (coder_steering.py): the pane content is what tmux
+#   serves — but WHO runs inside is a guess from the pane title/cwd,
+#   tokens never cross the wire, and a pane can be interrupted (C-c)
+#   yet never intercepted, so blocking is unavailable, not inferred.
+# - delivery-node (delivery/node_link.py): the node introduces itself
+#   with an authenticated hello and every attempt rides the command
+#   envelope, so identity and the assigned worktree head are the
+#   hub's own records. It exposes no tool hooks and reports no usage.
+# - mesh-node (intel/mesh_relay.py): a relayed inference endpoint.
+#   The hub knows which node it addressed (its own registry — hence
+#   inferred, not vouched by the far side) and nothing else.
+# - claude-code-hooks: declared here so HS-104-02 has a row to make
+#   true. Every cell starts ``unavailable`` — the ledger never
+#   promises ahead of the code; HS-104-02 flips exactly the entries
+#   it implements, in its own commit.
+LEDGER: MappingProxyType[str, MappingProxyType[Capability, Standing]] = MappingProxyType({
+    "tmux-pane": MappingProxyType({
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.INFERRED,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.INFERRED,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    }),
+    "delivery-node": MappingProxyType({
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.AUTHORITATIVE,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.AUTHORITATIVE,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    }),
+    "mesh-node": MappingProxyType({
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.INFERRED,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.UNAVAILABLE,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    }),
+    "claude-code-hooks": MappingProxyType({
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.UNAVAILABLE,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.UNAVAILABLE,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    }),
+})
+
+LEDGER_SCHEMA_VERSION = 1
+
+
+class CapabilityError(Exception):
+    """Base for ledger refusals."""
+
+
+class UnknownAdapterError(CapabilityError):
+    def __init__(self, adapter: str) -> None:
+        self.adapter = adapter
+        super().__init__(
+            f"unknown agent adapter {adapter!r}; the ledger declares {', '.join(ADAPTERS)}"
+        )
+
+
+class CapabilityUnavailableError(CapabilityError):
+    """The ledger cannot vouch: the standing is ``unavailable``."""
+
+    def __init__(self, adapter: str, capability: Capability, standing: Standing) -> None:
+        self.adapter = adapter
+        self.capability = capability
+        self.standing = standing
+        super().__init__(
+            f"adapter {adapter!r} declares {capability.value!r} as "
+            f"{standing.value!r}; refusing to act on a capability the "
+            "ledger cannot vouch for"
+        )
+
+
+def standing_for(adapter: str, capability: Capability) -> Standing:
+    """The declared standing, or :class:`UnknownAdapterError`."""
+    try:
+        row = LEDGER[adapter]
+    except KeyError:
+        raise UnknownAdapterError(adapter) from None
+    return row[Capability(capability)]
+
+
+def require_capability(adapter: str, capability: Capability) -> Standing:
+    """The enforcement hook downstream stories MUST route through.
+
+    Returns the standing (``authoritative`` or ``inferred`` — callers
+    that must distinguish label their surface with the return value)
+    and raises :class:`CapabilityUnavailableError` when the ledger
+    says ``unavailable``. The census pins every call site.
+    """
+    standing = standing_for(adapter, capability)
+    if standing is Standing.UNAVAILABLE:
+        raise CapabilityUnavailableError(adapter, Capability(capability), standing)
+    return standing
+
+
+@dataclass(frozen=True)
+class LedgerConsumer:
+    """A code path that acts on a declared capability.
+
+    Registered here in the same commit that adds the consumer, so the
+    doctor check can refuse a consumer the ledger cannot back.
+    """
+
+    consumer: str  # dotted code-path name, greppable
+    adapter: str
+    capability: Capability
+
+
+# HS-104-02 and HS-104-05 append here as they land their call sites.
+LEDGER_CONSUMERS: tuple[LedgerConsumer, ...] = ()
+
+
+def consumer_violations(
+    consumers: tuple[LedgerConsumer, ...] | None = None,
+) -> list[str]:
+    """Every registered consumer whose capability the ledger disowns."""
+    out: list[str] = []
+    for c in LEDGER_CONSUMERS if consumers is None else consumers:
+        try:
+            standing = standing_for(c.adapter, c.capability)
+        except UnknownAdapterError:
+            out.append(f"{c.consumer}: adapter {c.adapter!r} not in the ledger")
+            continue
+        if standing is Standing.UNAVAILABLE:
+            out.append(
+                f"{c.consumer}: requires {c.capability.value!r} on "
+                f"{c.adapter!r} but the ledger declares it unavailable"
+            )
+    return out
+
+
+def capabilities_payload() -> dict:
+    """The whole table, for ``GET /api/agents/capabilities``."""
+    return {
+        "ledger_schema": LEDGER_SCHEMA_VERSION,
+        "adapters": [
+            {
+                "adapter": adapter,
+                "capabilities": {
+                    cap.value: standing.value for cap, standing in row.items()
+                },
+            }
+            for adapter, row in LEDGER.items()
+        ],
+    }

--- a/holdspeak/commands/doctor.py
+++ b/holdspeak/commands/doctor.py
@@ -1271,7 +1271,36 @@ def collect_doctor_checks(*, skip_network: bool = False) -> list[DoctorCheck]:
         _check_pactl(),
         _check_system_audio_capture(),
         _check_connector_packs(),
+        _check_agent_capabilities(),
     ]
+
+
+def _check_agent_capabilities() -> DoctorCheck:
+    """HS-104-01: the capability-ledger census. Fails when any registered
+    ledger consumer requests a capability its adapter declares
+    ``unavailable`` — a lying surface caught before it renders."""
+    from ..agent_capabilities import LEDGER, LEDGER_CONSUMERS, consumer_violations
+
+    violations = consumer_violations()
+    if violations:
+        return DoctorCheck(
+            name="Agent capabilities",
+            status="FAIL",
+            detail=f"{len(violations)} consumer(s) outrun the ledger",
+            fix=(
+                "Align the consumer with holdspeak/agent_capabilities.py "
+                "(flip the standing in the same commit as the code, or drop "
+                "the consumer):\n  " + "\n  ".join(violations)
+            ),
+        )
+    return DoctorCheck(
+        name="Agent capabilities",
+        status="PASS",
+        detail=(
+            f"{len(LEDGER)} adapters declared, "
+            f"{len(LEDGER_CONSUMERS)} consumers, all backed by the ledger"
+        ),
+    )
 
 
 def _summarize(checks: list[DoctorCheck]) -> tuple[int, int, int]:

--- a/holdspeak/web/routes/system/__init__.py
+++ b/holdspeak/web/routes/system/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from ...context import WebContext
+from .agent_capabilities import build_agent_capabilities_router
 from .coder_steering_routes import build_coder_steering_router
 from .coders import build_coders_router
 from .health import build_health_router
@@ -21,6 +22,7 @@ from .ws import build_ws_router
 def build_system_router(ctx: WebContext) -> APIRouter:
     router = APIRouter()
     router.include_router(build_health_router(ctx))
+    router.include_router(build_agent_capabilities_router())
     router.include_router(build_coders_router(ctx))
     router.include_router(build_coder_steering_router(ctx))
     router.include_router(build_settings_router(ctx))

--- a/holdspeak/web/routes/system/agent_capabilities.py
+++ b/holdspeak/web/routes/system/agent_capabilities.py
@@ -1,0 +1,19 @@
+"""The one read API over the agent capability ledger (HS-104-01)."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from ....agent_capabilities import capabilities_payload
+
+
+def build_agent_capabilities_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/api/agents/capabilities")
+    async def api_agent_capabilities() -> Any:
+        return JSONResponse(capabilities_payload())
+
+    return router

--- a/pm/roadmap/holdspeak-mobile/contracts/schemas/agent-capabilities.schema.json
+++ b/pm/roadmap/holdspeak-mobile/contracts/schemas/agent-capabilities.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://holdspeak.dev/contracts/v0/agent-capabilities.schema.json",
+  "title": "AgentCapabilities",
+  "description": "HS-104-01: the agent capability ledger served at GET /api/agents/capabilities. Per adapter, the declared standing of each capability — authoritative, inferred, or unavailable — reviewed by hand, never detected at runtime. Spec artifact per the standing direction: the web desk is the reference implementation a Swift recreation later builds from.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["ledger_schema", "adapters"],
+  "properties": {
+    "ledger_schema": { "const": 1 },
+    "adapters": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["adapter", "capabilities"],
+        "properties": {
+          "adapter": {
+            "enum": ["tmux-pane", "delivery-node", "mesh-node", "claude-code-hooks"]
+          },
+          "capabilities": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tool_hooks", "session_identity", "usage_tokens", "repo_head", "blocking"],
+            "properties": {
+              "tool_hooks": { "$ref": "#/$defs/standing" },
+              "session_identity": { "$ref": "#/$defs/standing" },
+              "usage_tokens": { "$ref": "#/$defs/standing" },
+              "repo_head": { "$ref": "#/$defs/standing" },
+              "blocking": { "$ref": "#/$defs/standing" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "standing": { "enum": ["authoritative", "inferred", "unavailable"] }
+  }
+}

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -4,7 +4,15 @@
 > pick up, and the repo conventions that bite (PMO commit gate, write-once
 > evidence, no `Co-Authored-By`, metal-test exclusion).
 
-**Last updated:** 2026-07-26 — **Phase 105 (Workbench) CLOSED 7/7 in
+**Last updated:** 2026-07-26 — **Phase 104 (Borrowed Fire II) 1/7:
+HS-104-01 the capability ledger** — `holdspeak/agent_capabilities.py`
+(4 adapters × 5 capabilities, hand-declared standings:
+authoritative / inferred / unavailable), `GET /api/agents/capabilities`
++ contract schema validated against the live payload, the "Agent
+capabilities" doctor census (red on a consumer the ledger cannot
+back), and `require_capability` — the enforcement hook the gate
+(HS-104-02) and session receipts (HS-104-05) must route through.
+Earlier: **Phase 105 (Workbench) CLOSED 7/7 in
 two days**: icon system (1:1 pixel handles, real state images, live
 badges), drawers opening into remembering windows, Info/tooltypes on
 everything, drop-onto composition with named verbs, the menu bar on

--- a/pm/roadmap/holdspeak/phase-104-borrowed-fire-ii/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-104-borrowed-fire-ii/current-phase-status.md
@@ -1,6 +1,6 @@
 # Phase 104 - Borrowed Fire II: The Watched Hand
 
-**Status:** SCAFFOLDED (0/7, 2026-07-25). Chartered from a second
+**Status:** IN PROGRESS (1/7, 2026-07-26). Chartered from a second
 external-research pass in the Phase-103 mold: a study of
 `SirAllap/agentglass` (an MIT-licensed mission-control dashboard for
 AI coding agents — Claude Code hooks + OTel ingestion, a PreToolUse
@@ -16,7 +16,7 @@ OS-grade first; this phase's shade cards and receipt lines land on
 the icon/state/Info grammar Phase 105 installs. Activation order:
 Phase 103 close → Phase 105 → this phase.
 
-**Last updated:** 2026-07-25 (scaffolded; no story started).
+**Last updated:** 2026-07-26 (HS-104-01 shipped).
 
 ## Why this phase exists
 
@@ -112,7 +112,7 @@ provenance.
 
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
-| HS-104-01 | The capability ledger — what each adapter actually knows | backlog | [story-01-capability-ledger](./story-01-capability-ledger.md) | — |
+| HS-104-01 | The capability ledger — what each adapter actually knows | done | [story-01-capability-ledger](./story-01-capability-ledger.md) | [evidence-story-01](./evidence-story-01.md) |
 | HS-104-02 | The tool-call gate — a held hand, not a watched one | backlog | [story-02-tool-call-gate](./story-02-tool-call-gate.md) | — |
 | HS-104-03 | The gate under attack — restart, replay, TOCTOU | backlog | [story-03-gate-threat-model](./story-03-gate-threat-model.md) | — |
 | HS-104-04 | PR receipts — paying the candidate-Y deferral | backlog | [story-04-pr-receipts](./story-04-pr-receipts.md) | — |
@@ -134,6 +134,17 @@ provenance.
   37/61 executor spine once PR receipts exist.
 
 ## Where we are
+
+**2026-07-26 — activated; the ledger is in (1/7).** Phase 105 closed
+this morning and this phase went live. HS-104-01 shipped the same
+day: the frozen declaration table (`holdspeak/agent_capabilities.py`,
+4 adapters × 5 capabilities), `GET /api/agents/capabilities` with its
+contract schema validated against the live payload, the "Agent
+capabilities" doctor census (red on a consumer the ledger cannot
+back), and `require_capability` — the enforcement hook HS-104-02 and
+HS-104-05 must route through. `claude-code-hooks` sits all-
+`unavailable` until the gate story makes its cells true. Next:
+HS-104-02, the tool-call gate.
 
 **2026-07-25 — scaffolded, then re-sequenced.** The AgentGlass study
 and the council critique are recorded in this charter; seven

--- a/pm/roadmap/holdspeak/phase-104-borrowed-fire-ii/evidence-story-01.md
+++ b/pm/roadmap/holdspeak/phase-104-borrowed-fire-ii/evidence-story-01.md
@@ -1,0 +1,40 @@
+# Evidence - HS-104-01
+
+- **Story:** HS-104-01 - The capability ledger — what each adapter actually knows
+- **Status:** done
+- **Date:** 2026-07-26
+
+## What shipped
+
+- `holdspeak/agent_capabilities.py` — the frozen declaration table
+  (4 adapters × 5 capabilities, every cell a reviewed claim),
+  `require_capability()` (typed refusal naming adapter + standing),
+  `LEDGER_CONSUMERS` + `consumer_violations()` for the census.
+- `GET /api/agents/capabilities`
+  (`holdspeak/web/routes/system/agent_capabilities.py`, wired in the
+  system router); API-surface manifest regenerated (334 routes).
+- Contract schema (spec artifact):
+  `pm/roadmap/holdspeak-mobile/contracts/schemas/agent-capabilities.schema.json`
+  — the unit suite validates the LIVE route payload against it and
+  proves a lying payload rejects.
+- Doctor: "Agent capabilities" check — red when a registered consumer
+  requests a capability the ledger declares `unavailable`, proven by
+  a monkeypatched bad consumer in-test.
+- `claude-code-hooks` declared all-`unavailable` per the recipe: the
+  ledger never promises ahead of the code; HS-104-02 flips exactly
+  the cells it implements.
+
+## Proof
+
+### Captured run — 2026-07-26T17:58:22Z
+
+- **Command:** `uv run pytest -q tests/unit/test_agent_capabilities.py tests/unit/test_api_surface.py tests/unit/test_db.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** de3549638b27e0de0229f30453e6f3ee6eba0bb8
+
+```text
+........................................................................ [ 72%]
+...........................                                              [100%]
+99 passed in 6.75s
+```

--- a/pm/roadmap/holdspeak/phase-104-borrowed-fire-ii/story-01-capability-ledger.md
+++ b/pm/roadmap/holdspeak/phase-104-borrowed-fire-ii/story-01-capability-ledger.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 104
-- **Status:** backlog
+- **Status:** done
 - **Depends on:** none
 - **Unblocks:** HS-104-02, HS-104-05
 - **Owner:** unassigned

--- a/tests/unit/test_agent_capabilities.py
+++ b/tests/unit/test_agent_capabilities.py
@@ -1,0 +1,159 @@
+"""HS-104-01 — the capability ledger: matrix pins, enforcement, doctor census."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from holdspeak.agent_capabilities import (
+    ADAPTERS,
+    LEDGER,
+    Capability,
+    CapabilityUnavailableError,
+    LedgerConsumer,
+    Standing,
+    UnknownAdapterError,
+    capabilities_payload,
+    consumer_violations,
+    require_capability,
+    standing_for,
+)
+
+# The whole declaration table, pinned cell by cell. A standing change is a
+# reviewed edit that lands here in the same commit as the code it describes.
+EXPECTED = {
+    "tmux-pane": {
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.INFERRED,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.INFERRED,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    },
+    "delivery-node": {
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.AUTHORITATIVE,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.AUTHORITATIVE,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    },
+    "mesh-node": {
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.INFERRED,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.UNAVAILABLE,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    },
+    "claude-code-hooks": {
+        Capability.TOOL_HOOKS: Standing.UNAVAILABLE,
+        Capability.SESSION_IDENTITY: Standing.UNAVAILABLE,
+        Capability.USAGE_TOKENS: Standing.UNAVAILABLE,
+        Capability.REPO_HEAD: Standing.UNAVAILABLE,
+        Capability.BLOCKING: Standing.UNAVAILABLE,
+    },
+}
+
+
+def test_ledger_matches_the_pinned_matrix_exactly() -> None:
+    assert set(LEDGER) == set(EXPECTED) == set(ADAPTERS)
+    for adapter, row in EXPECTED.items():
+        assert dict(LEDGER[adapter]) == row, adapter
+        assert set(LEDGER[adapter]) == set(Capability), adapter
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS)
+@pytest.mark.parametrize("capability", list(Capability))
+def test_every_cell_answers(adapter: str, capability: Capability) -> None:
+    assert standing_for(adapter, capability) is EXPECTED[adapter][capability]
+
+
+def test_require_capability_returns_standing_when_vouched() -> None:
+    assert (
+        require_capability("delivery-node", Capability.SESSION_IDENTITY)
+        is Standing.AUTHORITATIVE
+    )
+    assert (
+        require_capability("tmux-pane", Capability.SESSION_IDENTITY)
+        is Standing.INFERRED
+    )
+
+
+def test_require_capability_refuses_unavailable_by_name() -> None:
+    with pytest.raises(CapabilityUnavailableError) as exc:
+        require_capability("tmux-pane", Capability.BLOCKING)
+    assert exc.value.adapter == "tmux-pane"
+    assert exc.value.capability is Capability.BLOCKING
+    assert "unavailable" in str(exc.value)
+    assert "tmux-pane" in str(exc.value)
+
+
+def test_unknown_adapter_refused_by_name() -> None:
+    with pytest.raises(UnknownAdapterError, match="not-an-adapter"):
+        require_capability("not-an-adapter", Capability.BLOCKING)
+
+
+def test_consumer_census_flags_unavailable_and_unknown() -> None:
+    bad = (
+        LedgerConsumer("gate.decide", "tmux-pane", Capability.BLOCKING),
+        LedgerConsumer("card.tokens", "ghost-adapter", Capability.USAGE_TOKENS),
+        LedgerConsumer("ok.attempts", "delivery-node", Capability.SESSION_IDENTITY),
+    )
+    violations = consumer_violations(bad)
+    assert len(violations) == 2
+    assert any("gate.decide" in v and "unavailable" in v for v in violations)
+    assert any("card.tokens" in v and "not in the ledger" in v for v in violations)
+
+
+def test_registered_consumers_are_all_backed() -> None:
+    assert consumer_violations() == []
+
+
+def test_doctor_check_goes_red_on_a_bad_consumer(monkeypatch) -> None:
+    import holdspeak.agent_capabilities as mod
+    from holdspeak.commands.doctor import _check_agent_capabilities
+
+    assert _check_agent_capabilities().status == "PASS"
+    monkeypatch.setattr(
+        mod,
+        "LEDGER_CONSUMERS",
+        (LedgerConsumer("bad.consumer", "tmux-pane", Capability.BLOCKING),),
+    )
+    check = _check_agent_capabilities()
+    assert check.status == "FAIL"
+    assert check.fix is not None and "bad.consumer" in check.fix
+
+
+def _schema() -> dict:
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "pm/roadmap/holdspeak-mobile/contracts/schemas/agent-capabilities.schema.json"
+    )
+    return json.loads(path.read_text())
+
+
+def test_route_serves_the_table_and_the_contract_validates_it() -> None:
+    from jsonschema import Draft202012Validator
+
+    from holdspeak.web.routes.system.agent_capabilities import (
+        build_agent_capabilities_router,
+    )
+
+    app = FastAPI()
+    app.include_router(build_agent_capabilities_router())
+    body = TestClient(app).get("/api/agents/capabilities").json()
+
+    validator = Draft202012Validator(_schema())
+    assert list(validator.iter_errors(body)) == []
+    assert body == capabilities_payload()
+    assert {row["adapter"] for row in body["adapters"]} == set(ADAPTERS)
+
+
+def test_contract_rejects_a_lying_payload() -> None:
+    from jsonschema import Draft202012Validator
+
+    validator = Draft202012Validator(_schema())
+    payload = capabilities_payload()
+    payload["adapters"][0]["capabilities"]["blocking"] = "probably"
+    assert list(validator.iter_errors(payload)) != []


### PR DESCRIPTION
Phase 104 (Borrowed Fire II) story 1/7.

- `holdspeak/agent_capabilities.py`: the frozen declaration table — 4 adapters × 5 capabilities, standings hand-declared (authoritative / inferred / unavailable), never runtime-detected.
- `GET /api/agents/capabilities` + contract schema (spec artifact) validated against the live payload in-test.
- Doctor "Agent capabilities" census: red when a registered consumer requests a capability the ledger disowns.
- `require_capability()`: the typed enforcement hook HS-104-02/05 must route through.
- `claude-code-hooks` declared all-unavailable — HS-104-02 flips exactly the cells it implements.

Evidence: `pm/roadmap/holdspeak/phase-104-borrowed-fire-ii/evidence-story-01.md` (99 focused tests, exit 0; full unit suite 3272 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)