### PR TITLE
HS-112-02: Speak speaks — the room performs the flagship act

### DIFF
--- a/holdspeak/web/routes/dictation/_helpers.py
+++ b/holdspeak/web/routes/dictation/_helpers.py
@@ -458,6 +458,7 @@ def _run_dictation_dry_run_text(
     telemetry: Any = None,
     journal: Any = None,
     activity_context: Optional[dict[str, Any]] = None,
+    journal_source: str = "dry_run",
 ) -> dict[str, Any]:
     """Execute the browser dry-run path for already-validated text.
 
@@ -466,6 +467,11 @@ def _run_dictation_dry_run_text(
     the rewrite can ground in a selected record — the remote relay passes it when
     a "Dictate with this" pin is pending. ``None`` keeps the historical
     target-only activity dict byte-identical.
+
+    ``journal_source`` (HS-112-02): which lane the run belongs to. The rich
+    pipeline is shared by the REHEARSE preview (``dry_run``) and by a real
+    delivery (``dictation``) — one helper, one journal schema, an honest row.
+    Only an explicit rehearsal writes a ``dry_run`` entry.
     """
     from ....config import Config
     from ....dictation_telemetry import summarize_dry_run
@@ -505,7 +511,7 @@ def _run_dictation_dry_run_text(
 
             recorded = journal.record(
                 passthrough_run(text),
-                source="dry_run",
+                source=journal_source,
                 transcript=text,
                 enabled=bool(getattr(cfg.pipeline, "journal_enabled", True)),
                 retention=int(getattr(cfg.pipeline, "journal_retention", 500)),
@@ -591,7 +597,7 @@ def _run_dictation_dry_run_text(
     if journal is not None:
         recorded = journal.record(
             run,
-            source="dry_run",
+            source=journal_source,
             transcript=text,
             target_profile=target_profile,
             project_root=project_root,

--- a/holdspeak/web/routes/dictation/pipeline.py
+++ b/holdspeak/web/routes/dictation/pipeline.py
@@ -28,6 +28,20 @@ from ._helpers import (
 
 log = get_logger("web.routes.dictation")
 
+# HS-112-02 — the kernel refusals that are known to have happened BEFORE any
+# keystroke left the machine. They are deterministic and safe to make terminal:
+# the room can name them ("no focus resolved") and the owner can simply speak
+# again. Anything else (a driver that raised mid-type) stays ambiguous and is
+# parked `pending` — an effect we cannot prove never replays itself.
+PRE_EFFECT_REFUSALS = frozenset(
+    {
+        "desktop_focus_unresolved",
+        "desktop_type_driver_unavailable",
+        "desktop_type_claim_refused",
+        "desktop_type_refused",
+    }
+)
+
 
 def build_pipeline_router(
     ctx: WebContext,
@@ -312,6 +326,18 @@ def build_pipeline_router(
         exactly like every other route when bound off-loopback — the companion client
         mirrors the server's ``web_auth_token`` on every request. Delivery is
         deliver-on-command (the client user pressed send); there is no autonomous path.
+
+        HS-112-02 — this is ALSO the Speak room's wire. The room named Speak holds
+        TALK, releases, and posts the transcript here: one delivery contract, one
+        pipeline, one journal, one idempotency claim, whoever is holding the key.
+        Two things the room needs and the companion never asked for:
+
+        * ``require_agent`` — an aimed AGENT delivery refuses honestly when nothing
+          is awaiting rather than silently free-typing into whatever happens to be
+          focused. Absent/false keeps the companion's fallback byte-identical.
+        * a deterministic kernel refusal (``desktop_focus_unresolved`` and friends)
+          comes back as a NAMED terminal refusal the deck renders in-flow, instead
+          of an ambiguous "pending" the owner cannot act on.
         """
         text = payload.get("text") if isinstance(payload, dict) else None
         if not isinstance(text, str) or not text.strip():
@@ -334,6 +360,10 @@ def build_pipeline_router(
                 {"error": 'target_mode must be one of "agent" or "focused"'},
                 status_code=400,
             )
+        # HS-112-02: an AIMED agent delivery. The Speak room's AGENT aim means
+        # "the awaiting agent, or nothing" — the desktop fallback is a companion
+        # convenience, not an aim.
+        require_agent = bool(payload.get("require_agent")) if isinstance(payload, dict) else False
 
         # HS-93-05: new companion clients choose a stable id before sending.
         # Claim it before pipeline/macro/delivery work so reconnect retries can
@@ -353,6 +383,7 @@ def build_pipeline_router(
                 "target": target_hints,
                 "target_mode": target_mode,
                 "raw": bool(payload.get("raw")),
+                "require_agent": require_agent,
             }
             request_hash = hashlib.sha256(
                 json.dumps(
@@ -451,28 +482,97 @@ def build_pipeline_router(
             # this id reads that state and never invokes the hook again.
             return JSONResponse(pending, status_code=425)
 
+        def refusal_response(reason: str, *, final_text: str = "") -> JSONResponse:
+            """A named, terminal refusal — nothing was typed, say so plainly."""
+            return terminal_response(
+                {
+                    "error": reason,
+                    "refusal": reason,
+                    "failure_category": "delivery_refused",
+                    "delivered": False,
+                    "final_text": final_text,
+                },
+                status_code=422,
+            )
+
+        def deliver(body_text: str) -> tuple[bool, dict[str, Any] | None, JSONResponse | None]:
+            """Run the ONE delivery hook. Returns (delivered, receipt, refusal).
+
+            HS-112-02: the two call sites (raw + processed) share this so the
+            room and the companion cannot drift apart on how a refusal reads.
+            """
+            from ....desktop_typing import DesktopTypeRefused
+
+            if ctx.on_remote_dictation is None:
+                return False, None, None
+            try:
+                if target_mode == "agent":
+                    # Byte-identical to the pre-15 call (a plain str hook): the
+                    # default path never threads the new keyword.
+                    outcome = ctx.on_remote_dictation(body_text)
+                else:
+                    outcome = ctx.on_remote_dictation(body_text, target=target_mode)
+            except DesktopTypeRefused as exc:
+                if str(exc.reason) in PRE_EFFECT_REFUSALS:
+                    return False, None, refusal_response(str(exc.reason), final_text=body_text)
+                log.error(f"Remote dictation delivery refused mid-effect: {exc}")
+                return (
+                    False,
+                    None,
+                    uncertain_delivery(
+                        {
+                            "error": f"delivery failed: {exc}",
+                            "final_text": body_text,
+                            "delivered": False,
+                        },
+                    ),
+                )
+            except Exception as exc:
+                log.error(f"Remote dictation delivery failed: {exc}")
+                return (
+                    False,
+                    None,
+                    uncertain_delivery(
+                        {
+                            "error": f"delivery failed: {exc}",
+                            "final_text": body_text,
+                            "delivered": False,
+                        },
+                    ),
+                )
+            receipt = dict(outcome) if isinstance(outcome, dict) else None
+            return True, receipt, None
+
+        # HS-112-02 — the aimed-agent refusal, decided BEFORE any pipeline or
+        # effect work: no awaiting agent means no delivery, named in one word.
+        if require_agent and target_mode == "agent":
+            from ....agent_context import get_recent_awaiting_agent_session
+
+            try:
+                awaiting = get_recent_awaiting_agent_session(max_age_seconds=120)
+            except Exception as exc:  # pragma: no cover - defensive probe
+                log.warning(f"Awaiting-agent probe failed: {exc}")
+                awaiting = None
+            if awaiting is None:
+                return refusal_response("no_awaiting_agent")
+
         # HSM-18-01 — verbatim delivery for a client holding a dry-run receipt.
         # A previewed `final_text` has already been through the pipeline; running
         # it again would make the receipt a lie (the rewrite is not idempotent).
         # `raw: true` types EXACTLY the given text: no pipeline, no macro
         # dispatch. Absent/false -> the paths below run byte-identical.
         if bool(payload.get("raw")):
-            delivered = False
-            if ctx.on_remote_dictation is not None:
-                try:
-                    if target_mode == "agent":
-                        ctx.on_remote_dictation(text)
-                    else:
-                        ctx.on_remote_dictation(text, target=target_mode)
-                    delivered = True
-                except Exception as exc:
-                    log.error(f"Remote dictation delivery failed: {exc}")
-                    return uncertain_delivery(
-                        {"error": f"delivery failed: {exc}", "final_text": text, "delivered": False},
-                    )
-            return terminal_response(
-                {"success": True, "final_text": text, "delivered": delivered}
-            )
+            delivered, receipt, refused = deliver(text)
+            if refused is not None:
+                return refused
+            body: dict[str, Any] = {
+                "success": True,
+                "final_text": text,
+                "delivered": delivered,
+            }
+            if receipt is not None:
+                body["delivery"] = receipt
+            return terminal_response(body)
 
         # HSM-18-02 — voice command macros must fire on the remote relay too, exactly
         # as they do on the local dictation path (dictation_capture._maybe_dispatch_
@@ -550,6 +650,11 @@ def build_pipeline_router(
                 telemetry=ctx.telemetry,
                 journal=ctx.journal,
                 activity_context=activity_context,
+                # HS-112-02: a delivery is a dictation, not a rehearsal. The
+                # journal now shows the room's and the companion's utterances
+                # beside the hotkey's, same schema; `dry_run` is reserved for
+                # the explicit REHEARSE preview.
+                journal_source="dictation",
             )
         except Exception as exc:
             log.error(f"Remote dictation pipeline failed: {exc}")
@@ -558,24 +663,13 @@ def build_pipeline_router(
         final_text = (
             processed.get("final_text", text) if isinstance(processed, dict) else text
         )
-        delivered = False
-        if ctx.on_remote_dictation is not None:
-            try:
-                if target_mode == "agent":
-                    # Byte-identical to the pre-15 call (a plain str hook): the
-                    # default path never threads the new keyword.
-                    ctx.on_remote_dictation(final_text)
-                else:
-                    ctx.on_remote_dictation(final_text, target=target_mode)
-                delivered = True
-            except Exception as exc:
-                log.error(f"Remote dictation delivery failed: {exc}")
-                return uncertain_delivery(
-                    {"error": f"delivery failed: {exc}", "final_text": final_text, "delivered": False},
-                )
-        return terminal_response(
-            {"success": True, "final_text": final_text, "delivered": delivered}
-        )
+        delivered, receipt, refused = deliver(final_text)
+        if refused is not None:
+            return refused
+        body = {"success": True, "final_text": final_text, "delivered": delivered}
+        if receipt is not None:
+            body["delivery"] = receipt
+        return terminal_response(body)
 
     @router.get("/api/dictation/corrections")
     async def api_dictation_corrections_list() -> Any:

--- a/pm/roadmap/holdspeak/phase-112-enough/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-112-enough/current-phase-status.md
@@ -70,7 +70,7 @@ it does not absorb it — it names it in the final summary.
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
 | HS-112-01 | One dial | ready | [story-01-one-dial](./story-01-one-dial.md) | — |
-| HS-112-02 | Speak speaks | backlog | [story-02-speak-speaks](./story-02-speak-speaks.md) | — |
+| HS-112-02 | Speak speaks | in-progress | [story-02-speak-speaks](./story-02-speak-speaks.md) | — (captured; ships with the flip) |
 | HS-112-03 | The architect's desk | backlog | [story-03-architects-desk](./story-03-architects-desk.md) | — |
 | HS-112-04 | The plain story | backlog | [story-04-plain-story](./story-04-plain-story.md) | — |
 | HS-112-05 | The sitting walk | backlog | [story-05-walk](./story-05-walk.md) | — |
@@ -78,7 +78,26 @@ it does not absorb it — it names it in the final summary.
 
 ## Where we are
 
-0/6. Chartered 2026-08-02 from the owner's post-111 verdict; the
+0/6 flipped; 02 BUILT (in-progress pending the live-metal proof).
+HS-112-02 implemented 2026-08-02: the Speak room's TALK key delivers
+for real through the one existing contract (/api/dictation/remote —
+no forked idempotency), with an AIM row (FOCUSED APP / AGENT / THIS
+FIELD), REHEARSE as an explicit mode never the default, opt-in
+require_agent strictness (companion fallback byte-identical), a
+pre-effect refusal classifier turning deterministic kernel refusals
+into named terminal 422s (retry replays the cached refusal;
+mid-type driver failures still honestly park pending), release-to-
+landed latency on the receipt, and journal_source=dictation — which
+also fixed a latent bug: companion deliveries had been journaling
+as dry_run rehearsals. Contract tests byte-identical (42 tests);
+new: 13 python + 12 web; suites 3464 unit + 456 web green (one
+environmental node-link flake passes in isolation). Named debt in
+the story report: two audio stacks, deprecated ScriptProcessorNode,
+twin preview stores, companion tap-toggle, macro-dispatch bypass,
+2-valued journal_source, no delivery_id on the transcribe leg. The
+flip to done awaits the live proof: TALK held in a real browser,
+text landing in a real focused app and a real agent pane, refusal
+shot legs, 1440+393. Chartered 2026-08-02. Chartered 2026-08-02 from the owner's post-111 verdict; the
 same day the owner chartered the open-mic rider live (HS-112-06 —
 the voice-first Desk: one mic grant, continuous stream, VAD; PTT
 byte-identical). The pre-charter survey (three parallel audits: the

--- a/pm/roadmap/holdspeak/phase-112-enough/story-02-speak-speaks.md
+++ b/pm/roadmap/holdspeak/phase-112-enough/story-02-speak-speaks.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 112
-- **Status:** backlog
+- **Status:** in-progress
 - **Depends on:** —
 - **Unblocks:** HS-112-04, HS-112-05
 - **Owner:** unassigned

--- a/tests/integration/test_web_dry_run_api.py
+++ b/tests/integration/test_web_dry_run_api.py
@@ -485,5 +485,5 @@ def test_dictation_page_includes_dry_run_section() -> None:
     assert '<div id="root"></div>' in response.text
     js = (Path(__file__).resolve().parents[2] / "web/src/pages/cores/DictationCore.tsx").read_text()
     assert "/api/dictation/dry-run" in js
-    assert "Run dry test" in js
+    assert "Rehearse" in js
     assert "projectRoot" in js and "Pipeline result" in js

--- a/tests/unit/test_speak_room_delivery.py
+++ b/tests/unit/test_speak_room_delivery.py
@@ -1,0 +1,361 @@
+"""HS-112-02 — the Speak room speaks through the ONE delivery contract.
+
+The room named Speak holds TALK, releases, and posts the transcript to
+``POST /api/dictation/remote`` — the same route, pipeline, journal, kernel
+warrant and idempotency claim the companion has always used. These tests pin
+the three things the room added to that contract:
+
+* the aimed AGENT refusal (``require_agent``): nothing awaiting means a NAMED
+  terminal refusal, never a silent free-type into whatever is focused;
+* a deterministic kernel refusal (``desktop_focus_unresolved``) comes back
+  named and terminal, while an ambiguous mid-effect failure still parks
+  ``pending`` and never replays;
+* a delivery journals as ``dictation``; only an explicit REHEARSE writes
+  ``dry_run``.
+
+The rich pipeline is stubbed (as in ``test_web_routes_remote_dictation``) so
+these isolate the route's wiring.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from holdspeak.db import Database
+from holdspeak.desktop_typing import DesktopTypeRefused
+from holdspeak.web.context import WebContext
+from holdspeak.web.routes.dictation.pipeline import build_pipeline_router
+
+PIPELINE = "holdspeak.web.routes.dictation.pipeline._run_dictation_dry_run_text"
+
+
+@pytest.fixture(autouse=True)
+def _stub_pipeline(monkeypatch):
+    monkeypatch.setattr(
+        PIPELINE, lambda text, *a, **k: {"final_text": f"[corrected] {text}"}
+    )
+
+
+@pytest.fixture(autouse=True)
+def _default_macros_off(monkeypatch):
+    from holdspeak.config import Config
+
+    monkeypatch.setattr(Config, "load", classmethod(lambda cls: Config()))
+
+
+@pytest.fixture(autouse=True)
+def _no_selection_pin():
+    from holdspeak.dictation_selection import clear_selected_record
+
+    clear_selected_record()
+
+
+def _ctx(**kw) -> WebContext:
+    return WebContext(get_state=lambda: {}, **kw)
+
+
+def _client(ctx: WebContext) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_pipeline_router(ctx, project_doc_suggestions={}))
+    return TestClient(app)
+
+
+def _room_payload(**overrides) -> dict:
+    """What the deck posts on TALK release (AIM = FOCUSED APP)."""
+    payload = {
+        "text": "ship it friday",
+        "target_mode": "focused",
+        # one id per utterance, exactly as the deck mints it
+        "delivery_id": f"speak:{uuid.uuid4()}",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ── the room lands through the shared claim ──────────────────────────────────
+
+
+def test_room_delivery_lands_once_under_a_retried_delivery_id(tmp_path):
+    """The web client mints one id per utterance; a retry of it lands ONCE."""
+    database = Database(tmp_path / "delivery.db")
+    typed: list = []
+    client = _client(
+        _ctx(
+            on_remote_dictation=lambda t, *, target="agent": typed.append((t, target)),
+            dictation_deliveries=database.dictation_deliveries,
+        )
+    )
+    payload = _room_payload()
+
+    first = client.post("/api/dictation/remote", json=payload)
+    retry = client.post("/api/dictation/remote", json=payload)
+
+    assert first.status_code == retry.status_code == 200
+    assert first.json()["deduplicated"] is False
+    assert retry.json()["deduplicated"] is True
+    assert retry.json()["final_text"] == "[corrected] ship it friday"
+    assert typed == [("[corrected] ship it friday", "focused")]
+
+
+def test_room_delivery_returns_the_kernel_receipt_for_the_deck():
+    """The hook's own receipt (method/target/operation_id) rides back so the
+    deck can name where the words landed instead of guessing."""
+    ctx = _ctx(
+        on_remote_dictation=lambda t, *, target="agent": {
+            "delivered": True,
+            "method": "desktop.type_text",
+            "target": "desktop-input:focus-3-abcd",
+            "operation_id": "op-7",
+        }
+    )
+    r = _client(ctx).post("/api/dictation/remote", json=_room_payload())
+
+    assert r.status_code == 200
+    assert r.json()["delivery"]["method"] == "desktop.type_text"
+    assert r.json()["delivery"]["operation_id"] == "op-7"
+
+
+# ── AIM = AGENT: the honest no-awaiting-agent refusal ────────────────────────
+
+
+def test_aimed_agent_refuses_by_name_when_nothing_is_awaiting(monkeypatch):
+    import holdspeak.agent_context as agent_context
+
+    monkeypatch.setattr(
+        agent_context, "get_recent_awaiting_agent_session", lambda **kw: None
+    )
+    delivered: list = []
+    ctx = _ctx(on_remote_dictation=lambda t: delivered.append(t))
+
+    r = _client(ctx).post(
+        "/api/dictation/remote",
+        json=_room_payload(target_mode="agent", require_agent=True),
+    )
+
+    assert r.status_code == 422
+    body = r.json()
+    assert body["refusal"] == "no_awaiting_agent"
+    assert body["failure_category"] == "delivery_refused"
+    assert body["delivered"] is False
+    assert delivered == [], "a refused aim never reaches the delivery hook"
+
+
+def test_aimed_agent_delivers_when_one_is_awaiting(monkeypatch):
+    import holdspeak.agent_context as agent_context
+
+    monkeypatch.setattr(
+        agent_context,
+        "get_recent_awaiting_agent_session",
+        lambda **kw: object(),
+    )
+    delivered: list = []
+    ctx = _ctx(on_remote_dictation=lambda t: delivered.append(t))
+
+    r = _client(ctx).post(
+        "/api/dictation/remote",
+        json=_room_payload(target_mode="agent", require_agent=True),
+    )
+
+    assert r.status_code == 200
+    assert r.json()["delivered"] is True
+    assert delivered == ["[corrected] ship it friday"]
+
+
+def test_unaimed_agent_send_keeps_the_companion_fallback(monkeypatch):
+    """No ``require_agent`` -> the companion's byte-identical path: the hook is
+    called and decides for itself (tmux pane, else desktop fallback)."""
+    import holdspeak.agent_context as agent_context
+
+    monkeypatch.setattr(
+        agent_context, "get_recent_awaiting_agent_session", lambda **kw: None
+    )
+    delivered: list = []
+    ctx = _ctx(on_remote_dictation=lambda t: delivered.append(t))
+
+    r = _client(ctx).post(
+        "/api/dictation/remote", json={"text": "ship it friday", "target_mode": "agent"}
+    )
+
+    assert r.status_code == 200
+    assert delivered == ["[corrected] ship it friday"]
+
+
+def test_require_agent_is_part_of_the_delivery_binding(tmp_path, monkeypatch):
+    """The same id may not silently switch between an aimed and a fallback
+    send — the destination is part of what the id promises."""
+    import holdspeak.agent_context as agent_context
+
+    monkeypatch.setattr(
+        agent_context,
+        "get_recent_awaiting_agent_session",
+        lambda **kw: object(),
+    )
+    database = Database(tmp_path / "delivery.db")
+    delivered: list = []
+    client = _client(
+        _ctx(
+            on_remote_dictation=lambda t: delivered.append(t),
+            dictation_deliveries=database.dictation_deliveries,
+        )
+    )
+    first = client.post(
+        "/api/dictation/remote",
+        json=_room_payload(target_mode="agent", require_agent=True, delivery_id="id-a-aimed"),
+    )
+    conflict = client.post(
+        "/api/dictation/remote",
+        json=_room_payload(target_mode="agent", delivery_id="id-a-aimed"),
+    )
+
+    assert first.status_code == 200
+    assert conflict.status_code == 409
+    assert conflict.json()["failure_category"] == "delivery_conflict"
+    assert delivered == ["[corrected] ship it friday"]
+
+
+# ── AIM = FOCUSED APP: the kernel's own refusal, named in-flow ───────────────
+
+
+def test_focus_unresolved_is_a_named_terminal_refusal(tmp_path):
+    """`desktop_focus_unresolved` is decided BEFORE a keystroke leaves: the
+    room gets the name, the claim closes, a retry replays the cached refusal
+    instead of re-entering the kernel."""
+    database = Database(tmp_path / "delivery.db")
+    calls = 0
+
+    def refuse(_text, *, target="agent"):
+        nonlocal calls
+        calls += 1
+        raise DesktopTypeRefused("desktop_focus_unresolved", operation_id="op-1")
+
+    client = _client(
+        _ctx(
+            on_remote_dictation=refuse,
+            dictation_deliveries=database.dictation_deliveries,
+        )
+    )
+    payload = _room_payload()
+    first = client.post("/api/dictation/remote", json=payload)
+    retry = client.post("/api/dictation/remote", json=payload)
+
+    assert first.status_code == retry.status_code == 422
+    assert first.json()["refusal"] == "desktop_focus_unresolved"
+    assert first.json()["delivered"] is False
+    assert retry.json()["deduplicated"] is True
+    assert calls == 1, "a terminal refusal never re-enters the kernel"
+
+
+def test_driver_unavailable_is_also_named():
+    def refuse(_text, *, target="agent"):
+        raise DesktopTypeRefused("desktop_type_driver_unavailable")
+
+    r = _client(_ctx(on_remote_dictation=refuse)).post(
+        "/api/dictation/remote", json={"text": "hi", "target_mode": "focused"}
+    )
+
+    assert r.status_code == 422
+    assert r.json()["refusal"] == "desktop_type_driver_unavailable"
+
+
+def test_mid_effect_refusal_still_parks_pending_and_never_replays(tmp_path):
+    """A driver that raised MID-type is ambiguous: we cannot prove nothing was
+    typed, so the claim stays pending and the effect is never repeated."""
+    database = Database(tmp_path / "delivery.db")
+    calls = 0
+
+    def half_typed(_text, *, target="agent"):
+        nonlocal calls
+        calls += 1
+        raise DesktopTypeRefused("desktop_type_driver_failed")
+
+    client = _client(
+        _ctx(
+            on_remote_dictation=half_typed,
+            dictation_deliveries=database.dictation_deliveries,
+        )
+    )
+    payload = _room_payload()
+    first = client.post("/api/dictation/remote", json=payload)
+    retry = client.post("/api/dictation/remote", json=payload)
+
+    assert first.status_code == retry.status_code == 425
+    assert first.json()["error_code"] == "delivery_pending"
+    assert calls == 1
+
+
+def test_raw_delivery_refusal_is_named_too():
+    """A REHEARSE receipt sent verbatim refuses with the same vocabulary."""
+
+    def refuse(_text, *, target="agent"):
+        raise DesktopTypeRefused("desktop_focus_unresolved")
+
+    r = _client(_ctx(on_remote_dictation=refuse)).post(
+        "/api/dictation/remote",
+        json={"text": "exact words", "raw": True, "target_mode": "focused"},
+    )
+
+    assert r.status_code == 422
+    assert r.json()["refusal"] == "desktop_focus_unresolved"
+
+
+# ── the journal reads the truth: delivery = dictation, rehearse = dry_run ────
+
+
+def test_delivery_journals_as_a_dictation_not_a_dry_run(monkeypatch):
+    seen: dict = {}
+
+    def capture(text, *a, **k):
+        seen["journal_source"] = k.get("journal_source")
+        return {"final_text": f"[corrected] {text}"}
+
+    monkeypatch.setattr(PIPELINE, capture)
+    _client(_ctx(on_remote_dictation=lambda t, *, target="agent": None)).post(
+        "/api/dictation/remote", json=_room_payload()
+    )
+
+    assert seen["journal_source"] == "dictation"
+
+
+def test_rehearsal_still_journals_as_a_dry_run(monkeypatch):
+    seen: dict = {}
+
+    def capture(text, *a, **k):
+        seen["journal_source"] = k.get("journal_source", "dry_run")
+        return {"final_text": text}
+
+    monkeypatch.setattr(PIPELINE, capture)
+    r = _client(_ctx()).post(
+        "/api/dictation/dry-run", json={"utterance": "rehearse this"}
+    )
+
+    assert r.status_code == 200
+    assert seen["journal_source"] == "dry_run"
+
+
+def test_journal_source_reaches_the_recorder(tmp_path):
+    """The helper actually threads the lane down to `journal.record`."""
+    from holdspeak.web.routes.dictation._helpers import _run_dictation_dry_run_text
+
+    recorded: list = []
+
+    class _Recorder:
+        repository = None
+
+        def record(self, run, *, source, **kw):
+            recorded.append(source)
+            return None
+
+    _run_dictation_dry_run_text(
+        "spoken words",
+        None,
+        None,
+        suggestions={},
+        journal=_Recorder(),
+        journal_source="dictation",
+    )
+
+    assert recorded == ["dictation"]

--- a/web/src/desk/desk.css
+++ b/web/src/desk/desk.css
@@ -4270,6 +4270,14 @@
   text-overflow: ellipsis;
   max-width: 18ch;
 }
+/* HS-112-02 — the aim row: one gadget sheet under the strip naming
+   where a released TALK sends the words. Never flex-compressed. */
+.desk-next .speak-aim {
+  flex: none;
+}
+.desk-next .speak-aim .gadget-group {
+  margin: 0;
+}
 /* The utterance well fills; the face never shows a void. */
 .desk-next .speak-well {
   display: flex;

--- a/web/src/pages/DictationPage.test.tsx
+++ b/web/src/pages/DictationPage.test.tsx
@@ -85,6 +85,9 @@ async function openTryIt() {
     </MemoryRouter>,
   );
   // HS-100-07: the loop IS the front face — no tab to reach it.
+  // HS-112-02: the deck's default action is a REAL delivery now; the
+  // dry run these recovery legs exercise is the explicit REHEARSE mode.
+  fireEvent.click(screen.getByRole("checkbox", { name: "Rehearse" }));
   const editor = await screen.findByLabelText("Utterance");
   fireEvent.change(editor, {
     target: { value: "A draft that must not disappear." },
@@ -109,12 +112,12 @@ describe("DictationPage Try it failure actions", () => {
       },
     });
     const editor = await openTryIt();
-    fireEvent.click(screen.getByRole("button", { name: "Run dry test" }));
+    fireEvent.click(screen.getByRole("button", { name: "Rehearse" }));
 
     await screen.findByText(/Delivery did not complete/);
     expect(editor).toHaveValue("A draft that must not disappear.");
     expect(
-      screen.getByRole("button", { name: "Retry dry test" }),
+      screen.getByRole("button", { name: "Retry rehearsal" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
     expect(
@@ -147,7 +150,7 @@ describe("DictationPage Try it failure actions", () => {
       },
     });
     await openTryIt();
-    fireEvent.click(screen.getByRole("button", { name: "Run dry test" }));
+    fireEvent.click(screen.getByRole("button", { name: "Rehearse" }));
     await screen.findByText(/Transcription timed out/);
 
     const picker = await screen.findByRole("combobox", { name: "Runs on" });
@@ -165,7 +168,7 @@ describe("DictationPage Try it failure actions", () => {
       dryRun: () => Promise.reject(new ApiError(401, "bad token", {})),
     });
     const editor = await openTryIt();
-    fireEvent.click(screen.getByRole("button", { name: "Run dry test" }));
+    fireEvent.click(screen.getByRole("button", { name: "Rehearse" }));
 
     await screen.findByText(/rejected the connection/);
     expect(editor).toHaveValue("A draft that must not disappear.");
@@ -173,7 +176,7 @@ describe("DictationPage Try it failure actions", () => {
     expect(screen.getByRole("button", { name: "Setup" })).toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Runs on" })).toBeNull();
     expect(
-      screen.getByRole("button", { name: "Run dry test" }),
+      screen.getByRole("button", { name: "Rehearse" }),
     ).toBeInTheDocument();
   });
 
@@ -182,7 +185,7 @@ describe("DictationPage Try it failure actions", () => {
       dryRun: () => Promise.reject(new ApiError(504, "timeout", {})),
     });
     await openTryIt();
-    fireEvent.click(screen.getByRole("button", { name: "Run dry test" }));
+    fireEvent.click(screen.getByRole("button", { name: "Rehearse" }));
     await screen.findByText(/Transcription timed out/);
 
     fireEvent.click(screen.getByRole("button", { name: "Keep as Note" }));

--- a/web/src/pages/cores/DictationCore.tsx
+++ b/web/src/pages/cores/DictationCore.tsx
@@ -26,7 +26,7 @@ import { Button } from "../../components/signal/Signal";
 import { RunsOnPicker } from "../../desk/components/RunsOnPicker";
 import { MicButton, type MicState } from "../../desk/components/MicButton";
 import type { InferenceTarget } from "../../desk/api";
-import { apiFetch, readableError, type JsonRecord } from "../../lib/api";
+import { ApiError, apiFetch, readableError, type JsonRecord } from "../../lib/api";
 import {
   DICTATION_FAILURES,
   applicableActions,
@@ -284,11 +284,72 @@ function ReadinessLine({
   );
 }
 
+/* HS-112-02 — the deck's full lifecycle, not just the capture half:
+   IDLE -> LISTENING (held) -> BUSY (transcribe + deliver) -> LANDED /
+   REFUSED. The register is the one place the room says where it is. */
 const STATE_TOKENS: { id: string; label: string }[] = [
   { id: "idle", label: "Idle" },
   { id: "listening", label: "Listening" },
-  { id: "transcribing", label: "Transcribing" },
+  { id: "busy", label: "Busy" },
+  { id: "landed", label: "Landed" },
+  { id: "refused", label: "Refused" },
 ];
+
+/* HS-112-02 — the AIM: where a released TALK sends the words. FOCUSED
+   APP and AGENT go through the real delivery contract; THIS FIELD is
+   the old speak-to-fill (the transcript lands in the well, nothing is
+   delivered). The pick is the owner's, and it is remembered. */
+const AIM_KEY = "holdspeak.speakAim";
+const AIM_OPTIONS = [
+  { value: "focused", label: "Focused app" },
+  { value: "agent", label: "Agent" },
+  { value: "field", label: "This field" },
+];
+const AIM_FACT: Record<string, string> = {
+  focused: "FOCUSED APP",
+  agent: "AGENT",
+  field: "THIS FIELD",
+};
+
+/* The kernel's own refusal vocabulary, rendered as WHAT in the fewest
+   words. An unknown code rides through verbatim — never swallowed. */
+const REFUSAL_LABELS: Record<string, string> = {
+  no_awaiting_agent: "NO AGENT AWAITING",
+  desktop_focus_unresolved: "NO FOCUSED APP",
+  desktop_type_driver_unavailable: "NO TYPING DRIVER",
+  desktop_type_claim_refused: "KERNEL CLAIM REFUSED",
+  desktop_type_refused: "KERNEL REFUSED",
+  delivery_pending: "OUTCOME UNKNOWN",
+  delivery_conflict: "DELIVERY CONFLICT",
+  no_delivery_target: "NO DELIVERY TARGET",
+};
+
+function refusalLabel(code: string): string {
+  return REFUSAL_LABELS[code] ?? code.replace(/_/g, " ").toUpperCase();
+}
+
+/** The named refusal behind a failed delivery, or "" when it is not one. */
+function refusalCode(reason: unknown): string {
+  if (!(reason instanceof ApiError)) return "";
+  const payload =
+    reason.payload && typeof reason.payload === "object"
+      ? (reason.payload as JsonRecord)
+      : {};
+  for (const key of ["refusal", "error_code", "failure_category"]) {
+    const value = payload[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return "";
+}
+
+/** One stable id per utterance — the delivery claim's whole point. */
+function newDeliveryId(): string {
+  const entropy =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return `speak:${Date.now()}-${entropy}`;
+}
 
 function SpeakFace() {
   const announce = useAnnounce();
@@ -312,6 +373,18 @@ function SpeakFace() {
   const [targetId, setTargetId] = useState("this_machine");
   const [micState, setMicState] = useState<MicState>("idle");
   const [level, setLevel] = useState(0);
+  // HS-112-02 — the delivery half of the deck.
+  const [aim, setAim] = useState(
+    () => localStorage.getItem(AIM_KEY) ?? "focused",
+  );
+  const [rehearse, setRehearse] = useState(false);
+  const [phase, setPhase] = useState<"idle" | "busy" | "landed" | "refused">(
+    "idle",
+  );
+  const [landedMs, setLandedMs] = useState<number | null>(null);
+  const [refusal, setRefusal] = useState("");
+  // release-to-landed is measured from the moment the key came up.
+  const releasedAt = useRef<number | null>(null);
   // The strip's readout cells read the same wire the footer reads.
   const stripRoot = localStorage.getItem("holdspeak.projectRootOverride") ?? "";
   const readiness = useResource<JsonRecord>(
@@ -324,7 +397,9 @@ function SpeakFace() {
   useEffect(() => {
     if (utteranceRecovered) announce("Draft restored");
   }, [utteranceRecovered, announce]);
-  const run = async () => {
+  /* REHEARSE — the explicit dry run. It previews the pipeline and
+     delivers NOTHING; it is never what a plain TALK release does. */
+  const run = async (text: string = utterance) => {
     setBusy(true);
     setError("");
     setFailure(null);
@@ -334,12 +409,13 @@ function SpeakFace() {
         await apiFetch<JsonRecord>("/api/dictation/dry-run", {
           method: "POST",
           json: {
-            utterance,
+            utterance: text,
             ...(projectRoot ? { project_root: projectRoot } : {}),
           },
         }),
       );
-      announce("");
+      setPhase("idle");
+      announce("REHEARSED · NOT DELIVERED");
       localStorage.setItem("holdspeak.projectRootOverride", projectRoot);
     } catch (reason) {
       const category = dictationFailure(reason);
@@ -350,6 +426,80 @@ function SpeakFace() {
     } finally {
       setBusy(false);
     }
+  };
+
+  const pickAim = (next: string) => {
+    setAim(next);
+    localStorage.setItem(AIM_KEY, next);
+  };
+
+  const refuse = (code: string) => {
+    setLandedMs(null);
+    setPhase("refused");
+    setRefusal(code);
+    announce(`⚠ REFUSED · ${refusalLabel(code)}`, "warn");
+  };
+
+  /* THE FLAGSHIP ACT — release TALK and the words land where you aimed
+     them, through the same route, pipeline, journal, kernel warrant and
+     idempotency claim as the global hotkey. One id per utterance. */
+  const deliver = async (text: string) => {
+    const spoken = text.trim();
+    if (!spoken) return;
+    const since = releasedAt.current ?? performance.now();
+    setBusy(true);
+    setPhase("busy");
+    setError("");
+    setFailure(null);
+    setRefusal("");
+    setVerdict("");
+    try {
+      const landed = await apiFetch<JsonRecord>("/api/dictation/remote", {
+        method: "POST",
+        json: {
+          text: spoken,
+          target_mode: aim === "agent" ? "agent" : "focused",
+          delivery_id: newDeliveryId(),
+          // an aimed AGENT send refuses rather than free-typing into
+          // whatever happens to be focused.
+          ...(aim === "agent" ? { require_agent: true } : {}),
+        },
+      });
+      setResult(landed);
+      if (landed.delivered === false) {
+        refuse("no_delivery_target");
+        return;
+      }
+      const took = Math.round(performance.now() - since);
+      setLandedMs(took);
+      setPhase("landed");
+      announce(`LANDED ${took} MS -> ${AIM_FACT[aim]}`);
+    } catch (reason) {
+      const code = refusalCode(reason);
+      if (code) {
+        refuse(code);
+        return;
+      }
+      const category = dictationFailure(reason);
+      setFailure(category);
+      const message = DICTATION_FAILURES[category].message;
+      setError(message);
+      setLandedMs(null);
+      setPhase("refused");
+      setRefusal(category);
+      announce(`⚠ ${message}`, "warn");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /* The one gesture contract: hold, talk, release. What happens on
+     release is the AIM's business, never a hidden default. */
+  const onReleased = (text: string) => {
+    setUtterance(text);
+    if (aim === "field" || !text.trim()) return;
+    if (rehearse) void run(text);
+    else void deliver(text);
   };
   const actions = failure
     ? applicableActions(failure, { draftPresent: Boolean(utterance.trim()) })
@@ -431,12 +581,19 @@ function SpeakFace() {
       setBusy(false);
     }
   };
+  /* The well's own verb: a rehearsal, or an aim that delivers nowhere,
+     previews; anything else delivers for real. */
+  const previewOnly = rehearse || aim === "field";
   const activeState =
-    micState === "busy"
-      ? "transcribing"
-      : micState === "listening"
-        ? "listening"
-        : "idle";
+    micState === "listening"
+      ? "listening"
+      : micState === "busy" || phase === "busy"
+        ? "busy"
+        : phase === "landed"
+          ? "landed"
+          : phase === "refused"
+            ? "refused"
+            : "idle";
   return (
     <div className="speak-face">
       <div className="speak-strip" role="group" aria-label="Dictation deck">
@@ -444,12 +601,26 @@ function SpeakFace() {
           variant="transport"
           draftScope="dictation-dry-run-voice"
           label="Hold to talk"
-          onText={(text) => setUtterance(text)}
-          onState={setMicState}
+          onText={onReleased}
+          onState={(next) => {
+            // the key came up: start the release-to-landed clock and
+            // clear the previous verdict off the register.
+            if (next === "busy") releasedAt.current = performance.now();
+            if (next === "listening") {
+              releasedAt.current = null;
+              setPhase("idle");
+              setLandedMs(null);
+              setRefusal("");
+            }
+            setMicState(next);
+          }}
           onLevel={setLevel}
-          onFailure={(category) =>
-            announce(`⚠ ${DICTATION_FAILURES[category].message}`, "warn")
-          }
+          onFailure={(category) => {
+            setPhase("refused");
+            setRefusal(category);
+            setLandedMs(null);
+            announce(`⚠ ${DICTATION_FAILURES[category].message}`, "warn");
+          }}
         />
         <LedMeter label="Level" value={level} scanning={micState === "busy"} />
         <span className="speak-register" aria-label="Dictation state">
@@ -482,6 +653,16 @@ function SpeakFace() {
             </span>
           </span>
           <span className="speak-cell">
+            <span className="speak-cell-label">Landed</span>
+            <span className="speak-cell-value" aria-label="Landed latency">
+              {phase === "refused" && refusal
+                ? refusalLabel(refusal)
+                : landedMs !== null
+                  ? `${landedMs} MS`
+                  : "—"}
+            </span>
+          </span>
+          <span className="speak-cell">
             <span className="speak-cell-label">Budget</span>
             <span className="speak-cell-value">
               {presentValue(readinessConfig.max_total_latency_ms)
@@ -490,6 +671,27 @@ function SpeakFace() {
             </span>
           </span>
         </span>
+      </div>
+      {/* HS-112-02 — the aim row: where a released TALK sends the
+          words, and whether this one is only a rehearsal. */}
+      <div className="speak-aim">
+        <GadgetGroup>
+          <GadgetRow label="Aim" fact={AIM_FACT[aim] ?? aim}>
+            <CycleGadget
+              label="Aim"
+              value={aim}
+              options={AIM_OPTIONS}
+              onChange={pickAim}
+            />
+          </GadgetRow>
+          <GadgetRow label="Rehearse" fact="DRY RUN">
+            <CheckGadget
+              label="Rehearse"
+              checked={rehearse}
+              onChange={setRehearse}
+            />
+          </GadgetRow>
+        </GadgetGroup>
       </div>
       <div className="speak-well">
         <PadGadget
@@ -505,9 +707,15 @@ function SpeakFace() {
           variant="primary"
           loading={busy}
           disabled={!utterance.trim()}
-          onClick={run}
+          onClick={() => (previewOnly ? void run() : void deliver(utterance))}
         >
-          {error && actions.includes("retry") ? "Retry dry test" : "Run dry test"}
+          {previewOnly
+            ? error && actions.includes("retry")
+              ? "Retry rehearsal"
+              : "Rehearse"
+            : error && actions.includes("retry")
+              ? "Retry delivery"
+              : "Deliver"}
         </Button>
         <span className="speak-grounding">
           <span className="speak-grounding-label">Grounding</span>

--- a/web/src/pages/cores/__tests__/speakRoom.test.tsx
+++ b/web/src/pages/cores/__tests__/speakRoom.test.tsx
@@ -1,0 +1,320 @@
+// HS-112-02 — the room named Speak performs the flagship act.
+//
+// Hold TALK, talk, release: the transcript goes through the REAL delivery
+// contract (`POST /api/dictation/remote`) with one `delivery_id` per
+// utterance, aimed by the deck's AIM row. THIS FIELD short-circuits to
+// speak-to-fill; REHEARSE is the explicit dry run and delivers nothing.
+// Every refusal lands in the footer receipt bar and the STATE register —
+// never a toast, never an overlay.
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DictationCore } from "../DictationCore";
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  startCapture: vi.fn(),
+  stopAndTranscribe: vi.fn(),
+}));
+
+vi.mock("../../../lib/api", () => {
+  class ApiError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+      public payload: unknown = {},
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  }
+  return {
+    ApiError,
+    apiFetch: mocks.apiFetch,
+    readableError: (error: unknown) =>
+      error instanceof Error ? error.message : "Request failed",
+  };
+});
+
+vi.mock("../../../lib/pendingVoice", () => ({
+  loadPendingVoice: vi.fn().mockResolvedValue(null),
+  savePendingVoice: vi.fn(),
+  clearPendingVoice: vi.fn(),
+}));
+
+vi.mock("../../../lib/speakToFill", () => ({
+  cancelCapture: vi.fn(),
+  speakToFillSupported: () => true,
+  speakToFillUnsupportedReason: () => null,
+  startCapture: mocks.startCapture,
+  stopAndTranscribe: mocks.stopAndTranscribe,
+  retryPendingTranscription: vi.fn().mockResolvedValue(null),
+  subscribeCaptureLevel: () => () => undefined,
+}));
+
+import { ApiError } from "../../../lib/api";
+
+type Route = (init?: { method?: string; json?: unknown }) => Promise<unknown>;
+
+function mockRoutes(routes: Record<string, Route> = {}) {
+  mocks.apiFetch.mockImplementation(
+    (path: string, init?: { method?: string; json?: unknown }) => {
+      for (const [prefix, handler] of Object.entries(routes))
+        if (path === prefix || path.startsWith(prefix)) return handler(init);
+      return Promise.resolve({});
+    },
+  );
+}
+
+/** Every call the deck made to one route, newest last. */
+function callsTo(path: string): { method?: string; json?: any }[] {
+  return mocks.apiFetch.mock.calls
+    .filter((call: unknown[]) => String(call[0]).startsWith(path))
+    .map((call: unknown[]) => (call[1] ?? {}) as { method?: string; json?: any });
+}
+
+async function openDeck() {
+  render(
+    <MemoryRouter>
+      <DictationCore />
+    </MemoryRouter>,
+  );
+  return screen.findByRole("button", { name: "Hold to talk" });
+}
+
+/** Hold the TALK key, speak, release — the one gesture contract. */
+async function holdAndRelease(talk: HTMLElement) {
+  fireEvent.pointerDown(talk);
+  await waitFor(() => expect(talk).toHaveAttribute("aria-pressed", "true"));
+  fireEvent.pointerUp(talk);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mocks.startCapture.mockResolvedValue(undefined);
+  mocks.stopAndTranscribe.mockResolvedValue("ship it friday");
+  mockRoutes();
+});
+
+describe("Speak delivers for real (HS-112-02)", () => {
+  it("posts a released utterance through the delivery contract with one delivery id", async () => {
+    mockRoutes({
+      "/api/dictation/remote": () =>
+        Promise.resolve({ success: true, delivered: true, final_text: "ship it friday" }),
+    });
+    const talk = await openDeck();
+
+    await holdAndRelease(talk);
+
+    await waitFor(() => expect(callsTo("/api/dictation/remote")).toHaveLength(1));
+    const [call] = callsTo("/api/dictation/remote");
+    expect(call.method).toBe("POST");
+    expect(call.json.text).toBe("ship it friday");
+    expect(call.json.target_mode).toBe("focused");
+    expect(String(call.json.delivery_id)).toMatch(/^speak:/);
+    // FOCUSED APP is not an aimed-agent send: no agent requirement rides along.
+    expect(call.json.require_agent).toBeUndefined();
+    // the dry run is NOT what a release does any more
+    expect(callsTo("/api/dictation/dry-run")).toHaveLength(0);
+  });
+
+  it("shows release-to-landed latency on the footer receipt and the register", async () => {
+    mockRoutes({
+      "/api/dictation/remote": () =>
+        Promise.resolve({ success: true, delivered: true, final_text: "ship it friday" }),
+    });
+    const talk = await openDeck();
+
+    await holdAndRelease(talk);
+
+    const receipt = await screen.findByText(/^LANDED \d+ MS -> FOCUSED APP$/);
+    expect(receipt).toBeVisible();
+    const register = screen.getByLabelText("Dictation state");
+    const landed = Array.from(
+      register.querySelectorAll(".speak-register-token"),
+    ).find((token) => token.textContent === "Landed");
+    expect(landed).toHaveAttribute("data-active");
+    expect(screen.getByLabelText("Landed latency").textContent).toMatch(/ MS$/);
+  });
+
+  it("mints a fresh delivery id for each utterance", async () => {
+    mockRoutes({
+      "/api/dictation/remote": () =>
+        Promise.resolve({ success: true, delivered: true, final_text: "ship it friday" }),
+    });
+    const talk = await openDeck();
+
+    await holdAndRelease(talk);
+    await waitFor(() => expect(callsTo("/api/dictation/remote")).toHaveLength(1));
+    await holdAndRelease(talk);
+    await waitFor(() => expect(callsTo("/api/dictation/remote")).toHaveLength(2));
+
+    const [first, second] = callsTo("/api/dictation/remote");
+    expect(first.json.delivery_id).not.toBe(second.json.delivery_id);
+  });
+});
+
+describe("Speak aim selector", () => {
+  it("aims at the awaiting agent and requires one to be awaiting", async () => {
+    mockRoutes({
+      "/api/dictation/remote": () =>
+        Promise.resolve({ success: true, delivered: true, final_text: "ship it friday" }),
+    });
+    const talk = await openDeck();
+    fireEvent.change(screen.getByRole("combobox", { name: "Aim" }), {
+      target: { value: "agent" },
+    });
+
+    await holdAndRelease(talk);
+
+    await waitFor(() => expect(callsTo("/api/dictation/remote")).toHaveLength(1));
+    const [call] = callsTo("/api/dictation/remote");
+    expect(call.json.target_mode).toBe("agent");
+    expect(call.json.require_agent).toBe(true);
+  });
+
+  it("THIS FIELD fills the well and delivers nothing", async () => {
+    const talk = await openDeck();
+    fireEvent.change(screen.getByRole("combobox", { name: "Aim" }), {
+      target: { value: "field" },
+    });
+
+    await holdAndRelease(talk);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Utterance")).toHaveValue("ship it friday"),
+    );
+    expect(callsTo("/api/dictation/remote")).toHaveLength(0);
+    expect(callsTo("/api/dictation/dry-run")).toHaveLength(0);
+  });
+
+  it("remembers the aim across a remount", async () => {
+    const first = render(
+      <MemoryRouter>
+        <DictationCore />
+      </MemoryRouter>,
+    );
+    fireEvent.change(await screen.findByRole("combobox", { name: "Aim" }), {
+      target: { value: "agent" },
+    });
+    expect(localStorage.getItem("holdspeak.speakAim")).toBe("agent");
+    first.unmount();
+
+    render(
+      <MemoryRouter>
+        <DictationCore />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole("combobox", { name: "Aim" })).toHaveValue(
+      "agent",
+    );
+  });
+});
+
+describe("Speak REHEARSE stays explicit", () => {
+  it("previews through the dry run and delivers nothing when armed", async () => {
+    mockRoutes({
+      "/api/dictation/dry-run": () =>
+        Promise.resolve({ final_text: "ship it friday", total_ms: 120 }),
+    });
+    const talk = await openDeck();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Rehearse" }));
+
+    await holdAndRelease(talk);
+
+    await waitFor(() => expect(callsTo("/api/dictation/dry-run")).toHaveLength(1));
+    expect(callsTo("/api/dictation/remote")).toHaveLength(0);
+    expect(await screen.findByText("REHEARSED · NOT DELIVERED")).toBeVisible();
+  });
+
+  it("names the well's verb after the mode it is in", async () => {
+    await openDeck();
+    expect(screen.getByRole("button", { name: "Deliver" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Rehearse" }));
+    expect(screen.getByRole("button", { name: "Rehearse" })).toBeInTheDocument();
+  });
+});
+
+describe("Speak refusals land in-flow", () => {
+  it("names an unresolved desktop focus in the receipt bar and the register", async () => {
+    mockRoutes({
+      "/api/dictation/remote": () =>
+        Promise.reject(
+          new ApiError(422, "desktop_focus_unresolved", {
+            refusal: "desktop_focus_unresolved",
+            failure_category: "delivery_refused",
+            delivered: false,
+          }),
+        ),
+    });
+    const talk = await openDeck();
+
+    await holdAndRelease(talk);
+
+    const receipt = await screen.findByText("⚠ REFUSED · NO FOCUSED APP");
+    expect(receipt).toBeVisible();
+    expect(receipt).toHaveAttribute("role", "alert");
+    // in-flow, in the ONE receipt channel — no dialog, no toast species
+    expect(screen.queryByRole("dialog")).toBeNull();
+    const register = screen.getByLabelText("Dictation state");
+    const refused = Array.from(
+      register.querySelectorAll(".speak-register-token"),
+    ).find((token) => token.textContent === "Refused");
+    expect(refused).toHaveAttribute("data-active");
+    expect(screen.getByLabelText("Landed latency")).toHaveTextContent(
+      "NO FOCUSED APP",
+    );
+  });
+
+  it("names an aimed agent with nothing awaiting", async () => {
+    mockRoutes({
+      "/api/dictation/remote": () =>
+        Promise.reject(
+          new ApiError(422, "no_awaiting_agent", {
+            refusal: "no_awaiting_agent",
+            failure_category: "delivery_refused",
+          }),
+        ),
+    });
+    const talk = await openDeck();
+    fireEvent.change(screen.getByRole("combobox", { name: "Aim" }), {
+      target: { value: "agent" },
+    });
+
+    await holdAndRelease(talk);
+
+    expect(
+      await screen.findByText("⚠ REFUSED · NO AGENT AWAITING"),
+    ).toBeVisible();
+  });
+
+  it("names a transcription failure without losing the deck", async () => {
+    mocks.stopAndTranscribe.mockRejectedValue(new ApiError(504, "timeout", {}));
+    const talk = await openDeck();
+
+    await holdAndRelease(talk);
+
+    expect(await screen.findByText(/Transcription timed out/)).toBeVisible();
+    expect(callsTo("/api/dictation/remote")).toHaveLength(0);
+    const register = screen.getByLabelText("Dictation state");
+    const refused = Array.from(
+      register.querySelectorAll(".speak-register-token"),
+    ).find((token) => token.textContent === "Refused");
+    expect(refused).toHaveAttribute("data-active");
+  });
+
+  it("refuses honestly when the hub has nothing to deliver into", async () => {
+    mockRoutes({
+      "/api/dictation/remote": () =>
+        Promise.resolve({ success: true, delivered: false, final_text: "ship it friday" }),
+    });
+    const talk = await openDeck();
+
+    await holdAndRelease(talk);
+
+    expect(
+      await screen.findByText("⚠ REFUSED · NO DELIVERY TARGET"),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
The Speak room's TALK key now delivers for real through the one existing contract (`/api/dictation/remote`, same delivery_id idempotency claim — no third delivery path). AIM row (FOCUSED APP / AGENT / THIS FIELD), REHEARSE explicit and never the default, opt-in `require_agent` strictness (companion fallback byte-identical), pre-effect kernel refusals named and terminal with cached-refusal replay, release-to-landed latency on the receipt, refusals in-flow only. Also fixes a latent bug: companion deliveries had been journaling as `dry_run` rehearsals — now `journal_source=dictation`.

Story stays **in-progress**: the flip to done awaits the live-metal proof (real TALK hold → text lands in a real app + agent pane, refusal shot legs, 1440+393). Contract tests unmodified byte-identical; new 13 python + 12 web tests; suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)