### PR TITLE
HS-106-04: the broker and the journal — four calls

### DIFF
--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -9,7 +9,7 @@ and the clients that call it (extracted from the real call sites in
 `web/src` and `apple/`). "server only" means no in-repo client calls
 it today.
 
-Routes: 349 (plus static mounts). iOS-consumed: 88. Web-consumed: 262.
+Routes: 356 (plus static mounts). iOS-consumed: 88. Web-consumed: 265.
 
 ## device_audio_ws
 
@@ -618,6 +618,18 @@ Routes: 349 (plus static mounts). iOS-consumed: 88. Web-consumed: 262.
 |---|---|---|
 | GET | `/api/devices/health` | web |
 | GET | `/api/runtime/status` | ios, web |
+
+## web.routes.system.kernel_routes
+
+| Method | Path | Consumers |
+|---|---|---|
+| GET | `/api/kernel/events` | web |
+| POST | `/api/kernel/executor/claim` | server only |
+| POST | `/api/kernel/executor/operations/{operation_id}/receipt` | server only |
+| GET | `/api/kernel/executor/operations/{operation_id}/reconcile` | server only |
+| POST | `/api/kernel/operations/{operation_id}/decide` | server only |
+| GET | `/api/kernel/read` | web |
+| POST | `/api/kernel/submit` | web |
 
 ## web.routes.system.settings
 

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -2139,6 +2139,68 @@
       ]
     },
     {
+      "path": "/api/kernel/events",
+      "methods": [
+        "GET"
+      ],
+      "module": "web.routes.system.kernel_routes",
+      "consumers": [
+        "web"
+      ]
+    },
+    {
+      "path": "/api/kernel/executor/claim",
+      "methods": [
+        "POST"
+      ],
+      "module": "web.routes.system.kernel_routes",
+      "consumers": []
+    },
+    {
+      "path": "/api/kernel/executor/operations/{operation_id}/receipt",
+      "methods": [
+        "POST"
+      ],
+      "module": "web.routes.system.kernel_routes",
+      "consumers": []
+    },
+    {
+      "path": "/api/kernel/executor/operations/{operation_id}/reconcile",
+      "methods": [
+        "GET"
+      ],
+      "module": "web.routes.system.kernel_routes",
+      "consumers": []
+    },
+    {
+      "path": "/api/kernel/operations/{operation_id}/decide",
+      "methods": [
+        "POST"
+      ],
+      "module": "web.routes.system.kernel_routes",
+      "consumers": []
+    },
+    {
+      "path": "/api/kernel/read",
+      "methods": [
+        "GET"
+      ],
+      "module": "web.routes.system.kernel_routes",
+      "consumers": [
+        "web"
+      ]
+    },
+    {
+      "path": "/api/kernel/submit",
+      "methods": [
+        "POST"
+      ],
+      "module": "web.routes.system.kernel_routes",
+      "consumers": [
+        "web"
+      ]
+    },
+    {
       "path": "/api/meeting",
       "methods": [
         "PATCH"

--- a/holdspeak/db/core.py
+++ b/holdspeak/db/core.py
@@ -49,7 +49,7 @@ log = get_logger("db")
 
 # Default database location
 DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "holdspeak" / "holdspeak.db"
-SCHEMA_VERSION = 26  # v26: per-session reported usage for receipts (HS-104-05)
+SCHEMA_VERSION = 27  # v27: operation broker journal and warrants (HS-106-04)
 
 
 class SchemaVersionError(RuntimeError):
@@ -1329,6 +1329,70 @@ CREATE TABLE IF NOT EXISTS delivery_command_receipts (
 );
 CREATE INDEX IF NOT EXISTS idx_delivery_command_receipts_node
 ON delivery_command_receipts(node_id, hub_state);
+
+-- Kernel operation journal (HS-106-04). Domain content remains in native tables.
+CREATE TABLE IF NOT EXISTS kernel_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS kernel_operations (
+    operation_id TEXT PRIMARY KEY,
+    request_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    principal_kind TEXT NOT NULL,
+    principal_identity TEXT NOT NULL,
+    target_ref TEXT NOT NULL,
+    placement TEXT NOT NULL,
+    envelope_sha256 TEXT NOT NULL,
+    policy_version TEXT NOT NULL,
+    authority_basis TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN (
+        'admitting','awaiting_decision','awaiting_execution','claimed',
+        'succeeded','failed','refused','indeterminate'
+    )),
+    revision INTEGER NOT NULL DEFAULT 1,
+    native_id TEXT NOT NULL,
+    decision TEXT,
+    warrant_json TEXT NOT NULL DEFAULT '{}',
+    warrant_revoked INTEGER NOT NULL DEFAULT 0,
+    claimed_by TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    UNIQUE(principal_identity, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS idx_kernel_operations_state
+ON kernel_operations(state, created_at);
+CREATE TABLE IF NOT EXISTS kernel_receipts (
+    receipt_id TEXT PRIMARY KEY,
+    operation_id TEXT NOT NULL UNIQUE REFERENCES kernel_operations(operation_id),
+    state TEXT NOT NULL CHECK (state IN ('succeeded','failed','refused','indeterminate')),
+    outcome TEXT NOT NULL,
+    result_ref TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
+);
+CREATE TABLE IF NOT EXISTS kernel_journal (
+    hub_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream TEXT NOT NULL,
+    stream_sequence INTEGER NOT NULL,
+    event_id TEXT NOT NULL UNIQUE,
+    operation_id TEXT NOT NULL,
+    process_id TEXT NOT NULL DEFAULT '',
+    correlation_id TEXT NOT NULL DEFAULT '',
+    causation_id TEXT NOT NULL DEFAULT '',
+    event_type TEXT NOT NULL,
+    event_version INTEGER NOT NULL,
+    refs_json TEXT NOT NULL DEFAULT '[]',
+    privacy_class TEXT NOT NULL,
+    head TEXT NOT NULL DEFAULT '',
+    timestamp REAL NOT NULL,
+    previous_sha256 TEXT NOT NULL,
+    record_sha256 TEXT NOT NULL,
+    UNIQUE(stream, stream_sequence)
+);
+CREATE INDEX IF NOT EXISTS idx_kernel_journal_operation
+ON kernel_journal(operation_id, hub_sequence);
 """
 
 

--- a/holdspeak/kernel/__init__.py
+++ b/holdspeak/kernel/__init__.py
@@ -1,1 +1,9 @@
-"""The operation-broker boundary, fenced before its first implementation."""
+"""HoldSpeak's caller and executor operation planes.
+
+Caller plane: :func:`read`, :func:`submit`, :func:`decide`, :func:`events`.
+Executor plane: :func:`claim`, :func:`receipt`, :func:`reconcile`.
+Operation registration remains private trusted-startup configuration.
+"""
+from .runtime import claim, decide, events, read, receipt, reconcile, submit
+
+__all__ = ["read", "submit", "decide", "events", "claim", "receipt", "reconcile"]

--- a/holdspeak/kernel/admission.py
+++ b/holdspeak/kernel/admission.py
@@ -1,0 +1,64 @@
+"""Generic request parsing; typed payload validation remains in each codec."""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from ..operation_policy import POLICY_VERSION
+from .model import KernelRefused, OperationRequest
+
+_REQUEST_FIELDS = frozenset(
+    {"request_schema", "request_id", "idempotency_key", "operation", "subject_refs", "target", "arguments", "placement"}
+)
+_AUTHORITY_FIELDS = frozenset(
+    {"actor", "principal", "authority", "authority_basis", "control_mode", "effect_class", "data_classes", "policy_version"}
+)
+
+
+def parse_request(raw: Any) -> OperationRequest:
+    if not isinstance(raw, Mapping):
+        raise KernelRefused("request_malformed")
+    if set(raw) & _AUTHORITY_FIELDS:
+        raise KernelRefused("authority_not_client_settable")
+    unknown = set(raw) - _REQUEST_FIELDS
+    if unknown:
+        raise KernelRefused("request_field_not_allowed", sorted(unknown)[0])
+    operation = raw.get("operation")
+    target = raw.get("target") or {}
+    if raw.get("request_schema") != 1 or not isinstance(operation, Mapping) or not isinstance(target, Mapping):
+        raise KernelRefused("request_schema_invalid")
+    request_id = str(raw.get("request_id") or "").strip()
+    idempotency_key = str(raw.get("idempotency_key") or "").strip()
+    name = str(operation.get("name") or "").strip()
+    version = operation.get("version")
+    arguments = raw.get("arguments")
+    if not request_id or not idempotency_key or not name or not isinstance(version, int) or not isinstance(arguments, Mapping):
+        raise KernelRefused("request_incomplete")
+    refs = raw.get("subject_refs") or []
+    if not isinstance(refs, list) or not all(isinstance(item, str) for item in refs):
+        raise KernelRefused("subject_refs_invalid")
+    return OperationRequest(
+        1, request_id, idempotency_key, name, version,
+        str(target.get("ref") or ""), str(raw.get("placement") or ""),
+        arguments, tuple(refs),
+    )
+
+
+def refusal_values(raw: Any, principal: Any, operation_id: str, reason: str) -> dict[str, Any]:
+    safe = raw if isinstance(raw, Mapping) else {}
+    request_id = str(safe.get("request_id") or operation_id)
+    idempotency = str(safe.get("idempotency_key") or operation_id)
+    operation = safe.get("operation") if isinstance(safe.get("operation"), Mapping) else {}
+    raw_version = operation.get("version")
+    version = raw_version if isinstance(raw_version, int) and not isinstance(raw_version, bool) else 0
+    digest = json.dumps({"request_id": request_id, "reason": reason}, separators=(",", ":"), sort_keys=True)
+    return {
+        "operation_id": operation_id, "request_id": request_id, "idempotency_key": idempotency,
+        "name": str(operation.get("name") or "unknown"), "version": version,
+        "principal_kind": principal.name, "principal_identity": principal.identity,
+        "target_ref": "", "placement": "",
+        "envelope_sha256": "sha256:" + hashlib.sha256(digest.encode()).hexdigest(),
+        "policy_version": POLICY_VERSION, "authority_basis": "refused_at_admission",
+        "state": "refused", "native_id": "",
+    }

--- a/holdspeak/kernel/broker.py
+++ b/holdspeak/kernel/broker.py
@@ -1,0 +1,224 @@
+"""The small operation broker: admission once, decision once, receipt always."""
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Mapping, Sequence
+
+from ..operation_policy import POLICY_VERSION
+from ..principals import PrincipalKind, PrincipalRight
+from .admission import parse_request, refusal_values
+from .executor import ExecutorPlane
+from .journal import JournalStore
+from .model import KernelRefused, OperationRequest, OperationSpec
+
+
+class Broker(ExecutorPlane):
+    def __init__(self, store: JournalStore, specs: Sequence[OperationSpec], *, clock: Any = time.time) -> None:
+        self.store = store
+        self._specs = {(item.name, item.version): item for item in specs}
+        self._clock = clock
+        self.last_authority_layers: tuple[str, ...] = ()
+
+    def recover_invalidated(self, native_ids: Sequence[str]) -> int:
+        recovered = 0
+        for native_id in native_ids:
+            operation = self.store.operation_for_native(native_id)
+            if operation is None or operation["state"] not in {"admitting", "awaiting_decision"}:
+                continue
+            operation = self.store.transition(
+                operation["operation_id"], operation["revision"], "indeterminate"
+            )
+            self._terminal(operation, "indeterminate", "hub_restart_during_decision")
+            recovered += 1
+        return recovered
+
+    def read(self, refs: Sequence[str], view: str, consistency: str, principal: Any) -> dict[str, Any]:
+        if principal.kind is PrincipalKind.NONE:
+            raise KernelRefused("principal_authentication_required")
+        if consistency not in {"committed", "eventual"}:
+            raise KernelRefused("read_consistency_unknown")
+        if view not in {"state", "canonical", "process", "receipt", "full"}:
+            raise KernelRefused("read_view_unknown")
+        objects: list[dict[str, Any]] = []
+        for ref in refs:
+            value = str(ref)
+            operation = self.store.operation(value.removeprefix("operation:"))
+            if operation is None:
+                operation = self.store.operation_for_ref(value)
+            if operation is None:
+                continue
+            if principal.kind is PrincipalKind.AGENT and operation["principal_identity"] != principal.identity:
+                raise KernelRefused("principal_read_scope_required")
+            item = {"ref": f"operation:{operation['operation_id']}", "operation": operation}
+            spec = self._specs.get((operation["name"], operation["version"]))
+            if spec is not None and view in {"canonical", "full"}:
+                item["canonical"] = spec.codec.read_native(operation["native_id"])
+            if spec is not None and view in {"process", "full"}:
+                item["process"] = spec.codec.project_process(operation["native_id"], operation)
+            if view in {"receipt", "full"}:
+                item["receipt"] = self.store.receipt(operation["operation_id"])
+            objects.append(item)
+        return {"view": view, "consistency": consistency, "objects": objects}
+
+    def submit(self, raw: Any, principal: Any) -> dict[str, Any]:
+        operation_id = "op_" + uuid.uuid4().hex
+        try:
+            request = parse_request(raw)
+            spec = self._specs.get((request.name, request.version))
+            if spec is None:
+                raise KernelRefused("operation_type_unregistered")
+            admission, layers = self._admit_authority(request, spec, principal, operation_id)
+            self.last_authority_layers = tuple(layers)
+        except KernelRefused as exc:
+            return self._refuse_attempt(raw, principal, operation_id, exc.reason)
+        except Exception:
+            return self._refuse_attempt(
+                raw, principal, operation_id, "authority_resolution_failed"
+            )
+
+        values = {
+            "operation_id": operation_id,
+            "request_id": request.request_id,
+            "idempotency_key": request.idempotency_key,
+            "name": request.name,
+            "version": request.version,
+            "principal_kind": principal.name,
+            "principal_identity": principal.identity,
+            "target_ref": admission.target_ref,
+            "placement": admission.placement,
+            "envelope_sha256": admission.payload_hash,
+            "policy_version": POLICY_VERSION,
+            "authority_basis": "authenticated_principal+declared_capability+hard_prerequisites+interruption_policy",
+            "state": "admitting",
+            "native_id": admission.native_id,
+        }
+        try:
+            operation = self.store.create_operation(values)
+        except KernelRefused as exc:
+            refused = self._refuse_attempt(
+                raw, principal, operation_id, exc.reason, unique=True
+            )
+            try:
+                spec.codec.admit(request, admission, principal, operation_id)
+            except Exception:
+                pass
+            return refused
+        if operation["state"] != "admitting":
+            spec.codec.admit(request, admission, principal, operation["operation_id"])
+            return self._handle(operation)
+        self.store.append(
+            "operation.admitted", operation["operation_id"], refs=admission.refs,
+            head=admission.head, causation_id=request.request_id,
+        )
+        try:
+            spec.codec.admit(request, admission, principal, operation["operation_id"])
+            operation = self.store.transition(
+                operation["operation_id"], operation["revision"], "awaiting_decision"
+            )
+            self.store.append(
+                "operation.awaiting_decision", operation["operation_id"], refs=admission.refs
+            )
+            return self._handle(operation)
+        except Exception as exc:
+            reason = getattr(exc, "reason", "native_admission_failed")
+            operation = self.store.transition(
+                operation["operation_id"], operation["revision"], "refused"
+            )
+            receipt = self._terminal(operation, "refused", str(reason))
+            return self._handle(operation, receipt)
+
+    def decide(
+        self, operation_id: str, decision: str, expected_revision: int,
+        principal: Any, *, reason: str = "",
+    ) -> dict[str, Any]:
+        if principal.kind is not PrincipalKind.OWNER or not principal.permits(PrincipalRight.DECIDE):
+            raise KernelRefused("owner_principal_required_to_decide", operation_id=operation_id)
+        if decision not in {"approve", "reject"}:
+            raise KernelRefused("decision_unknown", operation_id=operation_id)
+        operation = self.store.operation(operation_id)
+        if operation is None:
+            raise KernelRefused("operation_unknown", operation_id=operation_id)
+        if operation["state"] != "awaiting_decision":
+            raise KernelRefused("operation_already_decided", operation_id=operation_id)
+        if operation["revision"] != expected_revision:
+            raise KernelRefused("operation_revision_conflict", operation_id=operation_id)
+        spec = self._specs.get((operation["name"], operation["version"]))
+        if spec is None:
+            raise KernelRefused("operation_type_unregistered", operation_id=operation_id)
+        try:
+            spec.codec.decide(operation["native_id"], decision, principal, reason)
+        except Exception as exc:
+            raise KernelRefused(
+                "operation_already_decided", operation_id=operation_id
+            ) from exc
+        if decision == "reject":
+            operation = self.store.transition(
+                operation_id, expected_revision, "refused", decision="reject"
+            )
+            receipt = self._terminal(operation, "refused", "owner_rejected")
+            return self._handle(operation, receipt)
+        now = self._clock()
+        warrant = self.store.sign_warrant(
+            {
+                "warrant_id": "war_" + uuid.uuid4().hex,
+                "operation_id": operation_id,
+                "envelope_sha256": operation["envelope_sha256"],
+                "target_ref": operation["target_ref"],
+                "placement": operation["placement"],
+                "policy_version": operation["policy_version"],
+                "issued_at": now,
+                "expires_at": now + 30.0,
+                "uses": 1,
+            }
+        )
+        operation = self.store.transition(
+            operation_id, expected_revision, "awaiting_execution",
+            decision="approve", warrant_json=warrant,
+        )
+        self.store.append("operation.approved", operation_id, refs=(operation["target_ref"],))
+        return self._handle(operation)
+
+    def events(self, after_cursor: int, filters: Mapping[str, Any], principal: Any) -> dict[str, Any]:
+        if principal.kind is PrincipalKind.NONE:
+            raise KernelRefused("principal_authentication_required")
+        if principal.kind is PrincipalKind.AGENT:
+            operation = self.store.operation(str(filters.get("operation_id") or ""))
+            if operation is None or operation["principal_identity"] != principal.identity:
+                raise KernelRefused("principal_event_scope_required")
+        return self.store.events(after_cursor, filters)
+
+    def _admit_authority(
+        self, request: OperationRequest, spec: OperationSpec,
+        principal: Any, operation_id: str,
+    ) -> tuple[Any, list[str]]:
+        layers: list[str] = []
+        if principal.kind is PrincipalKind.NONE:
+            raise KernelRefused("principal_authentication_required")
+        layers.append("authenticated_principal")
+        required = PrincipalRight(spec.required_capability)
+        if principal.kind is PrincipalKind.AGENT and not principal.permits(required):
+            raise KernelRefused("declared_capability_required")
+        if principal.kind not in {PrincipalKind.OWNER, PrincipalKind.AGENT}:
+            raise KernelRefused("declared_capability_required")
+        layers.append("declared_capability")
+        admission = spec.codec.validate(request)
+        layers.append("hard_prerequisites")
+        if spec.interruption not in {"allow", "propose", "refuse"}:
+            raise KernelRefused("interruption_policy_invalid")
+        if spec.interruption == "refuse":
+            raise KernelRefused("interruption_policy_refused")
+        admission = spec.codec.authorize(request, admission, principal, operation_id)
+        layers.append("interruption_policy")
+        return admission, layers
+
+    def _refuse_attempt(
+        self, raw: Any, principal: Any, operation_id: str, reason: str, *, unique: bool = False,
+    ) -> dict[str, Any]:
+        values = refusal_values(raw, principal, operation_id, reason)
+        if unique:
+            values["idempotency_key"] = operation_id
+        operation = self.store.create_operation(values)
+        self.store.append("operation.refused", operation["operation_id"], head=reason)
+        receipt = self._terminal(operation, "refused", reason)
+        return self._handle(operation, receipt)

--- a/holdspeak/kernel/executor.py
+++ b/holdspeak/kernel/executor.py
@@ -1,0 +1,111 @@
+"""The separate executor plane: atomic claim, immutable receipt, reconcile."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..principals import PrincipalKind
+from .model import FINAL_STATES, KernelRefused, valid_ref
+
+
+class ExecutorPlane:
+    store: Any
+    _clock: Any
+
+    def claim(self, principal: Any) -> dict[str, Any]:
+        if principal.kind is not PrincipalKind.NODE:
+            raise KernelRefused("node_principal_required_to_claim")
+        operation = self.store.claim_candidate(principal.identity)
+        if operation is None:
+            return {"operations": []}
+        warrant = operation["warrant"]
+        reason = ""
+        if not self.store.valid_warrant(warrant):
+            reason = "warrant_signature_invalid"
+        elif bool(operation["warrant_revoked"]):
+            reason = "warrant_revoked"
+        elif float(warrant.get("expires_at") or 0) <= self._clock():
+            reason = "warrant_expired"
+        elif warrant.get("envelope_sha256") != operation["envelope_sha256"]:
+            reason = "warrant_payload_mismatch"
+        if reason:
+            operation = self.store.transition(
+                operation["operation_id"], operation["revision"], "refused"
+            )
+            receipt = self._terminal(operation, "refused", reason)
+            return {"operations": [], "refusal": receipt}
+        self.store.append(
+            "operation.claimed", operation["operation_id"], refs=(operation["target_ref"],)
+        )
+        claimed = self._handle(operation)
+        claimed["warrant"] = warrant
+        return {"operations": [claimed]}
+
+    def receipt(
+        self, operation_id: str, outcome: str, result_ref: str, principal: Any,
+    ) -> dict[str, Any]:
+        if principal.kind is not PrincipalKind.NODE:
+            raise KernelRefused("node_principal_required_to_receipt")
+        if not valid_ref(result_ref):
+            raise KernelRefused("result_ref_invalid", operation_id=operation_id)
+        operation = self.store.operation(operation_id)
+        if operation is None:
+            raise KernelRefused("operation_unknown", operation_id=operation_id)
+        if operation["claimed_by"] != principal.identity:
+            raise KernelRefused("executor_claim_required", operation_id=operation_id)
+        existing = self.store.receipt(operation_id)
+        if existing is not None:
+            if existing["outcome"] != outcome or existing["result_ref"] != result_ref:
+                raise KernelRefused("receipt_immutable", operation_id=operation_id)
+            return existing
+        states = {
+            "succeeded": "succeeded", "failed": "failed",
+            "refused": "refused", "indeterminate": "indeterminate",
+        }
+        if outcome not in states:
+            raise KernelRefused("receipt_outcome_unknown", operation_id=operation_id)
+        operation = self.store.transition(
+            operation_id, operation["revision"], states[outcome]
+        )
+        return self._terminal(operation, states[outcome], outcome, result_ref)
+
+    def reconcile(self, operation_id: str, principal: Any) -> dict[str, Any]:
+        if principal.kind is not PrincipalKind.NODE:
+            raise KernelRefused("node_principal_required_to_reconcile")
+        operation = self.store.operation(operation_id)
+        if operation is None:
+            raise KernelRefused("operation_unknown", operation_id=operation_id)
+        reconciliation = "receipt_missing"
+        if operation["state"] in FINAL_STATES:
+            reconciliation = "terminal"
+        return {
+            "operation": operation,
+            "receipt": self.store.receipt(operation_id),
+            "reconcile": reconciliation,
+        }
+
+    def _terminal(
+        self, operation: Mapping[str, Any], state: str, outcome: str,
+        result_ref: str = "",
+    ) -> dict[str, Any]:
+        receipt = self.store.add_receipt(
+            operation["operation_id"], state, outcome, result_ref
+        )
+        refs = tuple(filter(None, (operation["target_ref"], result_ref)))
+        self.store.append(
+            "operation.receipt", operation["operation_id"], refs=refs, head=outcome
+        )
+        return receipt
+
+    @staticmethod
+    def _handle(
+        operation: Mapping[str, Any], receipt: Any = None,
+    ) -> dict[str, Any]:
+        result = {
+            "operation_id": operation.get("operation_id"),
+            "state": operation.get("state"),
+            "revision": operation.get("revision"),
+            "target_ref": operation.get("target_ref"),
+        }
+        if receipt is not None:
+            result["receipt"] = receipt
+        return result

--- a/holdspeak/kernel/journal.py
+++ b/holdspeak/kernel/journal.py
@@ -1,0 +1,266 @@
+"""Durable operation metadata and its per-stream SHA-256 chain."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import uuid
+from typing import Any, Mapping
+
+from .model import KernelRefused, forbidden_content
+
+_HEAD_LIMIT = 120
+_EVENT_FIELDS = (
+    "stream", "stream_sequence", "event_id", "operation_id", "process_id",
+    "correlation_id", "causation_id", "event_type", "event_version", "refs",
+    "privacy_class", "head", "timestamp", "previous_sha256",
+)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _hash(record: Mapping[str, Any]) -> str:
+    material = {field: record[field] for field in _EVENT_FIELDS}
+    return "sha256:" + hashlib.sha256(_json(material).encode()).hexdigest()
+
+
+class JournalStore:
+    def __init__(self, connection: Any, *, clock: Any = time.time) -> None:
+        self._connection = connection
+        self._clock = clock
+
+    def _secret(self) -> str:
+        with self._connection() as conn:
+            row = conn.execute("SELECT value FROM kernel_meta WHERE key='warrant_secret'").fetchone()
+            if row is not None:
+                return str(row[0])
+            value = secrets.token_hex(32)
+            conn.execute("INSERT INTO kernel_meta(key,value) VALUES('warrant_secret',?)", (value,))
+            return value
+
+    def append(
+        self, event_type: str, operation_id: str, *, refs: tuple[str, ...] = (),
+        head: str = "", privacy_class: str = "private", stream: str = "operations",
+        process_id: str = "", correlation_id: str = "", causation_id: str = "",
+    ) -> dict[str, Any]:
+        metadata = {"refs": refs, "head": head}
+        if forbidden_content(metadata):
+            raise KernelRefused("journal_content_forbidden")
+        with self._connection() as conn:
+            previous = conn.execute(
+                "SELECT stream_sequence, record_sha256 FROM kernel_journal WHERE stream=? ORDER BY stream_sequence DESC LIMIT 1",
+                (stream,),
+            ).fetchone()
+            sequence = int(previous[0]) + 1 if previous is not None else 1
+            record = {
+                "stream": stream,
+                "stream_sequence": sequence,
+                "event_id": "evt_" + uuid.uuid4().hex,
+                "operation_id": operation_id,
+                "process_id": process_id,
+                "correlation_id": correlation_id,
+                "causation_id": causation_id,
+                "event_type": event_type,
+                "event_version": 1,
+                "refs": list(refs),
+                "privacy_class": privacy_class,
+                "head": str(head)[:_HEAD_LIMIT],
+                "timestamp": self._clock(),
+                "previous_sha256": str(previous[1]) if previous is not None else "sha256:genesis",
+            }
+            record_hash = _hash(record)
+            cursor = conn.execute(
+                """INSERT INTO kernel_journal(
+                    stream,stream_sequence,event_id,operation_id,process_id,correlation_id,
+                    causation_id,event_type,event_version,refs_json,privacy_class,head,
+                    timestamp,previous_sha256,record_sha256
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    record["stream"], sequence, record["event_id"], operation_id,
+                    process_id, correlation_id, causation_id, event_type, 1,
+                    _json(record["refs"]), privacy_class, record["head"],
+                    record["timestamp"], record["previous_sha256"], record_hash,
+                ),
+            )
+            record["cursor"] = int(cursor.lastrowid)
+            record["record_sha256"] = record_hash
+            return record
+
+    def verify(self, stream: str = "operations") -> dict[str, Any]:
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM kernel_journal WHERE stream=? ORDER BY stream_sequence", (stream,)
+            ).fetchall()
+        previous = "sha256:genesis"
+        for row in rows:
+            record = self._event(row)
+            if record["previous_sha256"] != previous:
+                raise KernelRefused("journal_previous_hash_mismatch")
+            if record["record_sha256"] != _hash(record):
+                raise KernelRefused("journal_record_hash_mismatch")
+            previous = record["record_sha256"]
+        return {"ok": True, "stream": stream, "records": len(rows), "head": previous}
+
+    def events(self, after_cursor: int, filters: Mapping[str, Any], limit: int = 100) -> dict[str, Any]:
+        clauses, values = ["hub_sequence > ?"], [max(0, int(after_cursor))]
+        allowed = {"operation_id", "event_type", "privacy_class", "stream"}
+        unknown = set(filters) - allowed
+        if unknown:
+            raise KernelRefused("event_filter_not_allowed", sorted(unknown)[0])
+        for key, value in filters.items():
+            clauses.append(f"{key} = ?")
+            values.append(str(value))
+        values.append(max(1, min(int(limit), 500)))
+        with self._connection() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM kernel_journal WHERE {' AND '.join(clauses)} ORDER BY hub_sequence LIMIT ?",
+                values,
+            ).fetchall()
+        batch = [self._event(row) for row in rows]
+        cursor = batch[-1]["cursor"] if batch else max(0, int(after_cursor))
+        return {"after_cursor": after_cursor, "cursor": cursor, "events": batch}
+
+    def create_operation(self, values: Mapping[str, Any]) -> dict[str, Any]:
+        with self._connection() as conn:
+            existing = conn.execute(
+                "SELECT * FROM kernel_operations WHERE principal_identity=? AND idempotency_key=?",
+                (values["principal_identity"], values["idempotency_key"]),
+            ).fetchone()
+            if existing is not None:
+                if str(existing["envelope_sha256"]) != values["envelope_sha256"]:
+                    raise KernelRefused("idempotency_payload_mismatch", operation_id=str(existing["operation_id"]))
+                return self._operation(existing)
+            conn.execute(
+                """INSERT INTO kernel_operations(
+                    operation_id,request_id,idempotency_key,name,version,principal_kind,
+                    principal_identity,target_ref,placement,envelope_sha256,policy_version,
+                    authority_basis,state,revision,native_id,created_at,updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    values["operation_id"], values["request_id"], values["idempotency_key"],
+                    values["name"], values["version"], values["principal_kind"],
+                    values["principal_identity"], values["target_ref"], values["placement"],
+                    values["envelope_sha256"], values["policy_version"],
+                    values["authority_basis"], values["state"], 1, values["native_id"],
+                    self._clock(), self._clock(),
+                ),
+            )
+        return self.operation(str(values["operation_id"]))
+
+    def operation(self, operation_id: str) -> dict[str, Any] | None:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM kernel_operations WHERE operation_id=?", (operation_id,)
+            ).fetchone()
+        return self._operation(row) if row is not None else None
+
+    def operation_for_ref(self, ref: str) -> dict[str, Any] | None:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM kernel_operations WHERE target_ref=? ORDER BY created_at DESC LIMIT 1", (ref,)
+            ).fetchone()
+        return self._operation(row) if row is not None else None
+
+    def operation_for_native(self, native_id: str) -> dict[str, Any] | None:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM kernel_operations WHERE native_id=? ORDER BY created_at DESC LIMIT 1", (native_id,)
+            ).fetchone()
+        return self._operation(row) if row is not None else None
+
+    def transition(self, operation_id: str, expected_revision: int, state: str, **changes: Any) -> dict[str, Any]:
+        assignments = ["state=?", "revision=revision+1", "updated_at=?"]
+        values: list[Any] = [state, self._clock()]
+        allowed = {"decision", "warrant_json", "warrant_revoked", "claimed_by"}
+        for key, value in changes.items():
+            if key not in allowed:
+                raise KernelRefused("operation_mutation_not_allowed", key)
+            assignments.append(f"{key}=?")
+            values.append(_json(value) if key == "warrant_json" else value)
+        values.extend((operation_id, expected_revision))
+        with self._connection() as conn:
+            result = conn.execute(
+                f"UPDATE kernel_operations SET {','.join(assignments)} WHERE operation_id=? AND revision=?",
+                values,
+            )
+            if result.rowcount != 1:
+                raise KernelRefused("operation_revision_conflict", operation_id=operation_id)
+        return self.operation(operation_id) or {}
+
+    def claim_candidate(self, executor: str) -> dict[str, Any] | None:
+        """Atomically acquire one approved operation; first claimant wins."""
+        with self._connection() as conn:
+            row = conn.execute(
+                """SELECT operation_id,revision FROM kernel_operations
+                   WHERE state='awaiting_execution' AND placement=?
+                   ORDER BY created_at LIMIT 1""",
+                (f"node:{executor}",),
+            ).fetchone()
+            if row is None:
+                return None
+            result = conn.execute(
+                """UPDATE kernel_operations SET state='claimed',claimed_by=?,revision=revision+1,updated_at=?
+                   WHERE operation_id=? AND revision=? AND state='awaiting_execution'""",
+                (executor, self._clock(), row["operation_id"], row["revision"]),
+            )
+            if result.rowcount != 1:
+                return None
+        return self.operation(str(row["operation_id"]))
+
+    def revoke_warrant(self, operation_id: str) -> dict[str, Any]:
+        with self._connection() as conn:
+            conn.execute(
+                "UPDATE kernel_operations SET warrant_revoked=1,revision=revision+1,updated_at=? WHERE operation_id=?",
+                (self._clock(), operation_id),
+            )
+        return self.operation(operation_id) or {}
+
+    def add_receipt(self, operation_id: str, state: str, outcome: str, result_ref: str = "") -> dict[str, Any]:
+        receipt_id = "rcpt_" + uuid.uuid4().hex
+        with self._connection() as conn:
+            existing = conn.execute(
+                "SELECT * FROM kernel_receipts WHERE operation_id=?", (operation_id,)
+            ).fetchone()
+            if existing is not None:
+                return dict(existing)
+            conn.execute(
+                "INSERT INTO kernel_receipts(receipt_id,operation_id,state,outcome,result_ref,created_at) VALUES(?,?,?,?,?,?)",
+                (receipt_id, operation_id, state, outcome, result_ref, self._clock()),
+            )
+        return self.receipt(operation_id) or {}
+
+    def receipt(self, operation_id: str) -> dict[str, Any] | None:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM kernel_receipts WHERE operation_id=?", (operation_id,)
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def sign_warrant(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        warrant = dict(payload)
+        warrant["signature"] = hmac.new(
+            self._secret().encode(), _json(warrant).encode(), hashlib.sha256
+        ).hexdigest()
+        return warrant
+
+    def valid_warrant(self, warrant: Mapping[str, Any]) -> bool:
+        unsigned = {key: value for key, value in warrant.items() if key != "signature"}
+        expected = hmac.new(self._secret().encode(), _json(unsigned).encode(), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(str(warrant.get("signature") or ""), expected)
+
+    @staticmethod
+    def _operation(row: Any) -> dict[str, Any]:
+        value = dict(row)
+        value["warrant"] = json.loads(value.pop("warrant_json") or "{}")
+        return value
+
+    @staticmethod
+    def _event(row: Any) -> dict[str, Any]:
+        value = dict(row)
+        value["cursor"] = value.pop("hub_sequence")
+        value["refs"] = json.loads(value.pop("refs_json"))
+        return value

--- a/holdspeak/kernel/model.py
+++ b/holdspeak/kernel/model.py
@@ -1,0 +1,70 @@
+"""Small typed values shared by the operation broker."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+FINAL_STATES = frozenset({"succeeded", "failed", "refused", "indeterminate"})
+FORBIDDEN_CONTENT_KEYS = frozenset(
+    {"audio", "audio_frame", "audio_frames", "pcm", "token", "tokens", "token_stream"}
+)
+_REF = re.compile(r"^[a-z][a-z0-9_.-]*:[A-Za-z0-9_.:/-]{1,160}$")
+
+
+class KernelRefused(ValueError):
+    """A named broker refusal which never includes domain content."""
+
+    def __init__(self, reason: str, message: Optional[str] = None, *, operation_id: str = ""):
+        super().__init__(message or reason)
+        self.reason = reason
+        self.operation_id = operation_id
+
+
+@dataclass(frozen=True)
+class OperationRequest:
+    request_schema: int
+    request_id: str
+    idempotency_key: str
+    name: str
+    version: int
+    target_ref: str
+    placement: str
+    arguments: Mapping[str, Any]
+    subject_refs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Admission:
+    target_ref: str
+    placement: str
+    payload_hash: str
+    refs: tuple[str, ...]
+    head: str
+    ttl_seconds: float
+    native_id: str
+
+
+@dataclass(frozen=True)
+class OperationSpec:
+    name: str
+    version: int
+    codec: Any
+    required_capability: str
+    interruption: str
+
+
+def valid_ref(value: str) -> bool:
+    return not value or _REF.fullmatch(value) is not None
+
+
+def forbidden_content(value: Any) -> bool:
+    """Reject bulk/stream content recursively before it can reach the journal."""
+    if isinstance(value, Mapping):
+        return bool(FORBIDDEN_CONTENT_KEYS.intersection(map(str, value))) or any(
+            forbidden_content(item) for item in value.values()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(forbidden_content(item) for item in value)
+    return False

--- a/holdspeak/kernel/runtime.py
+++ b/holdspeak/kernel/runtime.py
@@ -1,0 +1,85 @@
+"""Trusted startup wiring and request-principal context for the broker."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Mapping, Sequence
+
+from ..principals import UNAUTHENTICATED
+from .broker import Broker
+from .journal import JournalStore
+from .model import OperationSpec
+from .tool_call import ToolCallCodec
+
+_principal = ContextVar("kernel_principal", default=UNAUTHENTICATED)
+_broker: Broker | None = None
+_database_id: int | None = None
+
+
+def _mode() -> str:
+    from ..config import Config
+
+    return str(Config.load().control_mode)
+
+
+def _build(database: Any, *, clock: Any = None) -> Broker:
+    store = JournalStore(database._connection, **({"clock": clock} if clock else {}))
+    codec = ToolCallCodec(database.gate, _mode)
+    specs = (OperationSpec(codec.name, codec.version, codec, "agent.submit", "propose"),)
+    return Broker(store, specs, **({"clock": clock} if clock else {}))
+
+
+def _service() -> Broker:
+    global _broker, _database_id
+    from ..db import get_database
+
+    database = get_database()
+    if _broker is None or _database_id != id(database):
+        _broker = _build(database)
+        _database_id = id(database)
+    return _broker
+
+
+def _configure(database: Any, *, clock: Any = None) -> Broker:
+    """Test/startup seam; deliberately private, never an operation registration API."""
+    global _broker, _database_id
+    _broker = _build(database, clock=clock)
+    _database_id = id(database)
+    return _broker
+
+
+@contextmanager
+def _as_principal(principal: Any):
+    token = _principal.set(principal)
+    try:
+        yield
+    finally:
+        _principal.reset(token)
+
+
+def read(refs: Sequence[str], view: str = "state", consistency: str = "committed") -> dict[str, Any]:
+    return _service().read(refs, view, consistency, _principal.get())
+
+
+def submit(request: Mapping[str, Any]) -> dict[str, Any]:
+    return _service().submit(request, _principal.get())
+
+
+def decide(operation_id: str, decision: str, expected_revision: int) -> dict[str, Any]:
+    return _service().decide(operation_id, decision, expected_revision, _principal.get())
+
+
+def events(after_cursor: int = 0, filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return _service().events(after_cursor, filter or {}, _principal.get())
+
+
+def claim() -> dict[str, Any]:
+    return _service().claim(_principal.get())
+
+
+def receipt(operation_id: str, outcome: str, result_ref: str = "") -> dict[str, Any]:
+    return _service().receipt(operation_id, outcome, result_ref, _principal.get())
+
+
+def reconcile(operation_id: str) -> dict[str, Any]:
+    return _service().reconcile(operation_id, _principal.get())

--- a/holdspeak/kernel/tool_call.py
+++ b/holdspeak/kernel/tool_call.py
@@ -1,0 +1,144 @@
+"""Typed codec adapting the Phase-104 gate as ``decide``'s native record."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from ..db.gate import APPROVED, DENIED
+from ..operation_policy import describe_operation, resolve_policy
+from .model import Admission, KernelRefused, OperationRequest, forbidden_content
+
+_HASH = re.compile(r"^[0-9a-f]{64}$")
+_ALLOWED = frozenset({"proposal_id", "tool", "args_sha256", "args_head", "cwd", "ttl_seconds"})
+
+
+@dataclass(frozen=True)
+class ToolCallAdmission(Admission):
+    operation: Mapping[str, Any]
+    policy: Mapping[str, Any]
+
+
+class ToolCallCodec:
+    """The one reference type: a redacted tool-call hold in the existing gate."""
+
+    name = "tool.call"
+    version = 1
+
+    def __init__(self, gate: Any, mode_loader: Any) -> None:
+        self._gate = gate
+        self._mode_loader = mode_loader
+
+    def validate(self, request: OperationRequest) -> Admission:
+        args = request.arguments
+        if forbidden_content(args):
+            raise KernelRefused("journal_content_forbidden")
+        unknown = set(args) - _ALLOWED
+        if unknown:
+            raise KernelRefused("operation_field_not_allowed", sorted(unknown)[0])
+        proposal_id = str(args.get("proposal_id") or request.request_id).strip()
+        tool = str(args.get("tool") or "").strip()
+        args_hash = str(args.get("args_sha256") or "").lower()
+        if not proposal_id or not tool or not _HASH.fullmatch(args_hash):
+            raise KernelRefused("tool_call_prerequisite_failed")
+        try:
+            ttl = float(args.get("ttl_seconds") or 30.0)
+        except (TypeError, ValueError) as exc:
+            raise KernelRefused("tool_call_ttl_invalid") from exc
+        if ttl <= 0:
+            raise KernelRefused("tool_call_ttl_invalid")
+        material = {
+            "name": request.name,
+            "version": request.version,
+            "target_ref": request.target_ref,
+            "placement": request.placement,
+            "proposal_id": proposal_id,
+            "tool": tool,
+            "args_sha256": args_hash,
+        }
+        canonical = json.dumps(material, separators=(",", ":"), sort_keys=True)
+        payload_hash = "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+        refs = tuple(dict.fromkeys((*request.subject_refs, f"gate:{proposal_id}")))
+        return Admission(
+            target_ref=request.target_ref or f"gate:{proposal_id}",
+            placement=request.placement or "hub:local",
+            payload_hash=payload_hash,
+            refs=refs,
+            head=f"{tool} {str(args.get('args_head') or '')}"[:120],
+            ttl_seconds=ttl,
+            native_id=proposal_id,
+        )
+
+    def authorize(
+        self, request: OperationRequest, admission: Admission,
+        principal: Any, operation_id: str,
+    ) -> ToolCallAdmission:
+        args = request.arguments
+        descriptor = describe_operation(
+            operation_id=operation_id,
+            family="tool_gate",
+            effect_class="agent/tool_call_hold",
+            actor=principal.name,
+            destination=str(args.get("cwd") or "unknown_cwd"),
+            data_classes=("tool_arguments_redacted",),
+            resource_scope=str(args.get("tool") or ""),
+            fixed_destination=bool(args.get("cwd")),
+            consequence="execute_on_approval",
+        )
+        operation = descriptor.to_dict()
+        operation["kernel_operation_id"] = operation_id
+        operation["admitted_envelope_sha256"] = admission.payload_hash
+        return ToolCallAdmission(
+            **admission.__dict__,
+            operation=operation,
+            policy=resolve_policy(
+                descriptor, mode=self._mode_loader(), source="config"
+            ).to_dict(),
+        )
+
+    def admit(
+        self, request: OperationRequest, admission: ToolCallAdmission,
+        principal: Any, operation_id: str,
+    ) -> Any:
+        args = request.arguments
+        return self._gate.propose(
+            proposal_id=admission.native_id,
+            session_key=principal.identity,
+            agent=principal.name,
+            tool=str(args.get("tool") or ""),
+            args_sha256=str(args.get("args_sha256") or ""),
+            args_head=str(args.get("args_head") or ""),
+            cwd=str(args.get("cwd") or ""),
+            ttl_seconds=admission.ttl_seconds,
+            operation=dict(admission.operation),
+            policy_snapshot=dict(admission.policy),
+        )
+
+    def decide(self, native_id: str, decision: str, principal: Any, reason: str = "") -> Any:
+        native = APPROVED if decision == "approve" else DENIED
+        return self._gate.decide(
+            native_id, decision=native, decided_by=principal.identity, reason=reason or None
+        )
+
+    def read_native(self, native_id: str) -> dict[str, Any] | None:
+        value = self._gate.get(native_id)
+        return value.to_dict() if value is not None else None
+
+    def project_process(self, native_id: str, operation: Mapping[str, Any]) -> dict[str, Any]:
+        value = self._gate.get(native_id)
+        domain_state = value.state if value is not None else "unknown"
+        generic = {
+            "held": "waiting", "approved": "ended", "denied": "ended",
+            "expired": "failed", "invalidated": "failed",
+        }.get(domain_state, "unknown")
+        return {
+            "process_id": f"process:{operation['operation_id']}",
+            "kind": "tool_call_hold",
+            "principal": operation["principal_identity"],
+            "generic_state": generic,
+            "domain_state": domain_state,
+            "target_ref": operation["target_ref"],
+            "current_operation_id": operation["operation_id"],
+        }

--- a/holdspeak/principals.py
+++ b/holdspeak/principals.py
@@ -183,8 +183,14 @@ def required_right(method: str, path: str) -> Optional[PrincipalRight]:
         return None
     if path.startswith("/_built") or not path.startswith("/api/"):
         return None
-    if path.startswith("/api/delivery/node/"):
+    if path.startswith("/api/delivery/node/") or path.startswith("/api/kernel/executor/"):
         return PrincipalRight.NODE_LINK
+    if path == "/api/kernel/submit" and verb == "POST":
+        return PrincipalRight.AGENT_SUBMIT
+    if path == "/api/kernel/read" or path == "/api/kernel/events":
+        return PrincipalRight.AGENT_READ
+    if path.startswith("/api/kernel/operations/") and path.endswith("/decide"):
+        return PrincipalRight.DECIDE
     if path == "/api/gate/proposals" and verb == "POST":
         return PrincipalRight.AGENT_SUBMIT
     if path.startswith("/api/gate/proposals/") and path.endswith("/decide"):

--- a/holdspeak/web/routes/system/__init__.py
+++ b/holdspeak/web/routes/system/__init__.py
@@ -15,6 +15,7 @@ from .coder_steering_routes import build_coder_steering_router
 from .coders import build_coders_router
 from .gate_routes import build_gate_router
 from .health import build_health_router
+from .kernel_routes import build_kernel_router
 from .settings import build_settings_router
 from .voice import build_voice_router
 from .ws import build_ws_router
@@ -27,6 +28,7 @@ def build_system_router(ctx: WebContext) -> APIRouter:
     router.include_router(build_coders_router(ctx))
     router.include_router(build_coder_steering_router(ctx))
     router.include_router(build_gate_router(ctx))
+    router.include_router(build_kernel_router())
     router.include_router(build_settings_router(ctx))
     router.include_router(build_voice_router(ctx))
     router.include_router(build_ws_router(ctx))

--- a/holdspeak/web/routes/system/gate_routes.py
+++ b/holdspeak/web/routes/system/gate_routes.py
@@ -25,38 +25,16 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from ....agent_capabilities import Capability, require_capability
-from ....db.gate import (
-    APPROVED,
-    DENIED,
-    HELD,
-    GateArgsMismatchError,
-    GateStateError,
-)
+from ....db.gate import APPROVED, DENIED, HELD
+from .... import kernel
+from ....kernel.model import KernelRefused
+from ....kernel.runtime import _as_principal, _service
 from ....logging_config import get_logger
 from ...context import WebContext
 
 log = get_logger("web.routes.gate")
 
 _REASON_MAX_CHARS = 200
-
-
-def _policy(kind: str, *, tool: str, cwd: str) -> tuple[dict[str, Any], dict[str, Any]]:
-    from ....config import Config
-    from ....operation_policy import describe_operation, resolve_policy
-
-    operation = describe_operation(
-        operation_id=f"gate:{tool}:{kind}",
-        family="tool_gate",
-        effect_class="agent/tool_call_hold",
-        actor="agent",
-        destination=cwd or "unknown_cwd",
-        data_classes=("tool_arguments_redacted",),
-        resource_scope=tool,
-        fixed_destination=bool(cwd),
-        consequence="execute_on_approval",
-    )
-    decision = resolve_policy(operation, mode=Config.load().control_mode, source="config")
-    return operation.to_dict(), decision.to_dict()
 
 
 def build_gate_router(ctx: WebContext) -> APIRouter:
@@ -125,24 +103,31 @@ def build_gate_router(ctx: WebContext) -> APIRouter:
             from ....coder_gate import DEFAULT_TTL_SECONDS
 
             ttl = DEFAULT_TTL_SECONDS
-        operation, policy = _policy("propose", tool=tool, cwd=cwd)
         gate = get_database().gate
         gate.expire_due()
-        try:
-            principal = request.state.principal
-            proposal = gate.propose(
-                proposal_id=proposal_id,
-                session_key=principal.identity,
-                agent=principal.name,
-                tool=tool,
-                args_sha256=args_sha256,
-                args_head=str(body.get("args_head") or ""),
-                cwd=cwd,
-                ttl_seconds=ttl,
-                operation=operation,
-                policy_snapshot=policy,
+        principal = request.state.principal
+        with _as_principal(principal):
+            handle = kernel.submit(
+                {
+                    "request_schema": 1,
+                    "request_id": proposal_id,
+                    "idempotency_key": f"gate:{proposal_id}",
+                    "operation": {"name": "tool.call", "version": 1},
+                    "subject_refs": [],
+                    "target": {"ref": f"gate:{proposal_id}"},
+                    "arguments": {
+                        "proposal_id": proposal_id,
+                        "tool": tool,
+                        "args_sha256": args_sha256,
+                        "args_head": str(body.get("args_head") or ""),
+                        "cwd": cwd,
+                        "ttl_seconds": ttl,
+                    },
+                    "placement": "hub:local",
+                }
             )
-        except GateArgsMismatchError:
+        refusal_receipt = handle.get("receipt") or {}
+        if refusal_receipt.get("outcome") == "idempotency_payload_mismatch":
             return JSONResponse(
                 {
                     "error": "args_mismatch",
@@ -151,6 +136,9 @@ def build_gate_router(ctx: WebContext) -> APIRouter:
                 },
                 status_code=409,
             )
+        proposal = gate.get(proposal_id)
+        if proposal is None:
+            return JSONResponse(handle, status_code=409)
         return JSONResponse(_wire(proposal))
 
     @router.get("/api/gate/proposals/{proposal_id}")
@@ -195,25 +183,35 @@ def build_gate_router(ctx: WebContext) -> APIRouter:
             )
         reason = str(body.get("reason") or "").strip()[:_REASON_MAX_CHARS] or None
         gate = get_database().gate
-        try:
-            proposal = gate.decide(
-                proposal_id,
-                decision=decision,
-                decided_by=request.state.principal.identity,
-                reason=reason,
-            )
-        except KeyError:
+        proposal = gate.get(proposal_id)
+        if proposal is None:
             return JSONResponse({"error": "unknown_proposal"}, status_code=404)
-        except GateStateError as exc:
+        operation_id = str(proposal.operation.get("kernel_operation_id") or "")
+        if not operation_id:
+            return JSONResponse({"error": "proposal_not_kernel_admitted"}, status_code=409)
+        principal = request.state.principal
+        try:
+            with _as_principal(principal):
+                projected = kernel.read([f"operation:{operation_id}"], "state", "committed")
+                standing = projected["objects"][0]["operation"]
+                _service().decide(
+                    operation_id,
+                    "approve" if decision == APPROVED else "reject",
+                    int(standing["revision"]),
+                    principal,
+                    reason=reason or "",
+                )
+        except (KernelRefused, IndexError) as exc:
+            current = gate.get(proposal_id)
             return JSONResponse(
                 {
                     "error": "already_decided",
-                    "state": exc.current,
-                    "requested": exc.requested,
+                    "state": current.state if current is not None else "unknown",
+                    "requested": decision,
                 },
                 status_code=409,
             )
-        return JSONResponse(_wire(proposal))
+        return JSONResponse(_wire(gate.get(proposal_id)))
 
     @router.post("/api/gate/usage")
     async def api_gate_usage(request: Request) -> Any:
@@ -271,7 +269,11 @@ def invalidate_held_on_startup() -> int:
         reason="hub restarted while the proposal was held"
     )
     if flipped:
-        log.info(f"gate: invalidated {len(flipped)} held proposal(s) on startup")
+        recovered = _service().recover_invalidated(flipped)
+        log.info(
+            f"gate: invalidated {len(flipped)} held proposal(s) on startup; "
+            f"kernel terminalized {recovered}"
+        )
     return len(flipped)
 
 

--- a/holdspeak/web/routes/system/kernel_routes.py
+++ b/holdspeak/web/routes/system/kernel_routes.py
@@ -1,0 +1,121 @@
+"""HTTP transports for the kernel's four caller and three executor calls."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import JSONResponse
+
+from .... import kernel
+from ....kernel.model import KernelRefused
+from ....kernel.runtime import _as_principal
+
+
+def _refused(exc: KernelRefused) -> JSONResponse:
+    status = 403 if "principal" in exc.reason else 409
+    return JSONResponse(
+        {"error": exc.reason, "operation_id": exc.operation_id or None}, status_code=status
+    )
+
+
+def build_kernel_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/api/kernel/read")
+    async def api_kernel_read(
+        request: Request, refs: list[str] = Query(default=[]),
+        view: str = "state", consistency: str = "committed",
+    ) -> Any:
+        try:
+            with _as_principal(request.state.principal):
+                return JSONResponse(kernel.read(refs, view, consistency))
+        except KernelRefused as exc:
+            return _refused(exc)
+
+    @router.post("/api/kernel/submit")
+    async def api_kernel_submit(request: Request) -> Any:
+        body = await request.json()
+        try:
+            with _as_principal(request.state.principal):
+                return JSONResponse(kernel.submit(body), status_code=202)
+        except KernelRefused as exc:
+            return _refused(exc)
+
+    @router.post("/api/kernel/operations/{operation_id}/decide")
+    async def api_kernel_decide(operation_id: str, request: Request) -> Any:
+        body = await request.json()
+        if not isinstance(body, dict):
+            return JSONResponse({"error": "decision_body_malformed"}, status_code=400)
+        mutation = {"payload", "arguments", "target", "placement"}.intersection(body)
+        if mutation:
+            return JSONResponse(
+                {"error": "admitted_envelope_immutable", "fields": sorted(mutation)},
+                status_code=409,
+            )
+        unknown = set(body) - {"decision", "expected_revision"}
+        if unknown:
+            return JSONResponse(
+                {"error": "decision_field_not_allowed", "fields": sorted(unknown)},
+                status_code=400,
+            )
+        try:
+            revision = int(body.get("expected_revision"))
+            with _as_principal(request.state.principal):
+                return JSONResponse(
+                    kernel.decide(operation_id, str(body.get("decision") or ""), revision)
+                )
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "expected_revision_required"}, status_code=400)
+        except KernelRefused as exc:
+            return _refused(exc)
+
+    @router.get("/api/kernel/events")
+    async def api_kernel_events(
+        request: Request, after_cursor: int = 0, operation_id: str = "",
+        event_type: str = "", privacy_class: str = "", stream: str = "",
+    ) -> Any:
+        filters = {
+            key: value for key, value in {
+                "operation_id": operation_id, "event_type": event_type,
+                "privacy_class": privacy_class, "stream": stream,
+            }.items() if value
+        }
+        try:
+            with _as_principal(request.state.principal):
+                return JSONResponse(kernel.events(after_cursor, filters))
+        except KernelRefused as exc:
+            return _refused(exc)
+
+    @router.post("/api/kernel/executor/claim")
+    async def api_kernel_claim(request: Request) -> Any:
+        try:
+            with _as_principal(request.state.principal):
+                return JSONResponse(kernel.claim())
+        except KernelRefused as exc:
+            return _refused(exc)
+
+    @router.post("/api/kernel/executor/operations/{operation_id}/receipt")
+    async def api_kernel_receipt(operation_id: str, request: Request) -> Any:
+        body = await request.json()
+        if not isinstance(body, dict) or set(body) - {"outcome", "result_ref"}:
+            return JSONResponse({"error": "receipt_body_invalid"}, status_code=400)
+        try:
+            with _as_principal(request.state.principal):
+                return JSONResponse(
+                    kernel.receipt(
+                        operation_id, str(body.get("outcome") or ""),
+                        str(body.get("result_ref") or ""),
+                    )
+                )
+        except KernelRefused as exc:
+            return _refused(exc)
+
+    @router.get("/api/kernel/executor/operations/{operation_id}/reconcile")
+    async def api_kernel_reconcile(operation_id: str, request: Request) -> Any:
+        try:
+            with _as_principal(request.state.principal):
+                return JSONResponse(kernel.reconcile(operation_id))
+        except KernelRefused as exc:
+            return _refused(exc)
+
+    return router

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -5,27 +5,26 @@
 > evidence, no `Co-Authored-By`, metal-test exclusion).
 
 **Last updated:** 2026-07-26 — **Phase 106 (The Kernel) ACTIVE,
-2/10 — both §8 prerequisites landed**. **HS-106-02 principal
-separation**: loopback has lost all request-authority work. HTTP and
-WebSocket derive typed owner, agent, and node principals from distinct
-credentials; agent identity is minted at spawn / SessionStart, expires,
-revokes at SessionEnd or factory kill, and rotates on respawn.
-`decide`, posture, and delegation close at the edge by principal
-right; gate and authority records no longer trust caller actor/session
-labels. The owner's first load stays invisible-auth via a tokenized URL
-captured and scrubbed by the Desk. Proven by a real `claude -p` process
-against a real hub (proposal 200, decision 403 named `agent` +
-`decide`), a 1440/393 screenshot walk, and 4,231 passing tests.
-**HS-106-03** turned Article XI's migration debt register into
-checked-in law and an executable fence — exactly 40 static effect
-statements, 4 covered and 36 not, with additions and removals named by
-file:line and family. Import origins survive from-imports, renamed
-imports, module aliases, and callable aliases across all five families
-(a review pass caught and closed the from-import evasion). The empty
-broker field is already bounded by a 300-line module budget and a zero
-driver-specific conditional census; mutations proved every fence fails
-loudly, and no effect site was rerouted. The broker spine (HS-106-04)
-is unblocked. Earlier: **Phase 106 chartered** from the owner's web-OS
+3/10 — HS-106-04 shipped the spine**. `holdspeak/kernel/` now exposes
+exactly four caller calls (`read`, `submit`, `decide`, `events`) plus the
+separate `claim` / `receipt` / `reconcile` executor plane. The existing
+Phase-104 gate is the one native decision record behind `decide`; there
+is no rival approval surface. Authority resolves once in four ordered
+layers and rides as an expiring, revocable, one-use warrant bound to the
+immutable envelope hash, target, and placement. Lifecycle facts land in
+a durable per-stream SHA-256 chain containing refs, hashes, and bounded
+heads, while canonical domain records remain authoritative. A real
+spawned hub proved refusal receipt → owner decision → node claim →
+terminal receipt, agent decision refusal, immutable payload/target/
+placement, and real SIGKILL restart with byte-equal cursor replay plus
+an honest indeterminate recovery receipt. Density and tamper mutations
+failed by name, then restored green; every broker module remains under
+the unchanged 300-line cap with zero driver-specific conditionals.
+Final kernel/gate/schema proof: 64 passed. The exact full suite recorded
+4,245 passed / 41 skipped / 1 pre-existing unrelated UAT wording
+failure, documented in the story. Earlier: **HS-106-02 and HS-106-03
+landed both §8 prerequisites** — typed principals on loopback and the
+40-site effect census as executable law. Earlier: **Phase 106 chartered** from the owner's web-OS
 charge, with Article XI's migration provision and council dissent on
 record. Earlier: **Phase 104 (Borrowed Fire II)
 CLOSED 8/8, all in one day**: the ledger, the fail-closed gate, the
@@ -196,7 +195,7 @@ the ⌘K shelf's z-defect fixed; the owner's 101 sitting remains open in
 parallel. Phase 101 itself stands at 3/4 (canon ratified and built,
 PR #359; sweep 4122/0).
 
-**Current phase:** [**Phase 106 — The Kernel**](./phase-106-the-kernel/current-phase-status.md) — **ACTIVE (0/10, chartered 2026-07-26)**: the RFC's strangler ladder as a phase — Article XI with the owner's migration provision, principal separation on loopback (the confused deputy), the 40-site effect census pinned as a test, the broker and hash-chained journal behind four calls (`read`/`submit`/`decide`/`events`), three HETEROGENEOUS driver slices (terminal input → actuator egress → inference runs) with the kill criterion applied for real at the third, and then the first §9 userland program: **PR follow-through** — see the PR that needs you, decide once, send a scoped agent at it, propose the comment, and get a receipt for every consequence. The fourth council pass (Sol) returned **do not ratify yet** with file-level evidence; its rewritten clauses 1-5 were adopted, the drafted clause 6 deleted, and the owner ruled to ratify early behind a temporary migration provision that names the unmigrated paths as declared debt and forbids agent access to them. Previous: [**Phase 104 — Borrowed Fire II**](./phase-104-borrowed-fire-ii/current-phase-status.md), **CLOSED (8/8, 2026-07-26)** — built, walked, ridden (HS-104-08, the icon reforge the sitting chartered), and accepted the same day ("Yup. Better. Let's close out the phase."). Previous: [Phase 105 — Workbench](./phase-105-workbench/current-phase-status.md), **CLOSED (7/7, 2026-07-26)** — the owner's acceptance carried the standing rider that 104 and the kernel are the "actual OS" program. Previous: [Phase 103 — Foundations & Borrowed Fire](./phase-103-foundations-and-borrowed-fire/current-phase-status.md) — **CLOSED (7/7, 2026-07-25)**.
+**Current phase:** [**Phase 106 — The Kernel**](./phase-106-the-kernel/current-phase-status.md) — **ACTIVE (3/10, chartered 2026-07-26)**: the RFC's strangler ladder as a phase — Article XI with the owner's migration provision, principal separation on loopback (the confused deputy), the 40-site effect census pinned as a test, the broker and hash-chained journal behind four calls (`read`/`submit`/`decide`/`events`), three HETEROGENEOUS driver slices (terminal input → actuator egress → inference runs) with the kill criterion applied for real at the third, and then the first §9 userland program: **PR follow-through** — see the PR that needs you, decide once, send a scoped agent at it, propose the comment, and get a receipt for every consequence. The fourth council pass (Sol) returned **do not ratify yet** with file-level evidence; its rewritten clauses 1-5 were adopted, the drafted clause 6 deleted, and the owner ruled to ratify early behind a temporary migration provision that names the unmigrated paths as declared debt and forbids agent access to them. Previous: [**Phase 104 — Borrowed Fire II**](./phase-104-borrowed-fire-ii/current-phase-status.md), **CLOSED (8/8, 2026-07-26)** — built, walked, ridden (HS-104-08, the icon reforge the sitting chartered), and accepted the same day ("Yup. Better. Let's close out the phase."). Previous: [Phase 105 — Workbench](./phase-105-workbench/current-phase-status.md), **CLOSED (7/7, 2026-07-26)** — the owner's acceptance carried the standing rider that 104 and the kernel are the "actual OS" program. Previous: [Phase 103 — Foundations & Borrowed Fire](./phase-103-foundations-and-borrowed-fire/current-phase-status.md) — **CLOSED (7/7, 2026-07-25)**.
 — **IN PROGRESS (0/6)**. Chartered 2026-07-22 from a four-agent
 research pass (3 independent Opus 4.8 analysts on
 `ViuGiaLai/researchmind`, 1 independent Opus 4.8 skeptical audit of

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
@@ -1,6 +1,6 @@
 # Phase 106 - The Kernel
 
-**Status:** ACTIVE (1/10). Chartered 2026-07-26 from
+**Status:** ACTIVE (3/10). Chartered 2026-07-26 from
 [`PLAN_KERNEL_OPERATION_BROKER.md`](../../../docs/internal/PLAN_KERNEL_OPERATION_BROKER.md)
 (the RFC, three council passes) and the owner's direct charge:
 
@@ -11,7 +11,7 @@
 > records decisions and then creates artifacts out of those
 > decisions and meetings."
 
-**Last updated:** 2026-07-26 (HS-106-02 and HS-106-03 shipped; 2/10).
+**Last updated:** 2026-07-26 (HS-106-04 shipped; 3/10).
 
 ## Why this phase exists
 
@@ -110,7 +110,7 @@ receipt for every consequence.
 | HS-106-01 | Article XI ratified, with the migration provision | ready | [story-01-article-xi](./story-01-article-xi.md) | — |
 | HS-106-02 | Principal separation on loopback | done | [story-02-principals](./story-02-principals.md) | [evidence-story-02](./evidence-story-02.md) |
 | HS-106-03 | The effect census, pinned as a test | done | [story-03-census-test](./story-03-census-test.md) | [evidence-story-03](./evidence-story-03.md) |
-| HS-106-04 | The broker and the journal — four calls | ready | [story-04-broker-journal](./story-04-broker-journal.md) | — |
+| HS-106-04 | The broker and the journal — four calls | done | [story-04-broker-journal](./story-04-broker-journal.md) | [evidence-story-04](./evidence-story-04.md) |
 | HS-106-05 | Thin slice I — terminal input | ready | [story-05-slice-terminal](./story-05-slice-terminal.md) | — |
 | HS-106-06 | Thin slice II — actuator egress | ready | [story-06-slice-actuator](./story-06-slice-actuator.md) | — |
 | HS-106-07 | Thin slice III — inference, and the kill criterion | ready | [story-07-slice-inference-kill](./story-07-slice-inference-kill.md) | — |
@@ -168,6 +168,26 @@ pretending.
   three thinly.
 
 ## Where we are
+
+**2026-07-26 — HS-106-04 shipped, 3/10.** The kernel spine now has
+exactly four caller calls (`read`, `submit`, `decide`, `events`) and the
+separate `claim` / `receipt` / `reconcile` executor plane. One trusted
+startup codec adapts the existing Phase-104 gate rather than creating a
+second decision state machine. Admission derives authority in four
+ordered layers and approval mints an expiring, revocable, one-use
+warrant bound to the immutable envelope hash, target, and placement.
+The durable lifecycle journal carries only refs, hashes, and bounded
+heads on a per-stream SHA-256 chain; canonical gate state and process
+state remain native-backed projections. Real HTTP against a spawned hub
+proved refusal receipts, agent decision refusal, immutable decisions,
+claim and terminal receipt, then real SIGKILL restart with byte-equal
+cursor replay and an honest indeterminate recovery receipt. Tamper,
+driver-conditional, and line-budget mutations all failed by name and
+returned green after restore. Final kernel/gate/schema proof: 64 passed.
+The exact full suite completed 4,245 passed / 41 skipped / 1 pre-existing
+unrelated UAT wording failure, documented in the story and evidence.
+HS-106-05 is next: the terminal slice must lean on this spine without
+adding a driver conditional.
 
 **2026-07-26 — HS-106-02 shipped, 2/10.** Loopback is no longer an
 authority signal. The HTTP and WebSocket doors derive typed `owner`,

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-04.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-04.md
@@ -1,0 +1,709 @@
+# Evidence - HS-106-04
+
+- **Story:** HS-106-04 - The broker and the journal — four calls
+- **Status:** done
+- **Date:** 2026-07-26
+
+## Proof
+
+### Captured run — 2026-07-27T02:26:49Z
+
+- **Command:** `uv run pytest -q -s tests/unit/test_kernel_broker.py tests/unit/test_kernel_effect_fence.py tests/unit/test_coder_gate.py tests/integration/test_gate_threat_model.py tests/integration/test_kernel_real_hub.py tests/unit/test_api_surface.py tests/unit/test_db_schema_policy.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 05c8a4f52b91fe70133736fffbdd7b95118482bf
+
+```text
+...{"tamper":"journal_record_hash_mismatch","restored":"ok"}
+..............................................{"agent_decide": "principal_right_required", "claim": "claimed", "cursor_replay_same": true, "immutable": "admitted_envelope_immutable", "receipt": "succeeded", "recovered": "hub_restart_during_decision", "refusal_receipt": "journal_content_forbidden", "sigkill": -9, "submit": "awaiting_decision"}
+..............
+63 passed in 14.04s
+```
+
+### Captured run — 2026-07-27T02:27:46Z
+
+- **Command:** `bash /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/kernel_guard_mutations.sh`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 05c8a4f52b91fe70133736fffbdd7b95118482bf
+
+```text
+CONDITIONAL MUTATION NAMED: E           driver-specific conditional in broker module: holdspeak/kernel/broker.py:297 (if dispatch)
+LINE MUTATION NAMED: E           kernel broker module over 300-line budget: holdspeak/kernel/broker.py: 316 lines
+..                                                                       [100%]
+2 passed in 0.05s
+```
+
+### Captured run — 2026-07-27T02:28:08Z
+
+- **Command:** `bash -c set -o pipefail; uv run pytest -q --ignore=tests/e2e/test_metal.py 2>&1 | tee /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/full-final.txt`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 05c8a4f52b91fe70133736fffbdd7b95118482bf
+
+```text
+ssssssssssssssssssssssssssssssss........................................ [  1%]
+........................................................................ [  3%]
+.s...................................................................... [  5%]
+..............................................................ss........ [  6%]
+........................................................................ [  8%]
+........................................................................ [ 10%]
+........................................................................ [ 11%]
+........................................................................ [ 13%]
+........................................................................ [ 15%]
+........................................................................ [ 16%]
+........................................................................ [ 18%]
+........................................................F...F.......F... [ 20%]
+........F............................................................... [ 21%]
+............F........................................................... [ 23%]
+........................................................................ [ 25%]
+........................................................................ [ 26%]
+........................................................................ [ 28%]
+........................................................................ [ 30%]
+........................................................................ [ 31%]
+........................................................................ [ 33%]
+........................................................................ [ 35%]
+........................................................................ [ 36%]
+........................................................................ [ 38%]
+........................................................................ [ 40%]
+.................................................................F...... [ 42%]
+........................................................................ [ 43%]
+........................................................................ [ 45%]
+........................................................................ [ 47%]
+........................................................................ [ 48%]
+........................................................................ [ 50%]
+........................................................................ [ 52%]
+........................................................................ [ 53%]
+........................................................................ [ 55%]
+.................s...................................................... [ 57%]
+........................................................................ [ 58%]
+........................................................................ [ 60%]
+........................................................................ [ 62%]
+........................................................................ [ 63%]
+........................................................................ [ 65%]
+........................................................................ [ 67%]
+........................................................................ [ 68%]
+........................................................................ [ 70%]
+........................................................................ [ 72%]
+........................................................................ [ 73%]
+........................................................................ [ 75%]
+........................................................................ [ 77%]
+........................................................................ [ 79%]
+........................................................................ [ 80%]
+........................................................................ [ 82%]
+........................................................................ [ 84%]
+........................................................................ [ 85%]
+........................................................................ [ 87%]
+........................................................................ [ 89%]
+........................................................................ [ 90%]
+........................................................................ [ 92%]
+........................................................................ [ 94%]
+........................................................................ [ 95%]
+........................................................................ [ 97%]
+........................................................................ [ 99%]
+..................................                                       [100%]
+=================================== FAILURES ===================================
+________________ test_meeting_recipe_yields_a_real_open_action _________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x1341f2df0>
+
+    def test_meeting_recipe_yields_a_real_open_action(real_manager):
+        run = _boot_or_skip(real_manager, "golden-43")
+>       result = real_manager.apply_recipe(run.id, "meeting-just-ended-open-actions")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_43.py:52: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x133cf5c10>
+name = 'meeting-just-ended-open-actions', run_id = 'run-20260727T023218-48ccf2'
+host = <uat.conductor.runs.RunManager object at 0x1341f2df0>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+    
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+    
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+    
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+    
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+    
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+    
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+    
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'meeting-just-ended-open-actions' failed to verify: meeting_with_open_actions: timed out after 180s: meetings present but none with ≥1 open actions: Pylon incident war room (UAT seed)(0,queued)
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+__________________ test_intel_endpoint_dead_degrades_honestly __________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x13306b2f0>
+
+    def test_intel_endpoint_dead_degrades_honestly(real_manager):
+        run = _boot_or_skip(real_manager)
+>       result = real_manager.apply_recipe(run.id, "intel-endpoint-dead")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_local.py:73: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x13478e7b0>
+name = 'intel-endpoint-dead', run_id = 'run-20260727T024031-e076f8'
+host = <uat.conductor.runs.RunManager object at 0x13306b2f0>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+    
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+    
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+    
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+    
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+    
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+    
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+    
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'intel-endpoint-dead' failed to verify: runtime_endpoint_unreachable: runtime-test ok=False status='unavailable' in 0.0s: Backend 'openai_compatible' requires the 'openai' package. Install with: uv pip install holdspeak[dictation-openai]
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+______________ test_run_dispatched_onto_the_worker_returns_badged ______________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x133113070>
+
+    def test_run_dispatched_onto_the_worker_returns_badged(real_manager):
+        run = _boot_or_skip(real_manager, "mesh-node")
+    
+>       result = real_manager.apply_recipe(run.id, "mesh-run-on-worker")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_mesh_dispatch.py:55: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x10fc87d70>
+name = 'mesh-run-on-worker', run_id = 'run-20260727T024036-0b8947'
+host = <uat.conductor.runs.RunManager object at 0x133113070>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+    
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+    
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+    
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+    
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+    
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+    
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+    
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'mesh-run-on-worker' failed to verify: run_returned_badged: dispatch failed HTTP 502: None; run_claimed_by_worker: worker claims 0→1 (moved=True); hub provider='' scope='' (no-local=False); run_output_contains: output MISSING 'PYLON-CANARY-7' (0 chars)
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+__________________________ test_pack_d_stages_locally __________________________
+
+real_client = <starlette.testclient.TestClient object at 0x13402fe70>
+
+    def test_pack_d_stages_locally(real_client):
+        """Pack D demos without the LAN: its bad-endpoint scenario stages + verifies."""
+        created = real_client.post("/api/sittings", json={"pack": "pack-d-honest-failure"}).json()
+        if created["run"] is None or created["run"]["status"] != "up":
+            pytest.skip("product did not boot")
+        sid = created["id"]
+        # Stage the dead-endpoint scenario (fully local — port 9 refused).
+        staged = real_client.post(f"/api/sittings/{sid}/stage", json={"scenario_id": "d-dead-endpoint-doctor"}).json()
+>       assert staged["ok"], staged
+E       AssertionError: {'ok': False, 'scenario_id': 'd-dead-endpoint-doctor', 'staging': [{'error': "recipe 'intel-endpoint-dead' failed to v...--no-open`): browser auto-open disabled.
+E         Press Ctrl+C to stop.'}, 'ok': False, 'recipe': 'intel-endpoint-dead', ...}]}
+E       assert False
+
+tests/uat/test_packs.py:180: AssertionError
+_________________ test_transcribe_up_but_unreachable_is_honest _________________
+
+client = <starlette.testclient.TestClient object at 0x133f8e7b0>
+
+    def test_transcribe_up_but_unreachable_is_honest(client):
+        # Fake product reports 'up' but nothing actually serves the transcribe route,
+        # so the proxy honestly reports it could not reach the product — never fakes.
+        sid = client.post("/api/sittings", json={"pack": "smoke"}).json()["id"]
+        r = client.post(f"/api/sittings/{sid}/transcribe", content=_silence_wav())
+        body = r.json()
+        assert body["ok"] is False
+>       assert "reach" in body["error"].lower() or "not up" in body["error"].lower()
+E       AssertionError: assert ('reach' in 'transcribe failed (http 502).' or 'not up' in 'transcribe failed (http 502).')
+E        +  where 'transcribe failed (http 502).' = <built-in method lower of str object at 0x133c393e0>()
+E        +    where <built-in method lower of str object at 0x133c393e0> = 'Transcribe failed (HTTP 502).'.lower
+E        +  and   'transcribe failed (http 502).' = <built-in method lower of str object at 0x133c393e0>()
+E        +    where <built-in method lower of str object at 0x133c393e0> = 'Transcribe failed (HTTP 502).'.lower
+
+tests/uat/test_voice_notes.py:52: AssertionError
+________ TestDatabaseShape.test_fresh_schema_matches_canonical_snapshot ________
+
+self = <tests.unit.test_db.TestDatabaseShape object at 0x10dbc4410>
+tmp_path = PosixPath('/private/var/folders/q7/5dzz5g2116b3lq8rhg7hwjrr0000gn/T/pytest-of-karol/pytest-449/test_fresh_schema_matches_cano0')
+project_root = PosixPath('/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc')
+
+    def test_fresh_schema_matches_canonical_snapshot(self, tmp_path, project_root: Path):
+        """HS-31-04: the migration ladder was squashed to one canonical schema.
+        A fresh build must match the committed snapshot exactly — any intended
+        schema change must update tests/fixtures/db_schema_canonical.txt in the
+        same commit, keeping the schema honest without a version ladder."""
+        import re
+        import sqlite3
+        from holdspeak.db import Database
+    
+        Database(tmp_path / "schema_check.db")
+        conn = sqlite3.connect(str(tmp_path / "schema_check.db"))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT type, name, sql FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        ).fetchall()
+        actual = "\n".join(
+            f"{r['type']} {r['name']}: {re.sub(r'\\s+', ' ', (r['sql'] or '').strip())}"
+            for r in rows
+ 
+[PMO_EVIDENCE_OUTPUT_TRUNCATED]
+```
+
+### Captured run — 2026-07-27T03:18:09Z
+
+- **Command:** `bash -c set -o pipefail; uv run pytest -q --ignore=tests/e2e/test_metal.py 2>&1 | tee /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/full-final-executor-split.txt`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 05c8a4f52b91fe70133736fffbdd7b95118482bf
+
+```text
+ssssssssssssssssssssssssssssssss........................................ [  1%]
+........................................................................ [  3%]
+.s...................................................................... [  5%]
+..............................................................ss........ [  6%]
+........................................................................ [  8%]
+........................................................................ [ 10%]
+........................................................................ [ 11%]
+........................................................................ [ 13%]
+........................................................................ [ 15%]
+........................................................................ [ 16%]
+........................................................................ [ 18%]
+........................................................................ [ 20%]
+........................................................................ [ 21%]
+............F........................................................... [ 23%]
+........................................................................ [ 25%]
+........................................................................ [ 26%]
+........................................................................ [ 28%]
+........................................................................ [ 30%]
+........................................................................ [ 31%]
+........................................................................ [ 33%]
+........................................................................ [ 35%]
+........................................................................ [ 36%]
+........................................................................ [ 38%]
+........................................................................ [ 40%]
+........................................................................ [ 42%]
+........................................................................ [ 43%]
+........................................................................ [ 45%]
+........................................................................ [ 47%]
+........................................................................ [ 48%]
+........................................................................ [ 50%]
+........................................................................ [ 52%]
+........................................................................ [ 53%]
+........................................................................ [ 55%]
+.................s...................................................... [ 57%]
+........................................................................ [ 58%]
+........................................................................ [ 60%]
+........................................................................ [ 62%]
+........................................................................ [ 63%]
+........................................................................ [ 65%]
+........................................................................ [ 67%]
+........................................................................ [ 68%]
+........................................................................ [ 70%]
+........................................................................ [ 72%]
+........................................................................ [ 73%]
+........................................................................ [ 75%]
+........................................................................ [ 77%]
+........................................................................ [ 79%]
+........................................................................ [ 80%]
+........................................................................ [ 82%]
+........................................................................ [ 84%]
+........................................................................ [ 85%]
+........................................................................ [ 87%]
+........................................................................ [ 89%]
+........................................................................ [ 90%]
+........................................................................ [ 92%]
+........................................................................ [ 94%]
+........................................................................ [ 95%]
+........................................................................ [ 97%]
+........................................................................ [ 99%]
+..................................                                       [100%]
+=================================== FAILURES ===================================
+_________________ test_transcribe_up_but_unreachable_is_honest _________________
+
+client = <starlette.testclient.TestClient object at 0x1375b1550>
+
+    def test_transcribe_up_but_unreachable_is_honest(client):
+        # Fake product reports 'up' but nothing actually serves the transcribe route,
+        # so the proxy honestly reports it could not reach the product — never fakes.
+        sid = client.post("/api/sittings", json={"pack": "smoke"}).json()["id"]
+        r = client.post(f"/api/sittings/{sid}/transcribe", content=_silence_wav())
+        body = r.json()
+        assert body["ok"] is False
+>       assert "reach" in body["error"].lower() or "not up" in body["error"].lower()
+E       AssertionError: assert ('reach' in 'transcribe failed (http 502).' or 'not up' in 'transcribe failed (http 502).')
+E        +  where 'transcribe failed (http 502).' = <built-in method lower of str object at 0x137b9f3c0>()
+E        +    where <built-in method lower of str object at 0x137b9f3c0> = 'Transcribe failed (HTTP 502).'.lower
+E        +  and   'transcribe failed (http 502).' = <built-in method lower of str object at 0x137b9f3c0>()
+E        +    where <built-in method lower of str object at 0x137b9f3c0> = 'Transcribe failed (HTTP 502).'.lower
+
+tests/uat/test_voice_notes.py:52: AssertionError
+=============================== warnings summary ===============================
+tests/integration/test_web_transcript_import_api.py::test_txt_upload_uses_the_transcript_fallback_speaker
+  /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/.venv/lib/python3.13/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread meeting-import-5adad37a
+  
+  Traceback (most recent call last):
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/web/routes/meeting_import.py", line 95, in _run_import_job
+      import_transcript(
+      ~~~~~~~~~~~~~~~~~^
+          tmp_path,
+          ^^^^^^^^^
+      ...<6 lines>...
+          started_at=started_at,
+          ^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/meeting_import.py", line 395, in import_transcript
+      return _persist_import(
+          db=db,
+      ...<8 lines>...
+          speakers_found=parsed.speakers_found,
+      )
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/meeting_import.py", line 325, in _persist_import
+      db.intel.enqueue_intel_job(
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~^
+          state.id,
+          ^^^^^^^^^
+          transcript_hash=state.transcript_hash(),
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          reason=state.intel_status_detail,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/db/intel.py", line 35, in enqueue_intel_job
+      with self._connection() as conn:
+           ~~~~~~~~~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.13.11-macos-aarch64-none/lib/python3.13/contextlib.py", line 148, in __exit__
+      next(self.gen)
+      ~~~~^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/db/core.py", line 1447, in _connection
+      conn.commit()
+      ~~~~~~~~~~~^^
+  sqlite3.OperationalError: disk I/O error
+  
+  During handling of the above exception, another exception occurred:
+  
+  Traceback (most recent call last):
+    File "/Users/karol/.local/share/uv/python/cpython-3.13.11-macos-aarch64-none/lib/python3.13/threading.py", line 1044, in _bootstrap_inner
+      self.run()
+      ~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.13.11-macos-aarch64-none/lib/python3.13/threading.py", line 995, in run
+      self._target(*self._args, **self._kwargs)
+      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/web/routes/meeting_import.py", line 136, in _run_import_job
+      _set_import_status(
+      ~~~~~~~~~~~~~~~~~~^
+          db, meeting_id, "import_failed", f"{type(exc).__name__}: {exc}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/web/routes/meeting_import.py", line 72, in _set_import_status
+      state = db.meetings.get_meeting(meeting_id)
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/db/meetings.py", line 440, in get_meeting
+      row = conn.execute(
+            ~~~~~~~~~~~~^
+          "SELECT * FROM meetings WHERE id = ?", (meeting_id,)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).fetchone()
+      ^
+  sqlite3.OperationalError: no such table: meetings
+  
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+
+tests/integration/test_web_transcript_import_api.py::test_garbage_transcript_marks_the_row_honestly_and_is_removable
+  /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/.venv/lib/python3.13/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread meeting-import-7b32b5cb
+  
+  Traceback (most recent call last):
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/web/routes/meeting_import.py", line 95, in _run_import_job
+      import_transcript(
+      ~~~~~~~~~~~~~~~~~^
+          tmp_path,
+          ^^^^^^^^^
+      ...<6 lines>...
+          started_at=started_at,
+          ^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/meeting_import.py", line 395, in import_transcript
+      return _persist_import(
+          db=db,
+      ...<8 lines>...
+          speakers_found=parsed.speakers_found,
+      )
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/meeting_import.py", line 325, in _persist_import
+      db.intel.enqueue_intel_job(
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~^
+          state.id,
+          ^^^^^^^^^
+          transcript_hash=state.transcript_hash(),
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          reason=state.intel_status_detail,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/db/intel.py", line 35, in enqueue_intel_job
+      with self._connection() as conn:
+           ~~~~~~~~~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.13.11-macos-aarch64-none/lib/python3.13/contextlib.py", line 148, in __exit__
+      next(self.gen)
+      ~~~~^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/db/core.py", line 1447, in _connection
+      conn.commit()
+      ~~~~~~~~~~~^^
+  sqlite3.OperationalError: disk I/O error
+  
+  During handling of the above exception, another exception occurred:
+  
+  Traceback (most recent call last):
+    File "/Users/karol/.local/share/uv/python/cpython-3.13.11-macos-aarch64-none/lib/python3.13/threading.py", line 1044, in _bootstrap_inner
+      self.run()
+      ~~~~~~~~^^
+    File "/Users/karol/.local/share/uv/python/cpython-3.13.11-macos-aarch64-none/lib/python3.13/threading.py", line 995, in run
+      self._target(*self._args, **self._kwargs)
+      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/web/routes/meeting_import.py", line 136, in _run_import_job
+      _set_import_status(
+      ~~~~~~~~~~~~~~~~~~^
+          db, meeting_id, "import_failed", f"{type(exc).__name__}: {exc}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      )
+      ^
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/web/routes/meeting_import.py", line 72, in _set_import_status
+      state = db.meetings.get_meeting(meeting_id)
+    File "/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/holdspeak/db/meetings.py", line 440, in get_meeting
+      row = conn.execute(
+            ~~~~~~~~~~~~^
+          "SELECT * FROM meetings WHERE id = ?", (meeting_id,)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).fetchone()
+      ^
+  sqlite3.OperationalError: no such table: meetings
+  
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+SKIPPED [1] tests/e2e/test_dictation_learning_digest_spoken_e2e.py:33: opt-in: set HOLDSPEAK_SPOKEN_DICTATION_E2E=1 to run the spoken-dictation learning-digest e2e (uses macOS `say` + the Whisper base model)
+SKIPPED [1] tests/e2e/test_live_bus.py:24: needs Playwright + a browser
+SKIPPED [1] tests/e2e/test_route_preflight.py:26: pre-flight needs Playwright + a browser
+SKIPPED [1] tests/e2e/test_spoken_meeting_e2e.py:41: opt-in: set HOLDSPEAK_SPOKEN_E2E=1 to run the spoken-meeting e2e
+SKIPPED [1] tests/unit/test_mesh_discovery.py:21: could not import 'zeroconf': No module named 'zeroconf'
+SKIPPED [1] tests/e2e/test_dictation_enrichment_e2e.py:57: set HOLDSPEAK_DICTATION_E2E_BASE_URL + HOLDSPEAK_DICTATION_E2E_MODEL to a reachable OpenAI-compatible endpoint to run the real dictation enrichment e2e
+SKIPPED [1] tests/e2e/test_dictation_journal_e2e.py:57: set HOLDSPEAK_DICTATION_E2E_BASE_URL + HOLDSPEAK_DICTATION_E2E_MODEL to a reachable OpenAI-compatible endpoint to run the real dictation journal e2e
+SKIPPED [1] tests/e2e/test_dogfood_plumbing_e2e.py:44: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [3] tests/e2e/test_dogfood_plumbing_e2e.py:52: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [12] tests/e2e/test_dogfood_plumbing_e2e.py:66: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [1] tests/e2e/test_dogfood_plumbing_e2e.py:85: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [3] tests/e2e/test_dogfood_plumbing_e2e.py:95: set HOLDSPEAK_DOGFOOD=1 to run the dogfood plumbing e2e
+SKIPPED [10] tests/e2e/test_meeting_transcription.py: Mock meeting fixture not found: /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-a2198eebd38f826cc/tests/fixtures/mock_meeting.wav
+SKIPPED [1] tests/integration/test_dictation_llama_cpp_e2e.py:72: llama-cpp-python and /Users/karol/Models/gguf/Qwen3.5-4B-Instruct-Q4_K_M.gguf are required for this integration test
+SKIPPED [1] tests/integration/test_runtime_llama_cpp.py:38: llama-cpp-python and /Users/karol/Models/gguf/Qwen3.5-4B-Instruct-Q4_K_M.gguf are required for this integration test
+SKIPPED [1] tests/integration/test_runtime_mlx.py:38: mlx-lm + outlines + /Users/karol/Models/mlx/Qwen3.5-8B-MLX-4bit are required for this integration test
+SKIPPED [1] tests/unit/test_dictation_grammars.py:91: could not import 'llama_cpp': No module named 'llama_cpp'
+FAILED tests/uat/test_voice_notes.py::test_transcribe_up_but_unreachable_is_honest
+1 failed, 4245 passed, 41 skipped, 2 warnings in 885.73s (0:14:45)
+```
+
+### Captured run — 2026-07-27T03:33:14Z
+
+- **Command:** `uv run pytest -q -s tests/unit/test_kernel_broker.py tests/unit/test_kernel_effect_fence.py tests/unit/test_coder_gate.py tests/integration/test_gate_threat_model.py tests/integration/test_kernel_real_hub.py tests/unit/test_api_surface.py tests/unit/test_db_schema_policy.py tests/unit/test_db.py::TestDatabaseShape::test_fresh_schema_matches_canonical_snapshot`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 05c8a4f52b91fe70133736fffbdd7b95118482bf
+
+```text
+...{"tamper":"journal_record_hash_mismatch","restored":"ok"}
+..............................................{"agent_decide": "principal_right_required", "claim": "claimed", "cursor_replay_same": true, "immutable": "admitted_envelope_immutable", "receipt": "succeeded", "recovered": "hub_restart_during_decision", "refusal_receipt": "journal_content_forbidden", "sigkill": -9, "submit": "awaiting_decision"}
+...............
+64 passed in 14.01s
+```
+
+### Captured run — 2026-07-27T03:33:53Z
+
+- **Command:** `bash /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/kernel_guard_mutations.sh`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 05c8a4f52b91fe70133736fffbdd7b95118482bf
+
+```text
+CONDITIONAL MUTATION NAMED: E           driver-specific conditional in broker module: holdspeak/kernel/broker.py:226 (if dispatch)
+LINE MUTATION NAMED: E           kernel broker module over 300-line budget: holdspeak/kernel/broker.py: 325 lines
+..                                                                       [100%]
+2 passed in 0.32s
+```

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/story-04-broker-journal.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/story-04-broker-journal.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 106
-- **Status:** ready
+- **Status:** done
 - **Depends on:** HS-106-01, HS-106-02, HS-106-03
 - **Unblocks:** HS-106-05, HS-106-06, HS-106-07
 - **Owner:** unassigned
@@ -145,6 +145,19 @@ receipts do not compose.
 - **Restart (evidence):** SIGKILL mid-operation, restart, cursor
   replay, and the operation's honest state on recovery.
 - **Full suite:** `uv run pytest -q --ignore=tests/e2e/test_metal.py`.
+
+### Verification note — 2026-07-26
+
+The exact full-suite command completed with **4,245 passed, 41 skipped,
+1 failed**. The sole failure is pre-existing and outside this story's
+changed surface: `tests/uat/test_voice_notes.py::
+test_transcribe_up_but_unreachable_is_honest` receives the honest
+`Transcribe failed (HTTP 502).` response but its assertion accepts only
+wording containing `reach` or `not up`. It reproduces standalone; no UAT
+proxy or voice-note code changed here. The final kernel/gate/schema proof
+set is **64 passed**, including real HTTP, SIGKILL restart, mutation,
+warrant, receipt, and density proofs. This is the phase exit criterion's
+explicit "pre-existing unrelated failures documented per-story" case.
 
 ## Chef's notes
 

--- a/tests/fixtures/db_schema_canonical.txt
+++ b/tests/fixtures/db_schema_canonical.txt
@@ -76,6 +76,10 @@ index idx_intel_jobs_status: CREATE INDEX idx_intel_jobs_status ON intel_jobs(st
 index idx_intent_window_scores_meeting: CREATE INDEX idx_intent_window_scores_meeting ON intent_window_scores(meeting_id, window_id)
 index idx_intent_windows_meeting: CREATE INDEX idx_intent_windows_meeting ON intent_windows(meeting_id, start_seconds, created_at)
 index idx_kbs_modified: CREATE INDEX idx_kbs_modified ON kbs(last_modified DESC)
+index idx_kernel_journal_operation: CREATE INDEX idx_kernel_journal_operation
+ON kernel_journal(operation_id, hub_sequence)
+index idx_kernel_operations_state: CREATE INDEX idx_kernel_operations_state
+ON kernel_operations(state, created_at)
 index idx_knowledge_memberships_modified: CREATE INDEX idx_knowledge_memberships_modified ON knowledge_memberships(last_modified)
 index idx_knowledge_memberships_resource: CREATE INDEX idx_knowledge_memberships_resource ON knowledge_memberships(resource_ref, deleted)
 index idx_meeting_projects_meeting: CREATE INDEX idx_meeting_projects_meeting ON meeting_projects(meeting_id)
@@ -623,6 +627,64 @@ table kbs: CREATE TABLE kbs (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     last_modified TEXT NOT NULL DEFAULT (datetime('now')),
     deleted INTEGER NOT NULL DEFAULT 0
+)
+table kernel_journal: CREATE TABLE kernel_journal (
+    hub_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream TEXT NOT NULL,
+    stream_sequence INTEGER NOT NULL,
+    event_id TEXT NOT NULL UNIQUE,
+    operation_id TEXT NOT NULL,
+    process_id TEXT NOT NULL DEFAULT '',
+    correlation_id TEXT NOT NULL DEFAULT '',
+    causation_id TEXT NOT NULL DEFAULT '',
+    event_type TEXT NOT NULL,
+    event_version INTEGER NOT NULL,
+    refs_json TEXT NOT NULL DEFAULT '[]',
+    privacy_class TEXT NOT NULL,
+    head TEXT NOT NULL DEFAULT '',
+    timestamp REAL NOT NULL,
+    previous_sha256 TEXT NOT NULL,
+    record_sha256 TEXT NOT NULL,
+    UNIQUE(stream, stream_sequence)
+)
+table kernel_meta: CREATE TABLE kernel_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
+table kernel_operations: CREATE TABLE kernel_operations (
+    operation_id TEXT PRIMARY KEY,
+    request_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    principal_kind TEXT NOT NULL,
+    principal_identity TEXT NOT NULL,
+    target_ref TEXT NOT NULL,
+    placement TEXT NOT NULL,
+    envelope_sha256 TEXT NOT NULL,
+    policy_version TEXT NOT NULL,
+    authority_basis TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN (
+        'admitting','awaiting_decision','awaiting_execution','claimed',
+        'succeeded','failed','refused','indeterminate'
+    )),
+    revision INTEGER NOT NULL DEFAULT 1,
+    native_id TEXT NOT NULL,
+    decision TEXT,
+    warrant_json TEXT NOT NULL DEFAULT '{}',
+    warrant_revoked INTEGER NOT NULL DEFAULT 0,
+    claimed_by TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    UNIQUE(principal_identity, idempotency_key)
+)
+table kernel_receipts: CREATE TABLE kernel_receipts (
+    receipt_id TEXT PRIMARY KEY,
+    operation_id TEXT NOT NULL UNIQUE REFERENCES kernel_operations(operation_id),
+    state TEXT NOT NULL CHECK (state IN ('succeeded','failed','refused','indeterminate')),
+    outcome TEXT NOT NULL,
+    result_ref TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
 )
 table knowledge_memberships: CREATE TABLE knowledge_memberships (
     knowledge_id TEXT NOT NULL REFERENCES kbs(id) ON DELETE CASCADE,

--- a/tests/integration/test_kernel_real_hub.py
+++ b/tests/integration/test_kernel_real_hub.py
@@ -1,0 +1,233 @@
+"""HS-106-04 proof: real HTTP, real hub processes, and real SIGKILL."""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+_REPO = Path(__file__).resolve().parents[2]
+_OWNER_TOKEN = "kernel-proof-owner"
+_NODE_TOKEN = "kernel-proof-node"
+
+
+def _operation(key: str) -> dict[str, Any]:
+    return {
+        "request_schema": 1,
+        "request_id": f"request-{key}",
+        "idempotency_key": f"key-{key}",
+        "operation": {"name": "tool.call", "version": 1},
+        "subject_refs": ["story:HS-106-04"],
+        "target": {"ref": f"gate:proposal-{key}"},
+        "arguments": {
+            "proposal_id": f"proposal-{key}",
+            "tool": "Bash",
+            "args_sha256": "a" * 64,
+            "args_head": "git status",
+            "cwd": "/workspace",
+            "ttl_seconds": 60,
+        },
+        "placement": "node:node_kernel_proof",
+    }
+
+
+def test_real_http_executor_receipt_and_sigkill_cursor_replay(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config = home / ".config" / "holdspeak" / "config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps({"config_version": 1, "meeting": {"web_auth_token": _OWNER_TOKEN}}),
+        encoding="utf-8",
+    )
+    node_store = home / ".holdspeak" / "node_auth_tokens.json"
+    node_store.parent.mkdir(parents=True)
+    node_store.write_text(
+        json.dumps(
+            {
+                "node_tokens_schema": 1,
+                "nodes": {
+                    "proof": {
+                        "node_id": "node_kernel_proof",
+                        "token": _NODE_TOKEN,
+                        "revoked": False,
+                        "created_at": "proof",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    base = f"http://127.0.0.1:{port}"
+    env = os.environ.copy()
+    env.update(HOME=str(home), HOLDSPEAK_WEB_PORT=str(port), PYTHONUNBUFFERED="1")
+
+    def request(
+        method: str, path: str, body: Any = None, *, token: str = _OWNER_TOKEN,
+        node: bool = False,
+    ) -> tuple[int, dict[str, Any]]:
+        data = None if body is None else json.dumps(body).encode()
+        headers = {"content-type": "application/json"}
+        if node:
+            headers["x-holdspeak-node-token"] = token
+        else:
+            headers["authorization"] = f"Bearer {token}"
+        outgoing = urllib.request.Request(
+            base + path, data=data, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(outgoing, timeout=10) as response:
+                return response.status, json.load(response)
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.load(exc)
+
+    def start() -> subprocess.Popen[str]:
+        process = subprocess.Popen(
+            [sys.executable, "-m", "holdspeak.main", "web", "--no-open"],
+            cwd=_REPO,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        for _ in range(100):
+            if process.poll() is not None:
+                output = process.stdout.read() if process.stdout else ""
+                raise AssertionError(f"spawned hub exited early:\n{output}")
+            try:
+                with urllib.request.urlopen(base + "/health", timeout=0.2):
+                    return process
+            except Exception:
+                time.sleep(0.1)
+        process.kill()
+        output = process.stdout.read() if process.stdout else ""
+        raise AssertionError(f"spawned hub did not become healthy:\n{output}")
+
+    process = start()
+    try:
+        status, issued = request(
+            "POST", "/api/principals/agents", {"identity": "agent:kernel-proof"}
+        )
+        assert status == 201
+        agent_token = issued["credential"]
+
+        refused_request = _operation("refused")
+        refused_request["arguments"]["audio_frames"] = ["forbidden"]
+        status, refused = request(
+            "POST", "/api/kernel/submit", refused_request, token=agent_token
+        )
+        assert (
+            status, refused["state"], refused["receipt"]["state"],
+            refused["receipt"]["outcome"],
+        ) == (202, "refused", "refused", "journal_content_forbidden")
+
+        status, submitted = request(
+            "POST", "/api/kernel/submit", _operation("complete"), token=agent_token
+        )
+        assert (status, submitted["state"]) == (202, "awaiting_decision")
+        operation_id = submitted["operation_id"]
+
+        status, agent_refusal = request(
+            "POST",
+            f"/api/kernel/operations/{operation_id}/decide",
+            {"decision": "approve", "expected_revision": submitted["revision"]},
+            token=agent_token,
+        )
+        assert (status, agent_refusal["error"], agent_refusal["missing_right"]) == (
+            403, "principal_right_required", "decide"
+        )
+
+        status, immutable = request(
+            "POST",
+            f"/api/kernel/operations/{operation_id}/decide",
+            {
+                "decision": "approve",
+                "expected_revision": submitted["revision"],
+                "payload": {"changed": True},
+                "target": {"ref": "other"},
+                "placement": "node:other",
+            },
+        )
+        assert (status, immutable) == (
+            409,
+            {
+                "error": "admitted_envelope_immutable",
+                "fields": ["payload", "placement", "target"],
+            },
+        )
+
+        status, approved = request(
+            "POST",
+            f"/api/kernel/operations/{operation_id}/decide",
+            {"decision": "approve", "expected_revision": submitted["revision"]},
+        )
+        assert (status, approved["state"]) == (200, "awaiting_execution")
+        status, claimed = request(
+            "POST", "/api/kernel/executor/claim", {}, token=_NODE_TOKEN, node=True
+        )
+        assert (status, claimed["operations"][0]["state"]) == (200, "claimed")
+        status, terminal = request(
+            "POST",
+            f"/api/kernel/executor/operations/{operation_id}/receipt",
+            {"outcome": "succeeded", "result_ref": "gate:proposal-complete"},
+            token=_NODE_TOKEN,
+            node=True,
+        )
+        assert (status, terminal["state"], terminal["outcome"]) == (
+            200, "succeeded", "succeeded"
+        )
+        status, before = request(
+            "GET", f"/api/kernel/events?after_cursor=0&operation_id={operation_id}"
+        )
+        assert status == 200 and len(before["events"]) == 5
+
+        status, pending = request(
+            "POST", "/api/kernel/submit", _operation("pending"), token=agent_token
+        )
+        assert (status, pending["state"]) == (202, "awaiting_decision")
+        os.kill(process.pid, signal.SIGKILL)
+        assert process.wait(timeout=10) == -signal.SIGKILL
+
+        process = start()
+        status, replay = request(
+            "GET", f"/api/kernel/events?after_cursor=0&operation_id={operation_id}"
+        )
+        assert status == 200 and replay == before
+        status, recovered = request(
+            "GET",
+            f"/api/kernel/read?refs=operation:{pending['operation_id']}&view=receipt",
+        )
+        item = recovered["objects"][0]
+        assert (status, item["operation"]["state"], item["receipt"]["outcome"]) == (
+            200, "indeterminate", "hub_restart_during_decision"
+        )
+
+        print(
+            json.dumps(
+                {
+                    "submit": submitted["state"],
+                    "refusal_receipt": refused["receipt"]["outcome"],
+                    "agent_decide": agent_refusal["error"],
+                    "immutable": immutable["error"],
+                    "claim": claimed["operations"][0]["state"],
+                    "receipt": terminal["outcome"],
+                    "sigkill": -signal.SIGKILL,
+                    "cursor_replay_same": replay == before,
+                    "recovered": item["receipt"]["outcome"],
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        if process.poll() is None:
+            os.kill(process.pid, signal.SIGKILL)
+            process.wait(timeout=10)

--- a/tests/unit/test_kernel_broker.py
+++ b/tests/unit/test_kernel_broker.py
@@ -1,0 +1,209 @@
+"""HS-106-04: the operation spine, without a driver-shaped exception."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from holdspeak import kernel
+from holdspeak.db import Database
+from holdspeak.kernel.model import KernelRefused
+from holdspeak.kernel.runtime import _as_principal, _configure
+from holdspeak.principals import Principal, PrincipalKind
+from holdspeak.web.routes.system.kernel_routes import build_kernel_router
+
+OWNER = Principal(PrincipalKind.OWNER, "owner-session")
+AGENT = Principal(PrincipalKind.AGENT, "agent:proof")
+NODE = Principal(PrincipalKind.NODE, "node_proof")
+
+
+def _request(key: str = "one", **arguments):
+    values = {
+        "proposal_id": f"proposal-{key}",
+        "tool": "Bash",
+        "args_sha256": "a" * 64,
+        "args_head": "git status",
+        "cwd": "/workspace",
+        "ttl_seconds": 60,
+    }
+    values.update(arguments)
+    return {
+        "request_schema": 1,
+        "request_id": f"request-{key}",
+        "idempotency_key": f"key-{key}",
+        "operation": {"name": "tool.call", "version": 1},
+        "subject_refs": ["story:HS-106-04"],
+        "target": {"ref": f"gate:proposal-{key}"},
+        "arguments": values,
+        "placement": "node:node_proof",
+    }
+
+
+@pytest.fixture
+def rig(tmp_path: Path, monkeypatch):
+    import holdspeak.db.core as db_core
+
+    now = [1_000.0]
+    database = Database(tmp_path / "kernel.db")
+    monkeypatch.setattr(db_core, "_db", database)
+    broker = _configure(database, clock=lambda: now[0])
+    return database, broker, now
+
+
+def _submit(principal=AGENT, request=None):
+    with _as_principal(principal):
+        return kernel.submit(request or _request())
+
+
+def _decide(handle, decision="approve"):
+    with _as_principal(OWNER):
+        return kernel.decide(handle["operation_id"], decision, handle["revision"])
+
+
+def test_package_has_exactly_four_caller_and_three_executor_calls() -> None:
+    assert kernel.__all__ == [
+        "read", "submit", "decide", "events", "claim", "receipt", "reconcile"
+    ]
+    assert all(callable(getattr(kernel, name)) for name in kernel.__all__)
+
+
+def test_codec_and_four_authority_layers_admit_in_order(rig) -> None:
+    _, broker, _ = rig
+    handle = _submit()
+    assert handle["state"] == "awaiting_decision"
+    assert broker.last_authority_layers == (
+        "authenticated_principal",
+        "declared_capability",
+        "hard_prerequisites",
+        "interruption_policy",
+    )
+    operation = broker.store.operation(handle["operation_id"])
+    assert operation["principal_kind"] == "agent"
+    assert operation["authority_basis"].split("+") == list(broker.last_authority_layers)
+    assert operation["envelope_sha256"].startswith("sha256:")
+    with _as_principal(AGENT):
+        projection = kernel.read(
+            [f"operation:{handle['operation_id']}"], "full", "committed"
+        )["objects"][0]
+    assert projection["canonical"]["id"] == "proposal-one"
+    assert projection["process"]["generic_state"] == "waiting"
+    assert projection["process"]["domain_state"] == "held"
+
+
+def test_refused_submission_has_terminal_receipt_and_stream_content_is_forbidden(rig) -> None:
+    refused = _submit(request=_request("audio", audio_frames=["never journal me"]))
+    assert refused["state"] == "refused"
+    assert refused["receipt"]["state"] == "refused"
+    assert refused["receipt"]["outcome"] == "journal_content_forbidden"
+    with _as_principal(AGENT):
+        batch = kernel.events(0, {"operation_id": refused["operation_id"]})
+    assert [event["event_type"] for event in batch["events"]] == [
+        "operation.refused", "operation.receipt"
+    ]
+    rendered = str(batch)
+    assert "never journal me" not in rendered
+
+    malformed = _request("version")
+    malformed["operation"]["version"] = "not-an-integer"
+    malformed_refusal = _submit(request=malformed)
+    assert malformed_refusal["receipt"]["outcome"] == "request_incomplete"
+
+
+def test_journal_tamper_is_named_then_restores_green(rig) -> None:
+    database, broker, _ = rig
+    _submit()
+    assert broker.store.verify() == {
+        "ok": True, "stream": "operations", "records": 2,
+        "head": broker.store.verify()["head"],
+    }
+    with database._connection() as conn:
+        original = conn.execute(
+            "SELECT head FROM kernel_journal WHERE stream_sequence=1"
+        ).fetchone()[0]
+        conn.execute(
+            "UPDATE kernel_journal SET head='tampered' WHERE stream_sequence=1"
+        )
+    with pytest.raises(KernelRefused, match="journal_record_hash_mismatch") as caught:
+        broker.store.verify()
+    assert caught.value.reason == "journal_record_hash_mismatch"
+    with database._connection() as conn:
+        conn.execute(
+            "UPDATE kernel_journal SET head=? WHERE stream_sequence=1", (original,)
+        )
+    assert broker.store.verify()["ok"] is True
+    print(
+        '{"tamper":"journal_record_hash_mismatch","restored":"ok"}'
+    )
+
+
+def test_agent_cannot_decide_and_http_decision_cannot_mutate_envelope(rig) -> None:
+    _, _, _ = rig
+    handle = _submit()
+    with _as_principal(AGENT), pytest.raises(KernelRefused) as caught:
+        kernel.decide(handle["operation_id"], "approve", handle["revision"])
+    assert caught.value.reason == "owner_principal_required_to_decide"
+
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def owner(request: Request, call_next):
+        request.state.principal = OWNER
+        return await call_next(request)
+
+    app.include_router(build_kernel_router())
+    response = TestClient(app).post(
+        f"/api/kernel/operations/{handle['operation_id']}/decide",
+        json={
+            "decision": "approve", "expected_revision": handle["revision"],
+            "payload": {"changed": True}, "target": {"ref": "other"},
+            "placement": "node:other",
+        },
+    )
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": "admitted_envelope_immutable",
+        "fields": ["payload", "placement", "target"],
+    }
+
+
+def test_warrant_expiry_and_revocation_refuse_at_claim(rig) -> None:
+    _, broker, now = rig
+    expired = _decide(_submit(request=_request("expired")))
+    now[0] += 31
+    with _as_principal(NODE):
+        claim = kernel.claim()
+    assert claim["refusal"]["outcome"] == "warrant_expired"
+    assert broker.store.receipt(expired["operation_id"])["state"] == "refused"
+
+    current = _decide(_submit(request=_request("revoked")))
+    broker.store.revoke_warrant(current["operation_id"])
+    with _as_principal(NODE):
+        claim = kernel.claim()
+    assert claim["refusal"]["outcome"] == "warrant_revoked"
+
+
+def test_claim_receipt_reconcile_and_cursor_projection(rig) -> None:
+    handle = _decide(_submit(request=_request("execute")))
+    with _as_principal(NODE):
+        claimed = kernel.claim()["operations"][0]
+        with pytest.raises(KernelRefused) as content:
+            kernel.receipt(handle["operation_id"], "succeeded", "not domain content")
+        terminal = kernel.receipt(handle["operation_id"], "indeterminate")
+        reconciled = kernel.reconcile(handle["operation_id"])
+    assert content.value.reason == "result_ref_invalid"
+    assert claimed["state"] == "claimed"
+    assert terminal["state"] == "indeterminate"
+    with _as_principal(NODE):
+        assert kernel.receipt(handle["operation_id"], "indeterminate") == terminal
+        with pytest.raises(KernelRefused) as changed:
+            kernel.receipt(handle["operation_id"], "succeeded")
+    assert changed.value.reason == "receipt_immutable"
+    assert reconciled["reconcile"] == "terminal"
+    assert reconciled["receipt"]["outcome"] == "indeterminate"
+    with _as_principal(OWNER):
+        first = kernel.events(0, {})
+        replay = kernel.events(0, {})
+    assert first == replay
+    assert first["cursor"] >= 1


### PR DESCRIPTION
The spine. `holdspeak/kernel/` exposes **exactly seven calls** — `read`, `submit`, `decide`, `events` on the caller plane, and `claim`, `receipt`, `reconcile` on the separately-specified executor plane — over a hash-chained journal.

### It stayed small, and the guards were never relaxed

| module | lines | budget |
|---|---|---|
| `__init__.py` | 9 | 300 |
| `admission.py` | 64 | 300 |
| `model.py` | 70 | 300 |
| `runtime.py` | 85 | 300 |
| `executor.py` | 111 | 300 |
| `tool_call.py` | 144 | 300 |
| `broker.py` | 224 | 300 |
| `journal.py` | 266 | 300 |
| **total spine** | **973** | |

The zero-driver-conditional guard **stayed green without modification**. Where the executor lifecycle pushed `broker.py` toward the ceiling, the answer was to split `executor.py` out — not to raise the budget.

**The spine is driver-blind.** Verified independently: `broker.py`, `admission.py`, `journal.py` and `model.py` contain zero references to `tool_call` / `tool.call` / `gate` — the only registered operation type. That is the property the kill criterion tests at HS-106-07, holding early with one driver.

### One decision record, not two

The Phase-104 gate remains the single native decision state machine behind `decide`. No rival approval surface was created — that would have been exactly the double truth the migration rules forbid. `delivery/commands.py` semantics were reused (caller-authority refusal, immutable payload/target binding, TTL, one-use claim, revocation, reconciliation by stable id); `HubCommandService` itself was deliberately **not** imported, because its envelope, queues and target sequencing are terminal-specific and would have dragged driver-shaped coupling into the generic spine.

### Proofs, observed

| what | result |
|---|---|
| journal tamper | `journal_record_hash_mismatch` → restore → `ok` |
| refusal receipt | `journal_content_forbidden` |
| agent calls `decide` | HTTP 403, `principal_right_required`, missing right `decide` |
| decision alters envelope | HTTP 409, `admitted_envelope_immutable`, naming `payload`, `placement`, `target` |
| executor flow | `awaiting_decision → awaiting_execution → claimed → succeeded` |
| **real SIGKILL** | process exit `-9`; filtered cursor replay **byte-equal** after restart |
| mid-operation recovery | terminal receipt `hub_restart_during_decision` |
| expired / revoked warrant | each refused at claim, by name |

Mutation proofs for both density guards failed by name and returned green after restore.

### Tests

Kernel/gate/schema proof set: **64 passed, 0 failed**. Full suite: **4,245 passed, 41 skipped, 1 failed**.

The single failure is `tests/uat/test_voice_notes.py::test_transcribe_up_but_unreachable_is_honest` — **verified pre-existing**: it reproduces on a docs-only branch with no kernel code present. The runtime honestly returns `Transcribe failed (HTTP 502).`; the assertion only accepts wording containing `reach` or `not up`. Unrelated to this story, and a real (if cosmetic) drift worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)