### PR TITLE
HS-106-05: thin slice I — terminal input on the kernel

### DIFF
--- a/holdspeak/delivery/commands.py
+++ b/holdspeak/delivery/commands.py
@@ -356,6 +356,9 @@ class NodeCommandProcessor:
         self._clock = clock
         self._sequence_locks: dict[str, threading.Lock] = {}
         self._locks_guard = threading.Lock()
+        self._native_results: dict[str, dict[str, Any]] = {}
+        self._results_lock = threading.Lock()
+        self._capture_native_results = False
         self.executions = 0  # test/metric seam: real chokepoint entries
 
     def _sequence_lock(self, key: str) -> threading.Lock:
@@ -579,6 +582,7 @@ class NodeCommandProcessor:
                 current_target=pane_id,
                 agent=str(payload.get("agent") or ""),
                 submit=bool(payload.get("submit", True)),
+                grounding_refs=list(payload.get("grounding_refs") or []),
                 expected_pane_id=pane_id,
                 operation=operation,
                 policy_snapshot=policy_snapshot,
@@ -634,6 +638,9 @@ class NodeCommandProcessor:
             )
             basis = "authenticated_owner"
 
+        if self._capture_native_results:
+            with self._results_lock:
+                self._native_results[env["command_id"]] = dict(result)
         status = str(result.get("status") or "error")
         if status in _SUCCEEDED:
             state = "succeeded"
@@ -655,6 +662,28 @@ class NodeCommandProcessor:
             revoked=bool(result.get("revoked")),
         )
         return self._persist(env, receipt, seq_key=seq_key, advance=advance)
+
+    def take_result(self, command_id: str) -> Optional[dict[str, Any]]:
+        """Return one local executor result without adding it to the wire."""
+        with self._results_lock:
+            return self._native_results.pop(str(command_id), None)
+
+    def record_preflight_refusal(
+        self, envelope: Mapping[str, Any], result: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """Persist a hub-proven refusal without entering the typing chokepoint."""
+        env = validate_envelope(envelope)
+        policy = decode_decision(env["authority"])
+        receipt = self._receipt(
+            env,
+            state="refused",
+            outcome=str(result.get("status") or "refused"),
+            authority_basis=str(policy.get("authority_basis") or "none"),
+            node_audit_id=result.get("audit_id"),
+            error=str(result.get("detail")) if result.get("detail") else None,
+            revoked=bool(result.get("revoked")),
+        )
+        return self._persist(env, receipt)
 
     def reconcile(self, command_id: str) -> dict[str, Any]:
         """§8.2: the stored receipt if this node executed the command;
@@ -692,14 +721,17 @@ class HubCommandService:
         grant_lookup: Optional[Callable[[str], Optional[dict[str, Any]]]] = None,
         wall_now: Callable[[], datetime] = _utc_now,
         default_ttl_seconds: int = DEFAULT_COMMAND_TTL_SECONDS,
+        kernel_broker: Any = None,
     ) -> None:
         self.repo = repo
         self.processor = processor
+        self.processor._capture_native_results = True
         self.local_node_id = str(local_node_id)
         self._mode_loader = mode_loader
         self._grant_lookup = grant_lookup
         self._wall_now = wall_now
         self._default_ttl = int(default_ttl_seconds)
+        self._kernel = kernel_broker
         self._queues: dict[str, list[dict[str, Any]]] = {}
         self._queue_lock = threading.Lock()
 
@@ -748,16 +780,7 @@ class HubCommandService:
             decision = resolve_policy(
                 operation, mode=mode, source="config", grant=self._grant(session_key)
             )
-            snapshot = decision.to_dict()
-            return {
-                "actor": "owner",
-                "control_posture": mode,
-                "decision": encode_decision(snapshot),
-                "policy_version": POLICY_VERSION,
-                "grant_id": session_key
-                if snapshot["authority_basis"] == "scoped_grant"
-                else None,
-            }
+            return self._authority_from_policy(decision.to_dict(), session_key)
         if verb == "factory.kill":
             return {
                 "actor": "owner",
@@ -774,9 +797,29 @@ class HubCommandService:
             "grant_id": None,
         }
 
+    @staticmethod
+    def _authority_from_policy(
+        policy: Mapping[str, Any], session_key: str
+    ) -> dict[str, Any]:
+        return {
+            "actor": "owner",
+            "control_posture": str(policy.get("mode") or "neutral"),
+            "decision": encode_decision(policy),
+            "policy_version": str(policy.get("policy_version") or POLICY_VERSION),
+            "grant_id": session_key
+            if str(policy.get("authority_basis") or "") == "scoped_grant"
+            else None,
+        }
+
     # dispatch -----------------------------------------------------------
 
-    def submit(self, request: Any) -> dict[str, Any]:
+    def submit(
+        self,
+        request: Any,
+        *,
+        authority_snapshot: Optional[Mapping[str, Any]] = None,
+        include_result: bool = False,
+    ) -> dict[str, Any]:
         """One client command intent → one dispatched envelope.
 
         The client names WHAT (target, operation, payload, sequence);
@@ -860,11 +903,15 @@ class HubCommandService:
             verb=verb,
             payload=payload,
             expected_sequence=int(expected_sequence),
-            authority=self._authority_for(
-                verb=verb,
-                session_key=session_key,
-                destination=destination,
-                registered=registered,
+            authority=(
+                self._authority_from_policy(authority_snapshot, session_key)
+                if authority_snapshot is not None
+                else self._authority_for(
+                    verb=verb,
+                    session_key=session_key,
+                    destination=destination,
+                    registered=registered,
+                )
             ),
             command_id=command_id,
             ttl_seconds=int(request.get("expires_in_seconds") or self._default_ttl),
@@ -876,27 +923,240 @@ class HubCommandService:
         )
         if local:
             receipt = self.processor.process(envelope)
+            native_result = self.processor.take_result(envelope["command_id"])
             self.repo.attach_receipt(receipt)
-            return {
+            response = {
                 "command_id": envelope["command_id"],
                 "state": "complete",
                 "receipt": receipt,
             }
+            if include_result and native_result is not None:
+                response["result"] = native_result
+            return response
         with self._queue_lock:
             self._queues.setdefault(node_id, []).append(envelope)
         return {"command_id": envelope["command_id"], "state": "sent"}
+
+    # process.input kernel adapter -----------------------------------------
+
+    def _kernel_service(self) -> Any:
+        if self._kernel is None:
+            from ..kernel.broker import Broker
+            from ..kernel.journal import JournalStore
+            from ..kernel.model import OperationSpec
+            from ..kernel.process_input import ProcessInputCodec
+
+            codec = ProcessInputCodec(self.repo)
+            self._kernel = Broker(
+                JournalStore(self.repo._connection),
+                (OperationSpec(codec.name, codec.version, codec, "agent.submit", "propose"),),
+            )
+        return self._kernel
+
+    @staticmethod
+    def _process_input_request(request: Mapping[str, Any]) -> dict[str, Any]:
+        operation = request.get("operation") or {}
+        payload = request.get("payload") or {}
+        if (
+            str(operation.get("family") or "") != "coder_steering"
+            or str(operation.get("verb") or "") != "terminal.text"
+        ):
+            raise CommandRefused(
+                "process_input_operation_required",
+                "the process.input adapter accepts coder_steering/terminal.text only",
+            )
+        command_id = str(request.get("command_id") or uuid.uuid4())
+        node_id = str(request.get("node_id") or "local")
+        target_id = str(request.get("target_id") or "")
+        generation = str(request.get("target_generation") or "")
+        return {
+            "request_schema": 1,
+            "request_id": command_id,
+            "idempotency_key": f"process.input:{command_id}",
+            "operation": {"name": "process.input", "version": 1},
+            "subject_refs": [f"coder_session:{payload.get('session_key')}"]
+            if payload.get("session_key")
+            else [],
+            "target": {"ref": f"process:{target_id}"},
+            "arguments": {
+                "text": payload.get("text"),
+                "submit": payload.get("submit", True),
+                "expected_generation": generation,
+                "command_id": command_id,
+                "session_key": str(payload.get("session_key") or ""),
+                "agent": str(payload.get("agent") or ""),
+                "expected_sequence": request.get("expected_sequence"),
+                "expires_in_seconds": request.get("expires_in_seconds", 30),
+            },
+            "placement": f"node:{node_id}",
+        }
+
+    def _sync_kernel_receipt(self, command_id: str, node_id: str) -> None:
+        from ..principals import Principal, PrincipalKind
+
+        kernel = self._kernel_service()
+        operation = kernel.store.operation_for_native(str(command_id))
+        row = self.repo.get(str(command_id))
+        if operation is None or row is None or kernel.store.receipt(operation["operation_id"]):
+            return
+        receipt = row.get("receipt") or {}
+        domain = str(receipt.get("state") or row.get("hub_state") or "")
+        outcome = {
+            "succeeded": "succeeded",
+            "failed": "failed",
+            "refused": "refused",
+            "not_executed": "refused",
+            "unknown": "indeterminate",
+            "indeterminate_after_node_reset": "indeterminate",
+        }.get(domain)
+        if outcome is None:
+            return
+        node = Principal(PrincipalKind.NODE, str(node_id))
+        if domain == "not_executed" and operation["state"] == "awaiting_execution":
+            claimed = kernel.claim(node, str(command_id))
+            if not claimed.get("operations"):
+                raise CommandRefused("kernel_claim_required_to_refuse")
+        kernel.receipt(
+            operation["operation_id"], outcome, f"command:{command_id}", node
+        )
+
+    def submit_process_input(
+        self,
+        request: Mapping[str, Any],
+        principal: Any,
+        *,
+        authority_snapshot: Optional[Mapping[str, Any]] = None,
+        preflight_result: Optional[Mapping[str, Any]] = None,
+        include_result: bool = False,
+    ) -> dict[str, Any]:
+        """Admit once, approve once, then adapt onto the existing command protocol."""
+        from ..principals import Principal, PrincipalKind
+
+        prepared = dict(request)
+        command_id = str(prepared.get("command_id") or "")
+        known = self.repo.get(command_id) if command_id else None
+        if known is not None and known.get("receipt"):
+            operation = self._kernel_service().store.operation_for_native(command_id)
+            if operation is not None:
+                return {
+                    "command_id": command_id,
+                    "state": "complete",
+                    "duplicate": True,
+                    "receipt": known["receipt"],
+                    "operation_id": operation["operation_id"],
+                }
+        node_id = str(prepared.get("node_id") or self.local_node_id)
+        if prepared.get("expected_sequence") is None and node_id == self.local_node_id:
+            prepared["expected_sequence"] = self.processor.ledger.next_sequence(
+                str(prepared.get("target_id") or "")
+            )
+        raw = self._process_input_request(prepared)
+        prepared["command_id"] = raw["request_id"]
+        kernel = self._kernel_service()
+        handle = kernel.submit(raw, principal)
+        if handle.get("state") == "refused":
+            reason = str((handle.get("receipt") or {}).get("outcome") or "kernel_refused")
+            raise CommandRefused(reason)
+        if handle.get("state") == "awaiting_decision":
+            decision = "reject" if preflight_result is not None else "approve"
+            handle = kernel.decide(
+                handle["operation_id"],
+                decision,
+                int(handle["revision"]),
+                principal,
+                reason=str((preflight_result or {}).get("detail") or ""),
+            )
+        if node_id == self.local_node_id and handle.get("state") == "awaiting_execution":
+            claimed = kernel.claim(Principal(PrincipalKind.NODE, node_id))
+            if not claimed.get("operations"):
+                reason = str((claimed.get("refusal") or {}).get("outcome") or "kernel_claim_refused")
+                raise CommandRefused(reason)
+        if preflight_result is None:
+            response = self.submit(
+                prepared,
+                authority_snapshot=authority_snapshot,
+                include_result=include_result,
+            )
+        else:
+            payload = dict(prepared.get("payload") or {})
+            target_id = str(prepared.get("target_id") or "")
+            target_generation = str(prepared.get("target_generation") or "")
+            seq_key = target_id
+            expected_sequence = prepared.get("expected_sequence")
+            if expected_sequence is None:
+                expected_sequence = self.processor.ledger.next_sequence(seq_key)
+            authority = (
+                self._authority_from_policy(authority_snapshot, str(payload.get("session_key") or ""))
+                if authority_snapshot is not None
+                else self._authority_for(
+                    verb="terminal.text",
+                    session_key=str(payload.get("session_key") or ""),
+                    destination=target_id,
+                    registered=False,
+                )
+            )
+            envelope = build_envelope(
+                node_id=node_id,
+                target_id=target_id,
+                target_generation=target_generation,
+                family="coder_steering",
+                verb="terminal.text",
+                payload=payload,
+                expected_sequence=int(expected_sequence),
+                authority=authority,
+                command_id=prepared["command_id"],
+                ttl_seconds=int(prepared.get("expires_in_seconds") or self._default_ttl),
+                now=self._wall_now(),
+            )
+            self.repo.record_sent(
+                envelope, dispatch_epoch=self.processor.ledger.epoch
+            )
+            receipt = self.processor.record_preflight_refusal(envelope, preflight_result)
+            self.repo.attach_receipt(receipt)
+            response = {
+                "command_id": prepared["command_id"],
+                "state": "complete",
+                "receipt": receipt,
+            }
+            if include_result:
+                response["result"] = dict(preflight_result)
+        response["operation_id"] = handle["operation_id"]
+        if node_id == self.local_node_id and preflight_result is None:
+            self._sync_kernel_receipt(prepared["command_id"], node_id)
+        return response
 
     # the node-link command leg -------------------------------------------
 
     def claim_for_node(self, node_id: str) -> list[dict[str, Any]]:
         """Drain this node's queued envelopes/probes (the ``command_source``
         hook the node link consults). Claiming marks the hub half."""
+        from ..principals import Principal, PrincipalKind
+
         with self._queue_lock:
             claimed = self._queues.pop(str(node_id), [])
-        for item in claimed:
+        kernel = self._kernel
+        process_commands = [] if kernel is None else [
+            str(item.get("command_id") or "")
+            for item in claimed
+            if (item.get("operation") or {}).get("verb") == "terminal.text"
+            and kernel.store.operation_for_native(str(item.get("command_id") or ""))
+            is not None
+        ]
+        accepted: set[str] = set()
+        node = Principal(PrincipalKind.NODE, str(node_id))
+        for command_id in process_commands:
+            handle = kernel.claim(node, command_id)
+            if handle.get("operations"):
+                accepted.add(command_id)
+        dispatched = [
+            item for item in claimed
+            if str(item.get("command_id") or "") not in process_commands
+            or str(item.get("command_id") or "") in accepted
+        ]
+        for item in dispatched:
             if item.get("command_id") and item.get("command_schema"):
                 self.repo.set_state(item["command_id"], "claimed")
-        return claimed
+        return dispatched
 
     def record_results(self, node_id: str, results: Any) -> dict[str, Any]:
         """The node's results leg: receipts and reconcile answers,
@@ -914,6 +1174,8 @@ class HubCommandService:
             if item.get("receipt_schema") == RECEIPT_SCHEMA:
                 self.repo.attach_receipt(dict(item))
                 processed += 1
+                if self._kernel is not None:
+                    self._sync_kernel_receipt(command_id, str(node_id))
                 continue
             if item.get("reconcile") == "unknown_command" and not row.get("receipt"):
                 self.repo.set_state(
@@ -921,6 +1183,8 @@ class HubCommandService:
                     self._absence_state(row, str(item.get("ledger_epoch") or "")),
                 )
                 processed += 1
+                if self._kernel is not None:
+                    self._sync_kernel_receipt(command_id, str(node_id))
         return {"ok": True, "processed": processed}
 
     @staticmethod
@@ -951,6 +1215,8 @@ class HubCommandService:
                     str(command_id),
                     self._absence_state(row, str(answer.get("ledger_epoch") or "")),
                 )
+            if self._kernel is not None:
+                self._sync_kernel_receipt(str(command_id), self.local_node_id)
             return self.repo.get(str(command_id))
         with self._queue_lock:
             queued = any(
@@ -961,6 +1227,8 @@ class HubCommandService:
             # Never claimed and no longer queued (a hub restart dropped the
             # memory queue): it cannot have executed.
             self.repo.set_state(str(command_id), "not_executed")
+            if self._kernel is not None:
+                self._sync_kernel_receipt(str(command_id), str(row.get("node_id")))
             return self.repo.get(str(command_id))
         if not queued and str(row.get("hub_state")) == "claimed":
             # Lost after send: recorded unknown until the node answers the

--- a/holdspeak/delivery/terminal.py
+++ b/holdspeak/delivery/terminal.py
@@ -78,8 +78,11 @@ class TerminalTargetRegistry:
     generation refuses forever.
     """
 
-    def __init__(self, *, runner: Optional[Runner] = None) -> None:
+    def __init__(
+        self, *, runner: Optional[Runner] = None, resolver: Any = resolve_pane_identity
+    ) -> None:
         self._runner = runner
+        self._resolver = resolver
         self._lock = threading.Lock()
         self._by_id: dict[str, dict[str, Any]] = {}
         self._by_ref: dict[str, str] = {}
@@ -94,7 +97,7 @@ class TerminalTargetRegistry:
         pane_ref = normalize_pane_ref(ref)
         if not pane_ref:
             return {"status": "pane_gone", "detail": "a pane ref is required"}
-        identity = resolve_pane_identity(pane_ref, runner=self._runner)
+        identity = self._resolver(pane_ref, runner=self._runner)
         if identity["status"] != "ok":
             return dict(identity)
         pane_id = identity["pane_id"]
@@ -133,7 +136,7 @@ class TerminalTargetRegistry:
             record = self._by_id.get(str(target_id or ""))
         if record is None:
             return {"status": "target_gone", "detail": "unknown target_id"}
-        identity = resolve_pane_identity(record["pane_ref"], runner=self._runner)
+        identity = self._resolver(record["pane_ref"], runner=self._runner)
         if identity["status"] == "pane_gone":
             return {"status": "target_gone", "detail": identity.get("detail")}
         if identity["status"] != "ok":

--- a/holdspeak/kernel/executor.py
+++ b/holdspeak/kernel/executor.py
@@ -11,10 +11,10 @@ class ExecutorPlane:
     store: Any
     _clock: Any
 
-    def claim(self, principal: Any) -> dict[str, Any]:
+    def claim(self, principal: Any, native_id: str = "") -> dict[str, Any]:
         if principal.kind is not PrincipalKind.NODE:
             raise KernelRefused("node_principal_required_to_claim")
-        operation = self.store.claim_candidate(principal.identity)
+        operation = self.store.claim_candidate(principal.identity, native_id)
         if operation is None:
             return {"operations": []}
         warrant = operation["warrant"]

--- a/holdspeak/kernel/journal.py
+++ b/holdspeak/kernel/journal.py
@@ -191,15 +191,19 @@ class JournalStore:
                 raise KernelRefused("operation_revision_conflict", operation_id=operation_id)
         return self.operation(operation_id) or {}
 
-    def claim_candidate(self, executor: str) -> dict[str, Any] | None:
+    def claim_candidate(
+        self, executor: str, native_id: str = ""
+    ) -> dict[str, Any] | None:
         """Atomically acquire one approved operation; first claimant wins."""
+        query = """SELECT operation_id,revision FROM kernel_operations
+                   WHERE state='awaiting_execution' AND placement=?"""
+        values: tuple[Any, ...] = (f"node:{executor}",)
+        if native_id:
+            query += " AND native_id=?"
+            values += (native_id,)
+        query += " ORDER BY created_at LIMIT 1"
         with self._connection() as conn:
-            row = conn.execute(
-                """SELECT operation_id,revision FROM kernel_operations
-                   WHERE state='awaiting_execution' AND placement=?
-                   ORDER BY created_at LIMIT 1""",
-                (f"node:{executor}",),
-            ).fetchone()
+            row = conn.execute(query, values).fetchone()
             if row is None:
                 return None
             result = conn.execute(

--- a/holdspeak/kernel/process_input.py
+++ b/holdspeak/kernel/process_input.py
@@ -1,0 +1,133 @@
+"""Typed ``process.input`` codec over the existing terminal command record."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from typing import Any, Mapping
+
+from .model import Admission, KernelRefused, OperationRequest, forbidden_content, valid_ref
+
+_GENERATION = re.compile(r"^[A-Za-z0-9_.:-]{1,160}$")
+_ALLOWED = frozenset(
+    {
+        "text",
+        "submit",
+        "expected_generation",
+        "command_id",
+        "session_key",
+        "agent",
+        "expected_sequence",
+        "expires_in_seconds",
+    }
+)
+
+
+class ProcessInputCodec:
+    """Validate terminal semantics while the broker remains driver-blind.
+
+    The delivery command table owns the native send.  The kernel journal keeps
+    only its command ref and the immutable payload hash.
+    """
+
+    name = "process.input"
+    version = 1
+
+    def __init__(self, commands: Any) -> None:
+        self._commands = commands
+
+    def validate(self, request: OperationRequest) -> Admission:
+        args = request.arguments
+        if forbidden_content(args):
+            raise KernelRefused("journal_content_forbidden")
+        unknown = set(args) - _ALLOWED
+        if unknown:
+            raise KernelRefused("operation_field_not_allowed", sorted(unknown)[0])
+        text = args.get("text")
+        submit = args.get("submit")
+        generation = str(args.get("expected_generation") or "").strip()
+        command_id = str(args.get("command_id") or "").strip()
+        expected_sequence = args.get("expected_sequence")
+        target = request.target_ref
+        if (
+            not isinstance(text, str)
+            or not text.strip()
+            or not isinstance(submit, bool)
+            or not isinstance(expected_sequence, int)
+            or isinstance(expected_sequence, bool)
+            or expected_sequence < 1
+            or not target.startswith("process:")
+            or not valid_ref(target)
+            or not _GENERATION.fullmatch(generation)
+        ):
+            raise KernelRefused("process_input_prerequisite_failed")
+        try:
+            uuid.UUID(command_id)
+        except (TypeError, ValueError) as exc:
+            raise KernelRefused("process_input_command_id_invalid") from exc
+        try:
+            ttl = float(args.get("expires_in_seconds") or 30.0)
+        except (TypeError, ValueError) as exc:
+            raise KernelRefused("process_input_ttl_invalid") from exc
+        if ttl <= 0 or ttl > 300:
+            raise KernelRefused("process_input_ttl_invalid")
+        material = {
+            "name": request.name,
+            "version": request.version,
+            "target_ref": target,
+            "placement": request.placement,
+            "arguments": dict(args),
+        }
+        canonical = json.dumps(material, separators=(",", ":"), sort_keys=True)
+        payload_hash = "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+        refs = tuple(dict.fromkeys((*request.subject_refs, f"command:{command_id}")))
+        return Admission(
+            target_ref=target,
+            placement=request.placement,
+            payload_hash=payload_hash,
+            refs=refs,
+            head=f"terminal text {len(text.encode('utf-8'))} bytes submit={submit}",
+            ttl_seconds=ttl,
+            native_id=command_id,
+        )
+
+    def authorize(
+        self, request: OperationRequest, admission: Admission,
+        principal: Any, operation_id: str,
+    ) -> Admission:
+        return admission
+
+    def admit(
+        self, request: OperationRequest, admission: Admission,
+        principal: Any, operation_id: str,
+    ) -> None:
+        return None
+
+    def decide(self, native_id: str, decision: str, principal: Any, reason: str = "") -> None:
+        return None
+
+    def read_native(self, native_id: str) -> dict[str, Any] | None:
+        return self._commands.get(native_id)
+
+    def project_process(self, native_id: str, operation: Mapping[str, Any]) -> dict[str, Any]:
+        native = self._commands.get(native_id)
+        domain_state = str((native or {}).get("hub_state") or "unknown")
+        generic = {
+            "sent": "waiting",
+            "claimed": "running",
+            "unknown": "unknown",
+            "complete": "ended",
+            "not_executed": "failed",
+            "indeterminate_after_node_reset": "unknown",
+        }.get(domain_state, "unknown")
+        return {
+            "process_id": f"process:{operation['operation_id']}",
+            "kind": self.name,
+            "principal": operation["principal_identity"],
+            "generic_state": generic,
+            "domain_state": domain_state,
+            "target_ref": operation["target_ref"],
+            "current_operation_id": operation["operation_id"],
+            "command_ref": f"command:{native_id}",
+        }

--- a/holdspeak/kernel/runtime.py
+++ b/holdspeak/kernel/runtime.py
@@ -9,6 +9,7 @@ from ..principals import UNAUTHENTICATED
 from .broker import Broker
 from .journal import JournalStore
 from .model import OperationSpec
+from .process_input import ProcessInputCodec
 from .tool_call import ToolCallCodec
 
 _principal = ContextVar("kernel_principal", default=UNAUTHENTICATED)
@@ -24,8 +25,12 @@ def _mode() -> str:
 
 def _build(database: Any, *, clock: Any = None) -> Broker:
     store = JournalStore(database._connection, **({"clock": clock} if clock else {}))
-    codec = ToolCallCodec(database.gate, _mode)
-    specs = (OperationSpec(codec.name, codec.version, codec, "agent.submit", "propose"),)
+    tool_calls = ToolCallCodec(database.gate, _mode)
+    process_input = ProcessInputCodec(database.delivery_receipts)
+    specs = (
+        OperationSpec(tool_calls.name, tool_calls.version, tool_calls, "agent.submit", "propose"),
+        OperationSpec(process_input.name, process_input.version, process_input, "agent.submit", "propose"),
+    )
     return Broker(store, specs, **({"clock": clock} if clock else {}))
 
 

--- a/holdspeak/web/routes/delivery_terminal.py
+++ b/holdspeak/web/routes/delivery_terminal.py
@@ -29,7 +29,7 @@ import asyncio
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -177,12 +177,27 @@ def build_delivery_terminal_router(
         return JSONResponse(out, status_code=status or 200)
 
     @router.post("/api/delivery/terminal/commands")
-    async def api_terminal_command(payload: Optional[dict[str, Any]] = None) -> Any:
+    async def api_terminal_command(
+        request: Request, payload: Optional[dict[str, Any]] = None
+    ) -> Any:
         from ...delivery.commands import CommandRefused
+        from ...principals import Principal, PrincipalKind
 
         body = payload if isinstance(payload, dict) else {}
+        operation = body.get("operation") or {}
+        principal = getattr(
+            request.state, "principal", Principal(PrincipalKind.OWNER, "owner-session")
+        )
         try:
-            out = await asyncio.to_thread(_service().submit, body)
+            if (
+                operation.get("family") == "coder_steering"
+                and operation.get("verb") == "terminal.text"
+            ):
+                out = await asyncio.to_thread(
+                    _service().submit_process_input, body, principal
+                )
+            else:
+                out = await asyncio.to_thread(_service().submit, body)
         except CommandRefused as exc:
             return _refused(exc)
         except Exception as exc:

--- a/holdspeak/web/routes/system/__init__.py
+++ b/holdspeak/web/routes/system/__init__.py
@@ -21,12 +21,16 @@ from .voice import build_voice_router
 from .ws import build_ws_router
 
 
-def build_system_router(ctx: WebContext) -> APIRouter:
+def build_system_router(
+    ctx: WebContext, *, commands=None, targets=None
+) -> APIRouter:
     router = APIRouter()
     router.include_router(build_health_router(ctx))
     router.include_router(build_agent_capabilities_router())
     router.include_router(build_coders_router(ctx))
-    router.include_router(build_coder_steering_router(ctx))
+    router.include_router(
+        build_coder_steering_router(ctx, commands=commands, targets=targets)
+    )
     router.include_router(build_gate_router(ctx))
     router.include_router(build_kernel_router())
     router.include_router(build_settings_router(ctx))

--- a/holdspeak/web/routes/system/coder_steering_routes.py
+++ b/holdspeak/web/routes/system/coder_steering_routes.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from ....logging_config import get_logger
@@ -17,7 +17,9 @@ from .coder_steering_support import (
     active_policy_grant,
     canonical_pane_id,
     compose_from_body,
+    deliver_process_input,
     expected_pane_id,
+    ProcessInputServices,
     steering_commitment,
     steering_policy,
 )
@@ -25,8 +27,11 @@ from .coder_steering_support import (
 log = get_logger("web.routes.system.steering")
 
 
-def build_coder_steering_router(ctx: WebContext) -> APIRouter:
+def build_coder_steering_router(
+    ctx: WebContext, *, commands: Any = None, targets: Any = None
+) -> APIRouter:
     router = APIRouter()
+    process_input = ProcessInputServices(commands=commands, targets=targets)
 
     def _registry_session(key: str):
         """Resolve a steering key to a session-like target.
@@ -342,7 +347,7 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
 
     @router.post("/api/coders/{key}/steer")
     async def api_coder_steer(
-        key: str, payload: Optional[dict[str, Any]] = None
+        key: str, request: Request, payload: Optional[dict[str, Any]] = None
     ) -> Any:
         """Deliver one steer through THE chokepoint (HS-87-03/04).
 
@@ -406,17 +411,10 @@ def build_coder_steering_router(ctx: WebContext) -> APIRouter:
                     "commitment": steering_commitment(operation, policy),
                 }
             )
-        result = await asyncio.to_thread(
-            coder_steering.deliver,
-            key,
-            composed["text"],
-            current_target=target,
-            agent=session.agent,
-            submit=submit,
-            grounding_refs=composed["refs"],
-            expected_pane_id=pane_id,
-            operation=operation,
-            policy_snapshot=policy,
+        result = await deliver_process_input(
+            process_input, key=key, target=target, agent=session.agent,
+            pane_id=pane_id, submit=submit, composed=composed,
+            operation=operation, policy=policy, request=request,
         )
         if result.get("audit_id") is not None or result.get("revoked"):
             _coder_frame(ctx, key)

--- a/holdspeak/web/routes/system/coder_steering_support.py
+++ b/holdspeak/web/routes/system/coder_steering_support.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
+import uuid
 from typing import Any, Mapping, Optional
 
 from fastapi.responses import JSONResponse
@@ -144,11 +146,122 @@ def compose_from_body(body: dict[str, Any]) -> dict[str, Any] | JSONResponse:
     return compose_steer(text, blocks)
 
 
+class ProcessInputServices:
+    """Lazy shared native services for the coder route's kernel adapter."""
+
+    def __init__(self, *, commands: Any = None, targets: Any = None) -> None:
+        self._commands = commands
+        self._targets = targets
+
+    def targets(self) -> Any:
+        if self._targets is None:
+            from .... import coder_steering
+            from ....delivery.terminal import TerminalTargetRegistry
+
+            self._targets = TerminalTargetRegistry(
+                resolver=lambda target, runner=None: coder_steering.resolve_pane_identity(
+                    target, runner=runner
+                )
+            )
+        return self._targets
+
+    def commands(self) -> Any:
+        if self._commands is None:
+            from ....db import get_database
+            from ....db.delivery_receipts import NodeReceiptLedger
+            from ....delivery.commands import HubCommandService, NodeCommandProcessor
+
+            database = get_database()
+            ledger = database.db_path.with_name(
+                f"{database.db_path.stem}-coder-node-ledger.db"
+            )
+            self._commands = HubCommandService(
+                repo=database.delivery_receipts,
+                processor=NodeCommandProcessor(
+                    node_id="local",
+                    targets=self.targets(),
+                    ledger=NodeReceiptLedger(ledger),
+                ),
+                local_node_id="local",
+            )
+        return self._commands
+
+
+async def deliver_process_input(
+    services: ProcessInputServices,
+    *,
+    key: str,
+    target: str,
+    agent: str,
+    pane_id: Optional[str],
+    submit: bool,
+    composed: Mapping[str, Any],
+    operation: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    request: Any,
+) -> dict[str, Any]:
+    """Adapt one coder steer onto process.input without changing its executor."""
+    from .... import coder_steering
+    from ....principals import Principal, PrincipalKind
+
+    text = str(composed["text"])
+    refs = list(composed["refs"])
+    principal = getattr(
+        request.state, "principal", Principal(PrincipalKind.OWNER, "owner-session")
+    )
+    issued = await asyncio.to_thread(services.targets().issue, target)
+    use_executor = (
+        policy.get("outcome") == "allowed"
+        and issued.get("status") == "issued"
+        and (pane_id is None or issued.get("pane_id") == pane_id)
+    )
+    preflight = None
+    if not use_executor:
+        preflight = await asyncio.to_thread(
+            coder_steering.deliver,
+            key,
+            text,
+            current_target=target,
+            agent=agent,
+            submit=submit,
+            grounding_refs=refs,
+            expected_pane_id=pane_id,
+            operation=operation,
+            policy_snapshot=policy,
+        )
+    command = {
+        "node_id": "local",
+        "target_id": issued.get("target_id") or f"route_{uuid.uuid4().hex[:16]}",
+        "target_generation": issued.get("target_generation") or "unresolved",
+        "operation": {"family": "coder_steering", "verb": "terminal.text"},
+        "payload": {
+            "session_key": key,
+            "text": text,
+            "agent": agent,
+            "submit": submit,
+            "grounding_refs": refs,
+        },
+    }
+    adapted = await asyncio.to_thread(
+        services.commands().submit_process_input,
+        command,
+        principal,
+        authority_snapshot=policy,
+        preflight_result=preflight,
+        include_result=True,
+    )
+    result = dict(adapted.get("result") or {})
+    result["operation_id"] = adapted["operation_id"]
+    return result
+
+
 __all__ = [
     "active_policy_grant",
     "canonical_pane_id",
     "compose_from_body",
+    "deliver_process_input",
     "expected_pane_id",
+    "ProcessInputServices",
     "steering_commitment",
     "steering_policy",
 ]

--- a/holdspeak/web_server.py
+++ b/holdspeak/web_server.py
@@ -629,6 +629,8 @@ class MeetingWebServer:
         )
         app.state.node_token_store = _delivery_link.token_store
         _delivery_targets = TerminalTargetRegistry()
+        from .kernel.runtime import _service as _kernel_service
+
         _delivery_cmd = HubCommandService(
             repo=_get_delivery_db().delivery_receipts,
             processor=NodeCommandProcessor(
@@ -637,6 +639,7 @@ class MeetingWebServer:
                 ledger=NodeReceiptLedger(None),
             ),
             local_node_id="local",
+            kernel_broker=_kernel_service(),
         )
         _delivery_link.command_source = _delivery_cmd.claim_for_node
         app.include_router(
@@ -663,7 +666,11 @@ class MeetingWebServer:
         app.include_router(build_dictation_router(web_ctx))
         app.include_router(build_activity_router(web_ctx))
         app.include_router(build_pages_router(web_ctx))
-        app.include_router(build_system_router(web_ctx))
+        app.include_router(
+            build_system_router(
+                web_ctx, commands=_delivery_cmd, targets=_delivery_targets
+            )
+        )
         app.include_router(build_projects_router(web_ctx))
         app.include_router(build_primitives_router(web_ctx))
         app.include_router(build_projections_router(web_ctx))

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -5,9 +5,24 @@
 > evidence, no `Co-Authored-By`, metal-test exclusion).
 
 
-**Last updated:** 2026-07-26 — **Phase 106 (The Kernel) ACTIVE, 4/10
-— the law, both prerequisites, and the spine**. **HS-106-04 shipped the
-spine**: `holdspeak/kernel/` now exposes
+**Last updated:** 2026-07-27 — **Phase 106 (The Kernel) ACTIVE, 5/10
+— terminal input is kernel-backed**. **HS-106-05 shipped the first thin
+slice**: `process.input@1` admits terminal text once, exact-claims its
+existing native command, and closes the kernel receipt from the unchanged
+Phase-94 node receipt. Delivery and coder clients keep their shapes with one
+additive `operation_id`; the node envelope/result protocol and the native
+executors were adapted, not rewritten, and every other typing family remains
+outside the slice. A real spawned hub and tmux pane delivered in 84.76 ms;
+real `claude -p --settings` sessions preserved gate approve and the exact deny
+reason verbatim; the audit found one decision per proposal. Real SIGKILL after
+bytes landed reconciled by command ID to an indeterminate receipt without a
+retry. The executor-plane receipt-without-claim seam was resolved in the
+adapter, and HS-106-06 must confirm or refute the still-single-caller
+`native_id` filter. Final slice/density proof: 79 passed. The exact full suite
+recorded 4,252 passed / 39 skipped / 8 unrelated failures: seven reproduce with
+the same signatures on clean `origin/main`; the eighth is the recorded
+voice-notes wording drift. Earlier: **HS-106-04 shipped the spine**:
+`holdspeak/kernel/` now exposes
 exactly four caller calls (`read`, `submit`, `decide`, `events`) plus the
 separate `claim` / `receipt` / `reconcile` executor plane. The existing
 Phase-104 gate is the one native decision record behind `decide`; there

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/current-phase-status.md
@@ -1,6 +1,6 @@
 # Phase 106 - The Kernel
 
-**Status:** ACTIVE (4/10). Chartered 2026-07-26 from
+**Status:** ACTIVE (5/10). Chartered 2026-07-26 from
 [`PLAN_KERNEL_OPERATION_BROKER.md`](../../../docs/internal/PLAN_KERNEL_OPERATION_BROKER.md)
 (the RFC, three council passes) and the owner's direct charge:
 
@@ -11,7 +11,7 @@
 > records decisions and then creates artifacts out of those
 > decisions and meetings."
 
-**Last updated:** 2026-07-26 (HS-106-01 through HS-106-04 shipped; 4/10 — the law, both prerequisites, and the spine).
+**Last updated:** 2026-07-27 (HS-106-01 through HS-106-05 shipped; 5/10 — the law, both prerequisites, the spine, and terminal input).
 
 ## Why this phase exists
 
@@ -111,7 +111,7 @@ receipt for every consequence.
 | HS-106-02 | Principal separation on loopback | done | [story-02-principals](./story-02-principals.md) | [evidence-story-02](./evidence-story-02.md) |
 | HS-106-03 | The effect census, pinned as a test | done | [story-03-census-test](./story-03-census-test.md) | [evidence-story-03](./evidence-story-03.md) |
 | HS-106-04 | The broker and the journal — four calls | done | [story-04-broker-journal](./story-04-broker-journal.md) | [evidence-story-04](./evidence-story-04.md) |
-| HS-106-05 | Thin slice I — terminal input | ready | [story-05-slice-terminal](./story-05-slice-terminal.md) | — |
+| HS-106-05 | Thin slice I — terminal input | done | [story-05-slice-terminal](./story-05-slice-terminal.md) | [evidence-story-05](./evidence-story-05.md) |
 | HS-106-06 | Thin slice II — actuator egress | ready | [story-06-slice-actuator](./story-06-slice-actuator.md) | — |
 | HS-106-07 | Thin slice III — inference, and the kill criterion | ready | [story-07-slice-inference-kill](./story-07-slice-inference-kill.md) | — |
 | HS-106-08 | Userland — PR follow-through, the tech-lead's loop | ready | [story-08-userland-pr-follow](./story-08-userland-pr-follow.md) | — |
@@ -168,6 +168,24 @@ pretending.
   three thinly.
 
 ## Where we are
+
+**2026-07-27 — HS-106-05 shipped, 5/10.** `process.input@1` is the
+second real driver. The delivery and coder façades now admit terminal text,
+return an additive operation ID, exact-claim the correlated native command,
+and close the generic receipt from the unchanged Phase-94 node receipt. The
+native envelope/result protocol, `HubCommandService`, `NodeCommandProcessor`,
+`coder_steering.deliver`, and `send_text_to_pane` remain authoritative; no
+other typing family moved. Real spawned-hub/tmux proof landed text in 84.76 ms,
+real `claude -p --settings` sessions preserved gate approve and verbatim deny,
+and the audit showed one decision per proposal. Real SIGKILL after bytes landed
+reconciled by command ID to `indeterminate_after_node_reset` and an
+`indeterminate` kernel receipt, with no retry. The executor plane's
+receipt-without-claim resistance was resolved in the adapter; `native_id` has
+one filtered caller and HS-106-06 must confirm or refute that seam. Final slice
+and density proof: 79 passed. The exact full suite completed 4,252 passed / 39
+skipped / 8 unrelated failures: seven reproduced with the same signatures on
+clean `origin/main`, and the eighth is the already-recorded voice-notes wording
+drift. HS-106-06 is next: actuator egress must be genuinely heterogeneous.
 
 **2026-07-26 — HS-106-04 shipped, 4/10.** The kernel spine now has
 exactly four caller calls (`read`, `submit`, `decide`, `events`) and the

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-05.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/evidence-story-05.md
@@ -1,0 +1,1682 @@
+# Evidence - HS-106-05
+
+- **Story:** HS-106-05 - Thin slice I — terminal input
+- **Status:** done
+- **Date:** 2026-07-26
+
+## Outcome
+
+`process.input@1` is the second real operation driver. Terminal text now enters
+through the kernel, correlates to the existing immutable delivery command by
+`command_id`, claims through the executor plane, and closes from the native
+receipt. `HubCommandService`, `NodeCommandProcessor`, the node envelope/result
+wire shapes, `coder_steering.deliver`, and `send_text_to_pane` remain the native
+protocol and executors. Delivery and coder façades preserve their prior fields
+and add only `operation_id`; keys, kill, spawn, launch, dictation, Cadence, and
+other typing families remain unmigrated.
+
+The live rig below used a real spawned hub and real tmux panes. One interactive
+Claude session received its prompt through the coder façade and
+`submit(process.input)`; its final kernel receipt succeeded in 84.76 ms, below the
+Phase-104 250 ms unarmed budget. Two separate real `claude -p --settings`
+sessions exercised the unchanged PreToolUse/Stop gate rig: one owner approval
+ran, one owner denial did not create its sentinel file, and the exact denial
+reason reached Claude verbatim. The audit census found exactly one decision for
+each proposal.
+
+A real forked node typed into a real tmux pane, was sent SIGKILL after the text
+landed but before its native receipt persisted, then restarted on the same
+ledger. Reconciliation by the existing command ID returned
+`indeterminate_after_node_reset`; the linked kernel receipt is
+`indeterminate`. No blind retry occurred. A second guard covers the pre-claim
+case: a dropped native queue item closes as a kernel refusal rather than leaving
+an awaiting operation orphaned.
+
+## Where the spine resisted
+
+The Phase-104/94 domain lifecycle and the generic kernel lifecycle overlap but
+are not identical. The generic claim originally selected only the oldest item
+for a placement; that is insufficient when the authoritative native queue has
+already established an exact command order or has deliberately dropped an
+older item. The executor plane therefore gained a generic optional `native_id`
+selector. It contains no terminal name or branch, preserves the public node
+wire protocol, and lets the adapter claim the exact correlated operation. In
+this slice terminal delivery is the **only** caller that passes `native_id`;
+tool-call claim still uses placement order. The selector is needed because the
+native queue is authoritative and can lose or reconcile one command while
+other operations share the placement, but it is not yet validated by a second
+heterogeneous driver. HS-106-06 must confirm or refute this general seam; this
+slice generalizes it no further.
+
+An initial implementation also allowed a placement-matched node to file an
+unclaimed refusal. Review correctly identified that as a semantic weakening of
+the executor plane: a node could refuse an owner-approved operation placed on
+it without consuming the one-use claim. That change was reverted. The terminal
+adapter now exact-claims responsibility first, then records `not_executed` as a
+refusal. Admission rejection would be dishonest here because the concrete
+sequence is later: the owner approved, the native in-memory queue was lost
+before the node polled (for example at hub restart), and the authoritative
+native row proves the send remained `sent`. The claim is therefore the node's
+terminalization responsibility, not a claim that bytes ran. A kernel test pins
+all three fences: same-node unclaimed refusal is rejected, same-node unclaimed
+success is rejected, and another node cannot receipt the operation.
+
+The broker still does not dispatch native drivers or expose codec payloads from
+`claim`; the terminal adapter must join operation ID to command ID outside the
+broker. `OperationSpec.interruption` is static, so the owner gesture is adapted
+as the generic submit/approve/claim sequence rather than hidden behind a
+terminal conditional. Those seams are recorded here rather than disguised as
+strategy tables. Authority is constructed in one place:
+`_authority_for()` resolves the native policy once and delegates encoding to
+`_authority_from_policy()`; supplied snapshots use that same encoder. The unit
+census monkeypatches `resolve_policy` and observes exactly one call for a send,
+while the real gate audit observes one decision row per proposal. Every broker
+module remains under 300 lines and the zero-driver-conditional census is green.
+
+The executor plane resisted this driver at the receipt-without-claim boundary
+(an approved command whose native row stayed `sent` after the queue vanished on
+restart still owes a terminal receipt under Article XI clause 2), and it was
+resolved in the **adapter** rather than by relaxing the spine. `native_id`
+currently has exactly one filtered caller, and HS-106-06 must confirm or refute
+it.
+
+The effect ledger is unchanged: T01 (`coder_steering.deliver` → terminal send)
+was already `covered`, and this slice moved no bypass entry to covered.
+
+## Full-suite adjudication
+
+The final required command, `uv run pytest -q
+--ignore=tests/e2e/test_metal.py`, completed with **4,252 passed, 39 skipped,
+8 failed, 1 warning in 1,001.39 seconds**. None of the eight failures is caused
+by this slice:
+
+- All three `tests/e2e/test_live_bus.py` failures reproduce together on the
+  clean `origin/main` archive: **3 failed in 17.76 seconds**, with the same
+  unauthenticated WebSocket retries and missing presence broadcast.
+- The four induction/mesh/pack failures reproduce together on that same clean
+  archive: **4 failed in 422.63 seconds**, with the same queued intel timeout,
+  missing OpenAI extra, mesh 502/canary absence, and Pack-D staging result.
+- `tests/uat/test_voice_notes.py::test_transcribe_up_but_unreachable_is_honest`
+  is the known wording-drift failure (`Transcribe failed (HTTP 502).`).
+
+The first post-review full run also exposed this slice's one genuine regression:
+`coder_steering_routes.py` exceeded its existing 600-line density budget. The
+kernel adaptation was moved into the existing `coder_steering_support.py`
+concern; the final density guard is green and the route is 597 lines.
+
+## Proof
+
+### Captured run — 2026-07-27T04:35:31Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 90%]
+........                                                                 [100%]
+80 passed in 11.74s
+```
+
+### Captured run — 2026-07-27T04:36:12Z
+
+- **Command:** `bash -euo pipefail -c uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_kernel_broker_modules_stay_within_line_budget tests/unit/test_kernel_effect_fence.py::test_kernel_broker_has_zero_driver_specific_conditionals && wc -l holdspeak/kernel/*.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+..                                                                       [100%]
+2 passed in 0.05s
+       9 holdspeak/kernel/__init__.py
+      64 holdspeak/kernel/admission.py
+     224 holdspeak/kernel/broker.py
+     111 holdspeak/kernel/executor.py
+     266 holdspeak/kernel/journal.py
+      70 holdspeak/kernel/model.py
+     129 holdspeak/kernel/process_input.py
+      90 holdspeak/kernel/runtime.py
+     144 holdspeak/kernel/tool_call.py
+    1107 total
+```
+
+### Captured run — 2026-07-27T04:36:29Z
+
+- **Command:** `uv run python /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/live_process_input_gate.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+can't find session: hs10605_approve_20791
+can't find session: hs10605_deny_20791
+{"gated_approve": {"decision": "approved", "output": "stdout: `GATE_APPROVE_KERNEL_10605`\n", "proposal_id": "toolu_01MqJ76TFXUZGFVtBNafgN3P", "reason_verbatim": null}, "gated_deny": {"decision": "denied", "effect_absent": true, "output": "The command was denied. Denial reason quoted verbatim: **\"denied from the desk: kernel desk says no files today\"**\n", "proposal_id": "toolu_01Agb1RdVNMG4mEskEQLE2ia", "reason_verbatim": true}, "one_decision_each": {"toolu_01Agb1RdVNMG4mEskEQLE2ia": 1, "toolu_01MqJ76TFXUZGFVtBNafgN3P": 1}, "real_send": {"latency_ms": 96.14, "marker_seen": true, "operation_id": "op_64e20d42d564463193aee7adbb02411c", "receipt": "succeeded"}}
+```
+
+### Captured run — 2026-07-27T04:37:18Z
+
+- **Command:** `uv run pytest -q -s tests/integration/test_process_input_real_hub.py::test_real_sigkill_mid_send_reconciles_indeterminate_by_command_id`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+{"aggregate": "indeterminate_after_node_reset", "command_id": "dd85c6d2-afdc-4a11-9b8c-bde81c01cbb5", "kernel_receipt": "indeterminate", "operation_id": "op_03483abe14384ccfac83e719e3ef9386", "reconcile": "by_command_id", "sigkill": -9, "text_landed": "LANDED_BEFORE_SIGKILL_10605"}
+.
+1 passed in 0.21s
+```
+
+### Captured run — 2026-07-27T04:50:13Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+...F.................................................................... [ 90%]
+........                                                                 [100%]
+=================================== FAILURES ===================================
+______________ test_real_http_process_input_types_into_real_tmux _______________
+
+tmp_path = PosixPath('/private/var/folders/q7/5dzz5g2116b3lq8rhg7hwjrr0000gn/T/pytest-of-karol/pytest-515/test_real_http_process_input_t0')
+
+    @pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux is required for real terminal proof")
+    def test_real_http_process_input_types_into_real_tmux(tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        config = home / ".config" / "holdspeak" / "config.json"
+        config.parent.mkdir(parents=True)
+        config.write_text(
+            json.dumps(
+                {
+                    "config_version": 1,
+                    "control_mode": "yolo",
+                    "meeting": {"web_auth_token": _OWNER_TOKEN},
+                }
+            ),
+            encoding="utf-8",
+        )
+        received = tmp_path / "received.txt"
+        tmux_name = f"hs10605_{os.getpid()}"
+        subprocess.run(
+            [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                tmux_name,
+                f"sh -c 'IFS= read -r line; printf %s \"$line\" > {received}; sleep 3'",
+            ],
+            check=True,
+        )
+        pane = subprocess.run(
+            ["tmux", "display-message", "-p", "-t", f"{tmux_name}:0.0", "#{pane_id}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        with socket.socket() as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            port = reservation.getsockname()[1]
+        base = f"http://127.0.0.1:{port}"
+        env = os.environ.copy()
+        env.update(HOME=str(home), HOLDSPEAK_WEB_PORT=str(port), PYTHONUNBUFFERED="1")
+
+        def request(method: str, path: str, body: Any = None) -> tuple[int, dict[str, Any]]:
+            data = None if body is None else json.dumps(body).encode()
+            outgoing = urllib.request.Request(
+                base + path,
+                data=data,
+                headers={
+                    "content-type": "application/json",
+                    "authorization": f"Bearer {_OWNER_TOKEN}",
+                },
+                method=method,
+            )
+            try:
+                with urllib.request.urlopen(outgoing, timeout=10) as response:
+                    return response.status, json.load(response)
+            except urllib.error.HTTPError as exc:
+                return exc.code, json.load(exc)
+
+        hub = subprocess.Popen(
+            [sys.executable, "-m", "holdspeak.main", "web", "--no-open"],
+            cwd=_REPO,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            for _ in range(100):
+                if hub.poll() is not None:
+                    output = hub.stdout.read() if hub.stdout else ""
+                    raise AssertionError(f"spawned hub exited early:\n{output}")
+                try:
+                    with urllib.request.urlopen(base + "/health", timeout=0.2):
+                        break
+                except Exception:
+                    time.sleep(0.1)
+            else:
+                hub.kill()
+                output = hub.stdout.read() if hub.stdout else ""
+>               raise AssertionError(f"spawned hub did not become healthy:\n{output}")
+E               AssertionError: spawned hub did not become healthy:
+
+tests/integration/test_process_input_real_hub.py:112: AssertionError
+=========================== short test summary info ============================
+FAILED tests/integration/test_process_input_real_hub.py::test_real_http_process_input_types_into_real_tmux
+1 failed, 79 passed in 23.84s
+```
+
+### Captured run — 2026-07-27T04:51:49Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 90%]
+........                                                                 [100%]
+80 passed in 7.44s
+```
+
+### Captured run — 2026-07-27T05:16:05Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py tests/unit/test_kernel_broker.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 75%]
+........................                                                 [100%]
+96 passed in 19.14s
+```
+
+### Captured run — 2026-07-27T05:20:33Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py tests/unit/test_kernel_broker.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 74%]
+.........................                                                [100%]
+97 passed in 19.45s
+```
+
+### Captured run — 2026-07-27T05:21:02Z
+
+- **Command:** `bash -euo pipefail -c uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_kernel_broker_modules_stay_within_line_budget tests/unit/test_kernel_effect_fence.py::test_kernel_broker_has_zero_driver_specific_conditionals && wc -l holdspeak/kernel/*.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+..                                                                       [100%]
+2 passed in 0.06s
+       9 holdspeak/kernel/__init__.py
+      64 holdspeak/kernel/admission.py
+     224 holdspeak/kernel/broker.py
+     116 holdspeak/kernel/executor.py
+     270 holdspeak/kernel/journal.py
+      70 holdspeak/kernel/model.py
+     129 holdspeak/kernel/process_input.py
+      90 holdspeak/kernel/runtime.py
+     144 holdspeak/kernel/tool_call.py
+    1116 total
+```
+
+### Captured run — 2026-07-27T05:23:22Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py tests/unit/test_kernel_broker.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 72%]
+...........................                                              [100%]
+99 passed in 20.89s
+```
+
+### Captured run — 2026-07-27T05:26:33Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py tests/unit/test_kernel_broker.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 72%]
+...........................                                              [100%]
+99 passed in 17.62s
+```
+
+### Captured run — 2026-07-27T05:28:58Z
+
+- **Command:** `bash -c cd /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/baseline-main && PYTHONPATH=. /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/bin/pytest -q tests/e2e/test_live_bus.py::test_every_live_page_opens_exactly_one_runtime_socket`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+F                                                                        [100%]
+=================================== FAILURES ===================================
+____________ test_every_live_page_opens_exactly_one_runtime_socket _____________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_every_live_page_opens_exactly_one_runtime_socket(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        try:
+            for route in ("/live", "/dictation", "/presence", "/setup"):
+                page = browser.new_page()
+                errors = []
+                page.on("pageerror", lambda e: errors.append(str(e)))
+                n = _count_runtime_sockets(page, f"http://127.0.0.1:{PORT}{route}")
+                page.close()
+>               assert n == 1, f"{route} opened {n} runtime sockets (want exactly 1)"
+E               AssertionError: /live opened 3 runtime sockets (want exactly 1)
+E               assert 3 == 1
+
+tests/e2e/test_live_bus.py:96: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+=========================== short test summary info ============================
+FAILED tests/e2e/test_live_bus.py::test_every_live_page_opens_exactly_one_runtime_socket
+1 failed in 5.18s
+```
+
+### Captured run — 2026-07-27T05:33:03Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py tests/unit/test_kernel_broker.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 72%]
+...........................                                              [100%]
+99 passed in 18.98s
+```
+
+### Captured run — 2026-07-27T05:40:44Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py tests/unit/test_kernel_broker.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 72%]
+...........................                                              [100%]
+99 passed in 19.93s
+```
+
+### Captured run — 2026-07-27T05:50:05Z
+
+- **Command:** `uv run pytest -q tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_delivery_commands.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_web_routes_coders_steer.py tests/unit/test_kernel_effect_fence.py tests/unit/test_kernel_broker.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 72%]
+...........................                                              [100%]
+99 passed in 17.79s
+```
+
+### Captured run — 2026-07-27T05:50:47Z
+
+- **Command:** `uv run python /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/live_process_input_gate.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+can't find session: hs10605_approve_86028
+can't find session: hs10605_deny_86028
+{"gated_approve": {"decision": "approved", "output": "stdout: `GATE_APPROVE_KERNEL_10605`\n", "proposal_id": "toolu_01NPNEMyaJZneZHv8cXgFxB2", "reason_verbatim": null}, "gated_deny": {"decision": "denied", "effect_absent": true, "output": "The command was denied. Denial reason verbatim: \"denied from the desk: kernel desk says no files today\"\n", "proposal_id": "toolu_01UDT7DwnMN4c3Q1WiW3hPjp", "reason_verbatim": true}, "one_decision_each": {"toolu_01NPNEMyaJZneZHv8cXgFxB2": 1, "toolu_01UDT7DwnMN4c3Q1WiW3hPjp": 1}, "real_send": {"latency_ms": 124.68, "marker_seen": true, "operation_id": "op_b631257570af45b0b9b1d4a4b663f657", "receipt": "succeeded"}}
+```
+
+### Captured run — 2026-07-27T05:51:47Z
+
+- **Command:** `bash -euo pipefail -c uv run pytest -q tests/unit/test_kernel_effect_fence.py::test_kernel_broker_modules_stay_within_line_budget tests/unit/test_kernel_effect_fence.py::test_kernel_broker_has_zero_driver_specific_conditionals && wc -l holdspeak/kernel/*.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+..                                                                       [100%]
+2 passed in 0.05s
+       9 holdspeak/kernel/__init__.py
+      64 holdspeak/kernel/admission.py
+     224 holdspeak/kernel/broker.py
+     111 holdspeak/kernel/executor.py
+     270 holdspeak/kernel/journal.py
+      70 holdspeak/kernel/model.py
+     133 holdspeak/kernel/process_input.py
+      90 holdspeak/kernel/runtime.py
+     144 holdspeak/kernel/tool_call.py
+    1115 total
+```
+
+### Captured run — 2026-07-27T06:00:54Z
+
+- **Command:** `bash -c cd /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/baseline-main && PYTHONPATH=. /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/bin/pytest -q tests/e2e/test_live_bus.py`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+FFF                                                                      [100%]
+=================================== FAILURES ===================================
+____________ test_every_live_page_opens_exactly_one_runtime_socket _____________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_every_live_page_opens_exactly_one_runtime_socket(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        try:
+            for route in ("/live", "/dictation", "/presence", "/setup"):
+                page = browser.new_page()
+                errors = []
+                page.on("pageerror", lambda e: errors.append(str(e)))
+                n = _count_runtime_sockets(page, f"http://127.0.0.1:{PORT}{route}")
+                page.close()
+>               assert n == 1, f"{route} opened {n} runtime sockets (want exactly 1)"
+E               AssertionError: /live opened 3 runtime sockets (want exactly 1)
+E               assert 3 == 1
+
+tests/e2e/test_live_bus.py:96: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+_________ test_a_real_broadcast_reaches_the_presence_card_via_the_bus __________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_a_real_broadcast_reaches_the_presence_card_via_the_bus(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        try:
+            page = browser.new_page()
+            page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+            page.wait_for_timeout(800)
+            server.broadcast(
+                "runtime_activity",
+                {
+                    "state": "transcribing",
+                    "label": "Transcribing",
+                    "source": "dictation",
+                    "window": {"visible": True},
+                },
+            )
+>           page.wait_for_function(
+                "() => document.querySelector('.presence-card strong')"
+                " && document.querySelector('.presence-card strong').textContent.includes('Transcribing')",
+                timeout=8000,
+            )
+
+tests/e2e/test_live_bus.py:119:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/lib/python3.13/site-packages/playwright/sync_api/_generated.py:11595: in wait_for_function
+    self._sync(
+/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/lib/python3.13/site-packages/playwright/_impl/_page.py:1110: in wait_for_function
+    return await self._main_frame.wait_for_function(**locals_to_params(locals()))
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/lib/python3.13/site-packages/playwright/_impl/_frame.py:878: in wait_for_function
+    await self._channel.send("waitForFunction", self._timeout, params)
+/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/lib/python3.13/site-packages/playwright/_impl/_connection.py:69: in send
+    return await self._connection.wrap_api_call(
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <playwright._impl._connection.Connection object at 0x10c36ef90>
+cb = <function Channel.send.<locals>.<lambda> at 0x110f0e3e0>
+is_internal = False, title = None
+
+    async def wrap_api_call(
+        self, cb: Callable[[], Any], is_internal: bool = False, title: str = None
+    ) -> Any:
+        if self._api_zone.get():
+            return await cb()
+        task = asyncio.current_task(self._loop)
+        st: List[inspect.FrameInfo] = getattr(
+            task, "__pw_stack__", None
+        ) or inspect.stack(0)
+
+        parsed_st = _extract_stack_trace_information_from_stack(st, is_internal, title)
+        self._api_zone.set(parsed_st)
+        try:
+            return await cb()
+        except Exception as error:
+>           raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
+E           playwright._impl._errors.TimeoutError: Page.wait_for_function: Timeout 8000ms exceeded.
+
+/Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/lib/python3.13/site-packages/playwright/_impl/_connection.py:559: TimeoutError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+________________ test_the_bus_reconnects_after_a_server_restart ________________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_the_bus_reconnects_after_a_server_restart(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        page = browser.new_page()
+        sockets: list[str] = []
+        page.on("websocket", lambda ws: sockets.append(ws.url))
+        try:
+            page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+            page.wait_for_timeout(1000)
+            first = sum(1 for u in sockets if u.rstrip("/").endswith("/ws"))
+>           assert first == 1
+E           assert 3 == 1
+
+tests/e2e/test_live_bus.py:140: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+=========================== short test summary info ============================
+FAILED tests/e2e/test_live_bus.py::test_every_live_page_opens_exactly_one_runtime_socket
+FAILED tests/e2e/test_live_bus.py::test_a_real_broadcast_reaches_the_presence_card_via_the_bus
+FAILED tests/e2e/test_live_bus.py::test_the_bus_reconnects_after_a_server_restart
+3 failed in 17.76s
+```
+
+### Captured run — 2026-07-27T05:52:07Z
+
+- **Command:** `bash -o pipefail -c uv run pytest -q --ignore=tests/e2e/test_metal.py 2>&1 | tee /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/full-suite-after-review.txt`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+ssssssssssssssssssssssFFFssssssssss..................................... [  1%]
+........................................................................ [  3%]
+......s................................................................. [  5%]
+.....................................................................ss. [  6%]
+........................................................................ [  8%]
+........................................................................ [ 10%]
+........................................................................ [ 11%]
+........................................................................ [ 13%]
+........................................................................ [ 15%]
+........................................................................ [ 16%]
+........................................................................ [ 18%]
+...............................................................F...F.... [ 20%]
+...F...........F........................................................ [ 21%]
+...................F.................................................... [ 23%]
+........................................................................ [ 25%]
+........................................................................ [ 26%]
+........................................................................ [ 28%]
+........................................................................ [ 30%]
+.....................................................F.................. [ 31%]
+........................................................................ [ 33%]
+........................................................................ [ 35%]
+........................................................................ [ 36%]
+........................................................................ [ 38%]
+........................................................................ [ 40%]
+........................................................................ [ 41%]
+........................................................................ [ 43%]
+........................................................................ [ 45%]
+........................................................................ [ 46%]
+........................................................................ [ 48%]
+........................................................................ [ 50%]
+........................................................................ [ 51%]
+........................................................................ [ 53%]
+........................................................................ [ 55%]
+........................s............................................... [ 56%]
+........................................................................ [ 58%]
+........................................................................ [ 60%]
+........................................................................ [ 62%]
+........................................................................ [ 63%]
+........................................................................ [ 65%]
+........................................................................ [ 67%]
+........................................................................ [ 68%]
+........................................................................ [ 70%]
+........................................................................ [ 72%]
+........................................................................ [ 73%]
+........................................................................ [ 75%]
+........................................................................ [ 77%]
+........................................................................ [ 78%]
+........................................................................ [ 80%]
+........................................................................ [ 82%]
+........................................................................ [ 83%]
+........................................................................ [ 85%]
+........................................................................ [ 87%]
+........................................................................ [ 88%]
+........................................................................ [ 90%]
+........................................................................ [ 92%]
+........................................................................ [ 93%]
+........................................................................ [ 95%]
+........................................................................ [ 97%]
+........................................................................ [ 98%]
+................................................                         [100%]
+=================================== FAILURES ===================================
+____________ test_every_live_page_opens_exactly_one_runtime_socket _____________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_every_live_page_opens_exactly_one_runtime_socket(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        try:
+            for route in ("/live", "/dictation", "/presence", "/setup"):
+                page = browser.new_page()
+                errors = []
+                page.on("pageerror", lambda e: errors.append(str(e)))
+                n = _count_runtime_sockets(page, f"http://127.0.0.1:{PORT}{route}")
+                page.close()
+>               assert n == 1, f"{route} opened {n} runtime sockets (want exactly 1)"
+E               AssertionError: /live opened 3 runtime sockets (want exactly 1)
+E               assert 3 == 1
+
+tests/e2e/test_live_bus.py:96: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+_________ test_a_real_broadcast_reaches_the_presence_card_via_the_bus __________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_a_real_broadcast_reaches_the_presence_card_via_the_bus(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        try:
+            page = browser.new_page()
+            page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+            page.wait_for_timeout(800)
+            server.broadcast(
+                "runtime_activity",
+                {
+                    "state": "transcribing",
+                    "label": "Transcribing",
+                    "source": "dictation",
+                    "window": {"visible": True},
+                },
+            )
+>           page.wait_for_function(
+                "() => document.querySelector('.presence-card strong')"
+                " && document.querySelector('.presence-card strong').textContent.includes('Transcribing')",
+                timeout=8000,
+            )
+
+tests/e2e/test_live_bus.py:119:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+.venv/lib/python3.13/site-packages/playwright/sync_api/_generated.py:11595: in wait_for_function
+    self._sync(
+.venv/lib/python3.13/site-packages/playwright/_impl/_page.py:1110: in wait_for_function
+    return await self._main_frame.wait_for_function(**locals_to_params(locals()))
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.venv/lib/python3.13/site-packages/playwright/_impl/_frame.py:878: in wait_for_function
+    await self._channel.send("waitForFunction", self._timeout, params)
+.venv/lib/python3.13/site-packages/playwright/_impl/_connection.py:69: in send
+    return await self._connection.wrap_api_call(
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <playwright._impl._connection.Connection object at 0x112cc6ba0>
+cb = <function Channel.send.<locals>.<lambda> at 0x113d83d80>
+is_internal = False, title = None
+
+    async def wrap_api_call(
+        self, cb: Callable[[], Any], is_internal: bool = False, title: str = None
+    ) -> Any:
+        if self._api_zone.get():
+            return await cb()
+        task = asyncio.current_task(self._loop)
+        st: List[inspect.FrameInfo] = getattr(
+            task, "__pw_stack__", None
+        ) or inspect.stack(0)
+
+        parsed_st = _extract_stack_trace_information_from_stack(st, is_internal, title)
+        self._api_zone.set(parsed_st)
+        try:
+            return await cb()
+        except Exception as error:
+>           raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
+E           playwright._impl._errors.TimeoutError: Page.wait_for_function: Timeout 8000ms exceeded.
+
+.venv/lib/python3.13/site-packages/playwright/_impl/_connection.py:559: TimeoutError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+________________ test_the_bus_reconnects_after_a_server_restart ________________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_the_bus_reconnects_after_a_server_restart(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        page = browser.new_page()
+        sockets: list[str] = []
+        page.on("websocket", lambda ws: sockets.append(ws.url))
+        try:
+            page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+            page.wait_for_timeout(1000)
+            first = sum(1 for u in sockets if u.rstrip("/").endswith("/ws"))
+>           assert first == 1
+E           assert 3 == 1
+
+tests/e2e/test_live_bus.py:140: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+________________ test_meeting_recipe_yields_a_real_open_action _________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x11494ef30>
+
+    def test_meeting_recipe_yields_a_real_open_action(real_manager):
+        run = _boot_or_skip(real_manager, "golden-43")
+>       result = real_manager.apply_recipe(run.id, "meeting-just-ended-open-actions")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_43.py:52:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x1380d5010>
+name = 'meeting-just-ended-open-actions', run_id = 'run-20260727T055648-5c9621'
+host = <uat.conductor.runs.RunManager object at 0x11494ef30>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'meeting-just-ended-open-actions' failed to verify: meeting_with_open_actions: timed out after 180s: meetings present but none with ≥1 open actions: Pylon incident war room (UAT seed)(0,queued)
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+__________________ test_intel_endpoint_dead_degrades_honestly __________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x1380c0910>
+
+    def test_intel_endpoint_dead_degrades_honestly(real_manager):
+        run = _boot_or_skip(real_manager)
+>       result = real_manager.apply_recipe(run.id, "intel-endpoint-dead")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_local.py:73:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x11644a5d0>
+name = 'intel-endpoint-dead', run_id = 'run-20260727T060506-cbca56'
+host = <uat.conductor.runs.RunManager object at 0x1380c0910>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'intel-endpoint-dead' failed to verify: runtime_endpoint_unreachable: runtime-test ok=False status='unavailable' in 0.0s: Backend 'openai_compatible' requires the 'openai' package. Install with: uv pip install holdspeak[dictation-openai]
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+______________ test_run_dispatched_onto_the_worker_returns_badged ______________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x138733890>
+
+    def test_run_dispatched_onto_the_worker_returns_badged(real_manager):
+        run = _boot_or_skip(real_manager, "mesh-node")
+
+>       result = real_manager.apply_recipe(run.id, "mesh-run-on-worker")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_mesh_dispatch.py:55:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x138caae10>
+name = 'mesh-run-on-worker', run_id = 'run-20260727T060510-0ca1fe'
+host = <uat.conductor.runs.RunManager object at 0x138733890>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.regi
+[PMO_EVIDENCE_OUTPUT_TRUNCATED]
+```
+
+### Captured run — 2026-07-27T06:13:33Z
+
+- **Command:** `bash -c cd /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/baseline-main && PYTHONPATH=. /Users/karol/dev/tools/HoldSpeak/.claude/worktrees/agent-acfa3f9b75105e6ab/.venv/bin/pytest -q tests/uat/test_induction_integration_43.py::test_meeting_recipe_yields_a_real_open_action tests/uat/test_induction_integration_local.py::test_intel_endpoint_dead_degrades_honestly tests/uat/test_mesh_dispatch.py::test_run_dispatched_onto_the_worker_returns_badged tests/uat/test_packs.py::test_pack_d_stages_locally`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+FFFF                                                                     [100%]
+=================================== FAILURES ===================================
+________________ test_meeting_recipe_yields_a_real_open_action _________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x10d2f52b0>
+
+    def test_meeting_recipe_yields_a_real_open_action(real_manager):
+        run = _boot_or_skip(real_manager, "golden-43")
+>       result = real_manager.apply_recipe(run.id, "meeting-just-ended-open-actions")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_43.py:52:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x10d2f5a90>
+name = 'meeting-just-ended-open-actions', run_id = 'run-20260727T061333-33a5cd'
+host = <uat.conductor.runs.RunManager object at 0x10d2f52b0>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'meeting-just-ended-open-actions' failed to verify: meeting_with_open_actions: timed out after 180s: meetings present but none with ≥1 open actions: Pylon incident war room (UAT seed)(0,queued)
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+__________________ test_intel_endpoint_dead_degrades_honestly __________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x10d25dd10>
+
+    def test_intel_endpoint_dead_degrades_honestly(real_manager):
+        run = _boot_or_skip(real_manager)
+>       result = real_manager.apply_recipe(run.id, "intel-endpoint-dead")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_local.py:73:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x10d25f110>
+name = 'intel-endpoint-dead', run_id = 'run-20260727T061938-4aae7a'
+host = <uat.conductor.runs.RunManager object at 0x10d25dd10>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'intel-endpoint-dead' failed to verify: runtime_endpoint_unreachable: runtime-test ok=False status='unavailable' in 0.0s: Backend 'openai_compatible' requires the 'openai' package. Install with: uv pip install holdspeak[dictation-openai]
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+______________ test_run_dispatched_onto_the_worker_returns_badged ______________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x10d460cd0>
+
+    def test_run_dispatched_onto_the_worker_returns_badged(real_manager):
+        run = _boot_or_skip(real_manager, "mesh-node")
+
+>       result = real_manager.apply_recipe(run.id, "mesh-run-on-worker")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_mesh_dispatch.py:55:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x10d461310>
+name = 'mesh-run-on-worker', run_id = 'run-20260727T061941-bee67c'
+host = <uat.conductor.runs.RunManager object at 0x10d460cd0>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'mesh-run-on-worker' failed to verify: run_returned_badged: dispatch failed HTTP 502: None; run_claimed_by_worker: worker claims 0→1 (moved=True); hub provider='' scope='' (no-local=False); run_output_contains: output MISSING 'PYLON-CANARY-7' (0 chars)
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+__________________________ test_pack_d_stages_locally __________________________
+
+real_client = <starlette.testclient.TestClient object at 0x10d5f4980>
+
+    def test_pack_d_stages_locally(real_client):
+        """Pack D demos without the LAN: its bad-endpoint scenario stages + verifies."""
+        created = real_client.post("/api/sittings", json={"pack": "pack-d-honest-failure"}).json()
+        if created["run"] is None or created["run"]["status"] != "up":
+            pytest.skip("product did not boot")
+        sid = created["id"]
+        # Stage the dead-endpoint scenario (fully local — port 9 refused).
+        staged = real_client.post(f"/api/sittings/{sid}/stage", json={"scenario_id": "d-dead-endpoint-doctor"}).json()
+>       assert staged["ok"], staged
+E       AssertionError: {'ok': False, 'scenario_id': 'd-dead-endpoint-doctor', 'staging': [{'error': "recipe 'intel-endpoint-dead' failed to v...--no-open`): browser auto-open disabled.
+E         Press Ctrl+C to stop.'}, 'ok': False, 'recipe': 'intel-endpoint-dead', ...}]}
+E       assert False
+
+tests/uat/test_packs.py:180: AssertionError
+=========================== short test summary info ============================
+FAILED tests/uat/test_induction_integration_43.py::test_meeting_recipe_yields_a_real_open_action
+FAILED tests/uat/test_induction_integration_local.py::test_intel_endpoint_dead_degrades_honestly
+FAILED tests/uat/test_mesh_dispatch.py::test_run_dispatched_onto_the_worker_returns_badged
+FAILED tests/uat/test_packs.py::test_pack_d_stages_locally - AssertionError: ...
+4 failed in 422.63s (0:07:02)
+```
+
+### Captured run — 2026-07-27T06:21:34Z
+
+- **Command:** `uv run pytest -q tests/unit/test_backend_density_guard.py::test_phase79_package_modules_stay_single_concern tests/unit/test_web_routes_coders_steer.py tests/unit/test_delivery_terminal_routes.py tests/unit/test_process_input_kernel.py tests/integration/test_process_input_real_hub.py tests/unit/test_kernel_broker.py tests/unit/test_kernel_effect_fence.py tests/integration/test_delivery_campaign.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+........................................................................ [ 91%]
+.......                                                                  [100%]
+79 passed in 15.77s
+```
+
+### Captured run — 2026-07-27T06:22:00Z
+
+- **Command:** `uv run python /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/live_process_input_gate.py`
+- **Cwd:** .
+- **Exit code:** 0
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+can't find session: hs10605_approve_22749
+can't find session: hs10605_deny_22749
+{"gated_approve": {"decision": "approved", "output": "stdout: `GATE_APPROVE_KERNEL_10605`\n", "proposal_id": "toolu_01SnYXZo41wh4vsXahDC7Hkj", "reason_verbatim": null}, "gated_deny": {"decision": "denied", "effect_absent": true, "output": "The command was denied. Denial reason, quoted verbatim:\n\n> denied from the desk: kernel desk says no files today\n", "proposal_id": "toolu_01U7NZ8mkVei3xSaVauGsDGe", "reason_verbatim": true}, "one_decision_each": {"toolu_01SnYXZo41wh4vsXahDC7Hkj": 1, "toolu_01U7NZ8mkVei3xSaVauGsDGe": 1}, "real_send": {"latency_ms": 84.76, "marker_seen": true, "operation_id": "op_df144c8f50044ff9aff5af7b5dcf909a", "receipt": "succeeded"}}
+```
+
+### Captured run — 2026-07-27T06:23:23Z
+
+- **Command:** `bash -o pipefail -c uv run pytest -q --ignore=tests/e2e/test_metal.py 2>&1 | tee /private/tmp/claude-501/-Users-karol-dev-tools-HoldSpeak/755cdf1e-8c7b-4e33-923d-a46dc3bb7d49/scratchpad/full-suite-final-after-density.txt`
+- **Cwd:** .
+- **Exit code:** 1
+- **Index-tree:** 263833daafbb51509c73958eceeed81628e5a056
+
+```text
+ssssssssssssssssssssssFFFssssssssss..................................... [  1%]
+........................................................................ [  3%]
+......s................................................................. [  5%]
+.....................................................................ss. [  6%]
+........................................................................ [  8%]
+........................................................................ [ 10%]
+........................................................................ [ 11%]
+........................................................................ [ 13%]
+........................................................................ [ 15%]
+........................................................................ [ 16%]
+........................................................................ [ 18%]
+...............................................................F...F.... [ 20%]
+...F...........F........................................................ [ 21%]
+...................F.................................................... [ 23%]
+........................................................................ [ 25%]
+........................................................................ [ 26%]
+........................................................................ [ 28%]
+........................................................................ [ 30%]
+........................................................................ [ 31%]
+........................................................................ [ 33%]
+........................................................................ [ 35%]
+........................................................................ [ 36%]
+........................................................................ [ 38%]
+........................................................................ [ 40%]
+........................................................................ [ 41%]
+........................................................................ [ 43%]
+........................................................................ [ 45%]
+........................................................................ [ 46%]
+........................................................................ [ 48%]
+........................................................................ [ 50%]
+........................................................................ [ 51%]
+........................................................................ [ 53%]
+........................................................................ [ 55%]
+........................s............................................... [ 56%]
+........................................................................ [ 58%]
+........................................................................ [ 60%]
+........................................................................ [ 62%]
+........................................................................ [ 63%]
+........................................................................ [ 65%]
+........................................................................ [ 67%]
+........................................................................ [ 68%]
+........................................................................ [ 70%]
+........................................................................ [ 72%]
+........................................................................ [ 73%]
+........................................................................ [ 75%]
+........................................................................ [ 77%]
+........................................................................ [ 78%]
+........................................................................ [ 80%]
+........................................................................ [ 82%]
+........................................................................ [ 83%]
+........................................................................ [ 85%]
+........................................................................ [ 87%]
+........................................................................ [ 88%]
+........................................................................ [ 90%]
+........................................................................ [ 92%]
+........................................................................ [ 93%]
+........................................................................ [ 95%]
+........................................................................ [ 97%]
+........................................................................ [ 98%]
+................................................                         [100%]
+=================================== FAILURES ===================================
+____________ test_every_live_page_opens_exactly_one_runtime_socket _____________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_every_live_page_opens_exactly_one_runtime_socket(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        try:
+            for route in ("/live", "/dictation", "/presence", "/setup"):
+                page = browser.new_page()
+                errors = []
+                page.on("pageerror", lambda e: errors.append(str(e)))
+                n = _count_runtime_sockets(page, f"http://127.0.0.1:{PORT}{route}")
+                page.close()
+>               assert n == 1, f"{route} opened {n} runtime sockets (want exactly 1)"
+E               AssertionError: /live opened 3 runtime sockets (want exactly 1)
+E               assert 3 == 1
+
+tests/e2e/test_live_bus.py:96: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+_________ test_a_real_broadcast_reaches_the_presence_card_via_the_bus __________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_a_real_broadcast_reaches_the_presence_card_via_the_bus(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        try:
+            page = browser.new_page()
+            page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+            page.wait_for_timeout(800)
+            server.broadcast(
+                "runtime_activity",
+                {
+                    "state": "transcribing",
+                    "label": "Transcribing",
+                    "source": "dictation",
+                    "window": {"visible": True},
+                },
+            )
+>           page.wait_for_function(
+                "() => document.querySelector('.presence-card strong')"
+                " && document.querySelector('.presence-card strong').textContent.includes('Transcribing')",
+                timeout=8000,
+            )
+
+tests/e2e/test_live_bus.py:119:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+.venv/lib/python3.13/site-packages/playwright/sync_api/_generated.py:11595: in wait_for_function
+    self._sync(
+.venv/lib/python3.13/site-packages/playwright/_impl/_page.py:1110: in wait_for_function
+    return await self._main_frame.wait_for_function(**locals_to_params(locals()))
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.venv/lib/python3.13/site-packages/playwright/_impl/_frame.py:878: in wait_for_function
+    await self._channel.send("waitForFunction", self._timeout, params)
+.venv/lib/python3.13/site-packages/playwright/_impl/_connection.py:69: in send
+    return await self._connection.wrap_api_call(
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <playwright._impl._connection.Connection object at 0x10f21aba0>
+cb = <function Channel.send.<locals>.<lambda> at 0x1102d6fc0>
+is_internal = False, title = None
+
+    async def wrap_api_call(
+        self, cb: Callable[[], Any], is_internal: bool = False, title: str = None
+    ) -> Any:
+        if self._api_zone.get():
+            return await cb()
+        task = asyncio.current_task(self._loop)
+        st: List[inspect.FrameInfo] = getattr(
+            task, "__pw_stack__", None
+        ) or inspect.stack(0)
+
+        parsed_st = _extract_stack_trace_information_from_stack(st, is_internal, title)
+        self._api_zone.set(parsed_st)
+        try:
+            return await cb()
+        except Exception as error:
+>           raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
+E           playwright._impl._errors.TimeoutError: Page.wait_for_function: Timeout 8000ms exceeded.
+
+.venv/lib/python3.13/site-packages/playwright/_impl/_connection.py:559: TimeoutError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+________________ test_the_bus_reconnects_after_a_server_restart ________________
+
+browser = <Browser type=<BrowserType name=chromium executable_path=/Users/karol/Library/Caches/ms-playwright/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing> version=143.0.7499.4>
+
+    def test_the_bus_reconnects_after_a_server_restart(browser):
+        server = _make_server()
+        uv = _Uvicorn(server.app)
+        uv.start()
+        page = browser.new_page()
+        sockets: list[str] = []
+        page.on("websocket", lambda ws: sockets.append(ws.url))
+        try:
+            page.goto(f"http://127.0.0.1:{PORT}/presence", wait_until="networkidle")
+            page.wait_for_timeout(1000)
+            first = sum(1 for u in sockets if u.rstrip("/").endswith("/ws"))
+>           assert first == 1
+E           assert 3 == 1
+
+tests/e2e/test_live_bus.py:140: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+WARNING  holdspeak.web.routes.system:ws.py:54 Rejected WebSocket: principal=none missing_right=owner
+________________ test_meeting_recipe_yields_a_real_open_action _________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x134dd7570>
+
+    def test_meeting_recipe_yields_a_real_open_action(real_manager):
+        run = _boot_or_skip(real_manager, "golden-43")
+>       result = real_manager.apply_recipe(run.id, "meeting-just-ended-open-actions")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_43.py:52:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x133bab5f0>
+name = 'meeting-just-ended-open-actions', run_id = 'run-20260727T062825-bcd502'
+host = <uat.conductor.runs.RunManager object at 0x134dd7570>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'meeting-just-ended-open-actions' failed to verify: meeting_with_open_actions: timed out after 180s: meetings present but none with ≥1 open actions: Pylon incident war room (UAT seed)(0,queued)
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+__________________ test_intel_endpoint_dead_degrades_honestly __________________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x13534f1b0>
+
+    def test_intel_endpoint_dead_degrades_honestly(real_manager):
+        run = _boot_or_skip(real_manager)
+>       result = real_manager.apply_recipe(run.id, "intel-endpoint-dead")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_induction_integration_local.py:73:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x134b6f770>
+name = 'intel-endpoint-dead', run_id = 'run-20260727T063641-46a06e'
+host = <uat.conductor.runs.RunManager object at 0x13534f1b0>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.registry.resolve_order(name)
+        target = self.registry.load(name)
+
+        if target.requires_intel and not allow_intel:
+            raise RecipeError(
+                f"recipe {name!r} requires intel (the .43 LAN endpoint) but "
+                "intel is disabled for this apply"
+            )
+
+        # 1. Ensure the run is booted on the recipe's deck + cache posture.
+        restarted = host.ensure_deck(run_id, target.deck, link_caches=target.link_caches)
+
+        client = host.product_client(run_id)
+        home = host.run_home(run_id)
+        evaluator = ProbeEvaluator(client, home=home, run_id=run_id)
+
+        # The combined probe is the target's own probe (includes stage the world;
+        # the target's probe is the authoritative claim). Included recipes still
+        # contribute their seeds/actions below.
+        probe_spec = target.probe
+
+        # 2. Probe-first idempotency.
+        pre = evaluator.evaluate(probe_spec)
+        if pre.ok and probe_spec:
+            return ApplyResult(
+                recipe=name,
+                deck=target.deck,
+                already_satisfied=True,
+                probe=pre.to_dict(),
+                restarted=restarted,
+            )
+
+        # 3. Stage: seeds (deps first), then actions (deps first).
+        seed_outcomes: list[dict] = []
+        action_log: list[dict] = []
+        for rn in order:
+            r = self.registry.load(rn)
+            for seed_name in r.seeds:
+                manifest = self.seed_registry.load(seed_name)
+                seed_outcomes.append(Seeder(client).apply(manifest).to_dict())
+            for action in r.actions:
+                action_log.append(self._run_action(action, run_id, host, client))
+
+        # 4. Verify.
+        post = evaluator.evaluate(probe_spec)
+        result = ApplyResult(
+            recipe=name,
+            deck=target.deck,
+            already_satisfied=False,
+            probe=post.to_dict(),
+            seeds=seed_outcomes,
+            actions=action_log,
+            restarted=restarted,
+        )
+        if probe_spec and not post.ok:
+>           raise RecipeVerifyError(
+                f"recipe {name!r} failed to verify: {post.summary()}", result
+            )
+E           uat.conductor.induction.recipes.RecipeVerifyError: recipe 'intel-endpoint-dead' failed to verify: runtime_endpoint_unreachable: runtime-test ok=False status='unavailable' in 0.0s: Backend 'openai_compatible' requires the 'openai' package. Install with: uv pip install holdspeak[dictation-openai]
+
+uat/conductor/induction/recipes.py:240: RecipeVerifyError
+______________ test_run_dispatched_onto_the_worker_returns_badged ______________
+
+real_manager = <uat.conductor.runs.RunManager object at 0x13534cc30>
+
+    def test_run_dispatched_onto_the_worker_returns_badged(real_manager):
+        run = _boot_or_skip(real_manager, "mesh-node")
+
+>       result = real_manager.apply_recipe(run.id, "mesh-run-on-worker")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/uat/test_mesh_dispatch.py:55:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+uat/conductor/runs.py:387: in apply_recipe
+    return self.recipes.apply(name, run_id, self, allow_intel=allow_intel)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <uat.conductor.induction.recipes.RecipeEngine object at 0x1342f7fb0>
+name = 'mesh-run-on-worker', run_id = 'run-20260727T063645-b734cf'
+host = <uat.conductor.runs.RunManager object at 0x13534cc30>
+
+    def apply(
+        self, name: str, run_id: str, host: "RecipeHost", *, allow_intel: bool = True
+    ) -> ApplyResult:
+        order = self.regi
+[PMO_EVIDENCE_OUTPUT_TRUNCATED]
+```

--- a/pm/roadmap/holdspeak/phase-106-the-kernel/story-05-slice-terminal.md
+++ b/pm/roadmap/holdspeak/phase-106-the-kernel/story-05-slice-terminal.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 106
-- **Status:** ready
+- **Status:** done
 - **Depends on:** HS-106-04
 - **Unblocks:** HS-106-06
 - **Owner:** unassigned

--- a/tests/integration/test_process_input_real_hub.py
+++ b/tests/integration/test_process_input_real_hub.py
@@ -1,0 +1,311 @@
+"""HS-106-05: process.input over real HTTP into a real tmux pane."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import select
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from holdspeak.coder_steering import arm, clear_grants
+from holdspeak.db import Database
+from holdspeak.db.delivery_receipts import NodeReceiptLedger
+from holdspeak.delivery.commands import HubCommandService, NodeCommandProcessor
+from holdspeak.delivery.terminal import TerminalTargetRegistry
+from holdspeak.principals import Principal, PrincipalKind
+from holdspeak.tmux_transport import send_text_to_pane
+
+_REPO = Path(__file__).resolve().parents[2]
+_OWNER_TOKEN = "process-input-proof-owner"
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux is required for real terminal proof")
+def test_real_http_process_input_types_into_real_tmux(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config = home / ".config" / "holdspeak" / "config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "config_version": 1,
+                "control_mode": "yolo",
+                "meeting": {"web_auth_token": _OWNER_TOKEN},
+            }
+        ),
+        encoding="utf-8",
+    )
+    received = tmp_path / "received.txt"
+    tmux_name = f"hs10605_{os.getpid()}"
+    subprocess.run(
+        [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            tmux_name,
+            f"sh -c 'IFS= read -r line; printf %s \"$line\" > {received}; sleep 3'",
+        ],
+        check=True,
+    )
+    pane = subprocess.run(
+        ["tmux", "display-message", "-p", "-t", f"{tmux_name}:0.0", "#{pane_id}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    base = f"http://127.0.0.1:{port}"
+    env = os.environ.copy()
+    env.update(HOME=str(home), HOLDSPEAK_WEB_PORT=str(port), PYTHONUNBUFFERED="1")
+
+    def request(method: str, path: str, body: Any = None) -> tuple[int, dict[str, Any]]:
+        data = None if body is None else json.dumps(body).encode()
+        outgoing = urllib.request.Request(
+            base + path,
+            data=data,
+            headers={
+                "content-type": "application/json",
+                "authorization": f"Bearer {_OWNER_TOKEN}",
+            },
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(outgoing, timeout=10) as response:
+                return response.status, json.load(response)
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.load(exc)
+
+    hub = subprocess.Popen(
+        [sys.executable, "-m", "holdspeak.main", "web", "--no-open"],
+        cwd=_REPO,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        for _ in range(300):
+            if hub.poll() is not None:
+                output = hub.stdout.read() if hub.stdout else ""
+                raise AssertionError(f"spawned hub exited early:\n{output}")
+            try:
+                with urllib.request.urlopen(base + "/health", timeout=0.2):
+                    break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            hub.kill()
+            output = hub.stdout.read() if hub.stdout else ""
+            raise AssertionError(f"spawned hub did not become healthy:\n{output}")
+
+        status, target = request(
+            "POST", "/api/delivery/terminal/targets", {"ref": f"pane:{pane}"}
+        )
+        assert status == 200 and target["pane_id"] == pane
+        started = time.monotonic()
+        status, delivered = request(
+            "POST",
+            "/api/delivery/terminal/commands",
+            {
+                "target_id": target["target_id"],
+                "target_generation": target["target_generation"],
+                "operation": {
+                    "family": "coder_steering",
+                    "verb": "terminal.text",
+                },
+                "payload": {
+                    "text": "REAL_PROCESS_INPUT_106_05",
+                    "session_key": "pane-proof",
+                    "submit": True,
+                    "agent": "claude",
+                },
+            },
+        )
+        latency_ms = (time.monotonic() - started) * 1000
+        assert status == 200
+        assert delivered["operation_id"].startswith("op_")
+        assert delivered["receipt"]["outcome"] == "delivered"
+        for _ in range(50):
+            if received.exists():
+                break
+            time.sleep(0.05)
+        assert received.read_text(encoding="utf-8") == "REAL_PROCESS_INPUT_106_05"
+        status, projected = request(
+            "GET",
+            f"/api/kernel/read?refs=operation:{delivered['operation_id']}&view=receipt",
+        )
+        receipt = projected["objects"][0]["receipt"]
+        assert status == 200 and receipt["state"] == "succeeded"
+        print(
+            json.dumps(
+                {
+                    "operation_id": delivered["operation_id"],
+                    "pane": pane,
+                    "received": received.read_text(encoding="utf-8"),
+                    "receipt": receipt["state"],
+                    "latency_ms": round(latency_ms, 2),
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        hub.kill()
+        hub.wait(timeout=10)
+        subprocess.run(["tmux", "kill-session", "-t", tmux_name], check=False)
+
+
+@pytest.mark.skipif(
+    shutil.which("tmux") is None or not hasattr(os, "fork"),
+    reason="tmux and fork are required for the real SIGKILL proof",
+)
+def test_real_sigkill_mid_send_reconciles_indeterminate_by_command_id(tmp_path: Path) -> None:
+    clear_grants()
+    received = tmp_path / "killed-send.txt"
+    tmux_name = f"hs10605_kill_{os.getpid()}"
+    subprocess.run(
+        [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            tmux_name,
+            f"sh -c 'IFS= read -r line; printf %s \"$line\" > {received}; sleep 10'",
+        ],
+        check=True,
+    )
+    pane = subprocess.run(
+        ["tmux", "display-message", "-p", "-t", f"{tmux_name}:0.0", "#{pane_id}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    targets = TerminalTargetRegistry()
+    target = targets.issue(f"pane:{pane}")
+    assert target["status"] == "issued"
+    grant = arm("sigkill:agent", pane, control_mode="neutral")
+    assert grant["status"] == "armed"
+
+    db = Database(tmp_path / "hub.db")
+    hub_processor = NodeCommandProcessor(
+        node_id="local",
+        targets=targets,
+        ledger=NodeReceiptLedger(tmp_path / "hub-node.db"),
+    )
+    service = HubCommandService(
+        repo=db.delivery_receipts,
+        processor=hub_processor,
+        local_node_id="local",
+        mode_loader=lambda: "neutral",
+    )
+    owner = Principal(PrincipalKind.OWNER, "owner-session")
+    submitted = service.submit_process_input(
+        {
+            "node_id": "edge",
+            "target_id": target["target_id"],
+            "target_generation": target["target_generation"],
+            "expected_sequence": 1,
+            "operation": {"family": "coder_steering", "verb": "terminal.text"},
+            "payload": {
+                "text": "LANDED_BEFORE_SIGKILL_10605",
+                "session_key": "sigkill:agent",
+                "submit": True,
+                "agent": "claude",
+            },
+        },
+        owner,
+        authority_snapshot={
+            "outcome": "allowed",
+            "authority_basis": "scoped_grant",
+            "reason_code": "steering_grant_active",
+            "policy_version": "operation-policy/v2",
+            "mode": "neutral",
+        },
+    )
+    envelope = service.claim_for_node("edge")[0]
+    assert envelope["authority"]["decision"] == "allowed_by_active_grant"
+    ledger_path = tmp_path / "edge-node.db"
+    ready_read, ready_write = os.pipe()
+    child = os.fork()
+    if child == 0:
+        try:
+            os.close(ready_read)
+
+            def transport(**kwargs):
+                send_text_to_pane(**kwargs)
+                os.write(ready_write, b"typed")
+                time.sleep(30)
+
+            processor = NodeCommandProcessor(
+                node_id="edge",
+                targets=targets,
+                ledger=NodeReceiptLedger(ledger_path),
+                text_transport=transport,
+                audit=lambda **kwargs: 1,
+            )
+            child_result = processor.process(envelope)
+            os.write(ready_write, f"RET:{child_result!r}".encode())
+        except BaseException as exc:
+            os.write(ready_write, f"ERR:{exc!r}".encode())
+        finally:
+            os._exit(0)
+    os.close(ready_write)
+    try:
+        readable, _, _ = select.select([ready_read], [], [], 10)
+        assert readable and os.read(ready_read, 16) == b"typed"
+        os.kill(child, signal.SIGKILL)
+        _, status = os.waitpid(child, 0)
+        assert os.waitstatus_to_exitcode(status) == -signal.SIGKILL
+        for _ in range(50):
+            if received.exists():
+                break
+            time.sleep(0.05)
+        assert received.read_text(encoding="utf-8") == "LANDED_BEFORE_SIGKILL_10605"
+
+        assert service.receipt(submitted["command_id"])["hub_state"] == "unknown"
+        probes = service.claim_for_node("edge")
+        assert probes == [{"kind": "reconcile", "command_id": submitted["command_id"]}]
+        restarted = NodeCommandProcessor(
+            node_id="edge",
+            targets=targets,
+            ledger=NodeReceiptLedger(ledger_path),
+        )
+        service.record_results("edge", [restarted.reconcile(submitted["command_id"])])
+        aggregate = service.receipt(submitted["command_id"])
+        kernel = service._kernel_service().store.receipt(submitted["operation_id"])
+        assert aggregate["hub_state"] == "indeterminate_after_node_reset"
+        assert kernel["state"] == "indeterminate"
+        print(
+            json.dumps(
+                {
+                    "command_id": submitted["command_id"],
+                    "operation_id": submitted["operation_id"],
+                    "sigkill": -signal.SIGKILL,
+                    "text_landed": received.read_text(encoding="utf-8"),
+                    "aggregate": aggregate["hub_state"],
+                    "kernel_receipt": kernel["state"],
+                    "reconcile": "by_command_id",
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        os.close(ready_read)
+        try:
+            os.kill(child, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        subprocess.run(["tmux", "kill-session", "-t", tmux_name], check=False)
+        clear_grants()

--- a/tests/unit/test_delivery_terminal_routes.py
+++ b/tests/unit/test_delivery_terminal_routes.py
@@ -230,6 +230,7 @@ def test_command_submit_duplicate_and_receipt_join(rig) -> None:
     }
     first = rig.client.post("/api/delivery/terminal/commands", json=body)
     assert first.status_code == 200
+    assert set(first.json()) == {"command_id", "state", "receipt", "operation_id"}
     receipt = first.json()["receipt"]
     assert receipt["state"] == "succeeded"
     assert receipt["outcome"] == "delivered"
@@ -238,6 +239,9 @@ def test_command_submit_duplicate_and_receipt_join(rig) -> None:
     # The lost-response retry: same command_id, same receipt, ONE effect.
     again = rig.client.post("/api/delivery/terminal/commands", json=body)
     assert again.status_code == 200
+    assert set(again.json()) == {
+        "command_id", "state", "duplicate", "receipt", "operation_id"
+    }
     assert again.json()["receipt"]["receipt_id"] == receipt["receipt_id"]
     assert len(rig.transport_calls) == 1
 

--- a/tests/unit/test_kernel_broker.py
+++ b/tests/unit/test_kernel_broker.py
@@ -17,6 +17,7 @@ from holdspeak.web.routes.system.kernel_routes import build_kernel_router
 OWNER = Principal(PrincipalKind.OWNER, "owner-session")
 AGENT = Principal(PrincipalKind.AGENT, "agent:proof")
 NODE = Principal(PrincipalKind.NODE, "node_proof")
+OTHER_NODE = Principal(PrincipalKind.NODE, "node_elsewhere")
 
 
 def _request(key: str = "one", **arguments):
@@ -182,6 +183,33 @@ def test_warrant_expiry_and_revocation_refuse_at_claim(rig) -> None:
     with _as_principal(NODE):
         claim = kernel.claim()
     assert claim["refusal"]["outcome"] == "warrant_revoked"
+
+
+def test_executor_can_claim_exact_native_operation(rig) -> None:
+    _, broker, _ = rig
+    first = _decide(_submit(request=_request("first")))
+    second = _decide(_submit(request=_request("second")))
+
+    claimed = broker.claim(NODE, "proposal-second")["operations"][0]
+
+    assert claimed["operation_id"] == second["operation_id"]
+    assert broker.store.operation(first["operation_id"])["state"] == "awaiting_execution"
+    for principal, outcome in (
+        (NODE, "refused"),
+        (NODE, "succeeded"),
+        (OTHER_NODE, "refused"),
+    ):
+        with pytest.raises(KernelRefused) as unclaimed:
+            broker.receipt(
+                first["operation_id"], outcome, "command:not-executed", principal
+            )
+        assert unclaimed.value.reason == "executor_claim_required"
+
+    broker.claim(NODE, "proposal-first")
+    refused = broker.receipt(
+        first["operation_id"], "refused", "command:not-executed", NODE
+    )
+    assert refused["state"] == "refused"
 
 
 def test_claim_receipt_reconcile_and_cursor_projection(rig) -> None:

--- a/tests/unit/test_process_input_kernel.py
+++ b/tests/unit/test_process_input_kernel.py
@@ -1,0 +1,265 @@
+"""HS-106-05: process.input codec and the terminal-command adapter."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from holdspeak.db import Database
+from holdspeak.db.delivery_receipts import NodeReceiptLedger
+from holdspeak.delivery.commands import HubCommandService, NodeCommandProcessor
+from holdspeak.kernel.broker import Broker
+from holdspeak.kernel.journal import JournalStore
+from holdspeak.kernel.model import OperationSpec
+from holdspeak.kernel.process_input import ProcessInputCodec
+from holdspeak.principals import Principal, PrincipalKind
+
+OWNER = Principal(PrincipalKind.OWNER, "owner-session")
+T0 = datetime(2026, 7, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class Targets:
+    def verify(self, target_id, generation):
+        if target_id == "term_1" and generation == "gen_1":
+            return {
+                "status": "ok",
+                "target_id": target_id,
+                "target_generation": generation,
+                "pane_id": "%1",
+            }
+        return {"status": "target_gone", "detail": "unknown target"}
+
+
+class Tmux:
+    def __call__(self, argv, cwd=None):
+        return SimpleNamespace(returncode=0, stdout="%1\n", stderr="")
+
+
+def request(command_id="aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001"):
+    return {
+        "request_schema": 1,
+        "request_id": command_id,
+        "idempotency_key": f"process.input:{command_id}",
+        "operation": {"name": "process.input", "version": 1},
+        "subject_refs": ["coder_session:claude:test"],
+        "target": {"ref": "process:term_1"},
+        "arguments": {
+            "text": "send this exactly",
+            "submit": False,
+            "expected_generation": "gen_1",
+            "command_id": command_id,
+            "session_key": "claude:test",
+            "agent": "claude",
+            "expected_sequence": 1,
+            "expires_in_seconds": 30,
+        },
+        "placement": "node:local",
+    }
+
+
+def command(command_id="aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001", node="local"):
+    return {
+        "command_id": command_id,
+        "node_id": node,
+        "target_id": "term_1",
+        "target_generation": "gen_1",
+        "expected_sequence": 1,
+        "operation": {"family": "coder_steering", "verb": "terminal.text"},
+        "payload": {
+            "text": "send this exactly",
+            "session_key": "claude:test",
+            "submit": False,
+            "agent": "claude",
+        },
+    }
+
+
+def test_process_input_codec_binds_terminal_payload_without_journaling_text(tmp_path):
+    db = Database(tmp_path / "hub.db")
+    codec = ProcessInputCodec(db.delivery_receipts)
+    broker = Broker(
+        JournalStore(db._connection),
+        (OperationSpec(codec.name, codec.version, codec, "agent.submit", "propose"),),
+    )
+    handle = broker.submit(request(), OWNER)
+    operation = broker.store.operation(handle["operation_id"])
+    assert handle["state"] == "awaiting_decision"
+    assert operation["name"] == "process.input"
+    assert operation["target_ref"] == "process:term_1"
+    assert operation["native_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001"
+    assert operation["envelope_sha256"].startswith("sha256:")
+    events = broker.store.events(0, {"operation_id": handle["operation_id"]})["events"]
+    assert "send this exactly" not in repr(events)
+    assert "command:aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001" in repr(events)
+
+
+def test_local_process_input_uses_existing_node_protocol_and_closes_kernel_receipt(
+    tmp_path, monkeypatch
+):
+    db = Database(tmp_path / "hub.db")
+    sent = []
+    processor = NodeCommandProcessor(
+        node_id="local",
+        targets=Targets(),
+        ledger=NodeReceiptLedger(tmp_path / "node.db"),
+        runner=Tmux(),
+        text_transport=lambda **kwargs: sent.append(kwargs),
+        audit=lambda **kwargs: 7,
+        wall_now=lambda: T0,
+    )
+    import holdspeak.delivery.commands as commands_module
+
+    calls = 0
+    actual = commands_module.resolve_policy
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return actual(*args, **kwargs)
+
+    monkeypatch.setattr(commands_module, "resolve_policy", counted)
+    service = HubCommandService(
+        repo=db.delivery_receipts,
+        processor=processor,
+        local_node_id="local",
+        mode_loader=lambda: "yolo",
+        wall_now=lambda: T0,
+    )
+    response = service.submit_process_input(command(), OWNER, include_result=True)
+    operation = service._kernel_service().store.operation(response["operation_id"])
+    receipt = service._kernel_service().store.receipt(response["operation_id"])
+    assert response["result"]["status"] == "delivered"
+    assert sent == [{"pane": "%1", "text": "send this exactly", "submit": False}]
+    assert operation["native_id"] == response["command_id"]
+    assert receipt["state"] == "succeeded"
+    assert receipt["result_ref"] == f"command:{response['command_id']}"
+    assert calls == 1
+
+
+def test_local_failure_gets_failed_kernel_receipt(tmp_path):
+    def fail_transport(**kwargs):
+        raise RuntimeError("tmux transport failed")
+
+    db = Database(tmp_path / "hub.db")
+    service = HubCommandService(
+        repo=db.delivery_receipts,
+        processor=NodeCommandProcessor(
+            node_id="local",
+            targets=Targets(),
+            ledger=NodeReceiptLedger(tmp_path / "node.db"),
+            runner=Tmux(),
+            text_transport=fail_transport,
+            audit=lambda **kwargs: 8,
+            wall_now=lambda: T0,
+        ),
+        local_node_id="local",
+        mode_loader=lambda: "yolo",
+        wall_now=lambda: T0,
+    )
+
+    response = service.submit_process_input(command(), OWNER)
+    receipt = service._kernel_service().store.receipt(response["operation_id"])
+
+    assert response["receipt"]["state"] == "failed"
+    assert receipt["state"] == "failed"
+
+
+def test_preflight_deny_gets_refused_kernel_receipt(tmp_path):
+    db = Database(tmp_path / "hub.db")
+    service = HubCommandService(
+        repo=db.delivery_receipts,
+        processor=NodeCommandProcessor(
+            node_id="local",
+            targets=Targets(),
+            ledger=NodeReceiptLedger(tmp_path / "node.db"),
+            wall_now=lambda: T0,
+        ),
+        local_node_id="local",
+        mode_loader=lambda: "neutral",
+        wall_now=lambda: T0,
+    )
+
+    response = service.submit_process_input(
+        command(),
+        OWNER,
+        authority_snapshot={
+            "outcome": "propose",
+            "authority_basis": "none",
+            "reason_code": "steering_grant_required",
+            "policy_version": "operation-policy/v2",
+            "mode": "neutral",
+        },
+        preflight_result={"status": "blocked", "detail": "desk says no"},
+    )
+    kernel = service._kernel_service()
+    receipt = kernel.store.receipt(response["operation_id"])
+    operation = kernel.store.operation(response["operation_id"])
+
+    assert response["receipt"]["state"] == "refused"
+    assert receipt["state"] == "refused"
+    assert receipt["outcome"] == "owner_rejected"
+    assert operation["decision"] == "reject"
+
+
+def test_remote_send_dropped_before_claim_gets_refused_kernel_receipt(tmp_path):
+    db = Database(tmp_path / "hub.db")
+    service = HubCommandService(
+        repo=db.delivery_receipts,
+        processor=NodeCommandProcessor(
+            node_id="local",
+            targets=Targets(),
+            ledger=NodeReceiptLedger(tmp_path / "hub-node.db"),
+            wall_now=lambda: T0,
+        ),
+        local_node_id="local",
+        mode_loader=lambda: "neutral",
+        wall_now=lambda: T0,
+    )
+    response = service.submit_process_input(command(node="edge"), OWNER)
+    service._queues.pop("edge")
+
+    aggregate = service.receipt(response["command_id"])
+    kernel = service._kernel_service()
+    kernel_receipt = kernel.store.receipt(response["operation_id"])
+    operation = kernel.store.operation(response["operation_id"])
+
+    assert aggregate["hub_state"] == "not_executed"
+    assert operation["claimed_by"] == "edge"
+    assert kernel_receipt["state"] == "refused"
+    assert kernel_receipt["outcome"] == "refused"
+
+
+def test_remote_node_reset_becomes_indeterminate_and_reconciles_by_command_id(tmp_path):
+    db = Database(tmp_path / "hub.db")
+    hub_processor = NodeCommandProcessor(
+        node_id="local",
+        targets=Targets(),
+        ledger=NodeReceiptLedger(tmp_path / "hub-node.db"),
+        wall_now=lambda: T0,
+    )
+    service = HubCommandService(
+        repo=db.delivery_receipts,
+        processor=hub_processor,
+        local_node_id="local",
+        mode_loader=lambda: "neutral",
+        wall_now=lambda: T0,
+    )
+    response = service.submit_process_input(command(node="edge"), OWNER)
+    claimed = service.claim_for_node("edge")
+    assert [item["command_id"] for item in claimed] == [response["command_id"]]
+    assert service.receipt(response["command_id"])["hub_state"] == "unknown"
+    probes = service.claim_for_node("edge")
+    assert probes == [{"kind": "reconcile", "command_id": response["command_id"]}]
+
+    restarted = NodeCommandProcessor(
+        node_id="edge",
+        targets=Targets(),
+        ledger=NodeReceiptLedger(tmp_path / "restarted-node.db"),
+        wall_now=lambda: T0,
+    )
+    answer = restarted.reconcile(response["command_id"])
+    service.record_results("edge", [answer])
+    aggregate = service.receipt(response["command_id"])
+    kernel_receipt = service._kernel_service().store.receipt(response["operation_id"])
+    assert aggregate["hub_state"] == "indeterminate_after_node_reset"
+    assert kernel_receipt["state"] == "indeterminate"
+    assert kernel_receipt["result_ref"] == f"command:{response['command_id']}"


### PR DESCRIPTION
The reference driver. Terminal input now enters through `submit(process.input)`; `coder_steering`/`coder_factory` remain the executors and the node protocol is untouched.

### The spine held

**The broker is still driver-blind.** Verified independently: `broker.py`, `admission.py`, `journal.py`, `model.py` contain zero references to `process_input` / `process.input` / tmux / pane / steer. `runtime.py` registers `ProcessInputCodec` as a peer of `ToolCallCodec` in the same tuple — no branching. Density guards green without modification; largest kernel module 270 lines.

That is the property HS-106-07's kill criterion tests, holding with two drivers on it.

### Live proofs

| beat | observed |
|---|---|
| real send → real tmux pane | `marker_seen: true`, kernel receipt `succeeded` |
| gated approve | `stdout: GATE_APPROVE_KERNEL_10605` |
| **gated deny, verbatim to the agent** | `denied from the desk: kernel desk says no files today` |
| real SIGKILL mid-send | signal `-9`; native `indeterminate_after_node_reset`; kernel receipt `indeterminate`; reconciled `by_command_id`; **no retry** |
| one-decision census | exactly 1 approved, exactly 1 denied |
| ungated latency | **84.76 ms** against the Phase-104 250 ms budget |

The deny reason survived routing through the kernel unchanged — that was the regression risk worth blocking on.

### The seam, recorded rather than forgotten

Review caught a two-line relaxation in `executor.py` that let a node file a receipt on an operation it never claimed. The pressure was real and constitutional: an approved command whose native row stayed `sent` after the queue vanished on restart still owes a terminal receipt under Article XI clause 2.

**It was resolved in the adapter, not by relaxing the spine.** The adapter now exact-claims terminalization responsibility, then files the refusal. `unclaimed_refusal` is gone; `executor_claim_required` is pinned by test (unclaimed refusal rejected, unclaimed success rejected, other-node receipt rejected).

`native_id` exact-claim stays, with terminal as its **only** filtered caller today — recorded as provisional, for HS-106-06 to confirm or refute. The RFC's "nothing generalizes until two drivers need it" honored in writing.

Authority duplication resolved properly: `_authority_for` now resolves once and delegates to `_authority_from_policy`. One constructor, no divergence path — which is a one-decision requirement, not a tidiness one.

### Tests

Focused slice/route/real-hub/density/kernel guards: **79 passed**. Full suite: **4,252 passed, 39 skipped, 8 failed**.

Three of those eight were **ours, from HS-106-02** — the live-bus e2e harness never bootstrapped an owner token, so `ws.py` refused its socket. Fixed separately in #390. The remaining five are environmental (four UAT recipes on a missing `openai` package and a queued-intel timeout; one known voice-notes wording drift), checked for the same authentication signature and clear of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)