### PR TITLE
HS-106-02 rider: the live-bus e2e proof authenticates like the real Desk

### DIFF
--- a/tests/e2e/test_live_bus.py
+++ b/tests/e2e/test_live_bus.py
@@ -29,6 +29,19 @@ pytestmark = [pytest.mark.e2e, pytest.mark.requires_meeting]
 PORT = 8917
 
 
+# HS-106-02 made every request derive a principal, including on loopback, so a
+# browser that never bootstraps the owner token is refused at the socket
+# (`principal=none missing_right=owner`).  The real Desk gets its token from the
+# tokenized first-load URL; this harness has to do the same, and both servers in
+# the restart test must share one token or the reconnect authenticates against a
+# credential the page has never seen.
+TOKEN = "live-bus-e2e-owner-token"
+
+
+def _page_url(route: str) -> str:
+    return f"http://127.0.0.1:{PORT}{route}?token={TOKEN}"
+
+
 def _make_server():
     from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
 
@@ -39,6 +52,7 @@ def _make_server():
             get_state=lambda: {"activity": {"state": "idle", "source": "runtime"}},
         ),
         host="127.0.0.1",
+        auth_token=TOKEN,
     )
 
 
@@ -91,7 +105,7 @@ def test_every_live_page_opens_exactly_one_runtime_socket(browser):
             page = browser.new_page()
             errors = []
             page.on("pageerror", lambda e: errors.append(str(e)))
-            n = _count_runtime_sockets(page, f"http://127.0.0.1:{PORT}{route}")
+            n = _count_runtime_sockets(page, _page_url(route))
             page.close()
             assert n == 1, f"{route} opened {n} runtime sockets (want exactly 1)"
             assert not errors, f"{route} page errors: {errors}"
@@ -105,7 +119,7 @@ def test_a_real_broadcast_reaches_the_presence_card_via_the_bus(browser):
     uv.start()
     try:
         page = browser.new_page()
-        page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+        page.goto(_page_url("/presence"), wait_until="networkidle")
         page.wait_for_timeout(800)
         server.broadcast(
             "runtime_activity",
@@ -134,7 +148,7 @@ def test_the_bus_reconnects_after_a_server_restart(browser):
     sockets: list[str] = []
     page.on("websocket", lambda ws: sockets.append(ws.url))
     try:
-        page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+        page.goto(_page_url("/presence"), wait_until="networkidle")
         page.wait_for_timeout(1000)
         first = sum(1 for u in sockets if u.rstrip("/").endswith("/ws"))
         assert first == 1


### PR DESCRIPTION
Three `tests/e2e/test_live_bus.py` tests have been **red on main since #386**, and CI cannot see it.

### What broke

HS-106-02 made every request derive a principal, including on loopback. The harness navigates to bare URLs, so the page never bootstraps an owner token, its socket offers only `holdspeak.v1`, and `ws.py` refuses it by name:

```
Rejected WebSocket: principal=none missing_right=owner
```

**The product is not affected.** The real Desk gets its token from the tokenized first-load URL, and `websocketProtocols()` (`web/src/lib/auth.ts`) base64url-encodes it into a `holdspeak.auth.v1.*` subprotocol — the exact path this harness was skipping. Verified by reading the client, not by assuming.

**The proof was broken**, and CI is blind to it: these tests skip without Playwright and a built web bundle, and the bundle is gitignored.

### How it was found

Adjudicating HS-106-05's eight suite failures instead of accepting "pre-existing" at face value. They *are* pre-existing relative to slice 05 — and they are **ours, from 02**. The distinction matters: "not caused by this story" and "not caused by this phase" are different claims, and only the first one was true.

### The fix

The harness bootstraps like the Desk: a fixed `TOKEN` passed to `MeetingWebServer`, every `goto` through `_page_url()`.

The restart test needs the *fixed* token specifically — it constructs a **second** server, and an ephemeral per-server token would leave the reconnecting page holding a credential the new server never issued. That would be a different failure wearing the same red.

`tests/e2e/test_live_bus.py`: **3 passed** (was 3 failed on main).

### The other five failures

Checked for the same cause; they do not share it. Four are UAT induction recipes failing on a missing optional dependency (`requires the 'openai' package`) and a queued-intel timeout; one is the known voice-notes wording drift. No authentication signature in any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)