### PR TITLE
HS-106-03: the effect census pinned as a test (the Article XI debt register)

### DIFF
--- a/holdspeak/kernel/__init__.py
+++ b/holdspeak/kernel/__init__.py
@@ -1,0 +1,1 @@
+"""The operation-broker boundary, fenced before its first implementation."""

--- a/holdspeak/kernel/effect_ledger.json
+++ b/holdspeak/kernel/effect_ledger.json
@@ -1,0 +1,393 @@
+{
+  "schema_version": 1,
+  "title": "Article XI cooperating-path effect debt register",
+  "authority": "Constitution Article XI temporary migration provision; HS-106-03",
+  "snapshot": "ecc8308021a48c3fa66baafe79b16196c11bffbb",
+  "scope": "Static effect-capable statements under holdspeak/ in the five ratified census families. Ignored source paths are included; bytecode, source maps, and vendored/generated static assets are excluded.",
+  "counting_rule": "Count statements, not logical user actions. Every ambient boundary crossed by one action remains a separate site.",
+  "legal_effect": "Each non-covered entry is declared migration debt, not authority. No agent principal may reach a path named by this register. Covered entries record existing audited chokepoints and do not grant authority beyond those chokepoints.",
+  "status_definitions": {
+    "covered": "Every in-tree route reaches the statement through an audited chokepoint named by the census.",
+    "bypass": "A reachable route avoids all named audited chokepoints.",
+    "mixed": "Covered and bypass routes share this statement; treated as not covered.",
+    "dormant": "No current production caller, but the ambient capability can execute without a named chokepoint; treated as not covered."
+  },
+  "expected": {
+    "total": 40,
+    "covered": 4,
+    "not_covered": 36,
+    "families": {
+      "tmux_transport": 4,
+      "text_typer": 8,
+      "subprocess": 5,
+      "egress": 13,
+      "raw_desktop": 10
+    }
+  },
+  "sites": [
+    {
+      "id": "T01",
+      "family": "tmux_transport",
+      "status": "covered",
+      "path": "holdspeak/coder_steering.py",
+      "census_line": 651,
+      "selector": {"scope": "deliver", "target": "send", "ordinal": 1},
+      "reason": "Production transport invocation inside the audited coder_steering.deliver chokepoint; delivery-command traffic also carries its command receipt."
+    },
+    {
+      "id": "T02",
+      "family": "tmux_transport",
+      "status": "covered",
+      "path": "holdspeak/coder_steering.py",
+      "census_line": 792,
+      "selector": {"scope": "deliver_keys", "target": "send", "ordinal": 1},
+      "reason": "Production key transport invocation inside the audited coder_steering.deliver_keys chokepoint; delivery-command traffic adds its command receipt."
+    },
+    {
+      "id": "T03",
+      "family": "tmux_transport",
+      "status": "bypass",
+      "path": "holdspeak/runtime/dictation_capture.py",
+      "census_line": 429,
+      "selector": {"scope": "DictationCaptureMixin._try_tmux_agent_reply", "target": "send_text_to_pane", "ordinal": 1},
+      "reason": "Dictation-to-agent sends text and Enter through tmux_transport directly; retained only as declared migration debt until the terminal slice adapts it."
+    },
+    {
+      "id": "T04",
+      "family": "tmux_transport",
+      "status": "bypass",
+      "path": "holdspeak/web/routes/cadence.py",
+      "census_line": 256,
+      "selector": {"scope": "build_cadence_router.reply_to_agent", "target": "send_text_to_pane", "ordinal": 1},
+      "reason": "Cadence reply route sends to the loop pane directly after route-local lookup; retained only as declared migration debt."
+    },
+
+    {
+      "id": "D01",
+      "family": "text_typer",
+      "status": "bypass",
+      "path": "holdspeak/runtime/dictation_capture.py",
+      "census_line": 188,
+      "selector": {"scope": "DictationCaptureMixin._transcribe_and_type", "target": "type_text", "ordinal": 1},
+      "reason": "Local dictation fallback types into the focused app or agent target without an audited admission seam; retained pending typed admission split."
+    },
+    {
+      "id": "D02",
+      "family": "text_typer",
+      "status": "bypass",
+      "path": "holdspeak/runtime/dictation_capture.py",
+      "census_line": 284,
+      "selector": {"scope": "DictationCaptureMixin.type_dictation_preview", "target": "type_text", "ordinal": 1},
+      "reason": "The explicit preview Type action invokes TextTyper directly; retained as declared desktop.type_text migration debt."
+    },
+    {
+      "id": "D03",
+      "family": "text_typer",
+      "status": "bypass",
+      "path": "holdspeak/runtime/dictation_capture.py",
+      "census_line": 369,
+      "selector": {"scope": "DictationCaptureMixin._maybe_dispatch_voice_command._type", "target": "type_text", "ordinal": 1},
+      "reason": "The injected writer for type_text voice macros types into the ambient focused app without actuator admission; retained as migration debt."
+    },
+    {
+      "id": "D04",
+      "family": "text_typer",
+      "status": "bypass",
+      "path": "holdspeak/runtime/dictation_capture.py",
+      "census_line": 485,
+      "selector": {"scope": "DictationCaptureMixin._deliver_remote_dictation", "target": "type_text", "ordinal": 1},
+      "reason": "Remote dictation fallback may type to a recent agent session or ambient focus without audited admission; retained pending target-aware split."
+    },
+    {
+      "id": "D05",
+      "family": "text_typer",
+      "status": "bypass",
+      "path": "holdspeak/runtime/dictation_capture.py",
+      "census_line": 509,
+      "selector": {"scope": "DictationCaptureMixin._deliver_remote_dictation_focused", "target": "type_text", "ordinal": 1},
+      "reason": "Companion focused delivery deliberately types without Enter but still invokes ambient TextTyper directly; retained as migration debt."
+    },
+    {
+      "id": "D06",
+      "family": "text_typer",
+      "status": "bypass",
+      "path": "holdspeak/runtime/wake_glue.py",
+      "census_line": 291,
+      "selector": {"scope": "WakeWordGlueMixin._transcribe_wake", "target": "type_text", "ordinal": 1},
+      "reason": "Wake action type inserts processed dictation into the active app directly; retained as desktop.type_text migration debt."
+    },
+    {
+      "id": "D07",
+      "family": "text_typer",
+      "status": "bypass",
+      "path": "holdspeak/runtime/wake_glue.py",
+      "census_line": 346,
+      "selector": {"scope": "WakeWordGlueMixin._type_wake_preview", "target": "type_text", "ordinal": 1},
+      "reason": "The explicit wake-preview Type action invokes TextTyper directly; retained as desktop.type_text migration debt."
+    },
+    {
+      "id": "D08",
+      "family": "text_typer",
+      "status": "dormant",
+      "path": "holdspeak/plugins/voice_macro_connector.py",
+      "census_line": 118,
+      "selector": {"scope": "_default_type_writer", "target": "type_text", "ordinal": 1},
+      "reason": "Dormant default voice-macro writer can lazily create TextTyper without an audited seam; retained only until the fallback is removed or brokered."
+    },
+
+    {
+      "id": "C01",
+      "family": "subprocess",
+      "status": "mixed",
+      "path": "holdspeak/connector_runtime.py",
+      "census_line": 125,
+      "selector": {"scope": "PermissionGate.run_subprocess", "target": "actual", "ordinal": 1},
+      "reason": "Shared raw process boundary serves actuator-covered writes and unbrokered enrichment or voice routes; PermissionGate is enforcement but not an audited chokepoint."
+    },
+    {
+      "id": "C02",
+      "family": "subprocess",
+      "status": "bypass",
+      "path": "holdspeak/activity_github.py",
+      "census_line": 132,
+      "selector": {"scope": "run_github_cli_enrichment", "target": "run_subprocess", "ordinal": 1},
+      "reason": "GitHub activity enrichment invokes PermissionGate directly for metadata reads; retained as external.github.read migration debt."
+    },
+    {
+      "id": "C03",
+      "family": "subprocess",
+      "status": "bypass",
+      "path": "holdspeak/activity_jira.py",
+      "census_line": 124,
+      "selector": {"scope": "run_jira_cli_enrichment", "target": "run_subprocess", "ordinal": 1},
+      "reason": "Jira activity enrichment invokes PermissionGate directly for issue reads; retained as external.jira.read_issue migration debt."
+    },
+    {
+      "id": "C04",
+      "family": "subprocess",
+      "status": "mixed",
+      "path": "holdspeak/plugins/gated_connector.py",
+      "census_line": 224,
+      "selector": {"scope": "_route", "target": "run_subprocess", "ordinal": 1},
+      "reason": "Shared connector dispatch serves actuator-covered writes and direct voice-macro calls; retained until all callers share audited admission."
+    },
+    {
+      "id": "C05",
+      "family": "subprocess",
+      "status": "bypass",
+      "path": "holdspeak/missioncontrol_bridge.py",
+      "census_line": 38,
+      "selector": {"scope": "_default_runner", "target": "run", "ordinal": 1},
+      "reason": "Mission Control bridge runs Delivery Workbench and GitHub read commands directly; retained as read-path migration debt."
+    },
+
+    {
+      "id": "N01",
+      "family": "egress",
+      "status": "mixed",
+      "path": "holdspeak/connector_runtime.py",
+      "census_line": 144,
+      "selector": {"scope": "PermissionGate.open_outbound_socket", "target": "actual", "ordinal": 1},
+      "reason": "Shared raw network boundary has actuator-covered webhook traffic and an unowned default-socket branch; PermissionGate alone is not an audited chokepoint."
+    },
+    {
+      "id": "N02",
+      "family": "egress",
+      "status": "dormant",
+      "path": "holdspeak/plugins/gated_connector.py",
+      "census_line": 229,
+      "selector": {"scope": "_route", "target": "open_outbound_socket", "ordinal": 1},
+      "reason": "Dormant generic outbound branch can open a real socket through PermissionGate without destination-specific broker authority."
+    },
+    {
+      "id": "N03",
+      "family": "egress",
+      "status": "covered",
+      "path": "holdspeak/plugins/gated_connector.py",
+      "census_line": 233,
+      "selector": {"scope": "_route", "target": "open_outbound_socket", "ordinal": 2},
+      "reason": "Custom-opener outbound dispatch is reached in production only by Slack and generic webhook actuators through ActuatorExecutor."
+    },
+    {
+      "id": "N04",
+      "family": "egress",
+      "status": "covered",
+      "path": "holdspeak/plugins/builtin/webhook_post_actuator.py",
+      "census_line": 129,
+      "selector": {"scope": "_default_post", "target": "urlopen", "ordinal": 1},
+      "reason": "Production webhook HTTP send is constructed and executed only through the audited actuator route."
+    },
+    {
+      "id": "N05",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/intel_queue.py",
+      "census_line": 485,
+      "selector": {"scope": "IntelQueueWorker._post_failure_alert_webhook", "target": "urlopen", "ordinal": 1},
+      "reason": "Intel queue failure alert posts its webhook directly from the scheduler; retained as external.webhook.post_intel_queue_alert debt."
+    },
+    {
+      "id": "N06",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/intel/engine.py",
+      "census_line": 221,
+      "selector": {"scope": "MeetingIntel._chat_completion_text", "target": "create", "ordinal": 1},
+      "reason": "Initial non-streaming meeting-intel model request invokes the provider client directly; retained as inference.run migration debt."
+    },
+    {
+      "id": "N07",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/intel/engine.py",
+      "census_line": 229,
+      "selector": {"scope": "MeetingIntel._chat_completion_text", "target": "create", "ordinal": 2},
+      "reason": "Compatibility retry is a separate static provider invocation and remains direct inference.run migration debt."
+    },
+    {
+      "id": "N08",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/intel/engine.py",
+      "census_line": 300,
+      "selector": {"scope": "MeetingIntel._chat_completion_stream", "target": "create", "ordinal": 1},
+      "reason": "Initial streaming meeting-intel model request invokes the provider client directly; retained as inference.run migration debt."
+    },
+    {
+      "id": "N09",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/intel/engine.py",
+      "census_line": 307,
+      "selector": {"scope": "MeetingIntel._chat_completion_stream", "target": "create", "ordinal": 2},
+      "reason": "Streaming compatibility retry is a separate static provider invocation and remains direct inference.run migration debt."
+    },
+    {
+      "id": "N10",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/plugins/dictation/runtime_openai_compatible.py",
+      "census_line": 126,
+      "selector": {"scope": "OpenAICompatibleRuntime.classify", "target": "create", "ordinal": 1},
+      "reason": "Initial dictation intent-classification provider request bypasses broker admission; retained as inference.run migration debt."
+    },
+    {
+      "id": "N11",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/plugins/dictation/runtime_openai_compatible.py",
+      "census_line": 141,
+      "selector": {"scope": "OpenAICompatibleRuntime.classify", "target": "create", "ordinal": 2},
+      "reason": "Classification compatibility retry is a separate static provider invocation and remains direct inference.run migration debt."
+    },
+    {
+      "id": "N12",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/plugins/dictation/runtime_openai_compatible.py",
+      "census_line": 190,
+      "selector": {"scope": "OpenAICompatibleRuntime.rewrite", "target": "create", "ordinal": 1},
+      "reason": "Project-aware dictation rewrite invokes the provider directly; retained as inference.run migration debt."
+    },
+    {
+      "id": "N13",
+      "family": "egress",
+      "status": "bypass",
+      "path": "holdspeak/cadence_telegram.py",
+      "census_line": 38,
+      "selector": {"scope": "call_telegram", "target": "urlopen", "ordinal": 1},
+      "reason": "Cadence Telegram adapter directly posts Bot API methods; retained pending method-specific external.telegram admission."
+    },
+
+    {
+      "id": "A01",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 84,
+      "selector": {"scope": "TextTyper._paste_text", "target": "copy", "ordinal": 1},
+      "reason": "TextTyper replaces the system clipboard as a desktop.type_text substep; retained until the whole typing operation executes under one warrant."
+    },
+    {
+      "id": "A02",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 93,
+      "selector": {"scope": "TextTyper._paste_text", "target": "press", "ordinal": 1},
+      "reason": "TextTyper presses paste modifiers as a raw keyboard substep; retained until the whole typing operation executes under one warrant."
+    },
+    {
+      "id": "A03",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 94,
+      "selector": {"scope": "TextTyper._paste_text", "target": "press", "ordinal": 2},
+      "reason": "TextTyper presses the paste key as a raw keyboard substep; retained until the whole typing operation executes under one warrant."
+    },
+    {
+      "id": "A04",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 95,
+      "selector": {"scope": "TextTyper._paste_text", "target": "release", "ordinal": 1},
+      "reason": "TextTyper releases the paste key as a raw keyboard substep; retained until the whole typing operation executes under one warrant."
+    },
+    {
+      "id": "A05",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 97,
+      "selector": {"scope": "TextTyper._paste_text", "target": "release", "ordinal": 2},
+      "reason": "TextTyper releases paste modifiers as a raw keyboard substep; retained until the whole typing operation executes under one warrant."
+    },
+    {
+      "id": "A06",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 103,
+      "selector": {"scope": "TextTyper._paste_text", "target": "copy", "ordinal": 2},
+      "reason": "TextTyper restores the prior clipboard as a desktop.type_text substep; retained until the whole typing operation executes under one warrant."
+    },
+    {
+      "id": "A07",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 110,
+      "selector": {"scope": "TextTyper._type_text_slowly", "target": "type", "ordinal": 1},
+      "reason": "TextTyper emits synthetic characters directly in its slow path; retained until desktop.type_text executes under one warrant."
+    },
+    {
+      "id": "A08",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 114,
+      "selector": {"scope": "TextTyper._press_enter", "target": "press", "ordinal": 1},
+      "reason": "TextTyper presses Enter directly when submission is requested; retained pending target-aware desktop.type_text or process.input admission."
+    },
+    {
+      "id": "A09",
+      "family": "raw_desktop",
+      "status": "bypass",
+      "path": "holdspeak/typer.py",
+      "census_line": 115,
+      "selector": {"scope": "TextTyper._press_enter", "target": "release", "ordinal": 1},
+      "reason": "TextTyper releases Enter directly as part of submission; retained pending target-aware desktop.type_text or process.input admission."
+    },
+    {
+      "id": "A10",
+      "family": "raw_desktop",
+      "status": "dormant",
+      "path": "holdspeak/typer.py",
+      "census_line": 140,
+      "selector": {"scope": "type_with_applescript", "target": "run", "ordinal": 1},
+      "reason": "Dormant AppleScript helper can invoke osascript/System Events directly; retained only until the ambient helper is removed or brokered."
+    }
+  ]
+}

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -4,15 +4,15 @@
 > pick up, and the repo conventions that bite (PMO commit gate, write-once
 > evidence, no `Co-Authored-By`, metal-test exclusion).
 
-**Last updated:** 2026-07-26 — **Phase 106 (The Kernel) CHARTERED,
-0/10**: the RFC's ladder becomes a phase, from the owner's charge
-that HoldSpeak come a lot closer to a web Operating System for the
-Tech-Lead/Architect who works with AI daily. Article XI goes to the
-Constitution behind a migration provision (the fourth council pass
-refused the drafted clauses on evidence; its rewrite was adopted,
-its dissent recorded, the owner ruled to ratify early with declared
-debt). HS-106-02 and HS-106-03 activate first — pure hardening,
-unblocked by the constitutional question. Earlier: **Phase 104 (Borrowed Fire II)
+**Last updated:** 2026-07-26 — **Phase 106 (The Kernel) ACTIVE,
+1/10**: HS-106-03 turned Article XI's migration debt register into
+checked-in law and an executable fence — exactly 40 static effect
+statements, 4 covered and 36 not, with additions and removals named by
+file:line and family. The empty broker field is already bounded by a
+300-line module budget and a zero driver-specific conditional census;
+four mutations proved every fence fails loudly, and no effect site was
+rerouted. HS-106-01 and HS-106-02 remain the other pure-hardening
+prerequisites before the broker spine. Earlier: **Phase 104 (Borrowed Fire II)
 CLOSED 8/8, all in one day**: the ledger, the fail-closed gate, the
 gate under attack, PR receipts, session receipts, docs, the
 seven-beat walk, and the sitting's own rider — **HS-104-08 the icon

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -8,10 +8,12 @@
 1/10**: HS-106-03 turned Article XI's migration debt register into
 checked-in law and an executable fence — exactly 40 static effect
 statements, 4 covered and 36 not, with additions and removals named by
-file:line and family. The empty broker field is already bounded by a
-300-line module budget and a zero driver-specific conditional census;
-four mutations proved every fence fails loudly, and no effect site was
-rerouted. HS-106-01 and HS-106-02 remain the other pure-hardening
+file:line and family. Import origins survive from-imports, renamed
+imports, module aliases, and callable aliases across all five families.
+The empty broker field is already bounded by a 300-line module budget
+and a zero driver-specific conditional census; mutations proved every
+fence fails loudly, and no effect site was rerouted. HS-106-01 and
+HS-106-02 remain the other pure-hardening
 prerequisites before the broker spine. Earlier: **Phase 104 (Borrowed Fire II)
 CLOSED 8/8, all in one day**: the ledger, the fail-closed gate, the
 gate under attack, PR receipts, session receipts, docs, the

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
@@ -174,8 +174,10 @@ debt register is now checked-in data: 40 static statements, 4 covered
 and 36 not, with the ratified 4/8/5/13/10 family split and the ban on
 agent principals reaching its named paths stated in the artifact. A
 filesystem AST walk fences additions and removals by stable selector
-while reporting the live file:line and family; four mutation proofs
-showed both directions fail by name. The broker field is still empty,
+while reporting the live file:line and family. Imported origins survive
+plain from-imports, renamed imports, module aliases, and simple callable
+aliases across all five families; the follow-up mutation named seven
+such sites in one pass. The broker field is still empty,
 but its 300-line module budget and zero driver-specific conditional
 census already stand around it, including match, ternary, registry,
 and table dispatch. No effect site was rerouted. HS-106-01 and

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
@@ -1,6 +1,6 @@
 # Phase 106 - The Kernel
 
-**Status:** ACTIVE (0/10). Chartered 2026-07-26 from
+**Status:** ACTIVE (1/10). Chartered 2026-07-26 from
 [`PLAN_KERNEL_OPERATION_BROKER.md`](../../../docs/internal/PLAN_KERNEL_OPERATION_BROKER.md)
 (the RFC, three council passes) and the owner's direct charge:
 
@@ -11,7 +11,7 @@
 > records decisions and then creates artifacts out of those
 > decisions and meetings."
 
-**Last updated:** 2026-07-26 (chartered; no story shipped yet).
+**Last updated:** 2026-07-26 (HS-106-03 shipped; 1/10).
 
 ## Why this phase exists
 
@@ -109,7 +109,7 @@ receipt for every consequence.
 |---|---|---|---|---|
 | HS-106-01 | Article XI ratified, with the migration provision | ready | [story-01-article-xi](./story-01-article-xi.md) | — |
 | HS-106-02 | Principal separation on loopback | ready | [story-02-principals](./story-02-principals.md) | — |
-| HS-106-03 | The effect census, pinned as a test | ready | [story-03-census-test](./story-03-census-test.md) | — |
+| HS-106-03 | The effect census, pinned as a test | done | [story-03-census-test](./story-03-census-test.md) | [evidence-story-03](./evidence-story-03.md) |
 | HS-106-04 | The broker and the journal — four calls | ready | [story-04-broker-journal](./story-04-broker-journal.md) | — |
 | HS-106-05 | Thin slice I — terminal input | ready | [story-05-slice-terminal](./story-05-slice-terminal.md) | — |
 | HS-106-06 | Thin slice II — actuator egress | ready | [story-06-slice-actuator](./story-06-slice-actuator.md) | — |
@@ -169,12 +169,15 @@ pretending.
 
 ## Where we are
 
-**2026-07-26 — chartered, 0/10.** The RFC ladder is now a phase.
-Nothing is built yet. The fourth council pass has already run and
-returned **do not ratify yet**; the owner overruled it in favour of
-ratifying with a migration provision, and both the verdict and the
-dissent are on the record. HS-106-02 and HS-106-03 are activated
-first — both are pure hardening, unblocked by the constitutional
-question, and Sol's findings made 02 more urgent than the RFC
-assumed: the gate's decision route currently takes `actor` from the
-request body and defaults it to `owner`.
+**2026-07-26 — HS-106-03 shipped, 1/10.** The Article XI migration
+debt register is now checked-in data: 40 static statements, 4 covered
+and 36 not, with the ratified 4/8/5/13/10 family split and the ban on
+agent principals reaching its named paths stated in the artifact. A
+filesystem AST walk fences additions and removals by stable selector
+while reporting the live file:line and family; four mutation proofs
+showed both directions fail by name. The broker field is still empty,
+but its 300-line module budget and zero driver-specific conditional
+census already stand around it, including match, ternary, registry,
+and table dispatch. No effect site was rerouted. HS-106-01 and
+HS-106-02 remain the other pure-hardening prerequisites before the
+broker spine.

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-03.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-03.md
@@ -1,0 +1,594 @@
+# Evidence - HS-106-03
+
+- **Story:** HS-106-03 - The effect census, pinned as a test
+- **Status:** done
+- **Date:** 2026-07-26
+
+## Proof
+
+### Captured run — 2026-07-26T22:18:14Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+F                                                                        [100%]
+=================================== FAILURES ===================================
+__________________ test_effect_ledger_is_complete_and_current __________________
+
+    def test_effect_ledger_is_complete_and_current() -> None:
+        ledger = _load_ledger()
+        entries = ledger["sites"]
+        actual = _walk_effect_sites()
+    
+        ledger_by_key = {_ledger_key(entry): entry for entry in entries}
+        actual_by_key = {site.key: site for site in actual}
+        assert len(ledger_by_key) == len(entries), "effect ledger contains duplicate selectors"
+        assert len(actual_by_key) == len(actual), "source walker produced duplicate selectors"
+    
+        unledgered = [actual_by_key[key] for key in actual_by_key.keys() - ledger_by_key.keys()]
+        missing = [ledger_by_key[key] for key in ledger_by_key.keys() - actual_by_key.keys()]
+        family_mismatches = [
+            (ledger_by_key[key], actual_by_key[key])
+            for key in ledger_by_key.keys() & actual_by_key.keys()
+            if ledger_by_key[key]["family"] != actual_by_key[key].family
+        ]
+    
+        failures = [
+            f"UNLEDGERED effect site: {site.label} "
+            f"scope={site.scope} target={site.target} ordinal={site.ordinal}"
+            for site in sorted(unledgered, key=lambda item: (item.path, item.line))
+        ]
+        failures.extend(
+            f"MISSING ledgered effect site: {entry['id']} "
+            f"{entry['path']}:{entry['census_line']} [{entry['family']}] "
+            f"selector={entry['selector']}"
+            for entry in sorted(missing, key=lambda item: item["id"])
+        )
+        failures.extend(
+            f"FAMILY CHANGED for {entry['id']}: ledger={entry['family']} "
+            f"source={site.family} at {site.path}:{site.line}"
+            for entry, site in family_mismatches
+        )
+>       assert not failures, "effect census drift:\n  " + "\n  ".join(failures)
+E       AssertionError: effect census drift:
+E           UNLEDGERED effect site: holdspeak/plugins/_effect_census_mutation.py:5 [subprocess] scope=mutate target=run ordinal=1
+E       assert not ['UNLEDGERED effect site: holdspeak/plugins/_effect_census_mutation.py:5 [subprocess] scope=mutate target=run ordinal=1']
+
+tests/unit/test_kernel_effect_fence.py:403: AssertionError
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current
+1 failed, 2 warnings in 1.19s
+```
+
+### Captured run — 2026-07-26T22:18:31Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 2 warnings in 1.72s
+```
+
+### Captured run — 2026-07-26T22:18:53Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+F                                                                        [100%]
+=================================== FAILURES ===================================
+__________________ test_effect_ledger_is_complete_and_current __________________
+
+    def test_effect_ledger_is_complete_and_current() -> None:
+        ledger = _load_ledger()
+        entries = ledger["sites"]
+        actual = _walk_effect_sites()
+    
+        ledger_by_key = {_ledger_key(entry): entry for entry in entries}
+        actual_by_key = {site.key: site for site in actual}
+        assert len(ledger_by_key) == len(entries), "effect ledger contains duplicate selectors"
+        assert len(actual_by_key) == len(actual), "source walker produced duplicate selectors"
+    
+        unledgered = [actual_by_key[key] for key in actual_by_key.keys() - ledger_by_key.keys()]
+        missing = [ledger_by_key[key] for key in ledger_by_key.keys() - actual_by_key.keys()]
+        family_mismatches = [
+            (ledger_by_key[key], actual_by_key[key])
+            for key in ledger_by_key.keys() & actual_by_key.keys()
+            if ledger_by_key[key]["family"] != actual_by_key[key].family
+        ]
+    
+        failures = [
+            f"UNLEDGERED effect site: {site.label} "
+            f"scope={site.scope} target={site.target} ordinal={site.ordinal}"
+            for site in sorted(unledgered, key=lambda item: (item.path, item.line))
+        ]
+        failures.extend(
+            f"MISSING ledgered effect site: {entry['id']} "
+            f"{entry['path']}:{entry['census_line']} [{entry['family']}] "
+            f"selector={entry['selector']}"
+            for entry in sorted(missing, key=lambda item: item["id"])
+        )
+        failures.extend(
+            f"FAMILY CHANGED for {entry['id']}: ledger={entry['family']} "
+            f"source={site.family} at {site.path}:{site.line}"
+            for entry, site in family_mismatches
+        )
+>       assert not failures, "effect census drift:\n  " + "\n  ".join(failures)
+E       AssertionError: effect census drift:
+E           MISSING ledgered effect site: C05 holdspeak/missioncontrol_bridge.py:38 [subprocess] selector={'scope': '_default_runner', 'target': 'run', 'ordinal': 1}
+E       assert not ["MISSING ledgered effect site: C05 holdspeak/missioncontrol_bridge.py:38 [subprocess] selector={'scope': '_default_runner', 'target': 'run', 'ordinal': 1}"]
+
+tests/unit/test_kernel_effect_fence.py:403: AssertionError
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current
+1 failed, 2 warnings in 1.59s
+```
+
+### Captured run — 2026-07-26T22:19:10Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 2 warnings in 1.16s
+```
+
+### Captured run — 2026-07-26T22:19:28Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_kernel_broker_modules_stay_within_line_budget`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+F                                                                        [100%]
+=================================== FAILURES ===================================
+______________ test_kernel_broker_modules_stay_within_line_budget ______________
+
+    def test_kernel_broker_modules_stay_within_line_budget() -> None:
+        offenders: list[str] = []
+        for path in _broker_modules():
+            budget = _BROKER_INIT_BUDGET if path.name == "__init__.py" else _BROKER_MODULE_BUDGET
+            lines = _line_count(path)
+            if lines > budget:
+                offenders.append(
+                    f"kernel broker module over {budget}-line budget: "
+                    f"{path.relative_to(_REPO)}: {lines} lines"
+                )
+>       assert not offenders, (
+            "broker density guard failed — carve a typed concern module; don't bump "
+            "the budget:\n  " + "\n  ".join(offenders)
+        )
+E       AssertionError: broker density guard failed — carve a typed concern module; don't bump the budget:
+E           kernel broker module over 300-line budget: holdspeak/kernel/broker.py: 301 lines
+E       assert not ['kernel broker module over 300-line budget: holdspeak/kernel/broker.py: 301 lines']
+
+tests/unit/test_kernel_effect_fence.py:457: AssertionError
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/unit/test_kernel_effect_fence.py::test_kernel_broker_modules_stay_within_line_budget
+1 failed, 2 warnings in 0.31s
+```
+
+### Captured run — 2026-07-26T22:19:42Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_kernel_broker_modules_stay_within_line_budget`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 2 warnings in 0.26s
+```
+
+### Captured run — 2026-07-26T22:19:55Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_kernel_broker_has_zero_driver_specific_conditionals`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+F                                                                        [100%]
+=================================== FAILURES ===================================
+___________ test_kernel_broker_has_zero_driver_specific_conditionals ___________
+
+    def test_kernel_broker_has_zero_driver_specific_conditionals() -> None:
+        findings = [
+            finding
+            for path in _broker_modules()
+            for finding in _driver_conditional_findings(path)
+        ]
+>       assert not findings, (
+            "broker driver-conditional census expected zero; typed operation modules "
+            "must own driver behavior:\n  " + "\n  ".join(findings)
+        )
+E       AssertionError: broker driver-conditional census expected zero; typed operation modules must own driver behavior:
+E           driver-specific conditional in broker module: holdspeak/kernel/broker.py:2 (match dispatch)
+E       assert not ['driver-specific conditional in broker module: holdspeak/kernel/broker.py:2 (match dispatch)']
+
+tests/unit/test_kernel_effect_fence.py:528: AssertionError
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/unit/test_kernel_effect_fence.py::test_kernel_broker_has_zero_driver_specific_conditionals
+1 failed, 2 warnings in 0.28s
+```
+
+### Captured run — 2026-07-26T22:20:09Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_kernel_broker_has_zero_driver_specific_conditionals`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+../../../../../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434
+  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+  
+    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 2 warnings in 0.25s
+```
+
+### Captured run — 2026-07-26T23:00:06Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+......                                                                   [100%]
+6 passed in 0.76s
+```
+
+### Captured run — 2026-07-26T23:03:06Z
+
+- **Command:** `env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost zsh -o pipefail -c uv run pytest -q --ignore=tests/e2e/test_metal.py | tee /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/hs-106-03-captured-full-suite.txt`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+ssssssssssssssssssssssssssssssss........................................ [  1%]
+........................................................................ [  3%]
+.s...................................................................... [  5%]
+.......................................................ss............... [  6%]
+........................................................................ [  8%]
+........................................................................ [ 10%]
+........................................................................ [ 11%]
+........................................................................ [ 13%]
+........................................................................ [ 15%]
+........................................................................ [ 16%]
+........................................................................ [ 18%]
+........................................................................ [ 20%]
+........................................................................ [ 21%]
+........................................................................ [ 23%]
+........................................................................ [ 25%]
+........................................................................ [ 27%]
+........................................................................ [ 28%]
+........................................................................ [ 30%]
+........................................................................ [ 32%]
+........................................................................ [ 33%]
+........................................................................ [ 35%]
+........................................................................ [ 37%]
+........................................................................ [ 38%]
+........................................................................ [ 40%]
+........................................................................ [ 42%]
+........................................................................ [ 43%]
+........................................................................ [ 45%]
+........................................................................ [ 47%]
+........................................................................ [ 48%]
+........................................................................ [ 50%]
+........................................................................ [ 52%]
+........................................................................ [ 54%]
+........................................................................ [ 55%]
+..........s............................................................. [ 57%]
+........................................................................ [ 59%]
+........................................................................ [ 60%]
+........................................................................ [ 62%]
+........................................................................ [ 64%]
+........................................................................ [ 65%]
+........................................................................ [ 67%]
+........................................................................ [ 69%]
+........................................................................ [ 70%]
+........................................................................ [ 72%]
+........................................................................ [ 74%]
+........................................................................ [ 75%]
+........................................................................ [ 77%]
+........................................................................ [ 79%]
+........................................................................ [ 81%]
+........................................................................ [ 82%]
+........................................................................ [ 84%]
+........................................................................ [ 86%]
+........................................................................ [ 87%]
+........................................................................ [ 89%]
+........................................................................ [ 91%]
+........................................................................ [ 92%]
+........................................................................ [ 94%]
+........................................................................ [ 96%]
+........................................................................ [ 97%]
+........................................................................ [ 99%]
+..................                                                       [100%]
+=============================== warnings summary ===============================
+tests/integration/test_web_transcript_import_api.py::test_txt_upload_uses_the_transcript_fallback_speaker
+  /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/.venv/lib/python3.14/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread meeting-import-8faa6792
+  
+  Traceback (most recent call last):
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 95, in _run_import_job
+      import_transcript(
+      ~~~~~~~~~~~~~~~~~^
+          tmp_path,
+          ^^^^^^^^^
+      ...<6 lines>...
+          started_at=started_at,
+          ^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 395, in import_transcript
+      return _persist_import(
+          db=db,
+      ...<8 lines>...
+          speakers_found=parsed.speakers_found,
+      )
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 325, in _persist_import
+      db.intel.enqueue_intel_job(
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~^
+          state.id,
+          ^^^^^^^^^
+          transcript_hash=state.transcript_hash(),
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          reason=state.intel_status_detail,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/intel.py", line 35, in enqueue_intel_job
+      with self._connection() as conn:
+           ~~~~~~~~~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/contextlib.py", line 148, in __exit__
+      next(self.gen)
+      ~~~~^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/core.py", line 1383, in _connection
+      conn.commit()
+      ~~~~~~~~~~~^^
+  sqlite3.OperationalError: disk I/O error
+  
+  During handling of the above exception, another exception occurred:
+  
+  Traceback (most recent call last):
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
+      self._context.run(self.run)
+      ~~~~~~~~~~~~~~~~~^^^^^^^^^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1024, in run
+      self._target(*self._args, **self._kwargs)
+      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 136, in _run_import_job
+      _set_import_status(
+      ~~~~~~~~~~~~~~~~~~^
+          db, meeting_id, "import_failed", f"{type(exc).__name__}: {exc}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 72, in _set_import_status
+      state = db.meetings.get_meeting(meeting_id)
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/meetings.py", line 440, in get_meeting
+      row = conn.execute(
+            ~~~~~~~~~~~~^
+          "SELECT * FROM meetings WHERE id = ?", (meeting_id,)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).fetchone()
+      ^
+  sqlite3.OperationalError: no such table: meetings
+  
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+
+tests/integration/test_web_transcript_import_api.py::test_garbage_transcript_marks_the_row_honestly_and_is_removable
+  /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/.venv/lib/python3.14/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread meeting-import-5c3d0cd6
+  
+  Traceback (most recent call last):
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 95, in _run_import_job
+      import_transcript(
+      ~~~~~~~~~~~~~~~~~^
+          tmp_path,
+          ^^^^^^^^^
+      ...<6 lines>...
+          started_at=started_at,
+          ^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 395, in import_transcript
+      return _persist_import(
+          db=db,
+      ...<8 lines>...
+          speakers_found=parsed.speakers_found,
+      )
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 325, in _persist_import
+      db.intel.enqueue_intel_job(
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~^
+          state.id,
+          ^^^^^^^^^
+          transcript_hash=state.transcript_hash(),
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          reason=state.intel_status_detail,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/intel.py", line 35, in enqueue_intel_job
+      with self._connection() as conn:
+           ~~~~~~~~~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/contextlib.py", line 148, in __exit__
+      next(self.gen)
+      ~~~~^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/core.py", line 1383, in _connection
+      conn.commit()
+      ~~~~~~~~~~~^^
+  sqlite3.OperationalError: disk I/O error
+  
+  During handling of the above exception, another exception occurred:
+  
+  Traceback (most recent call last):
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
+      self._context.run(self.run)
+      ~~~~~~~~~~~~~~~~~^^^^^^^^^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1024, in run
+      self._target(*self._args, **self._kwargs)
+      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 136, in _run_import_job
+      _set_import_status(
+      ~~~~~~~~~~~~~~~~~~^
+          db, meeting_id, "import_failed", f"{type(exc).__name__}: {exc}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 72, in _set_import_status
+      state = db.meetings.get_meeting(meeting_id)
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/meetings.py", line 440, in get_meeting
+      row = conn.execute(
+            ~~~~~~~~~~~~^
+          "SELECT * FROM meetings WHERE id = ?", (meeting_id,)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).fetchone()
+      ^
+  sqlite3.OperationalError: no such table: meetings
+  
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+SKIPPED [1] tests/e2e/test_dictation_learning_digest_spoken_e2e.py:33: opt-in: set HOLDSPEAK_SPOKEN_DICTATION_E2E=1 to run the spoken-dictation learning-digest e2e (uses macOS `say` + the Whisper base model)
+SKIPPED [1] tests/e2e/test_live_bus.py:24: needs Playwright + a browser
+SKIPPED [1] tests/e2e/test_route_preflight.py:26: pre-flight needs Playwright + a browser
+SKIPPED [1] tests/e2e/test_spoken_meeting_e2e.py:41: opt-in: set HOLDSPEAK_SPOKEN_E2E=1 to run the spoken-meeting e2e
+SKIPPED [1] tests/unit/test_mesh_discovery.py:21: could not import 'zeroconf': No module named 'zeroconf'
+SKIPPED [1] tests/e2e/test_dictation_enrichment_e2e.py:57: set HOLDSPEAK_DICTATION_E2E_BASE_URL + HOLDSPEAK_DICTATION_E2E_MODEL to a reachable OpenAI-compatible endpoint to run the real dictation enrichment e2e
+SKIPPED [1] tests/e2e/test_dictation_journal_e2e.py:57: set HOLDSPEAK_DICTATION_E2E_BASE_URL + HOLDSPEAK_DICTATION_E2E_MODEL to a reachable OpenAI-compatible endpoint to run the real dictation journal e2e
+SKIPPED [1] tests/e2e/test_dogfood_plumbing_e2e.py:44: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [3] tests/e2e/test_dogfood_plumbing_e2e.py:52: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [12] tests/e2e/test_dogfood_plumbing_e2e.py:66: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [1] tests/e2e/test_dogfood_plumbing_e2e.py:85: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [3] tests/e2e/test_dogfood_plumbing_e2e.py:95: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [10] tests/e2e/test_meeting_transcription.py: Mock meeting fixture not found: /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/tests/fixtures/mock_meeting.wav
+SKIPPED [1] tests/integration/test_dictation_llama_cpp_e2e.py:72: llama-cpp-python and /Users/karol/Models/gguf/Qwen3.5-4B-Instruct-Q4_K_M.gguf are required for this integration test
+SKIPPED [1] tests/integration/test_runtime_llama_cpp.py:38: llama-cpp-python and /Users/karol/Models/gguf/Qwen3.5-4B-Instruct-Q4_K_M.gguf are required for this integration test
+SKIPPED [1] tests/integration/test_runtime_mlx.py:38: mlx-lm + outlines + /Users/karol/Models/mlx/Qwen3.5-8B-MLX-4bit are required for this integration test
+SKIPPED [1] tests/unit/test_dictation_grammars.py:91: could not import 'llama_cpp': No module named 'llama_cpp'
+4230 passed, 41 skipped, 2 warnings in 806.97s (0:13:26)
+```
+
+### Captured run — 2026-07-26T23:17:05Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** df6be66562be2cc682add6ba9706a17c381aed21
+
+```text
+......                                                                   [100%]
+6 passed in 0.99s
+```

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-03.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-03.md
@@ -592,3 +592,503 @@ SKIPPED [1] tests/unit/test_dictation_grammars.py:91: could not import 'llama_cp
 ......                                                                   [100%]
 6 passed in 0.99s
 ```
+
+### Captured run — 2026-07-26T23:27:23Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 70a250478247bab9b05a8d25e035806a442a3478
+
+```text
+F                                                                        [100%]
+=================================== FAILURES ===================================
+__________________ test_effect_ledger_is_complete_and_current __________________
+
+    def test_effect_ledger_is_complete_and_current() -> None:
+        ledger = _load_ledger()
+        entries = ledger["sites"]
+        actual = _walk_effect_sites()
+    
+        ledger_by_key = {_ledger_key(entry): entry for entry in entries}
+        actual_by_key = {site.key: site for site in actual}
+        assert len(ledger_by_key) == len(entries), "effect ledger contains duplicate selectors"
+        assert len(actual_by_key) == len(actual), "source walker produced duplicate selectors"
+    
+        unledgered = [actual_by_key[key] for key in actual_by_key.keys() - ledger_by_key.keys()]
+        missing = [ledger_by_key[key] for key in ledger_by_key.keys() - actual_by_key.keys()]
+        family_mismatches = [
+            (ledger_by_key[key], actual_by_key[key])
+            for key in ledger_by_key.keys() & actual_by_key.keys()
+            if ledger_by_key[key]["family"] != actual_by_key[key].family
+        ]
+    
+        failures = [
+            _unledgered_message(site)
+            for site in sorted(unledgered, key=lambda item: (item.path, item.line))
+        ]
+        failures.extend(
+            f"MISSING ledgered effect site: {entry['id']} "
+            f"{entry['path']}:{entry['census_line']} [{entry['family']}] "
+            f"selector={entry['selector']}"
+            for entry in sorted(missing, key=lambda item: item["id"])
+        )
+        failures.extend(
+            f"FAMILY CHANGED for {entry['id']}: ledger={entry['family']} "
+            f"source={site.family} at {site.path}:{site.line}"
+            for entry, site in family_mismatches
+        )
+>       assert not failures, "effect census drift:\n  " + "\n  ".join(failures)
+E       AssertionError: effect census drift:
+E           UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:11 [subprocess] scope=mutate target=run ordinal=1
+E           UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:12 [subprocess] scope=mutate target=_sneaky_run ordinal=1
+E           UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:13 [subprocess] scope=mutate target=run ordinal=2
+E           UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:14 [tmux_transport] scope=mutate target=push ordinal=1
+E           UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:15 [text_typer] scope=mutate target=type_text ordinal=1
+E           UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:16 [egress] scope=mutate target=fetch ordinal=1
+E           UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:17 [raw_desktop] scope=mutate target=stash ordinal=1
+E       assert not ['UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:11 [subprocess] scope=mutate target=run ordinal=1', 'UNL...1', 'UNLEDGERED effect site: holdspeak/_alias_effect_mutation.py:16 [egress] scope=mutate target=fetch ordinal=1', ...]
+
+tests/unit/test_kernel_effect_fence.py:522: AssertionError
+=========================== short test summary info ============================
+FAILED tests/unit/test_kernel_effect_fence.py::test_effect_ledger_is_complete_and_current
+1 failed in 1.21s
+```
+
+### Captured run — 2026-07-26T23:27:57Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 70a250478247bab9b05a8d25e035806a442a3478
+
+```text
+.......                                                                  [100%]
+7 passed in 1.42s
+```
+
+### Captured run — 2026-07-26T23:30:57Z
+
+- **Command:** `env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost zsh -o pipefail -c uv run pytest -q --ignore=tests/e2e/test_metal.py | tee /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/hs-106-03-alias-full-suite.txt`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 70a250478247bab9b05a8d25e035806a442a3478
+
+```text
+ssssssssssssssssssssssssssssssss........................................ [  1%]
+........................................................................ [  3%]
+.s...................................................................... [  5%]
+.......................................................ss............... [  6%]
+........................................................................ [  8%]
+........................................................................ [ 10%]
+........................................................................ [ 11%]
+........................................................................ [ 13%]
+........................................................................ [ 15%]
+........................................................................ [ 16%]
+........................................................................ [ 18%]
+...................................................F.F.................. [ 20%]
+........................................................................ [ 21%]
+........................................................................ [ 23%]
+........................................................................ [ 25%]
+........................................................................ [ 26%]
+........................................................................ [ 28%]
+........................................................................ [ 30%]
+........................................................................ [ 32%]
+........................................................................ [ 33%]
+........................................................................ [ 35%]
+........................................................................ [ 37%]
+........................................................................ [ 38%]
+........................................................................ [ 40%]
+........................................................................ [ 42%]
+........................................................................ [ 43%]
+........................................................................ [ 45%]
+........................................................................ [ 47%]
+........................................................................ [ 48%]
+........................................................................ [ 50%]
+........................................................................ [ 52%]
+........................................................................ [ 53%]
+........................................................................ [ 55%]
+..........s............................................................. [ 57%]
+........................................................................ [ 59%]
+........................................................................ [ 60%]
+........................................................................ [ 62%]
+........................................................................ [ 64%]
+........................................................................ [ 65%]
+........................................................................ [ 67%]
+........................................................................ [ 69%]
+........................................................................ [ 70%]
+........................................................................ [ 72%]
+........................................................................ [ 74%]
+........................................................................ [ 75%]
+........................................................................ [ 77%]
+........................................................................ [ 79%]
+........................................................................ [ 80%]
+........................................................................ [ 82%]
+........................................................................ [ 84%]
+........................................................................ [ 86%]
+........................................................................ [ 87%]
+........................................................................ [ 89%]
+........................................................................ [ 91%]
+........................................................................ [ 92%]
+........................................................................ [ 94%]
+........................................................................ [ 96%]
+........................................................................ [ 97%]
+........................................................................ [ 99%]
+...................                                                      [100%]
+=================================== FAILURES ===================================
+_________________________ test_fresh_desk_probe_green __________________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x11045b750>
+
+    def test_fresh_desk_probe_green(real_manager):
+        run = _boot_or_skip(real_manager)
+>       result = real_manager.apply_recipe(run.id, "fresh-desk")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_local.py:42: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+uat/conductor/runs.py:392: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x139414a70>
+name = 'fresh-desk', run_id = 'run-20260726T234026-1de94d'
+host = <uat.conductor.runs.RunManager object at 0x11045b750>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+    
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+    
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+    
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+    
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+    
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+    
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+    
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'fresh-desk' failed to verify: setup_reachable: /api/setup/status HTTP 401
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+__________________ test_intel_endpoint_dead_degrades_honestly __________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x110875810>
+
+    def test_intel_endpoint_dead_degrades_honestly(real_manager):
+        run = _boot_or_skip(real_manager)
+>       result = real_manager.apply_recipe(run.id, "intel-endpoint-dead")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_local.py:73: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+uat/conductor/runs.py:392: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x135f8fef0>
+name = 'intel-endpoint-dead', run_id = 'run-20260726T234029-3e76ed'
+host = <uat.conductor.runs.RunManager object at 0x110875810>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+    
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+    
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+    
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+    
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+    
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+    
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+    
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'intel-endpoint-dead' failed to verify: runtime_endpoint_unreachable: probe raised: [Errno 61] Connection refused
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+=============================== warnings summary ===============================
+tests/integration/test_web_transcript_import_api.py::test_txt_upload_uses_the_transcript_fallback_speaker
+  /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/.venv/lib/python3.14/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread meeting-import-e8f05041
+  
+  Traceback (most recent call last):
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 95, in _run_import_job
+      import_transcript(
+      ~~~~~~~~~~~~~~~~~^
+          tmp_path,
+          ^^^^^^^^^
+      ...<6 lines>...
+          started_at=started_at,
+          ^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 395, in import_transcript
+      return _persist_import(
+          db=db,
+      ...<8 lines>...
+          speakers_found=parsed.speakers_found,
+      )
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 325, in _persist_import
+      db.intel.enqueue_intel_job(
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~^
+          state.id,
+          ^^^^^^^^^
+          transcript_hash=state.transcript_hash(),
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          reason=state.intel_status_detail,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/intel.py", line 35, in enqueue_intel_job
+      with self._connection() as conn:
+           ~~~~~~~~~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/contextlib.py", line 148, in __exit__
+      next(self.gen)
+      ~~~~^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/core.py", line 1383, in _connection
+      conn.commit()
+      ~~~~~~~~~~~^^
+  sqlite3.OperationalError: disk I/O error
+  
+  During handling of the above exception, another exception occurred:
+  
+  Traceback (most recent call last):
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
+      self._context.run(self.run)
+      ~~~~~~~~~~~~~~~~~^^^^^^^^^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1024, in run
+      self._target(*self._args, **self._kwargs)
+      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 136, in _run_import_job
+      _set_import_status(
+      ~~~~~~~~~~~~~~~~~~^
+          db, meeting_id, "import_failed", f"{type(exc).__name__}: {exc}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 72, in _set_import_status
+      state = db.meetings.get_meeting(meeting_id)
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/meetings.py", line 440, in get_meeting
+      row = conn.execute(
+            ~~~~~~~~~~~~^
+          "SELECT * FROM meetings WHERE id = ?", (meeting_id,)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).fetchone()
+      ^
+  sqlite3.OperationalError: no such table: meetings
+  
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+
+tests/integration/test_web_transcript_import_api.py::test_garbage_transcript_marks_the_row_honestly_and_is_removable
+  /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/.venv/lib/python3.14/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread meeting-import-bc8a4898
+  
+  Traceback (most recent call last):
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 95, in _run_import_job
+      import_transcript(
+      ~~~~~~~~~~~~~~~~~^
+          tmp_path,
+          ^^^^^^^^^
+      ...<6 lines>...
+          started_at=started_at,
+          ^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 395, in import_transcript
+      return _persist_import(
+          db=db,
+      ...<8 lines>...
+          speakers_found=parsed.speakers_found,
+      )
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/meeting_import.py", line 325, in _persist_import
+      db.intel.enqueue_intel_job(
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~^
+          state.id,
+          ^^^^^^^^^
+          transcript_hash=state.transcript_hash(),
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          reason=state.intel_status_detail,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/intel.py", line 35, in enqueue_intel_job
+      with self._connection() as conn:
+           ~~~~~~~~~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/contextlib.py", line 148, in __exit__
+      next(self.gen)
+      ~~~~^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/core.py", line 1383, in _connection
+      conn.commit()
+      ~~~~~~~~~~~^^
+  sqlite3.OperationalError: disk I/O error
+  
+  During handling of the above exception, another exception occurred:
+  
+  Traceback (most recent call last):
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
+      self._context.run(self.run)
+      ~~~~~~~~~~~~~~~~~^^^^^^^^^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/threading.py", line 1024, in run
+      self._target(*self._args, **self._kwargs)
+      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 136, in _run_import_job
+      _set_import_status(
+      ~~~~~~~~~~~~~~~~~~^
+          db, meeting_id, "import_failed", f"{type(exc).__name__}: {exc}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/web/routes/meeting_import.py", line 72, in _set_import_status
+      state = db.meetings.get_meeting(meeting_id)
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-ad8939833d1006d21/holdspeak/db/meetings.py", line 440, in get_meeting
+      row = conn.execute(
+            ~~~~~~~~~~~~^
+          "SELECT * FROM meetings WHERE id = ?", (meeting_id,)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).fetchone()
+      ^
+  sqlite3.OperationalError: no such table: meetings
+  
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+SKIPPED [1] tests/e2e/test_dictatio
+[PMO_EVIDENCE_OUTPUT_TRUNCATED]
+```
+
+### Captured run — 2026-07-26T23:46:12Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 70a250478247bab9b05a8d25e035806a442a3478
+
+```text
+.......                                                                  [100%]
+7 passed in 1.07s
+```
+
+### Captured run — 2026-07-26T23:46:22Z
+
+- **Command:** `env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost uv run pytest -q tests/uat/test_induction_integration_local.py::test_fresh_desk_probe_green tests/uat/test_induction_integration_local.py::test_intel_endpoint_dead_degrades_honestly`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 70a250478247bab9b05a8d25e035806a442a3478
+
+```text
+..                                                                       [100%]
+2 passed in 5.75s
+```
+
+### Captured run — 2026-07-26T23:50:05Z
+
+- **Command:** `uv run pytest -q tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 70a250478247bab9b05a8d25e035806a442a3478
+
+```text
+.......                                                                  [100%]
+7 passed in 1.06s
+```

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/story-03-census-test.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/story-03-census-test.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 106
-- **Status:** ready
+- **Status:** done
 - **Depends on:** none
 - **Unblocks:** HS-106-04, HS-106-05, HS-106-06, HS-106-07
 

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/story-03-census-test.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/story-03-census-test.md
@@ -105,3 +105,8 @@ finding is that this has already happened 36 times.
   (`send_text_to_pane`) for the typing families — that is the
   chokepoint the terminal slice will adapt, so make sure the ledger
   makes it obvious.
+- The shipped walker resolves import provenance before classification:
+  plain and renamed from-imports, module aliases, and simple callable
+  aliases must classify exactly like their canonical API in all five
+  families. Permanent fixtures pin this because a syntactic spelling
+  must never become an Article XI escape hatch.

--- a/tests/unit/test_kernel_effect_fence.py
+++ b/tests/unit/test_kernel_effect_fence.py
@@ -66,7 +66,8 @@ class CallRule:
             return False
         if self.scopes and scope not in self.scopes:
             return False
-        return target in self.targets and (
+        resolved_target = full.rsplit(".", 1)[-1] if full else target
+        return (target in self.targets or resolved_target in self.targets) and (
             not self.full_suffixes
             or any(full == suffix or full.endswith(f".{suffix}") for suffix in self.full_suffixes)
         )
@@ -93,6 +94,15 @@ _CALL_RULES = (
             "TextTyper._paste_text",
             "TextTyper._type_text_slowly",
             "TextTyper._press_enter",
+        ),
+    ),
+    CallRule(
+        FAMILY_RAW_DESKTOP,
+        ("press", "release", "type"),
+        full_suffixes=(
+            "pynput.keyboard.Controller().press",
+            "pynput.keyboard.Controller().release",
+            "pynput.keyboard.Controller().type",
         ),
     ),
     CallRule(
@@ -220,6 +230,7 @@ class _EffectVisitor(ast.NodeVisitor):
     def __init__(self, relative_path: str) -> None:
         self.relative_path = relative_path
         self.scope_stack: list[str] = []
+        self.bindings: list[dict[str, str]] = [{}]
         self.ordinals: defaultdict[tuple[str, str], int] = defaultdict(int)
         self.sites: list[EffectSite] = []
 
@@ -227,21 +238,93 @@ class _EffectVisitor(ast.NodeVisitor):
     def scope(self) -> str:
         return ".".join(self.scope_stack) or "<module>"
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        self.scope_stack.append(node.name)
-        self.generic_visit(node)
+    def _push_scope(self, name: str) -> None:
+        self.scope_stack.append(name)
+        self.bindings.append({})
+
+    def _pop_scope(self) -> None:
+        self.bindings.pop()
         self.scope_stack.pop()
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self.scope_stack.append(node.name)
+    def _resolve_name(self, name: str) -> str:
+        seen: set[str] = set()
+        current = name
+        while current not in seen:
+            seen.add(current)
+            bound = next(
+                (scope[current] for scope in reversed(self.bindings) if current in scope),
+                None,
+            )
+            if bound is None or bound == current:
+                break
+            current = bound
+        return current
+
+    def _resolved_expr(self, node: ast.AST) -> str:
+        if isinstance(node, ast.Name):
+            return self._resolve_name(node.id)
+        if isinstance(node, ast.Attribute):
+            prefix = self._resolved_expr(node.value)
+            return f"{prefix}.{node.attr}" if prefix else node.attr
+        if isinstance(node, ast.Call):
+            return f"{self._resolved_expr(node.func)}()"
+        return ""
+
+    def _bind(self, target: ast.expr, origin: str) -> None:
+        if isinstance(target, ast.Name):
+            if origin:
+                self.bindings[-1][target.id] = origin
+            else:
+                self.bindings[-1].pop(target.id, None)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".", 1)[0]
+            origin = alias.name if alias.asname else local
+            self.bindings[-1][local] = origin
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            local = alias.asname or alias.name
+            origin = f"{module}.{alias.name}" if module else alias.name
+            self.bindings[-1][local] = origin
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        origin = self._resolved_expr(node.value)
+        for target in node.targets:
+            self._bind(target, origin)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self.visit(node.value)
+            self._bind(node.target, self._resolved_expr(node.value))
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._push_scope(node.name)
         self.generic_visit(node)
-        self.scope_stack.pop()
+        self._pop_scope()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._push_scope(node.name)
+        arguments = (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
+        for argument in arguments:
+            self.bindings[-1][argument.arg] = argument.arg
+        if node.args.vararg is not None:
+            self.bindings[-1][node.args.vararg.arg] = node.args.vararg.arg
+        if node.args.kwarg is not None:
+            self.bindings[-1][node.args.kwarg.arg] = node.args.kwarg.arg
+        self.generic_visit(node)
+        self._pop_scope()
 
     visit_AsyncFunctionDef = visit_FunctionDef
 
     def visit_Call(self, node: ast.Call) -> None:
         target = _call_target(node.func)
-        full = _dotted_expr(node.func)
+        full = self._resolved_expr(node.func)
         ordinal_key = (self.scope, target)
         self.ordinals[ordinal_key] += 1
         ordinal = self.ordinals[ordinal_key]
@@ -298,7 +381,8 @@ def _classify_call(
     *, path: str, scope: str, target: str, full: str, node: ast.Call
 ) -> str | None:
     process_targets = {"run", "Popen", "call", "check_call", "check_output"}
-    if target in process_targets and any(
+    resolved_target = full.rsplit(".", 1)[-1] if full else target
+    if resolved_target in process_targets and any(
         "osascript" in value.lower() for value in _literal_strings(node)
     ):
         return FAMILY_RAW_DESKTOP
@@ -350,6 +434,13 @@ def _ledger_key(entry: dict[str, Any]) -> tuple[str, str, str, int]:
     )
 
 
+def _unledgered_message(site: EffectSite) -> str:
+    return (
+        f"UNLEDGERED effect site: {site.label} "
+        f"scope={site.scope} target={site.target} ordinal={site.ordinal}"
+    )
+
+
 def test_effect_family_classifier_fixtures() -> None:
     fixtures = (
         ("holdspeak/scratch.py", "send_text_to_pane(pane='p', text='x')", FAMILY_TMUX),
@@ -364,6 +455,57 @@ def test_effect_family_classifier_fixtures() -> None:
             f"fixture for {expected} classified as "
             f"{[site.family for site in found]}"
         )
+
+
+def test_import_and_callable_aliases_cannot_evade_any_effect_family() -> None:
+    fixtures = (
+        # Subprocess: plain from-import, aliased from-import, module alias, and
+        # every process API named by the census scope.
+        ("subprocess run from-import", "from subprocess import run\nrun(['true'])", FAMILY_SUBPROCESS),
+        ("subprocess run alias", "from subprocess import run as sneaky\nsneaky(['true'])", FAMILY_SUBPROCESS),
+        ("subprocess module alias", "import subprocess as sp\nsp.run(['true'])", FAMILY_SUBPROCESS),
+        ("subprocess Popen alias", "from subprocess import Popen as launch\nlaunch(['true'])", FAMILY_SUBPROCESS),
+        ("subprocess call alias", "from subprocess import call as invoke\ninvoke(['true'])", FAMILY_SUBPROCESS),
+        ("subprocess check_output alias", "from subprocess import check_output as output\noutput(['true'])", FAMILY_SUBPROCESS),
+        ("subprocess check_call alias", "from subprocess import check_call as checked\nchecked(['true'])", FAMILY_SUBPROCESS),
+        # Tmux transport: both imported boundary names survive renaming.
+        ("tmux text alias", "from holdspeak.tmux_transport import send_text_to_pane as push\npush(pane='p', text='x')", FAMILY_TMUX),
+        ("tmux keys module alias", "import holdspeak.tmux_transport as tmux\ntmux.send_keys_to_pane(pane='p', keys=[])", FAMILY_TMUX),
+        # TextTyper: class aliases and aliases of the bound method itself.
+        ("TextTyper class alias", "from holdspeak.typer import TextTyper as Typer\nTyper().type_text('x')", FAMILY_TYPER),
+        ("TextTyper bound method alias", "from holdspeak.typer import TextTyper as Typer\nwriter = Typer().type_text\nwriter('x')", FAMILY_TYPER),
+        # Egress: HTTP, socket, and model-call aliases all retain provenance.
+        ("urlopen alias", "from urllib.request import urlopen as fetch\nfetch('https://example.test')", FAMILY_EGRESS),
+        ("urllib module alias", "import urllib.request as net\nnet.urlopen('https://example.test')", FAMILY_EGRESS),
+        ("socket alias", "from socket import create_connection as connect\nconnect(('example.test', 443))", FAMILY_EGRESS),
+        ("model method alias", "request = client.chat.completions.create\nrequest()", FAMILY_EGRESS),
+        # Raw desktop: clipboard, pyautogui, AX/Quartz, and AppleScript process
+        # aliases remain raw primitives rather than generic subprocess sites.
+        ("clipboard alias", "from pyperclip import copy as stash\nstash('x')", FAMILY_RAW_DESKTOP),
+        ("clipboard module alias", "import pyperclip as clipboard\nclipboard.copy('x')", FAMILY_RAW_DESKTOP),
+        ("pyautogui alias", "from pyautogui import hotkey as chord\nchord('ctrl', 'v')", FAMILY_RAW_DESKTOP),
+        ("pynput controller alias", "from pynput.keyboard import Controller as Keys\nkeyboard = Keys()\nkeyboard.press('x')", FAMILY_RAW_DESKTOP),
+        ("Quartz alias", "from Quartz import CGEventPost as post\npost(0, event)", FAMILY_RAW_DESKTOP),
+        ("AX alias", "from ApplicationServices import AXUIElementSetAttributeValue as set_ax\nset_ax(element, attr, value)", FAMILY_RAW_DESKTOP),
+        ("AppleScript process alias", "from subprocess import run as execute\nexecute(['osascript', '-e', script])", FAMILY_RAW_DESKTOP),
+    )
+
+    for name, source, expected_family in fixtures:
+        sites = _classify_source("holdspeak/alias_mutation.py", source)
+        assert len(sites) == 1, f"{name} escaped or double-counted: {sites}"
+        site = sites[0]
+        assert site.family == expected_family, (
+            f"{name} classified as {site.family}, expected {expected_family}"
+        )
+        message = _unledgered_message(site)
+        assert "holdspeak/alias_mutation.py:" in message
+        assert f"[{expected_family}]" in message
+        assert f"target={site.target}" in message
+
+    shadowed = "from subprocess import run\ndef harmless(run):\n    run(['not-the-import'])\n"
+    assert not _classify_source("holdspeak/shadowed.py", shadowed), (
+        "a function argument must shadow an imported effect name"
+    )
 
 
 def test_effect_ledger_is_complete_and_current() -> None:
@@ -385,8 +527,7 @@ def test_effect_ledger_is_complete_and_current() -> None:
     ]
 
     failures = [
-        f"UNLEDGERED effect site: {site.label} "
-        f"scope={site.scope} target={site.target} ordinal={site.ordinal}"
+        _unledgered_message(site)
         for site in sorted(unledgered, key=lambda item: (item.path, item.line))
     ]
     failures.extend(

--- a/tests/unit/test_kernel_effect_fence.py
+++ b/tests/unit/test_kernel_effect_fence.py
@@ -1,0 +1,563 @@
+"""HS-106-03: make the effect census and broker density limits executable.
+
+The census is deliberately an explicit AST table, not a call-graph guess.  It
+counts static statements in the five ratified families.  One logical action can
+therefore produce several sites.  When this fence fires, inspect the statement
+and amend the Article XI debt register deliberately; never hide it by weakening
+a rule.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import json
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_REPO = Path(__file__).resolve().parents[2]
+_SOURCE = _REPO / "holdspeak"
+_KERNEL = _SOURCE / "kernel"
+_LEDGER = _KERNEL / "effect_ledger.json"
+
+FAMILY_TMUX = "tmux_transport"
+FAMILY_TYPER = "text_typer"
+FAMILY_SUBPROCESS = "subprocess"
+FAMILY_EGRESS = "egress"
+FAMILY_RAW_DESKTOP = "raw_desktop"
+_FAMILIES = {
+    FAMILY_TMUX,
+    FAMILY_TYPER,
+    FAMILY_SUBPROCESS,
+    FAMILY_EGRESS,
+    FAMILY_RAW_DESKTOP,
+}
+_STATUSES = {"covered", "bypass", "mixed", "dormant"}
+
+# The broker is intended to stay smaller than one Phase-79 concern module.
+# Raising this number is an architecture decision; the ordinary response to a
+# failure is to carve a typed concern module, not grow the broker.
+_BROKER_MODULE_BUDGET = 300
+_BROKER_INIT_BUDGET = 60
+
+
+@dataclass(frozen=True)
+class CallRule:
+    """One explicit effect-family syntax rule.
+
+    ``path_globs`` and ``scopes`` narrow indirect calls whose target name alone
+    is not meaningful (the two ``actual(...)`` boundaries and coder steering's
+    injected ``send(...)``).  Direct APIs remain broad so a newly introduced
+    ambient call cannot hide in a new module.
+    """
+
+    family: str
+    targets: tuple[str, ...]
+    full_suffixes: tuple[str, ...] = ()
+    path_globs: tuple[str, ...] = ("holdspeak/*.py", "holdspeak/**/*.py")
+    scopes: tuple[str, ...] = ()
+
+    def matches(self, *, path: str, scope: str, target: str, full: str) -> bool:
+        if not any(fnmatch.fnmatchcase(path, pattern) for pattern in self.path_globs):
+            return False
+        if self.scopes and scope not in self.scopes:
+            return False
+        return target in self.targets and (
+            not self.full_suffixes
+            or any(full == suffix or full.endswith(f".{suffix}") for suffix in self.full_suffixes)
+        )
+
+
+# Ordering is classification precedence.  The AppleScript process invocation is
+# a raw desktop primitive, not one of the plugin/connector subprocess rows.
+_CALL_RULES = (
+    CallRule(
+        FAMILY_RAW_DESKTOP,
+        ("run", "Popen", "call", "check_call", "check_output"),
+        path_globs=("holdspeak/*.py", "holdspeak/**/*.py"),
+    ),
+    CallRule(
+        FAMILY_RAW_DESKTOP,
+        ("copy",),
+        full_suffixes=("pyperclip.copy",),
+    ),
+    CallRule(
+        FAMILY_RAW_DESKTOP,
+        ("press", "release", "type"),
+        path_globs=("holdspeak/typer.py",),
+        scopes=(
+            "TextTyper._paste_text",
+            "TextTyper._type_text_slowly",
+            "TextTyper._press_enter",
+        ),
+    ),
+    CallRule(
+        FAMILY_RAW_DESKTOP,
+        ("write", "press", "hotkey", "keyDown", "keyUp"),
+        full_suffixes=(
+            "pyautogui.write",
+            "pyautogui.press",
+            "pyautogui.hotkey",
+            "pyautogui.keyDown",
+            "pyautogui.keyUp",
+        ),
+    ),
+    CallRule(
+        FAMILY_RAW_DESKTOP,
+        ("CGEventPost", "AXUIElementSetAttributeValue"),
+    ),
+    CallRule(
+        FAMILY_TMUX,
+        ("send_text_to_pane", "send_keys_to_pane"),
+    ),
+    CallRule(
+        FAMILY_TMUX,
+        ("send",),
+        path_globs=("holdspeak/coder_steering.py",),
+        scopes=("deliver", "deliver_keys"),
+    ),
+    CallRule(FAMILY_TYPER, ("type_text",)),
+    CallRule(FAMILY_SUBPROCESS, ("run_subprocess",)),
+    CallRule(
+        FAMILY_SUBPROCESS,
+        ("actual",),
+        path_globs=("holdspeak/connector_runtime.py",),
+        scopes=("PermissionGate.run_subprocess",),
+    ),
+    CallRule(
+        FAMILY_SUBPROCESS,
+        ("run", "Popen", "call", "check_call", "check_output"),
+        full_suffixes=(
+            "subprocess.run",
+            "subprocess.Popen",
+            "subprocess.call",
+            "subprocess.check_call",
+            "subprocess.check_output",
+        ),
+    ),
+    CallRule(FAMILY_EGRESS, ("open_outbound_socket",)),
+    CallRule(
+        FAMILY_EGRESS,
+        ("actual",),
+        path_globs=("holdspeak/connector_runtime.py",),
+        scopes=("PermissionGate.open_outbound_socket",),
+    ),
+    CallRule(
+        FAMILY_EGRESS,
+        ("urlopen", "create_connection"),
+        full_suffixes=("urlopen", "socket.create_connection"),
+    ),
+    CallRule(
+        FAMILY_EGRESS,
+        ("create",),
+        full_suffixes=("chat.completions.create", "responses.create"),
+    ),
+)
+
+# These are the census's inspected, deliberate scope exclusions.  Keeping them
+# explicit means a newly added process or network statement fails even when it
+# lands outside today's plugin/connector denominator.  Selectors are line-
+# independent so harmless edits above a call do not create false drift.
+_EXCLUDED_CALLS: dict[tuple[str, str, str, int], str] = {
+    ("holdspeak/tmux_transport.py", "_run_tmux", "run", 1): "raw tmux implementation traced from T01-T04",
+    ("holdspeak/coder_steering.py", "_default_runner", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/target_profile.py", "_collect_macos_hints", "run", 1): "read-only frontmost-app probe",
+    ("holdspeak/target_profile.py", "_run_text", "run", 1): "read-only Linux target-profile probe",
+    ("holdspeak/meeting_recorder.py", "MeetingRecorder._start_system_ffmpeg", "Popen", 1): "process site outside plugin/connector scope",
+    ("holdspeak/audio_devices.py", "_pactl_stdout", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/meeting_import.py", "_decode_with_ffmpeg", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/agent_summarizer.py", "summarize_agent_session", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/delivery/dossiers.py", "_default_runner", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/delivery/factory_launch.py", "_default_git_runner", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/delivery/pr_receipts.py", "_default_runner", "run", 1): "process site outside plugin/connector scope, added after census snapshot",
+    ("holdspeak/delivery/registry.py", "_default_git_runner", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/delivery/collector.py", "_default_runner", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/agent_context/hooks.py", "_read_tmux_display", "run", 1): "process site outside plugin/connector scope",
+    ("holdspeak/coder_steering_relay.py", "_default_opener", "urlopen", 1): "placement transport, not a second terminal-input effect",
+    ("holdspeak/commands/node_serve.py", "_default_http_post", "urlopen", 1): "delivery-node operation-state transport",
+    ("holdspeak/commands/mesh_serve.py", "_default_http_post", "urlopen", 1): "inference-mesh operation-state transport",
+    ("holdspeak/commands/doctor.py", "_check_meeting_intel_cloud_preflight", "urlopen", 1): "setup/diagnostic network probe",
+    ("holdspeak/setup_runtime.py", "_default_http_get", "urlopen", 1): "setup/diagnostic network probe",
+    ("holdspeak/setup_runtime.py", "_default_http_json", "urlopen", 1): "setup/diagnostic network probe",
+    ("holdspeak/coder_gate.py", "_send", "urlopen", 1): "loopback gate protocol transport outside census egress scope",
+}
+
+_SKIP_DIRS = {
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    "assets",
+    "generated",
+    "static",
+    "vendor",
+    "vendored",
+}
+
+
+@dataclass(frozen=True)
+class EffectSite:
+    family: str
+    path: str
+    line: int
+    scope: str
+    target: str
+    ordinal: int
+
+    @property
+    def key(self) -> tuple[str, str, str, int]:
+        return (self.path, self.scope, self.target, self.ordinal)
+
+    @property
+    def label(self) -> str:
+        return f"{self.path}:{self.line} [{self.family}]"
+
+
+class _EffectVisitor(ast.NodeVisitor):
+    def __init__(self, relative_path: str) -> None:
+        self.relative_path = relative_path
+        self.scope_stack: list[str] = []
+        self.ordinals: defaultdict[tuple[str, str], int] = defaultdict(int)
+        self.sites: list[EffectSite] = []
+
+    @property
+    def scope(self) -> str:
+        return ".".join(self.scope_stack) or "<module>"
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.scope_stack.append(node.name)
+        self.generic_visit(node)
+        self.scope_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.scope_stack.append(node.name)
+        self.generic_visit(node)
+        self.scope_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Call(self, node: ast.Call) -> None:
+        target = _call_target(node.func)
+        full = _dotted_expr(node.func)
+        ordinal_key = (self.scope, target)
+        self.ordinals[ordinal_key] += 1
+        ordinal = self.ordinals[ordinal_key]
+
+        family = _classify_call(
+            path=self.relative_path,
+            scope=self.scope,
+            target=target,
+            full=full,
+            node=node,
+        )
+        if family is not None:
+            site = EffectSite(
+                family=family,
+                path=self.relative_path,
+                line=node.lineno,
+                scope=self.scope,
+                target=target,
+                ordinal=ordinal,
+            )
+            if site.key not in _EXCLUDED_CALLS:
+                self.sites.append(site)
+        self.generic_visit(node)
+
+
+def _call_target(function: ast.expr) -> str:
+    if isinstance(function, ast.Name):
+        return function.id
+    if isinstance(function, ast.Attribute):
+        return function.attr
+    return type(function).__name__
+
+
+def _dotted_expr(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_expr(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    if isinstance(node, ast.Call):
+        return f"{_dotted_expr(node.func)}()"
+    return ""
+
+
+def _literal_strings(node: ast.AST) -> set[str]:
+    return {
+        child.value
+        for child in ast.walk(node)
+        if isinstance(child, ast.Constant) and isinstance(child.value, str)
+    }
+
+
+def _classify_call(
+    *, path: str, scope: str, target: str, full: str, node: ast.Call
+) -> str | None:
+    process_targets = {"run", "Popen", "call", "check_call", "check_output"}
+    if target in process_targets and any(
+        "osascript" in value.lower() for value in _literal_strings(node)
+    ):
+        return FAMILY_RAW_DESKTOP
+
+    # The first raw-desktop rule is intentionally restricted here: ordinary
+    # subprocess calls continue into the subprocess rule below.
+    for index, rule in enumerate(_CALL_RULES):
+        if index == 0:
+            continue
+        if rule.matches(path=path, scope=scope, target=target, full=full):
+            return rule.family
+    return None
+
+
+def _classify_source(relative_path: str, source: str) -> list[EffectSite]:
+    tree = ast.parse(source, filename=relative_path)
+    visitor = _EffectVisitor(relative_path)
+    visitor.visit(tree)
+    return visitor.sites
+
+
+def _source_paths() -> list[Path]:
+    return sorted(
+        path
+        for path in _SOURCE.rglob("*.py")
+        if not any(part in _SKIP_DIRS for part in path.relative_to(_SOURCE).parts)
+    )
+
+
+def _walk_effect_sites() -> list[EffectSite]:
+    sites: list[EffectSite] = []
+    for path in _source_paths():
+        relative = path.relative_to(_REPO).as_posix()
+        sites.extend(_classify_source(relative, path.read_text(encoding="utf-8")))
+    return sorted(sites, key=lambda site: (site.path, site.line, site.family))
+
+
+def _load_ledger() -> dict[str, Any]:
+    return json.loads(_LEDGER.read_text(encoding="utf-8"))
+
+
+def _ledger_key(entry: dict[str, Any]) -> tuple[str, str, str, int]:
+    selector = entry["selector"]
+    return (
+        entry["path"],
+        selector["scope"],
+        selector["target"],
+        selector["ordinal"],
+    )
+
+
+def test_effect_family_classifier_fixtures() -> None:
+    fixtures = (
+        ("holdspeak/scratch.py", "send_text_to_pane(pane='p', text='x')", FAMILY_TMUX),
+        ("holdspeak/scratch.py", "typer.type_text('x')", FAMILY_TYPER),
+        ("holdspeak/scratch.py", "import subprocess\nsubprocess.run(['true'])", FAMILY_SUBPROCESS),
+        ("holdspeak/scratch.py", "import urllib.request\nurllib.request.urlopen('https://example.test')", FAMILY_EGRESS),
+        ("holdspeak/scratch.py", "import pyperclip\npyperclip.copy('x')", FAMILY_RAW_DESKTOP),
+    )
+    for path, source, expected in fixtures:
+        found = _classify_source(path, source)
+        assert [site.family for site in found] == [expected], (
+            f"fixture for {expected} classified as "
+            f"{[site.family for site in found]}"
+        )
+
+
+def test_effect_ledger_is_complete_and_current() -> None:
+    ledger = _load_ledger()
+    entries = ledger["sites"]
+    actual = _walk_effect_sites()
+
+    ledger_by_key = {_ledger_key(entry): entry for entry in entries}
+    actual_by_key = {site.key: site for site in actual}
+    assert len(ledger_by_key) == len(entries), "effect ledger contains duplicate selectors"
+    assert len(actual_by_key) == len(actual), "source walker produced duplicate selectors"
+
+    unledgered = [actual_by_key[key] for key in actual_by_key.keys() - ledger_by_key.keys()]
+    missing = [ledger_by_key[key] for key in ledger_by_key.keys() - actual_by_key.keys()]
+    family_mismatches = [
+        (ledger_by_key[key], actual_by_key[key])
+        for key in ledger_by_key.keys() & actual_by_key.keys()
+        if ledger_by_key[key]["family"] != actual_by_key[key].family
+    ]
+
+    failures = [
+        f"UNLEDGERED effect site: {site.label} "
+        f"scope={site.scope} target={site.target} ordinal={site.ordinal}"
+        for site in sorted(unledgered, key=lambda item: (item.path, item.line))
+    ]
+    failures.extend(
+        f"MISSING ledgered effect site: {entry['id']} "
+        f"{entry['path']}:{entry['census_line']} [{entry['family']}] "
+        f"selector={entry['selector']}"
+        for entry in sorted(missing, key=lambda item: item["id"])
+    )
+    failures.extend(
+        f"FAMILY CHANGED for {entry['id']}: ledger={entry['family']} "
+        f"source={site.family} at {site.path}:{site.line}"
+        for entry, site in family_mismatches
+    )
+    assert not failures, "effect census drift:\n  " + "\n  ".join(failures)
+
+
+def test_effect_ledger_asserts_the_ratified_40_4_36_counts() -> None:
+    ledger = _load_ledger()
+    entries = ledger["sites"]
+    expected = ledger["expected"]
+
+    families = Counter(entry["family"] for entry in entries)
+    statuses = Counter(entry["status"] for entry in entries)
+    covered = statuses["covered"]
+    not_covered = len(entries) - covered
+
+    assert set(families) == _FAMILIES
+    assert set(statuses) <= _STATUSES
+    assert len(entries) == expected["total"] == 40, (
+        f"effect census must state 40 total sites, found {len(entries)}"
+    )
+    assert covered == expected["covered"] == 4, (
+        f"effect census must state 4 covered sites, found {covered}"
+    )
+    assert not_covered == expected["not_covered"] == 36, (
+        f"effect census must state 36 not-covered sites, found {not_covered}"
+    )
+    assert dict(families) == expected["families"] == {
+        FAMILY_TMUX: 4,
+        FAMILY_TYPER: 8,
+        FAMILY_SUBPROCESS: 5,
+        FAMILY_EGRESS: 13,
+        FAMILY_RAW_DESKTOP: 10,
+    }, f"effect family breakdown changed: {dict(families)}"
+    assert all(entry["reason"].strip() for entry in entries)
+    assert len({entry["id"] for entry in entries}) == 40
+    assert "No agent principal may reach" in ledger["legal_effect"]
+
+
+def _broker_modules() -> list[Path]:
+    return sorted(_KERNEL.glob("*.py"))
+
+
+def _line_count(path: Path) -> int:
+    return len(path.read_text(encoding="utf-8").splitlines())
+
+
+def test_kernel_broker_modules_stay_within_line_budget() -> None:
+    offenders: list[str] = []
+    for path in _broker_modules():
+        budget = _BROKER_INIT_BUDGET if path.name == "__init__.py" else _BROKER_MODULE_BUDGET
+        lines = _line_count(path)
+        if lines > budget:
+            offenders.append(
+                f"kernel broker module over {budget}-line budget: "
+                f"{path.relative_to(_REPO)}: {lines} lines"
+            )
+    assert not offenders, (
+        "broker density guard failed — carve a typed concern module; don't bump "
+        "the budget:\n  " + "\n  ".join(offenders)
+    )
+
+
+_DRIVER_WORDS = re.compile(
+    r"driver|terminal|actuator|inference|operation\.(?:type|kind|family)",
+    re.IGNORECASE,
+)
+_DRIVER_CLASS = re.compile(
+    r"(?:Terminal|Actuator|Inference)\w*Driver|\w+Driver|"
+    r"ProcessInput\w*|DesktopType\w*|External\w*Operation"
+)
+_DRIVER_LITERALS = {
+    "terminal",
+    "terminal_input",
+    "actuator",
+    "actuator_egress",
+    "inference",
+    "inference_run",
+}
+_DRIVER_OPERATION_PREFIXES = ("process.", "desktop.", "external.", "inference.")
+
+
+def _source_mentions_driver_dispatch(node: ast.AST) -> bool:
+    rendered = ast.unparse(node)
+    if _DRIVER_WORDS.search(rendered) or _DRIVER_CLASS.search(rendered):
+        return True
+    literals = {value.lower() for value in _literal_strings(node)}
+    return bool(literals & _DRIVER_LITERALS) or any(
+        value.startswith(_DRIVER_OPERATION_PREFIXES) for value in literals
+    )
+
+
+def _driver_conditional_findings(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    try:
+        relative = path.relative_to(_REPO).as_posix()
+    except ValueError:
+        relative = path.as_posix()
+    findings: set[tuple[int, str]] = set()
+
+    for node in ast.walk(tree):
+        kind: str | None = None
+        subject: ast.AST | None = None
+        if isinstance(node, ast.If):
+            kind, subject = "if dispatch", node.test
+        elif isinstance(node, ast.IfExp):
+            kind, subject = "ternary dispatch", node.test
+        elif isinstance(node, ast.Match):
+            kind, subject = "match dispatch", node
+        elif isinstance(node, ast.Subscript):
+            # Catches HANDLERS[driver.kind] and drivers[operation.type] style
+            # table dispatch even though neither form contains a literal if.
+            kind, subject = "table dispatch", node
+        elif isinstance(node, ast.Call):
+            full = _dotted_expr(node.func)
+            if (
+                _call_target(node.func) in {"isinstance", "issubclass", "type"}
+                or full.endswith(".get")
+                or full.endswith(".register")
+                or full.endswith(".dispatch")
+            ):
+                kind, subject = "type/registry dispatch", node
+        elif isinstance(node, ast.Dict):
+            if any(
+                isinstance(key, ast.Constant) and key.value in _DRIVER_LITERALS
+                for key in node.keys
+                if key is not None
+            ):
+                kind, subject = "driver-keyed dispatch table", node
+
+        if kind is not None and subject is not None and _source_mentions_driver_dispatch(subject):
+            findings.add((node.lineno, kind))
+
+    return [
+        f"driver-specific conditional in broker module: {relative}:{line} ({kind})"
+        for line, kind in sorted(findings)
+    ]
+
+
+def test_kernel_broker_has_zero_driver_specific_conditionals() -> None:
+    findings = [
+        finding
+        for path in _broker_modules()
+        for finding in _driver_conditional_findings(path)
+    ]
+    assert not findings, (
+        "broker driver-conditional census expected zero; typed operation modules "
+        "must own driver behavior:\n  " + "\n  ".join(findings)
+    )
+
+
+def test_driver_conditional_census_catches_non_if_dispatch(tmp_path: Path) -> None:
+    cases = {
+        "ternary.py": "result = terminal if driver.kind == 'terminal' else inference\n",
+        "match.py": "match driver.kind:\n    case 'terminal':\n        result = 1\n",
+        "table.py": "result = handlers[driver.kind]\n",
+        "operation_table.py": "result = handlers[operation.type]\n",
+        "registry.py": "result = registry.dispatch(driver)\n",
+    }
+    for name, source in cases.items():
+        path = tmp_path / name
+        path.write_text(source, encoding="utf-8")
+        findings = _driver_conditional_findings(path)
+        assert findings, f"non-if driver dispatch fixture escaped: {name}"

--- a/uat/features.yaml
+++ b/uat/features.yaml
@@ -15,7 +15,7 @@ source:
   inventory: pm/roadmap/holdspeak-uat/phase-2-the-inventory/directory/_raw-inventory-rows.json
   additions: uat/feature-additions.yaml
   phase_index: pm/roadmap/holdspeak/README.md
-  phases_total: 103
+  phases_total: 104
 features:
 - key: activity.candidates.meeting
   title: Activity-derived meeting candidates
@@ -4290,4 +4290,6 @@ phase_map:
   '101':
   - internal/no-uat-surface
   '103':
+  - internal/no-uat-surface
+  '106':
   - internal/no-uat-surface


### PR DESCRIPTION
Converts the effect census from a photograph into a fence. **No effect site is rerouted** — rung 1 of the RFC ladder is explicitly "no rerouting yet."

### What ships

- **`holdspeak/kernel/effect_ledger.json`** — all 40 sites with stable selectors, family, status, census line, and the reason each exists. This is not a scratch file: it is the **debt register of Article XI's migration provision**, and it carries the legal framing — *"Each non-covered entry is declared migration debt, not authority. No agent principal may reach a path named by this register."*
- **`tests/unit/test_kernel_effect_fence.py`** — a static AST walk over `holdspeak/` diffed against the ledger. Additions, removals, family drift and count drift all fail **by name** with file:line.
- **The two broker density guards** (RFC §12), landing *before* the broker exists: a 300-line budget on broker modules, and a zero-driver-conditional check that catches `if`, ternaries, `match`, type/registry calls, and driver-keyed dispatch tables.

Ledger reproduces the census exactly: **40 sites — 4 tmux transport, 8 TextTyper, 5 subprocess, 13 egress, 10 raw desktop; 4 covered, 36 not.** The resolved walk surfaced no sites the census missed.

### Review note — a hole was found and closed

The first pass caught only the attribute form `subprocess.run(...)`. Both from-import forms walked straight past it silently:

```python
from subprocess import run as _sneaky_run   # 6 passed. no failure.
```

That is the exact failure the story warns about, and it mattered constitutionally: a path that can join the debt register silently defeats the clause that makes early ratification of Article XI defensible. Sent back and fixed by resolving imported names to canonical origins across **all five families** — not by special-casing `subprocess`.

Re-verified independently after the fix, in a file the implementing agent never touched. All caught, correctly classified:

| form | result |
|---|---|
| `from subprocess import run` | caught |
| `from subprocess import run as _sneaky_run` | caught |
| `import subprocess as sp` then `sp.run(...)` | caught |
| two-hop callable alias | caught |
| `from urllib.request import urlopen as _fetch` | caught, classified `egress` |

Honest boundary, stated rather than papered over: this is a **static** fence and does not claim to catch arbitrary runtime reflection (`getattr(subprocess, "run")`). Lexical shadowing is handled without false positives.

### Tests

`uv run pytest -q --ignore=tests/e2e/test_metal.py` → **4229 passed, 41 skipped, 2 failed**. Both failures are unrelated local UAT process flakes (`/api/setup/status` transient 401; a transient connection refusal), green on immediate targeted retry. Fence suite 7/7; ruff green; `dw check` and `dw verify` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)