### PR TITLE
HS-112-03: The architect's desk — packaged seed + tombstone reset

### DIFF
--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -9,7 +9,7 @@ and the clients that call it (extracted from the real call sites in
 `web/src` and `apple/`). "server only" means no in-repo client calls
 it today.
 
-Routes: 373 (plus static mounts). iOS-consumed: 88. Web-consumed: 282.
+Routes: 375 (plus static mounts). iOS-consumed: 88. Web-consumed: 284.
 
 ## device_audio_ws
 
@@ -225,6 +225,13 @@ Routes: 373 (plus static mounts). iOS-consumed: 88. Web-consumed: 282.
 | GET | `/api/desk/actuators/status` | ios |
 | POST | `/api/desk/actuators/webhook/propose` | ios, web |
 | POST | `/api/desk/actuators/webhook/{proposal_id}/decision` | ios, web |
+
+## web.routes.desk_seed
+
+| Method | Path | Consumers |
+|---|---|---|
+| POST | `/api/desk/reset` | web |
+| POST | `/api/desk/seed` | web |
 
 ## web.routes.dictation.agent
 

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -1482,6 +1482,26 @@
       ]
     },
     {
+      "path": "/api/desk/reset",
+      "methods": [
+        "POST"
+      ],
+      "module": "web.routes.desk_seed",
+      "consumers": [
+        "web"
+      ]
+    },
+    {
+      "path": "/api/desk/seed",
+      "methods": [
+        "POST"
+      ],
+      "module": "web.routes.desk_seed",
+      "consumers": [
+        "web"
+      ]
+    },
+    {
       "path": "/api/devices/audio",
       "methods": [
         "WS"

--- a/holdspeak/commands/seed.py
+++ b/holdspeak/commands/seed.py
@@ -1,0 +1,27 @@
+"""`holdspeak seed` — apply the packaged architect's-desk seed (HS-112-03).
+
+Idempotent by deterministic id: running it twice leaves one desk. It only
+ever adds/updates the seed's own `hs-desk-*` objects; nothing else on the
+desk is touched (reset lives in the app's Prefs, behind its own confirm).
+"""
+
+from __future__ import annotations
+
+
+def run_seed_command(args) -> int:
+    """Handle `holdspeak seed`. Returns a process exit code."""
+    from ..db import get_database
+    from ..db.seed import SeedError, apply_seed
+
+    try:
+        report = apply_seed(get_database())
+    except SeedError as exc:
+        print(f"Seed failed: {exc}")
+        return 1
+
+    print(f"Applied the packaged '{report.manifest}' seed:")
+    for section, count in sorted(report.applied.items()):
+        print(f"  {section}: {count}")
+    print(f"  filed: {report.filed}")
+    print("Re-running is safe: the seed upserts by id, never duplicates.")
+    return 0

--- a/holdspeak/db/seed.py
+++ b/holdspeak/db/seed.py
@@ -1,0 +1,213 @@
+"""The architect's desk seed + reset-to-seed (HS-112-03).
+
+The product-side sibling of the UAT seed rig (``uat/conductor/induction/
+seeds.py`` — the proven pattern, deliberately not imported: the quarantine
+runs both ways). The manifest ships inside the package
+(``holdspeak/seeds/fresh-desk.yaml``); this module applies it through the
+same repositories the primitive routes wrap, so a seeded object is
+indistinguishable from a user-made one.
+
+Idempotency is the contract: every item carries a deterministic
+``hs-desk-*`` id, so re-applying upserts in place — never a duplicate desk.
+Nothing here runs at boot; the seed is an explicit act (CLI verb, route,
+or the reset).
+
+Reset TOMBSTONES, never purges: ``/api/sync/pull`` ships
+``include_deleted=True`` so tombstones propagate last-write-wins to paired
+devices — a hard purge would simply be resurrected by the next push.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .core import Database
+
+SEEDS_DIR = Path(__file__).resolve().parent.parent / "seeds"
+DEFAULT_SEED = "fresh-desk"
+
+# Manifest sections in dependency order (containers before members), each
+# mapped to the membership ref kind (`kind:id`, the filing wire contract).
+_SECTION_KINDS: dict[str, str] = {
+    "directories": "zone",
+    "kbs": "knowledge",
+    "notes": "note",
+    "recipes": "persona",
+    "chains": "sequence",
+    "workflows": "workflow",
+}
+
+
+class SeedError(ValueError):
+    pass
+
+
+@dataclass
+class SeedReport:
+    manifest: str
+    applied: dict[str, int] = field(default_factory=dict)
+    filed: int = 0
+
+    @property
+    def total(self) -> int:
+        return sum(self.applied.values())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest": self.manifest,
+            "applied": dict(self.applied),
+            "filed": self.filed,
+            "total": self.total,
+        }
+
+
+@dataclass
+class ResetReport:
+    tombstoned: dict[str, int] = field(default_factory=dict)
+    seed: SeedReport | None = None
+
+    @property
+    def tombstoned_total(self) -> int:
+        return sum(self.tombstoned.values())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tombstoned": dict(self.tombstoned),
+            "tombstoned_total": self.tombstoned_total,
+            "seed": self.seed.to_dict() if self.seed else None,
+        }
+
+
+def load_manifest(name: str = DEFAULT_SEED) -> dict[str, Any]:
+    path = SEEDS_DIR / f"{name}.yaml"
+    if not path.exists():
+        raise SeedError(f"unknown packaged seed: {name!r} (looked in {SEEDS_DIR})")
+    doc = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(doc, dict):
+        raise SeedError(f"seed {name!r} must be a mapping")
+    return doc
+
+
+def apply_seed(db: "Database", name: str = DEFAULT_SEED) -> SeedReport:
+    """Upsert the packaged seed into the desk repositories (idempotent by id)."""
+    manifest = load_manifest(name)
+    report = SeedReport(manifest=name)
+
+    # Deterministic id -> qualified membership ref, derived from the section
+    # each item is declared in (the UAT rig's same refs contract).
+    refs: dict[str, str] = {
+        str(item["id"]): f"{kind}:{item['id']}"
+        for section, kind in _SECTION_KINDS.items()
+        for item in manifest.get(section) or []
+        if isinstance(item, dict) and item.get("id")
+    }
+
+    filings: list[tuple[str, str]] = []  # (qualified member ref, directory id)
+    for section in _SECTION_KINDS:
+        for item in manifest.get(section) or []:
+            if not isinstance(item, dict) or not str(item.get("id") or "").strip():
+                raise SeedError(
+                    f"{section} item missing deterministic id "
+                    f"(the idempotency contract): {item!r}"
+                )
+            _apply_item(db, section, item)
+            report.applied[section] = report.applied.get(section, 0) + 1
+            if section == "directories":
+                for mid in item.get("member_ids") or []:
+                    ref = str(mid) if ":" in str(mid) else refs.get(str(mid), "")
+                    if not ref:
+                        raise SeedError(
+                            f"zone {item['id']} files unknown member: {mid!r}"
+                        )
+                    filings.append((ref, str(item["id"])))
+
+    for ref, directory_id in filings:
+        db.directory_memberships.upsert(primitive_id=ref, directory_id=directory_id)
+        report.filed += 1
+    return report
+
+
+def _apply_item(db: "Database", section: str, item: dict[str, Any]) -> None:
+    item_id = str(item["id"]).strip()
+    if section == "directories":
+        db.directories.upsert(
+            directory_id=item_id,
+            name=str(item.get("name") or ""),
+            parent_id=item.get("parent_id") or None,
+        )
+    elif section == "notes":
+        db.notes.upsert(
+            note_id=item_id,
+            title=str(item.get("title") or ""),
+            body_markdown=str(item.get("body_markdown") or ""),
+            tags=[str(tag) for tag in item.get("tags") or []],
+        )
+    elif section == "kbs":
+        db.kbs.upsert(kb_id=item_id, name=str(item.get("name") or ""))
+    elif section == "recipes":
+        db.recipes.upsert(
+            recipe_id=item_id,
+            name=str(item.get("name") or ""),
+            role=str(item.get("role") or ""),
+            system_prompt=str(item.get("system_prompt") or ""),
+            user_template=str(item.get("user_template") or ""),
+        )
+    elif section == "chains":
+        db.chains.upsert(
+            chain_id=item_id,
+            name=str(item.get("name") or ""),
+            steps=[str(step) for step in item.get("steps") or []],
+        )
+    elif section == "workflows":
+        db.workflows.upsert(
+            workflow_id=item_id,
+            name=str(item.get("name") or ""),
+            prompt=str(item.get("prompt") or ""),
+            graph_json=item.get("graph_json") or None,
+        )
+    else:  # pragma: no cover — _SECTION_KINDS is the closed roster
+        raise SeedError(f"unknown seed section: {section}")
+
+
+def reset_desk(db: "Database", name: str = DEFAULT_SEED) -> ResetReport:
+    """Tombstone every live desk primitive, then re-apply the packaged seed.
+
+    Repository ``.delete()`` only (tombstone; the sync contract above).
+    What survives, by design: the meetings archive, the dictation journal,
+    settings/config, and profiles — none are desk primitives.
+    """
+    report = ResetReport()
+    sweeps = [
+        ("notes", db.notes),
+        ("kbs", db.kbs),
+        ("recipes", db.recipes),
+        ("chains", db.chains),
+        ("workflows", db.workflows),
+    ]
+    for label, repo in sweeps:
+        count = 0
+        for record in repo.list(limit=2000):
+            if repo.delete(record.id):
+                count += 1
+        report.tombstoned[label] = count
+
+    count = 0
+    for membership in db.directory_memberships.list(limit=5000):
+        if db.directory_memberships.delete(membership.primitive_id):
+            count += 1
+    report.tombstoned["directory_memberships"] = count
+
+    # Directories last: their delete also tombstones remaining memberships
+    # and re-roots child zones, so nothing strands.
+    count = 0
+    for directory in db.directories.list(limit=2000):
+        if db.directories.delete(directory.id):
+            count += 1
+    report.tombstoned["directories"] = count
+
+    report.seed = apply_seed(db, name)
+    return report

--- a/holdspeak/main.py
+++ b/holdspeak/main.py
@@ -50,6 +50,7 @@ Examples:
   holdspeak import call.wav  # Import an existing recording as a meeting
   holdspeak backup       # Back up the database before upgrading
   holdspeak restore      # List backups, or restore one (holdspeak restore <file>)
+  holdspeak seed         # Apply the packaged architect's-desk seed (idempotent)
   holdspeak agent-hook templates --agent claude
                         # Print Claude/Codex hook templates for context capture
   holdspeak intel        # Inspect or process deferred meeting intelligence
@@ -423,6 +424,11 @@ Logs are written to: {LOG_FILE}
         help="Skip the overwrite confirmation prompt",
     )
 
+    subparsers.add_parser(
+        "seed",
+        help="Apply the packaged architect's-desk seed (idempotent; never deletes)",
+    )
+
     args = parser.parse_args()
 
     # Setup logging (always to file, optionally to stderr)
@@ -526,6 +532,12 @@ Logs are written to: {LOG_FILE}
         from .commands.backup import run_restore_command
 
         raise SystemExit(run_restore_command(args))
+
+    # Handle seed subcommand (HS-112-03)
+    if args.command == "seed":
+        from .commands.seed import run_seed_command
+
+        raise SystemExit(run_seed_command(args))
 
     # Default mode: web-first runtime.
     log.info("HoldSpeak default mode routing to web")

--- a/holdspeak/seeds/fresh-desk.yaml
+++ b/holdspeak/seeds/fresh-desk.yaml
@@ -1,0 +1,66 @@
+# The architect's desk (HS-112-03) — the packaged fresh-desk seed.
+#
+# Six drawers a Senior Software Architect wants on a fresh desk, one
+# honest starter object where a starter earns its place, nothing else.
+# Deterministic `hs-desk-*` ids are the idempotency contract: re-applying
+# upserts in place — never a duplicate desk. Applied by
+# `holdspeak.db.seed` (repository-level), reachable via `holdspeak seed`
+# and POST /api/desk/seed. Never auto-applied at boot: a fresh install
+# stays an empty floor until the owner asks.
+directories:
+  - id: hs-desk-adrs
+    name: ADRs
+    member_ids: [hs-desk-note-adr-template]
+  - id: hs-desk-meetings
+    name: Meetings
+  - id: hs-desk-rules
+    name: Rules
+    member_ids: [hs-desk-note-working-rules]
+  - id: hs-desk-decisions
+    name: Decisions
+  - id: hs-desk-reference
+    name: Reference
+  - id: hs-desk-inbox
+    name: Inbox
+notes:
+  - id: hs-desk-note-adr-template
+    title: ADR template
+    tags: [adr, template]
+    body_markdown: |
+      # ADR-NNN: <decision title>
+
+      - Status: Proposed | Accepted | Superseded by ADR-NNN
+      - Date: YYYY-MM-DD
+      - Deciders: <who was in the room>
+
+      ## Context
+
+      The problem and the forces at play. Name the constraint that makes
+      a decision necessary now. Two or three sentences, no history essay.
+
+      ## Decision
+
+      We will <the decision, one active sentence>.
+
+      Alternatives set aside, one line each on why they lost:
+
+      - <alternative> — <why not>
+
+      ## Consequences
+
+      - <what becomes easier>
+      - <what becomes harder, and who carries it>
+      - <what we agree to revisit, and the trigger that reopens it>
+  - id: hs-desk-note-working-rules
+    title: Working rules
+    tags: [rules]
+    body_markdown: |
+      # Working rules
+
+      - File objects into drawers. A clean floor is the default.
+      - The Inbox is the landing zone. Unfiled things go there first.
+      - One decision per ADR. Consequences are part of the decision.
+      - Decisions file into Decisions. KBs and reading into Reference.
+      - Meeting records file into Meetings.
+      - Reset to seed lives in Prefs. Desk objects reset; meetings,
+        journal, and settings survive.

--- a/holdspeak/web/routes/__init__.py
+++ b/holdspeak/web/routes/__init__.py
@@ -15,6 +15,7 @@ from .authority import build_authority_router
 from .cadence import build_cadence_router
 from .decisions import build_decisions_router
 from .desk_actuators import build_desk_actuators_router
+from .desk_seed import build_desk_seed_router
 from .core import build_core_router
 from .delivery import build_delivery_router
 from .delivery_attempts import build_delivery_attempts_router
@@ -43,6 +44,7 @@ __all__ = [
     "build_cadence_router",
     "build_decisions_router",
     "build_desk_actuators_router",
+    "build_desk_seed_router",
     "build_core_router",
     "build_delivery_router",
     "build_delivery_attempts_router",

--- a/holdspeak/web/routes/desk_seed.py
+++ b/holdspeak/web/routes/desk_seed.py
@@ -1,0 +1,57 @@
+"""The architect's desk — seed + reset routes (HS-112-03).
+
+Thin wrappers over ``holdspeak.db.seed`` (the same repositories the
+primitive routes wrap). Both are POSTs under ``/api/`` with no narrower
+right named in ``principals.required_right``, so the centralized edge
+gate requires the OWNER principal — reset is the desk's first
+destructive act and belongs to the owner alone.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from ...logging_config import get_logger
+from ..context import WebContext
+from ..runtime_support import error_500
+
+log = get_logger("web.routes.desk_seed")
+
+
+def build_desk_seed_router(ctx: WebContext) -> APIRouter:
+    router = APIRouter()
+
+    @router.post("/api/desk/seed")
+    async def api_desk_seed() -> Any:
+        try:
+            from ...db import get_database
+            from ...db.seed import apply_seed
+
+            report = apply_seed(get_database())
+            return JSONResponse({"success": True, **report.to_dict()})
+        except Exception as exc:
+            return error_500(exc, log, "Failed to seed the desk")
+
+    @router.post("/api/desk/reset")
+    async def api_desk_reset() -> Any:
+        try:
+            from ...db import get_database
+            from ...db.seed import reset_desk
+
+            report = reset_desk(get_database())
+            seed = report.seed
+            return JSONResponse({
+                "success": True,
+                "tombstoned": dict(report.tombstoned),
+                "tombstoned_total": report.tombstoned_total,
+                "seeded": dict(seed.applied) if seed else {},
+                "seeded_total": seed.total if seed else 0,
+                "filed": seed.filed if seed else 0,
+                "manifest": seed.manifest if seed else None,
+            })
+        except Exception as exc:
+            return error_500(exc, log, "Failed to reset the desk")
+
+    return router

--- a/holdspeak/web_server.py
+++ b/holdspeak/web_server.py
@@ -547,6 +547,7 @@ class MeetingWebServer:
             build_delivery_factory_router,
             build_dictation_router,
             build_desk_actuators_router,
+            build_desk_seed_router,
             build_meeting_import_router,
             build_meetings_router,
             build_memory_router,
@@ -611,6 +612,7 @@ class MeetingWebServer:
         app.include_router(build_memory_router(web_ctx))
         app.include_router(build_meetings_router(web_ctx))
         app.include_router(build_desk_actuators_router(web_ctx))
+        app.include_router(build_desk_seed_router(web_ctx))
         app.include_router(build_meeting_import_router(web_ctx))
         app.include_router(build_mesh_router(web_ctx))
         app.include_router(build_missioncontrol_router(web_ctx))

--- a/pm/roadmap/holdspeak/phase-112-enough/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-112-enough/current-phase-status.md
@@ -71,14 +71,36 @@ it does not absorb it — it names it in the final summary.
 |---|---|---|---|---|
 | HS-112-01 | One dial | ready | [story-01-one-dial](./story-01-one-dial.md) | — |
 | HS-112-02 | Speak speaks | backlog | [story-02-speak-speaks](./story-02-speak-speaks.md) | — |
-| HS-112-03 | The architect's desk | backlog | [story-03-architects-desk](./story-03-architects-desk.md) | — |
+| HS-112-03 | The architect's desk | in-progress | [story-03-architects-desk](./story-03-architects-desk.md) | — |
 | HS-112-04 | The plain story | backlog | [story-04-plain-story](./story-04-plain-story.md) | — |
 | HS-112-05 | The sitting walk | backlog | [story-05-walk](./story-05-walk.md) | — |
 | HS-112-06 | The open mic | backlog | [story-06-open-mic](./story-06-open-mic.md) | — |
 
 ## Where we are
 
-0/6. Chartered 2026-08-02 from the owner's post-111 verdict; the
+0/6 flipped; 03 BUILT (in-progress pending the live screenshot
+walk). HS-112-03 implemented 2026-08-02: the packaged fresh-desk
+seed ships in the wheel (holdspeak/seeds/fresh-desk.yaml — six
+hs-desk-* drawers: ADRs, Meetings, Rules, Decisions, Reference,
+Inbox; two authored starter notes: the ADR template and the
+Working rules), applied by a repository-level idempotent seeder
+(holdspeak/db/seed.py), reachable as `holdspeak seed`, POST
+/api/desk/seed, an EmptyDesk "Seed the desk" chip, and the Prefs
+Desk module. Reset-to-seed is the desk's first destructive act,
+done honestly: tombstone-only sweep (sync include_deleted ships the
+deletions — a paired device can never resurrect the clutter; pinned
+by test), re-seed, then the six ghost layout keys swept only after
+the wire says ok; the ConfirmVerb arming (RESET TO SEED → danger
+RESET DESK?, 3s auto-disarm) with fact labels naming what RESETS
+and what KEEPS (meetings, journal, settings, runs-on targets), and
+a TOMBSTONED N · SEEDED M receipt. The desk.reset-to-seed verb
+never destroys from a menu tap — it opens the Prefs face. UAT
+quarantine + fresh-desk empty assertions hold (no auto-seed at
+boot). 112 targeted python + 10-test story suite + 453 web green;
+full-suite failures triaged pre-existing/environmental in the
+report. The flip awaits the live walk: first boot, drawer open,
+ADR template read, reset confirm + after, 1440+393. Chartered
+2026-08-02. Chartered 2026-08-02 from the owner's post-111 verdict; the
 same day the owner chartered the open-mic rider live (HS-112-06 —
 the voice-first Desk: one mic grant, continuous stream, VAD; PTT
 byte-identical). The pre-charter survey (three parallel audits: the

--- a/pm/roadmap/holdspeak/phase-112-enough/story-03-architects-desk.md
+++ b/pm/roadmap/holdspeak/phase-112-enough/story-03-architects-desk.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 112
-- **Status:** backlog
+- **Status:** in-progress
 - **Depends on:** —
 - **Unblocks:** HS-112-04, HS-112-05
 - **Owner:** unassigned

--- a/tests/unit/test_desk_seed.py
+++ b/tests/unit/test_desk_seed.py
@@ -1,0 +1,245 @@
+"""HS-112-03 — the architect's desk seed + reset-to-seed.
+
+The packaged fresh-desk manifest applies through the repositories,
+idempotent by deterministic id; reset TOMBSTONES every desk primitive
+(rows retained, `deleted=1` — sync would resurrect a hard purge) and
+re-applies the seed. Meetings and the dictation journal survive by
+design. Routes are exercised over a real tmp-path Database, the same
+harness the sibling primitive-route tests use.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import holdspeak.db as hsdb
+from holdspeak.db import Database, reset_database
+from holdspeak.meeting_session import MeetingState
+from holdspeak.db.seed import DEFAULT_SEED, apply_seed, load_manifest, reset_desk
+from holdspeak.principals import PrincipalRight, required_right
+from holdspeak.web.context import WebContext
+from holdspeak.web.routes import build_desk_seed_router, build_sync_router
+
+DRAWERS = {
+    "hs-desk-adrs": "ADRs",
+    "hs-desk-meetings": "Meetings",
+    "hs-desk-rules": "Rules",
+    "hs-desk-decisions": "Decisions",
+    "hs-desk-reference": "Reference",
+    "hs-desk-inbox": "Inbox",
+}
+
+
+@pytest.fixture
+def db(tmp_path):
+    reset_database()
+    database = Database(tmp_path / "holdspeak.db")
+    yield database
+    reset_database()
+
+
+@pytest.fixture
+def client(db, monkeypatch) -> TestClient:
+    monkeypatch.setattr(hsdb, "get_database", lambda *a, **k: db)
+    app = FastAPI()
+    ctx = WebContext(get_state=lambda: {})
+    app.include_router(build_desk_seed_router(ctx))
+    app.include_router(build_sync_router(ctx))
+    return TestClient(app)
+
+
+def _snapshot(db: Database) -> dict:
+    """The live desk, content included — the identity the id contract pins."""
+    return {
+        "directories": [(d.id, d.name, d.parent_id) for d in db.directories.list()],
+        "notes": [(n.id, n.title, n.body_markdown, tuple(n.tags)) for n in db.notes.list()],
+        "memberships": sorted(
+            (m.primitive_id, m.directory_id) for m in db.directory_memberships.list()
+        ),
+        "kbs": [k.id for k in db.kbs.list()],
+        "recipes": [r.id for r in db.recipes.list()],
+        "chains": [c.id for c in db.chains.list()],
+        "workflows": [w.id for w in db.workflows.list()],
+    }
+
+
+# ── the seed ───────────────────────────────────────────────────────────────
+def test_fresh_db_seeds_exactly_the_manifest(db) -> None:
+    report = apply_seed(db)
+    assert report.manifest == DEFAULT_SEED
+    assert report.applied == {"directories": 6, "notes": 2}
+    assert report.filed == 2
+
+    snap = _snapshot(db)
+    assert dict((i, n) for i, n, _ in snap["directories"]) == DRAWERS
+    # Six drawers, two starter notes, NOTHING else — sparse is the contract.
+    assert snap["kbs"] == snap["recipes"] == snap["chains"] == snap["workflows"] == []
+
+    notes = {n[0]: n for n in snap["notes"]}
+    adr = notes["hs-desk-note-adr-template"]
+    assert adr[1] == "ADR template"
+    for heading in ("## Context", "## Decision", "## Consequences", "Status:"):
+        assert heading in adr[2]
+    rules = notes["hs-desk-note-working-rules"]
+    assert rules[1] == "Working rules"
+    assert "Inbox is the landing zone" in rules[2]
+    assert "Reset to seed lives in Prefs" in rules[2]
+
+    assert snap["memberships"] == [
+        ("note:hs-desk-note-adr-template", "hs-desk-adrs"),
+        ("note:hs-desk-note-working-rules", "hs-desk-rules"),
+    ]
+
+
+def test_apply_twice_is_identical_no_duplicates(db) -> None:
+    apply_seed(db)
+    first = _snapshot(db)
+    report = apply_seed(db)
+    assert report.applied == {"directories": 6, "notes": 2}
+    assert _snapshot(db) == first  # ids stable, zero duplicates
+
+
+def test_seed_route_applies_the_packaged_manifest(client, db) -> None:
+    resp = client.post("/api/desk/seed")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["applied"] == {"directories": 6, "notes": 2}
+    assert body["filed"] == 2
+    assert body["total"] == 8
+    assert {d.id for d in db.directories.list()} == set(DRAWERS)
+
+
+# ── the reset ──────────────────────────────────────────────────────────────
+def _populate_clutter(db: Database) -> None:
+    db.notes.upsert(note_id="clutter-note", title="Scratch")
+    db.kbs.upsert(kb_id="clutter-kb", name="Old KB")
+    db.recipes.upsert(recipe_id="clutter-agent", name="Old agent")
+    db.chains.upsert(chain_id="clutter-chain", name="Old chain", steps=["clutter-agent"])
+    db.workflows.upsert(workflow_id="clutter-wf", name="Old wf", prompt="p")
+    db.directories.upsert(directory_id="clutter-zone", name="Junk drawer")
+    db.directory_memberships.upsert(
+        primitive_id="note:clutter-note", directory_id="clutter-zone"
+    )
+
+
+def test_reset_tombstones_clutter_and_reseeds(db) -> None:
+    _populate_clutter(db)
+    report = reset_desk(db)
+
+    assert report.tombstoned == {
+        "notes": 1, "kbs": 1, "recipes": 1, "chains": 1, "workflows": 1,
+        "directory_memberships": 1, "directories": 1,
+    }
+    # Tombstone, never purge: the rows REMAIN with deleted=1.
+    assert db.notes.get("clutter-note") is None
+    assert db.notes.get("clutter-note", include_deleted=True).deleted is True
+    assert db.directories.get("clutter-zone", include_deleted=True).deleted is True
+    assert db.kbs.get("clutter-kb", include_deleted=True).deleted is True
+    membership = db.directory_memberships.get("note:clutter-note", include_deleted=True)
+    assert membership is not None and membership.deleted is True
+
+    # The seed is present and is the whole live desk.
+    assert {d.id for d in db.directories.list()} == set(DRAWERS)
+    assert {n.id for n in db.notes.list()} == {
+        "hs-desk-note-adr-template", "hs-desk-note-working-rules",
+    }
+    assert report.seed is not None and report.seed.total == 8
+
+
+def test_reset_leaves_meetings_and_journal_alone(db) -> None:
+    db.meetings.save_meeting(
+        MeetingState(id="m1", started_at=datetime.now(), title="Sprint review")
+    )
+    db.dictation_journal.record(
+        source="dictation", transcript="hello", final_text="hello", total_ms=10.0
+    )
+    _populate_clutter(db)
+
+    reset_desk(db)
+
+    assert [m.id for m in db.meetings.list_meetings()] == ["m1"]
+    assert db.dictation_journal.count() == 1
+
+
+def test_reset_route_names_the_counts(client, db) -> None:
+    _populate_clutter(db)
+    resp = client.post("/api/desk/reset")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["tombstoned_total"] == 7
+    assert body["tombstoned"]["directories"] == 1
+    assert body["seeded"] == {"directories": 6, "notes": 2}
+    assert body["seeded_total"] == 8
+    assert body["filed"] == 2
+    assert body["manifest"] == DEFAULT_SEED
+
+
+def test_sync_pull_reports_tombstones_never_resurrects(client, db) -> None:
+    _populate_clutter(db)
+    assert client.post("/api/desk/reset").status_code == 200
+
+    pull = client.get("/api/sync/pull").json()
+    by_id = {rec["meta"]["id"]: rec["meta"] for rec in pull["notes"]}
+    assert by_id["clutter-note"]["deleted"] is True  # the tombstone RIDES
+    assert by_id["hs-desk-note-adr-template"]["deleted"] is False
+    dirs = {rec["meta"]["id"]: rec["meta"] for rec in pull["directories"]}
+    assert dirs["clutter-zone"]["deleted"] is True
+    assert dirs["hs-desk-inbox"]["deleted"] is False
+    memberships = {
+        rec["meta"]["id"]: rec["meta"] for rec in pull["directory_memberships"]
+    }
+    assert memberships["note:clutter-note"]["deleted"] is True
+
+    # Pulling again after a re-seed still reports the tombstones (a paired
+    # device can never win them back with a stale copy).
+    again = client.get("/api/sync/pull").json()
+    assert {r["meta"]["id"] for r in again["notes"] if r["meta"]["deleted"]} == {
+        "clutter-note"
+    }
+
+
+# ── the edge ───────────────────────────────────────────────────────────────
+def test_seed_and_reset_are_owner_verbs(client) -> None:
+    # The centralized route-right table (the one enforcement point,
+    # HS-106-02) requires OWNER for both POSTs.
+    assert required_right("POST", "/api/desk/seed") is PrincipalRight.OWNER
+    assert required_right("POST", "/api/desk/reset") is PrincipalRight.OWNER
+
+
+def test_unauthenticated_gets_the_named_refusal() -> None:
+    from unittest.mock import MagicMock
+
+    from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
+
+    server = MeetingWebServer(
+        WebRuntimeCallbacks(
+            on_bookmark=MagicMock(return_value={"timestamp": 1.0, "label": "x"}),
+            on_stop=MagicMock(return_value={"status": "stopped"}),
+            get_state=MagicMock(
+                return_value={"id": "t", "duration": 1, "bookmarks": []}
+            ),
+        ),
+        host="0.0.0.0",
+        auth_token="s3cret",
+    )
+    edge = TestClient(server.app)
+    edge.headers.pop("x-holdspeak-token", None)
+    for path in ("/api/desk/seed", "/api/desk/reset"):
+        refused = edge.post(path)
+        assert refused.status_code == 401
+        body = refused.json()
+        assert body["error"] == "principal_right_required"
+        assert body["principal"] == "none"
+        assert body["missing_right"] == "owner"
+
+
+def test_manifest_ships_in_the_package() -> None:
+    manifest = load_manifest()
+    ids = [item["id"] for item in manifest["directories"]]
+    assert ids == list(DRAWERS)
+    assert all(i.startswith("hs-desk-") for i in ids)

--- a/web/src/desk/__tests__/deskReset.test.ts
+++ b/web/src/desk/__tests__/deskReset.test.ts
@@ -1,0 +1,89 @@
+/** HS-112-03 — the reset-to-seed store contract: the wire call first,
+ * and ONLY on success the ghost-layout sweep (every localStorage key
+ * the pre-charter survey named) + the in-memory settle + refresh. A
+ * refused reset touches nothing. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GHOST_LAYOUT_KEYS, useDesk } from "../store";
+
+const ok = (body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("resetDesk / seedDesk (HS-112-03)", () => {
+  const refresh = vi.fn(async () => {});
+
+  beforeEach(() => {
+    localStorage.clear();
+    refresh.mockClear();
+    useDesk.setState({ refresh });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("names every ghost layout key the survey found", () => {
+    expect([...GHOST_LAYOUT_KEYS]).toEqual([
+      "hs.diorama.pos",
+      "hs.desk.panels",
+      "hs.desk.zonew",
+      "hs.desk.zone-views",
+      "hs.desk.zone-windows",
+      "hs.desk.open-windows",
+    ]);
+  });
+
+  it("a successful reset sweeps the keys, settles the store, refreshes", async () => {
+    for (const key of GHOST_LAYOUT_KEYS)
+      localStorage.setItem(key, JSON.stringify({ ghost: true }));
+    useDesk.setState({
+      positions: { dead: { x: 0.1, y: 0.2 } },
+      panelOrder: ["surface-dead"],
+      selectedIds: ["dead"],
+      divedZone: "dead-zone",
+    });
+    const fetchMock = vi.fn(async () =>
+      ok({ success: true, tombstoned_total: 7, seeded_total: 8 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const counts = await useDesk.getState().resetDesk();
+
+    expect(counts).toEqual({ tombstoned: 7, seeded: 8 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/desk/reset",
+      expect.objectContaining({ method: "POST" }),
+    );
+    for (const key of GHOST_LAYOUT_KEYS)
+      expect(localStorage.getItem(key)).toBeNull();
+    const state = useDesk.getState();
+    expect(state.positions).toEqual({});
+    expect(state.panelOrder).toEqual([]);
+    expect(state.selectedIds).toEqual([]);
+    expect(state.divedZone).toBeNull();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("a refused reset touches nothing", async () => {
+    localStorage.setItem("hs.diorama.pos", "{}");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 401 })),
+    );
+    expect(await useDesk.getState().resetDesk()).toBeNull();
+    expect(localStorage.getItem("hs.diorama.pos")).toBe("{}");
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("seedDesk posts the seed and refreshes (additive; no sweep)", async () => {
+    localStorage.setItem("hs.diorama.pos", "{}");
+    const fetchMock = vi.fn(async () => ok({ success: true, total: 8 }));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await useDesk.getState().seedDesk()).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/desk/seed",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(localStorage.getItem("hs.diorama.pos")).toBe("{}"); // untouched
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/desk/__tests__/verbRegistry.test.ts
+++ b/web/src/desk/__tests__/verbRegistry.test.ts
@@ -12,6 +12,7 @@ import {
   verbsFor,
 } from "../verbRegistry";
 import { DESK_TOOLS } from "../tools";
+import { registerSurface } from "../shell";
 
 const CTX = { selectedRef: null };
 
@@ -58,9 +59,24 @@ describe("the verb registry (HS-105-05 / HS-111-07 v2)", () => {
       "desk.arrange",
       "desk.overview",
       "desk.reset-layout",
+      "desk.reset-to-seed",
       "desk.refresh",
     ])
       expect(floor).toContain(id);
+  });
+
+  it("reset-to-seed opens the Prefs Desk module — never destroys directly (HS-112-03)", () => {
+    const verb = VERBS.find((v) => v.id === "desk.reset-to-seed")!;
+    expect(verb.scope).toBe("floor");
+    expect(verb.ghost(CTX)).toBeNull();
+    const opened: Array<string | undefined> = [];
+    const off = registerSurface("configure-settings", (scope) =>
+      opened.push(scope),
+    );
+    verb.run(CTX);
+    off();
+    // The verb's whole act is opening the armed confirm face.
+    expect(opened).toEqual(["desk"]);
   });
 
   it("the Go menu derives from DESK_TOOLS — the deck's same truth", () => {

--- a/web/src/desk/components/EmptyDesk.tsx
+++ b/web/src/desk/components/EmptyDesk.tsx
@@ -12,6 +12,7 @@ export function EmptyDesk({
   arrivalRequired?: boolean;
 }) {
   const [continued, setContinued] = useState(false);
+  const [seeding, setSeeding] = useState(false);
   const setup = useDesk((s) => s.setup);
   const badge = egressBadge(setup);
   return (
@@ -22,6 +23,22 @@ export function EmptyDesk({
         ◍
       </div>
       <DeskStartActions />
+      {/* HS-112-03 — the empty floor's start verb: the architect's desk
+          in one press (additive seed; the drawers materialize). */}
+      <button
+        type="button"
+        className="desk-chip desk-start-action"
+        disabled={seeding}
+        onClick={() => {
+          setSeeding(true);
+          void useDesk
+            .getState()
+            .seedDesk()
+            .finally(() => setSeeding(false));
+        }}
+      >
+        <span aria-hidden="true">▤</span> {seeding ? "Seeding…" : "Seed the desk"}
+      </button>
       <p className={`desk-empty-trust is-${badge.scope}`} title={badge.title}>
         <span className="desk-empty-trust-dot" aria-hidden="true" />
         {badge.scope === "local"

--- a/web/src/desk/store.ts
+++ b/web/src/desk/store.ts
@@ -396,6 +396,14 @@ interface DeskState {
   toggleMaximizePanel(id: string): void;
   /** Forget every arranged rect and lifecycle mark (the reset verb). */
   resetLayout(): void;
+  /** HS-112-03 — apply the packaged architect's-desk seed (idempotent;
+   * additive by id, never destructive). */
+  seedDesk(): Promise<boolean>;
+  /** HS-112-03 — the desk's first destructive verb: tombstone every desk
+   * primitive on the hub, re-seed, then sweep the ghost layout keys the
+   * dead desk left behind. Confirmed in-world (Prefs) BEFORE this runs.
+   * Returns the hub's counts, or null on refusal/unreachable. */
+  resetDesk(): Promise<{ tombstoned: number; seeded: number } | null>;
   /** Forget a window's arranged rect (back to its CSS default corner). */
   resetPanelRect(id: string): void;
   /** Bring a desk window to the front of the focus order. */
@@ -1040,4 +1048,70 @@ export const useDesk = create<DeskState>((set, get) => ({
     });
     savePanelLayout({}, [], [], []);
   },
+
+  async seedDesk() {
+    try {
+      const res = await apiRequest("/api/desk/seed", { method: "POST" });
+      if (!res.ok) return false;
+    } catch {
+      return false;
+    }
+    await get().refresh();
+    return true;
+  },
+
+  async resetDesk() {
+    let counts: { tombstoned: number; seeded: number };
+    try {
+      const res = await apiRequest("/api/desk/reset", { method: "POST" });
+      if (!res.ok) return null;
+      const data = await res.json().catch(() => ({}));
+      counts = {
+        tombstoned: Number(data?.tombstoned_total ?? 0),
+        seeded: Number(data?.seeded_total ?? 0),
+      };
+    } catch {
+      return null;
+    }
+    // The dead desk's ghost layout: positions, rects, widths, and open
+    // sets keyed by ids that no longer live. Sweep the persisted keys
+    // (resetLayout covers only the panel layout) and the in-memory
+    // mirrors, then settle to the seeded truth.
+    for (const key of GHOST_LAYOUT_KEYS) {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        /* storage may be unavailable; the ghost just lingers until it is */
+      }
+    }
+    set({
+      positions: {},
+      zoneWidths: {},
+      panelRects: {},
+      panelSaved: [],
+      panelOrder: [],
+      panelMin: [],
+      panelMax: [],
+      pullouts: [],
+      zoneWindows: [],
+      zoneViewPrefs: {},
+      infoWindows: [],
+      divedZone: null,
+      editingId: null,
+      selectedIds: [],
+    });
+    await get().refresh();
+    return counts;
+  },
 }));
+
+/** HS-112-03 — every localStorage key that layouts the desk by object
+ * id; a reset sweeps them all (the pre-charter survey's ghost list). */
+export const GHOST_LAYOUT_KEYS = [
+  "hs.diorama.pos",
+  "hs.desk.panels",
+  "hs.desk.zonew",
+  "hs.desk.zone-views",
+  "hs.desk.zone-windows",
+  "hs.desk.open-windows",
+] as const;

--- a/web/src/desk/verbRegistry.ts
+++ b/web/src/desk/verbRegistry.ts
@@ -193,6 +193,18 @@ export const VERBS: Verb[] = [
     run: () => useDesk.getState().resetLayout(),
   },
   {
+    // HS-112-03 — the desk's first destructive verb NEVER fires from a
+    // menu tap: it opens the Prefs Desk module, where the armed confirm
+    // (RESET DESK?) states what resets and what survives.
+    id: "desk.reset-to-seed",
+    label: "Reset to seed…",
+    scope: "floor",
+    group: "floor",
+    keywords: ["fresh", "seed", "wipe", "architect"],
+    ghost: never,
+    run: () => openSurfaceOr("configure-settings", "/settings", "desk"),
+  },
+  {
     id: "desk.refresh",
     label: "Refresh from hub",
     scope: "floor",

--- a/web/src/pages/cores/SettingsCore.tsx
+++ b/web/src/pages/cores/SettingsCore.tsx
@@ -32,6 +32,7 @@ import {
   EXPORT_FORMAT_OPTIONS,
   INTEL_PROVIDER_OPTIONS,
   LANGUAGE_OPTIONS,
+  DeskModule,
   MIR_PROFILE_OPTIONS,
   PREF_MODULES,
   PrefsFace,
@@ -132,7 +133,7 @@ function SettingsFace({ hero, scope }: CoreProps) {
   const authority = useResource<JsonRecord>("/api/authority/policy", {});
   // null = the drawer face; a module id = that module owns the body.
   const [moduleId, setModuleId] = useState<string | null>(
-    integrationSubject ? "integrations" : null,
+    integrationSubject ? "integrations" : scope === "desk" ? "desk" : null,
   );
   const [highlight, setHighlight] = useState("");
   const [saving, setSaving] = useState(false);
@@ -230,6 +231,11 @@ function SettingsFace({ hero, scope }: CoreProps) {
   useEffect(() => {
     if (integrationSubject) setModuleId("integrations");
   }, [integrationSubject]);
+
+  // HS-112-03 — the reset-to-seed verb lands on the Desk module directly.
+  useEffect(() => {
+    if (scope === "desk") setModuleId("desk");
+  }, [scope]);
 
   /* ── the deep setting index for the drawer filter ── */
   const deepIndex = useMemo<DeepHit[]>(() => {
@@ -772,6 +778,8 @@ function SettingsFace({ hero, scope }: CoreProps) {
             onCommit={(next) => update(["dictation", "runtime"], next)}
           />
         );
+      case "desk":
+        return <DeskModule />;
       case "integrations":
         return (
           <GadgetGroup label="Credentials">

--- a/web/src/pages/cores/__tests__/deskModule.test.tsx
+++ b/web/src/pages/cores/__tests__/deskModule.test.tsx
@@ -1,0 +1,53 @@
+/** HS-112-03 — the Prefs Desk module: the desk's first destructive
+ * verb confirms in-world with the kit's arming grammar (press → RESET
+ * DESK? → press again), states in labels what resets and what
+ * survives, and receipts the hub's counts. No modal, no confirm(). */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDesk } from "../../../desk/store";
+import { DeskModule, PREF_MODULES } from "../settingsPrefs";
+
+describe("DeskModule (HS-112-03)", () => {
+  const resetDesk = vi.fn(async () => ({ tombstoned: 7, seeded: 8 }));
+
+  beforeEach(() => {
+    resetDesk.mockClear();
+    useDesk.setState({ resetDesk });
+  });
+
+  it("is a registered pref module", () => {
+    expect(PREF_MODULES.some((m) => m.id === "desk")).toBe(true);
+  });
+
+  it("states what resets and what survives, as labels", () => {
+    render(<DeskModule />);
+    expect(
+      screen.getByText(/RESETS · NOTES · KNOWLEDGE · AGENTS · WORKFLOWS · DRAWERS · LAYOUT/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/KEEPS · MEETINGS · JOURNAL · SETTINGS · RUNS-ON TARGETS/),
+    ).toBeInTheDocument();
+  });
+
+  it("arms before it fires: first press asks, second press resets", async () => {
+    const user = userEvent.setup();
+    render(<DeskModule />);
+    await user.click(screen.getByRole("button", { name: "RESET TO SEED" }));
+    expect(resetDesk).not.toHaveBeenCalled(); // armed, not fired
+    await user.click(screen.getByRole("button", { name: "RESET DESK?" }));
+    expect(resetDesk).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "TOMBSTONED 7 · SEEDED 8",
+    );
+  });
+
+  it("a refused reset says so in the danger tone", async () => {
+    resetDesk.mockResolvedValueOnce(null as never);
+    const user = userEvent.setup();
+    render(<DeskModule />);
+    await user.click(screen.getByRole("button", { name: "RESET TO SEED" }));
+    await user.click(screen.getByRole("button", { name: "RESET DESK?" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("RESET REFUSED");
+  });
+});

--- a/web/src/pages/cores/settingsPrefs.tsx
+++ b/web/src/pages/cores/settingsPrefs.tsx
@@ -7,8 +7,11 @@ import { CONTROL_MODES, controlModeLabel } from "../../lib/productLanguage";
 import {
   CycleGadget,
   EgressChip,
+  GadgetGroup,
   StringGadget,
 } from "../../desk/surface/gadgets";
+import { ConfirmVerb } from "../../desk/surface/Surface";
+import { useDesk } from "../../desk/store";
 
 /* ── the roster (audit §3.2) ── */
 
@@ -32,6 +35,7 @@ export const PREF_MODULES: PrefModule[] = [
   { id: "devices", label: "Devices", glyph: "device", keys: ["device", "mesh"] },
   { id: "delivery", label: "Delivery", glyph: "delivery", keys: [] },
   { id: "models", label: "Models", glyph: "models", keys: [] },
+  { id: "desk", label: "Desk", glyph: "desk", keys: [] },
   { id: "integrations", label: "Integrations", glyph: "secret", keys: [] },
   { id: "system", label: "System", glyph: "system", keys: [] },
 ];
@@ -141,6 +145,7 @@ export function SettingGlyph({ name }: { name: string }) {
     device: "M4.5 2.5h7v11h-7Z M7 11.5h2",
     delivery: "M2.5 5.5h11v8h-11Z M2.5 5.5 8 2.5l5.5 3M8 8.5v5",
     models: "M4.5 4.5h7v7h-7Z M8 1.5v3M8 11.5v3M1.5 8h3M11.5 8h3",
+    desk: "M2.5 3.5h11v9h-11Z M2.5 8h11 M6.5 5.75h3 M6.5 10.25h3",
     system: "M3 4.5h10M3 8h10M3 11.5h10M6 3v3M10 6.5v3M5 10v3",
   };
   return (
@@ -160,6 +165,61 @@ export function SettingGlyph({ name }: { name: string }) {
         }
       />
     </svg>
+  );
+}
+
+/* ── the Desk module (HS-112-03): reset-to-seed, the desk's FIRST
+   destructive verb. Armed in-world in the kit's own grammar (the
+   GadgetTable delete pattern — press, RESET DESK?, press again), never
+   a modal, never a browser confirm. The face states in labels what
+   resets and what survives; the receipt names the hub's counts. ── */
+
+export function DeskModule() {
+  const [busy, setBusy] = useState(false);
+  const [receipt, setReceipt] = useState("");
+  const [refused, setRefused] = useState(false);
+  const fire = async () => {
+    setBusy(true);
+    setRefused(false);
+    setReceipt("");
+    const counts = await useDesk.getState().resetDesk();
+    setBusy(false);
+    if (!counts) {
+      setRefused(true);
+      return;
+    }
+    setReceipt(`TOMBSTONED ${counts.tombstoned} · SEEDED ${counts.seeded}`);
+  };
+  return (
+    <GadgetGroup label="Reset to seed">
+      <div className="prefs-egress-line">
+        <span className="gadget-fact">
+          RESETS · NOTES · KNOWLEDGE · AGENTS · WORKFLOWS · DRAWERS · LAYOUT
+        </span>
+      </div>
+      <div className="prefs-egress-line">
+        <span className="gadget-fact">
+          KEEPS · MEETINGS · JOURNAL · SETTINGS · RUNS-ON TARGETS
+        </span>
+      </div>
+      <div className="prefs-egress-line">
+        <ConfirmVerb
+          label="RESET TO SEED"
+          confirmLabel="RESET DESK?"
+          busy={busy}
+          onConfirm={() => void fire()}
+        />
+        {refused ? (
+          <span className="gadget-fact" data-tone="danger" role="alert">
+            ⚠ RESET REFUSED
+          </span>
+        ) : receipt ? (
+          <span className="gadget-fact" role="status">
+            {receipt}
+          </span>
+        ) : null}
+      </div>
+    </GadgetGroup>
   );
 }
 


### PR DESCRIPTION
The curated fresh desk ships in the product: six `hs-desk-*` drawers (ADRs / Meetings / Rules / Decisions / Reference / Inbox) with two authored starter notes (ADR template; Working rules), an idempotent repository-level seeder (`holdspeak seed`, `POST /api/desk/seed`, EmptyDesk chip, Prefs Desk module), and reset-to-seed as the desk's first destructive act — tombstone-only (pairing can never resurrect clutter, pinned by sync test), ghost layout keys swept only on wire success, ConfirmVerb two-press arming with RESETS/KEEPS fact labels and a `TOMBSTONED N · SEEDED M` receipt. UAT quarantine + fresh-desk empty-boot assertions hold.

Story stays **in-progress**: the flip awaits the live screenshot walk (first boot, drawer open, ADR template, reset confirm + after, 1440+393).

🤖 Generated with [Claude Code](https://claude.com/claude-code)