### PR TITLE
HS-112-04: The plain story — one paragraph, three moves, entry points true

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Platform: macOS | Linux](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)](#platform-support)
 
-Hold a key and speak, and your words land in whatever app you are in,
-optionally rewritten by your own model with your project's context. Record or
-import a meeting, and it comes back as reviewable decisions, action items, and
-typed artifacts, with a follow-up panel that shows what is still open. One
-local runtime on macOS and Linux does both, for the two places a developer's
-voice does work: the keyboard and the meeting. Whisper runs locally; the LLM is
-one you run or point at. No cloud, no account, no telemetry.
+HoldSpeak is a local-first voice desk OS. Hold a key in any app, or press the
+mic on the Desk, speak, and release: the words land where you aimed them, in
+the app you were working in, in a coder session waiting on an answer, or in the
+field in front of you. Whisper transcribes on this machine. Every model call
+runs on a destination you name once under Settings, Models, and every
+model-backed feature (dictation, meeting intelligence, agents, the rails
+observer) picks from that one list. What you produce stays on the Desk as
+objects you file and reopen: meetings, notes, decisions, artifacts. The badge in
+the corner names what leaves this machine and where it goes.
 
 A meeting should change what happens next, not disappear into an archive.
 HoldSpeak keeps decisions as durable records with transcript moments, lets you
@@ -111,9 +113,10 @@ of reach by design.
 - **Every run names its destination.** Transcription and model-backed work can
   run on this device, a paired device, a private endpoint, or an external
   OpenAI-compatible service.
-  Name those as reusable **Runs on destinations** and assign one per Agent;
-  the destination definition syncs across your surfaces while the API key stays
-  on each one. A destination can name another of your machines: run
+  Author them once under **Settings, Models** as reusable destinations, then
+  assign one per feature with the Runs on pickers, and one per Agent where you
+  author it. The destination definition syncs across your surfaces while
+  the API key stays on each one. A destination can name another of your machines: run
   `holdspeak mesh serve` there and every run against that destination executes on
   that node, with its own model and keys.
   See [Security & privacy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/SECURITY.md) and [Models](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md).
@@ -246,6 +249,46 @@ pip install 'holdspeak[dictation-openai]' # the dictation pipeline via an OpenAI
 The dictation and meeting LLM is yours to choose. See
 [`docs/MODELS.md`](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md) for the contract and current suggestions.
 
+### The three moves
+
+Installed and running, setup is three moves, in this order.
+
+**1. Seed the desk.** A fresh install is an empty floor. Press **Seed the
+desk** on it, or run `holdspeak seed`, and six drawers appear (ADRs,
+Meetings, Rules, Decisions, Reference, Inbox) holding two starter notes: an
+ADR template and the working rules. The seed upserts by id, so running it
+twice leaves one desk. To go back to that state later, open **Settings,
+Desk** and arm **Reset to seed**; it names what it clears and what it keeps
+before you confirm.
+
+**2. Set the dial.** Open **Settings, Models**. Add a destination (an
+endpoint, this device, a paired device, or a mesh node) with its name, URL,
+and model, then use the **Runs on** pickers to say where dictation, meeting
+intelligence, and the rails observer run. A destination's key never lives in
+the destination: the hub reads it from `HOLDSPEAK_PROFILE_<ID>_KEY` at run
+time. **Probe** tests the dictation leg against the destination you picked.
+This is the only place endpoint and model identity is edited.
+
+**3. Hold the key.** Hold the global hotkey in any app (Right Option on
+macOS, Right Alt on Linux), speak, release, and the text lands in that app.
+The same act has a face on the Desk: open **Speak**, set the **Aim** row to
+Focused app, Agent, or This field, and hold **TALK**. Aimed at Agent it
+delivers into a coder session that is waiting and refuses if none is, rather
+than typing into whatever happens to be in front. The receipt shows how many
+milliseconds passed between release and landing. **Rehearse** is the
+explicit dry run, never what a plain release does.
+
+Or stop holding anything. **Open mic** asks for the microphone once and keeps
+the grant: an on-device VAD finds where each utterance starts and stops, and
+every one it hears lands through the same Aim, the same pipeline, and the same
+delivery contract as a held release. Push-to-talk still wins the floor, so a
+hold silences the open mic mid-word and drops whatever it had in flight. The
+mic lamp in the Desk chrome reports the session in its own words (idle, open,
+speech, held) and disappears only when the device is actually released, which
+is what pressing Open mic again does. HoldSpeak arbitrates one microphone
+across the whole machine, so if a meeting already holds it the mic refuses by
+name (`FLOOR HELD MEETING`) instead of quietly recording next to it.
+
 ### Upgrading and your data
 
 Your whole HoldSpeak database is a single SQLite file. Before a version jump you
@@ -365,7 +408,9 @@ are in the [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpea
 | Browse all the docs | [Documentation index](https://github.com/karolswdev/HoldSpeak/blob/main/docs/README.md) |
 | Understand how it works, with diagrams | [Architecture](https://github.com/karolswdev/HoldSpeak/blob/main/docs/ARCHITECTURE.md) |
 | Get it running and verify my setup | [Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) |
+| Seed the desk, set the dial, hold the key | [Getting Started, the three moves](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md#4-move-1-seed-the-desk) |
 | Choose / configure a model | [Models (bring your own)](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md) |
+| Point every feature at one endpoint | [Inference destinations](https://github.com/karolswdev/HoldSpeak/blob/main/docs/INFERENCE_TARGETS.md) |
 | Live on the Desk (the web front door) | [The Desk](https://github.com/karolswdev/HoldSpeak/blob/main/docs/WEB_DESK.md) |
 | See speech become a project-grounded task | [The Dictation Copilot](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_COPILOT.md) |
 | Set up the dictation pipeline for Codex / Claude | [Dictation Pipeline Setup](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md) |
@@ -383,8 +428,14 @@ are in the [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpea
 ## Configuration
 
 Config lives at `~/.config/holdspeak/config.json`, but you rarely edit it by hand.
-The Settings window on the Desk exposes the hotkey, model, meeting intel,
-dictation pipeline, and presence options. The full reference is in
+The Settings window on the Desk exposes the hotkey, meeting intel, dictation
+pipeline, and presence options. Endpoint and model identity has exactly one
+editor, **Settings, Models**: the destination list plus the Runs on pickers.
+The old `intel_cloud_*` and `openai_compatible_*` fields no longer configure
+anything. An upgrade reads them once, turns them into destinations named
+`legacy-intel` and `legacy-dictation`, and points the matching feature at
+them; after that the destination is the truth and the fields are ignored.
+The full reference is in
 [Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) and the guides above.
 
 ## Contributing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,8 +24,11 @@ blocks:
 - **Meetings** turn captured or imported audio into a transcript, typed
   artifacts, and an aftercare digest, with approval-gated actions out.
 
-Transcription is local (`Transcriber`, MLX or faster-whisper). The LLM is
-whichever backend you configure. State lives in one SQLite database behind
+Transcription is local (`Transcriber`, MLX or faster-whisper). The LLM runs
+wherever you pointed it: since HS-112-01 the `profiles` table is the single
+source of truth for endpoint and model identity (an `InferenceTarget`), each
+feature holds one pointer into it, and `resolve_inference_target` is the one
+resolver. State lives in one SQLite database behind
 a set of repositories. Nothing takes an outbound action without an explicit
 approval, and the network crossings are enumerated in the
 [trust boundary](#the-trust-boundary) below and in

--- a/docs/DICTATION_COPILOT.md
+++ b/docs/DICTATION_COPILOT.md
@@ -177,17 +177,16 @@ at any local or LAN [OpenAI-compatible / GGUF / MLX endpoint](./MODELS.md)):
       "target_detect_llm_below": 0.8
     },
     "runtime": {
-      "backend": "openai_compatible",
-      "openai_compatible_base_url": "http://127.0.0.1:8080/v1",
-      "openai_compatible_model": "your-model-id"
+      "backend": "openai_compatible"
     }
   }
 }
 ```
 
-Prefer the picker: author the endpoint once as a Runs on destination (the Web
-compatibility route is `/profiles`), then pick it under Dictation → Runtime →
-**Runs on**. The fields above remain the fallback when nothing is selected.
+The endpoint and model are not config fields any more (HS-112-01). Author the
+endpoint once as a destination under **Settings, Models** and pick it as the
+dictation **Runs on**; assigning it also selects the `openai_compatible`
+backend. Its key lives in the environment as `HOLDSPEAK_PROFILE_<ID>_KEY`.
 
 </details>
 

--- a/docs/DICTATION_PIPELINE_GUIDE.md
+++ b/docs/DICTATION_PIPELINE_GUIDE.md
@@ -119,23 +119,19 @@ Config file shape:
     },
     "runtime": {
       "backend": "openai_compatible",
-      "openai_compatible_base_url": "http://127.0.0.1:8000/v1",
-      "openai_compatible_model": "qwen2.5-7b-instruct",
-      "openai_compatible_api_key_env": "OPENAI_API_KEY",
       "openai_compatible_timeout_seconds": 8
     }
   }
 }
 ```
 
-Endpoints are also available as Runs on destinations: author the endpoint once
-(the Web compatibility route is `/profiles`), then pick it under Dictation →
-Runtime → **Runs on**. A selected destination supplies the endpoint and model;
-the fields above remain the fallback when nothing is selected. See
+The endpoint and model are not config fields (HS-112-01). Author the endpoint
+once as a destination under **Settings, Models** and pick it as the dictation
+**Runs on**; assigning it also selects the `openai_compatible` backend. See
 [MODELS.md](./MODELS.md).
 
-HoldSpeak reads the API key from the named environment variable. Do not put API
-keys in `.hs/` files.
+HoldSpeak reads the API key from `HOLDSPEAK_PROFILE_<ID>_KEY` for that
+destination. Do not put API keys in `.hs/` files.
 
 > **Extended thinking disabled by default.** HoldSpeak sets `thinking: false` on
 > every call to an OpenAI-compatible endpoint. This prevents extended-thinking
@@ -156,9 +152,6 @@ A known-good local profile:
     },
     "runtime": {
       "backend": "openai_compatible",
-      "openai_compatible_base_url": "http://127.0.0.1:8080/v1",
-      "openai_compatible_model": "Qwen3.5-9B-UD-Q6_K_XL.gguf",
-      "openai_compatible_api_key_env": "OPENAI_API_KEY",
       "openai_compatible_timeout_seconds": 20
     }
   }
@@ -862,9 +855,6 @@ For daily coding-agent dictation, use:
     },
     "runtime": {
       "backend": "openai_compatible",
-      "openai_compatible_base_url": "http://127.0.0.1:8000/v1",
-      "openai_compatible_model": "qwen2.5-7b-instruct",
-      "openai_compatible_api_key_env": "OPENAI_API_KEY",
       "openai_compatible_timeout_seconds": 8,
       "warm_on_start": false
     }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -5,9 +5,18 @@
 </p>
 
 Five minutes from install to speaking a sentence into another app: that is
-this guide's whole job. Voice typing is the foundation everything else
-(the dictation pipeline, meetings) builds on, so get this working first;
-the deeper guides pick up where it ends.
+this guide's whole job. After you install and run `holdspeak doctor`, setup
+is three moves, in this order:
+
+1. **Seed the desk.** A fresh install is an empty floor. One press, or
+   `holdspeak seed`, puts six drawers and two starter notes on it.
+2. **Set the dial.** Settings, Models is the one place endpoint and model
+   identity is edited: a destination list, and a Runs on picker per feature.
+3. **Hold the key.** Hold the hotkey anywhere, speak, release, and the words
+   land in the app you were in. The Speak window is the same act with a face.
+
+Voice typing is the foundation everything else (the dictation pipeline,
+meetings) builds on, so get move 3 working before you turn anything else on.
 
 ## 1. Install
 
@@ -58,33 +67,67 @@ holdspeak
 ```
 
 This starts the local web runtime on loopback (`127.0.0.1`). On a fresh install
-the terminal points you straight at the welcome wizard:
+the terminal points you at the Desk and your first words:
 
 ```text
 HoldSpeak web runtime is running at: http://127.0.0.1:PORT
-  → Welcome! Get set up in a minute: open http://127.0.0.1:PORT/welcome
+  → Welcome! Say your first words on the Desk: open http://127.0.0.1:PORT/
 ```
 
-## 4. The welcome wizard
+## 4. Move 1: seed the desk
 
-A fresh launch opens **`/welcome`**, a full-screen, step-by-step wizard that
-takes you from install to your first words, **no file editing**:
+A fresh install is an empty floor. Nothing is seeded at boot: you ask for it.
 
-1. **Welcome**: what HoldSpeak does (voice typing *and* meeting notes).
-2. **Permissions**: a live check of microphone, text insertion, and the hotkey
-   (they turn green as you grant them).
-3. **Model**: pick your intelligence level (Basic / Apple MLX / GGUF /
-   OpenAI-compatible), each with a one-click **Test**. Basic needs nothing.
-4. **First dictation**: hold your hotkey, speak, release; it celebrates
-   **"✓ It worked"** live and shows your transcript.
-5. **Desktop presence**: flip a switch (no env var) for the ambient HUD.
-6. **You're set**: jump into dictation, a meeting, or the copilot.
+Press **Seed the desk** on the empty floor, or run:
 
-![The HoldSpeak welcome wizard: a full-screen first-run screen headlined "Hold a key. Speak. Watch it type." with a step rail (Welcome · Permissions · Model · First dictation · Presence · You're set) and a "Get started" button; the footer reads "Local · 127.0.0.1".](assets/screenshots/welcome.png)
+```bash
+holdspeak seed
+```
 
-*The `/welcome` wizard on a fresh install. It takes you from a fresh clone to a verified first dictation, with no file editing.*
+Either way you get six drawers (ADRs, Meetings, Rules, Decisions, Reference,
+Inbox) and two starter notes filed into them: an **ADR template** and
+**Working rules**. The seed upserts by deterministic id, so running it twice
+leaves one desk, and it only ever touches its own objects.
 
-A returning user lands on **the Desk** instead (the wizard never nags): your
+To go back to that state later, open **Settings, Desk** and arm **Reset to
+seed**. It states what it clears (notes, knowledge, agents, workflows,
+drawers, layout) and what it keeps (meetings, journal, settings, Runs on
+targets) before you confirm, then reports `TOMBSTONED N · SEEDED M`. The
+deletions are tombstones, so a paired device cannot resurrect the clutter.
+
+## 5. Move 2: set the dial
+
+Open **Settings, Models**. This is the only face that edits endpoint and model
+identity.
+
+1. Under **Destinations**, add a target: a name, a kind (`ENDPOINT`,
+   `THIS DEVICE`, `PAIRED`, `MESH`), its base URL, its model, and its context
+   window. A lamp reports readiness, and the key column reads `SET` or
+   `UNSET`.
+2. If the destination needs a key, put it in the environment as
+   `HOLDSPEAK_PROFILE_<ID>_KEY`. The key is never stored in the destination
+   and never syncs; the hub joins it to the request at run time. A destination
+   never borrows another one's key.
+3. Press **PROBE** to test the dictation leg against the selected
+   destination.
+4. Under **Runs on**, point each feature at a destination: dictation,
+   meetings, and rails. Leaving one on `HUB DEFAULT` runs it on the hub's own
+   engine, which you configure in the same module (backend `AUTO` / `MLX` /
+   `LLAMA.CPP`, model, context window, warm on start, idle eviction).
+
+The old config fields (`meeting.intel_cloud_*`, `dictation.runtime.openai_compatible_*`)
+no longer configure anything. An upgrade reads a configured legacy endpoint
+once, turns it into a destination named `legacy-intel` or `legacy-dictation`,
+and points the matching feature at it. After that the destination is the truth.
+The legacy key environment variable deliberately does not carry over: give the
+new destination its own `HOLDSPEAK_PROFILE_<ID>_KEY`.
+
+See [Models (bring your own)](MODELS.md) for what to run, and
+[Inference destinations](INFERENCE_TARGETS.md) for the API contract.
+
+## 6. The Desk, in passing
+
+A returning user lands on **the Desk** (there is no wizard): your
 meetings, notes, knowledge bases, and agents as objects in a spatial world.
 Tap an object to open it in place, drag it onto a zone to file it, press the
 orb to record, and ask an agent from the rail: its answer lands on the desk
@@ -106,15 +149,17 @@ the matching window open:
 
 | Deep link | Opens the window |
 | --- | --- |
-| `/welcome` | The first-run wizard: the single arrival on a fresh install |
+| `/welcome` | A compatibility route to the same first-words atom the Desk shows |
 | `/` | The Desk itself: your primitives as a spatial world (record, create, open, file, run) |
-| `/dictation` | Dictation: voice typing, the journal, learning, pre-briefing. An optional preview mode (Settings, Voice) shows each dictation on a card first: Type it commits, Discard drops it. |
+| `/dictation` | Speak: the TALK key and its Aim row, the journal, learning, pre-briefing. An optional preview mode (Settings, Voice) shows each dictation on a card first: Type it commits, Discard drops it. |
 | `/history` | Meetings: capture or import, the archive, aftercare |
 | `/studio` | Studio: the advanced tier (Workbench, Cadence, Commands, and more) |
 | `/settings` | Settings (sectioned and searchable) |
 | `/setup` | Setup and health: readiness plus the single next step |
 
-## 5. Try Basic Voice Typing
+## 7. Move 3: hold the key
+
+The flagship act, on the global hotkey:
 
 1. Start HoldSpeak with `holdspeak`.
 2. Click into a text field in another app.
@@ -130,6 +175,61 @@ Default hotkey:
 If global hotkeys or synthetic typing are blocked, keep the HoldSpeak window
 focused and use the focused hold-to-talk fallback.
 
+The same act has a face on the Desk. Open **Speak** (deep link `/dictation`)
+and it delivers for real through the same route, pipeline, journal, and
+kernel warrant as the hotkey:
+
+- **Aim** says where a released **TALK** sends the words: `FOCUSED APP`
+  types into the app you were in, `AGENT` delivers into a coder session that
+  is waiting, and `THIS FIELD` just fills the well below. The pick is
+  remembered.
+- Aimed at `AGENT` it refuses when no session is awaiting (`NO AGENT
+  AWAITING`) rather than free-typing into whatever happens to be focused.
+  Other refusals read the same way: `NO FOCUSED APP`, `NO TYPING DRIVER`,
+  `KERNEL REFUSED`.
+- The receipt reports release-to-landed latency in milliseconds.
+- **REHEARSE** is the explicit dry run. It previews the pipeline and delivers
+  nothing, and it is never what a plain release does.
+
+### The open mic
+
+**OPEN MIC** is the latch next to TALK, for when you do not want to hold
+anything:
+
+- **One grant.** The browser is asked for the microphone once and the grant is
+  kept. Between utterances the session suspends (the audio context suspends
+  and the tracks are disabled, so nothing is captured) rather than asking
+  again. A pause longer than 15 seconds releases the device on its own.
+- **Utterances land the same way.** A voice-activity detector on this machine
+  decides where each utterance starts and ends (energy with hysteresis and a
+  700 ms hangover, 300 ms of pre-roll so the first phoneme survives). Each one
+  goes through the same transcription route, the same Aim, and the same
+  delivery contract as a held release, so an ambient utterance and a held one
+  are indistinguishable downstream. Speech shorter than 350 ms is a cough, not
+  words: it is dropped. An empty transcript is dropped silently, without
+  spending a delivery, a journal row, or a receipt.
+- **Holding wins.** TALK, the global hotkey, and any mic on the Desk preempt
+  the open mic: while a hold is live the ambient path is gated off and its
+  in-flight utterance is discarded. One floor, one owner, the same as the
+  physical key.
+- **The lamp does not lie.** The Desk chrome carries a mic lamp that reads
+  `Mic idle`, `Mic open`, `Mic speech`, or `Mic held` from every room. It is
+  absent only when the device is genuinely released, so its presence is the
+  honest signal that audio is live. Pressing OPEN MIC again stops the tracks
+  for real; it does not mute them.
+- **The floor is shared with the rest of the machine.** The browser claims the
+  same one-at-a-time audio floor the hotkey, the meeting recorder, and the
+  wake listener use, on a lease it heartbeats. If a meeting holds it, the claim
+  is refused with the owner named (`FLOOR HELD MEETING`) and the device never
+  opens. If a meeting takes it mid-session, the mic goes down first and the
+  room tells you who took it. The lease means a closed tab cannot wedge your
+  hotkey.
+
+A browser that cannot capture audio shows OPEN MIC disabled with the reason on
+it, rather than hiding it. Serving the hub over plain HTTP to another machine
+is the usual cause: browsers withhold the microphone outside a secure origin,
+so reach it over localhost or HTTPS.
+
 > **Tip: see what the copilot is doing without the dashboard.** Turn on **desktop
 > presence** in **Settings** (or set `presence.enabled` in your config) to get an
 > ambient, native surface (a floating HUD on macOS and X11, a tray glyph plus
@@ -138,7 +238,7 @@ focused and use the focused hold-to-talk fallback.
 > headless launch you can force it on with `HOLDSPEAK_DESKTOP_PRESENCE=1 holdspeak`.
 > See [Desktop Presence](DICTATION_PIPELINE_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
 
-## 6. Use Punctuation Commands
+## 8. Use Punctuation Commands
 
 Say punctuation naturally:
 
@@ -167,7 +267,7 @@ becomes:
 Hello, can you review this?
 ```
 
-## 7. Use Clipboard Insertion
+## 9. Use Clipboard Insertion
 
 Say `clipboard` inside a dictated phrase when you want HoldSpeak to splice in
 the current clipboard text. The word `clipboard` is removed from the output and
@@ -182,7 +282,7 @@ Taking a look at this clipboard could you refactor it?
 If the clipboard contains a code block, that code is inserted into the same
 dictated request before HoldSpeak types or pastes it.
 
-## 8. Set Up A Project Root
+## 10. Set Up A Project Root
 
 Open:
 
@@ -202,7 +302,7 @@ Good project markers include:
 - `.holdspeak/`
 - `.hs/`
 
-## 9. Enable The Dictation Pipeline Later
+## 11. Enable The Dictation Pipeline Later
 
 Do not enable the dictation LLM pipeline until basic typing is working.
 When ready, continue with:
@@ -210,7 +310,7 @@ When ready, continue with:
 - [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md)
 - [User Guide](USER_GUIDE.md)
 
-## 10. Where To Go Next
+## 12. Where To Go Next
 
 Once hold-to-talk feels natural, the rest is one setting away each:
 
@@ -244,4 +344,6 @@ Once hold-to-talk feels natural, the rest is one setting away each:
   works, turn on the project-aware copilot.
 - [Meeting Mode Guide](MEETING_MODE_GUIDE.md): meeting-specific setup and capture.
 - [Models (bring your own)](MODELS.md): pick and point at an LLM.
+- [Inference destinations](INFERENCE_TARGETS.md): the destination contract behind
+  Settings, Models.
 - [Security & Privacy](SECURITY.md): what's stored and what can leave your machine.

--- a/docs/MEETING_MODE_GUIDE.md
+++ b/docs/MEETING_MODE_GUIDE.md
@@ -58,11 +58,11 @@ holdspeak
   larger models give better intel at the cost of speed.
 - Optional endpoint mode: `intel_provider: "cloud"` (or `auto` fallback) points
   at **any OpenAI-compatible endpoint**: a self-hosted LAN server, Ollama, vLLM,
-  llama.cpp-server, or a hosted API. Author the endpoint once as a Runs on
-  destination (the Web compatibility route is `/profiles`) and pick it under
-  Settings → **Runs on**; the API key is optional for keyless self-hosted
-  endpoints. The `intel_cloud_base_url` config field still works when no
-  destination is selected.
+  llama.cpp-server, or a hosted API. Author the endpoint once as a destination
+  under **Settings, Models** and pick it as the meetings **Runs on**; the API
+  key is optional for keyless self-hosted endpoints. The `intel_cloud_*`
+  config fields are dead (HS-112-01): an upgrade converts a configured legacy
+  endpoint into a `legacy-intel` destination, once.
 
 ### For Web Interfaces
 - **FastAPI + Uvicorn** - Web server dependencies
@@ -177,10 +177,11 @@ Use this during or after meetings for cross-session management:
 - Run MIR CLI dry-run and manual reroute flows for saved meetings
 - Edit app settings from browser, including cloud options:
   - `intel_provider` (`local`, `cloud`, `auto`)
-  - `intel_cloud_model`
-  - `intel_cloud_api_key_env`
-  - `intel_cloud_base_url` (OpenAI-compatible endpoint override)
-  - `intel_cloud_store`: when `true`, HoldSpeak sends OpenAI's `store` flag with
+  - the endpoint itself is not a settings field: it is the destination picked
+    as the meetings **Runs on** under Settings, Models. The settings write path
+    strips `intel_cloud_model`, `intel_cloud_api_key_env`, and
+    `intel_cloud_base_url` from the wire (HS-112-01).
+  - `intel_cloud_store` (**dead, HS-112-01**): when `true`, HoldSpeak sends OpenAI's `store` flag with
     each request. **Advisory:** this only takes effect if your endpoint honors
     the `store` parameter (OpenAI does; many OpenAI-compatible servers ignore
     unknown fields). HoldSpeak forwards the flag but cannot guarantee the remote
@@ -289,10 +290,9 @@ Notes:
 For local-first capture plus remote intel on your LAN:
 
 1. Run an OpenAI-compatible endpoint on homelab (for example vLLM/Ollama-compatible API).
-2. Author it as a Runs on destination (the Web compatibility route is
-   `/profiles`, with the endpoint's `http://host:port/v1` URL) and pick it
-   under Settings → **Runs on**. Setting `intel_cloud_base_url` by hand still
-   works when no destination is selected.
+2. Author it as a destination under **Settings, Models** (with the endpoint's
+   `http://host:port/v1` URL) and pick it as the meetings **Runs on**. There
+   is no hand-edited alternative; `intel_cloud_base_url` is dead.
 3. Keep `intel_deferred_enabled: true` so meetings continue when the homelab is temporarily unavailable.
 4. Export your API key environment variable and run `holdspeak doctor` to preflight reachability and model availability; its Runs on line names the destination each pipeline resolves to.
 
@@ -552,6 +552,10 @@ Configuration file: `~/.config/holdspeak/config.json`
 
 ### Meeting Settings
 
+Every key the `meeting` config block still holds, with its default. The
+`intel_cloud_*` keys are listed because they persist on disk; they are dead
+(HS-112-01) and the reference table below says so per row.
+
 ```json
 {
   "meeting": {
@@ -609,11 +613,11 @@ Configuration file: `~/.config/holdspeak/config.json`
 | `intel_retry_failure_webhook_url` | string | null | Optional HTTP(S) webhook for sustained failure alerts |
 | `intel_retry_failure_webhook_header_name` | string | null | Optional custom header name added to failure-alert webhooks |
 | `intel_retry_failure_webhook_header_value` | string | null | Optional custom header value (set together with header name) |
-| `intel_cloud_model` | string | "gpt-5-mini" | Cloud model used when provider is `cloud` or `auto` falls back to cloud |
-| `intel_cloud_api_key_env` | string | "OPENAI_API_KEY" | Environment variable name containing your cloud API key |
-| `intel_cloud_base_url` | string | null | Optional OpenAI-compatible base URL (for proxies/compatible providers) |
-| `intel_cloud_reasoning_effort` | string | null | Optional cloud reasoning setting (provider dependent) |
-| `intel_cloud_store` | bool | false | Allow provider-side storage for cloud requests |
+| `intel_cloud_model` | string | "gpt-5-mini" | **Dead (HS-112-01).** Read once by the legacy migration, then ignored. The model comes from the meetings Runs on destination. |
+| `intel_cloud_api_key_env` | string | "OPENAI_API_KEY" | **Dead (HS-112-01).** The destination's key is `HOLDSPEAK_PROFILE_<ID>_KEY`; this default only names the hub's fallback env when no destination is assigned. |
+| `intel_cloud_base_url` | string | null | **Dead (HS-112-01).** Read once by the legacy migration, then ignored. The URL comes from the meetings Runs on destination. |
+| `intel_cloud_reasoning_effort` | string | null | **Dead (HS-112-01).** Read only by the one-time legacy migration. |
+| `intel_cloud_store` | bool | false | **Dead (HS-112-01).** Read only by the one-time legacy migration. |
 | `intel_summary_model` | string | null | Path to larger model for end-of-meeting summary. Falls back to realtime model if null. |
 | `intel_deferred_enabled` | bool | true | Queue meeting intel for later if no compatible local model is currently available |
 | `web_auto_open` | bool | false | Auto-open browser when meeting starts |
@@ -765,9 +769,9 @@ Send `"ping"` text message, receive `"pong"` response.
 
 1. Run `holdspeak doctor` and check the `Cloud intel preflight` line.
 2. If it reports DNS/connection failures, verify the homelab hostname/IP, LAN routing, and firewall.
-3. If it reports auth failures (HTTP 401/403), verify your `intel_cloud_api_key_env` value and token.
-4. If it reports model mismatch, set `intel_cloud_model` to one of the model IDs exposed by `/models`.
-5. Verify `intel_cloud_base_url` starts with `http://` or `https://` and includes the right API prefix (commonly `/v1`).
+3. If it reports auth failures (HTTP 401/403), check that `HOLDSPEAK_PROFILE_<ID>_KEY` is exported for the destination the meetings Runs on picker names.
+4. If it reports model mismatch, set that destination's model to one of the model IDs exposed by `/models`.
+5. Verify that destination's base URL starts with `http://` or `https://` and includes the right API prefix (commonly `/v1`). PROBE in Settings, Models tests reachability.
 
 ### Transcription quality is poor
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -72,24 +72,27 @@ bridge, vLLM, llama.cpp-server, LM Studio, LiteLLM, or an actual cloud API. The
 endpoint owns model loading; HoldSpeak needs no local weights.
 
 - **Install:** `uv pip install -e '.[dictation-openai]'` (dictation side)
-- **Configure:** author the endpoint once as a **Runs on destination**. The
-  compatibility route remains `/profiles`; give it a name, base URL, and
-  model, then choose it where work runs:
-  - **Meeting intelligence:** Settings → **Runs on**.
-  - **Dictation:** Dictation → Runtime → **Runs on**.
-  - **Agents:** use the Agent editor's **Runs on** picker.
-- **Configure by hand:** the compatibility shape lives in `config.json` and
-  still works when no destination is selected:
-  `dictation.runtime.openai_compatible_base_url` + `_model` + `_api_key_env`
-  for dictation; `meeting.intel_provider: "cloud"` (or `"auto"` for
-  local-first with endpoint fallback) + `meeting.intel_cloud_base_url` +
-  `intel_cloud_model` for meeting intel.
+- **Configure:** author the endpoint once as a destination under **Settings,
+  Models** (the API resource is `/api/inference-targets`; `/api/profiles` is a
+  read-only alias). Give it a name, base URL, model, and context window, then
+  choose where it runs:
+  - **Dictation, meetings, rails:** the **Runs on** pickers in the same module.
+  - **Agents:** the **Runs on** picker where you author the Agent.
+- **Keys:** a destination never stores its key. Export it as
+  `HOLDSPEAK_PROFILE_<ID>_KEY` and the hub joins it at run time. A keyless
+  self-hosted endpoint needs no key at all.
 
-> **On the name `cloud`.** The intel provider called `cloud` just means
-> "the endpoint provider"; it is **not** necessarily a hosted/paid API. Point
-> `intel_cloud_base_url` at a self-hosted LAN server and it stays entirely local.
-> The API key (`intel_cloud_api_key_env`) is **optional** for keyless
-> self-hosted endpoints.
+There is no hand-edited alternative. `dictation.runtime.openai_compatible_*`
+and `meeting.intel_cloud_*` are dead fields: an upgrade reads a configured
+legacy endpoint once, converts it into a `legacy-dictation` or `legacy-intel`
+destination, and points the feature at it. After that the destination is the
+only truth.
+
+> **On the name `cloud`.** `meeting.intel_provider` still chooses whether the
+> meeting-intel leg runs `local` (in-process GGUF), `cloud`, or `auto`.
+> `cloud` means "the endpoint leg", not necessarily a hosted or paid API:
+> point its destination at a self-hosted LAN server and it stays entirely
+> local.
 
 ---
 
@@ -116,10 +119,9 @@ a browser) shows it as unavailable rather than pretending. The key stays with
 each surface and is joined only at request time. See
 [Security & privacy](SECURITY.md#5-secrets-handling).
 
-Runs on destinations also drive the desktop hub's pipelines: meeting intelligence and
-the dictation rewrite each carry a "Runs on" picker (Settings → Cloud &
-advanced, and Dictation → Runtime), so one destination can serve
-Agents, Meetings, and dictation. `holdspeak doctor` reports
+Destinations also drive the desktop hub's pipelines. **Settings, Models** holds
+a **Runs on** picker for dictation, meetings, and rails, so one destination can
+serve Agents, Meetings, and dictation. `holdspeak doctor` reports
 which destination each pipeline resolves to, warns when an assigned destination is
 missing, and names the exact `HOLDSPEAK_PROFILE_<ID>_KEY` variable to export
 when a destination needs a key on this machine.
@@ -163,7 +165,7 @@ model can follow an instruction and return JSON when asked.
 | Dictation | `llama_cpp` (GGUF) | a current small instruct GGUF (e.g. `Qwen3.5-4B-Instruct-Q4_K_M`) | `dictation.runtime.llama_cpp_model_path` |
 | Dictation | `mlx` (Apple) | a current Qwen3.5 MLX build (e.g. `Qwen3.5-8B-MLX-4bit`) | `dictation.runtime.mlx_model` |
 | Meeting intel | `local` (GGUF) | a current small/mid instruct GGUF (e.g. `Qwen3.5-9B-Instruct-Q6_K`) | `meeting.intel_realtime_model` |
-| Meeting intel | `cloud` (endpoint) | whatever your endpoint serves | `meeting.intel_cloud_model` + `meeting.intel_cloud_base_url` |
+| Meeting intel | `cloud` (endpoint) | whatever your endpoint serves | a destination under Settings, Models, chosen as the meetings **Runs on** |
 
 **Sizing intuition:** a small instruct model (~4-9B, Q4-Q6) is fast and good
 enough for routing/enrichment and most meeting intel; a mid model (~14-32B) gives

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,8 +1,10 @@
 # HoldSpeak Security & Privacy Posture
 
 **Status:** living document.
-**Last updated:** 2026-07-29 (empty effect debt register, desktop executor
-confinement, generic operation liveness).
+**Last updated:** 2026-08-02 (HS-112-04: the one dial's per-destination key
+rule, the browser mic's local-only transcription route held and continuous,
+the Speak room as a delivering caller of `/api/dictation/remote`, and the
+browser's leased seat at the audio floor).
 
 This document is the threat model for HoldSpeak: what data it holds, where that
 data lives, what can leave the machine, and the decisions behind its at-rest
@@ -78,7 +80,7 @@ make that promise auditable rather than aspirational.
 | **Raw meeting audio** | Apple Documents, `meeting-audio/<meeting-id>.wav`, plus a PCM journal while capture is recoverable | High | The flagship app checkpoints the take on device and finalizes it to a replayable WAV. Recovery manifests and partial PCM are removed after successful finalization; the WAV remains until its app data is removed. |
 | **Config** | `~/.config/holdspeak/config.json` | Medium | Includes the **device PSK** and **web auth token** (secrets); the cloud API key is referenced by *env-var name*, not stored. |
 | **Web recovery drafts** | Browser `localStorage`, under versioned `hs.draft.v1.*` keys | High | Editable First Words, Dictation, Ask, Agent, capability, Coder session reply, and steering drafts. Written synchronously in this browser's storage; cleared after a confirmed retaining action where the surface has one. |
-| **Web pending voice capture** | Browser IndexedDB, `holdspeak-voice-recovery` | High | One bounded WAV per voice-to-fill scope, retained only when transcription has not confirmed text. A retry reuses this local audio; successful transcription deletes it. No capture enters first-value measurement. |
+| **Web pending voice capture** | Browser IndexedDB, `holdspeak-voice-recovery` | High | One bounded WAV per voice-to-fill scope, retained only when transcription has not confirmed text. A retry reuses this local audio; successful transcription deletes it. No capture enters first-value measurement. Open-mic segments do not use this store: they are held in memory, posted, and dropped. |
 | **Native paired-dictation recovery draft** | Apple `UserDefaults`, `hs.dictate.recovery.v1` | High | The editable words, named destination, raw/processed flag, and opaque delivery id. Cleared only after the desktop confirms delivery. |
 | **Native pending voice capture** | Apple Application Support, `HoldSpeak/dictation-recovery.pcm16` | High | Bounded 16 kHz mono PCM retained when on-device transcription fails or the app relaunches before text exists; deleted after transcription succeeds. |
 | **First-value mechanics** | same DB (`first_value_attempts`, `first_value_events`) | Low | Bounded event names, ids, destination class, timing, counts, and failure category. The schema has no phrase, transcript, content, or audio column. |
@@ -136,12 +138,20 @@ SQLCipher) becomes warranted and should be its own story.
 3. **The device link** (`/api/devices/audio`): AIPI-Lite and compatible clients
    authenticate with a pre-shared key (PSK) compared in constant time
    (`device_audio.verify_psk`). Same-LAN scope today; cross-network reach is planned.
-4. **Connector packs**: user-supplied code under `~/.holdspeak/connector_packs/`
+4. **The audio floor** (`/api/dictation/floor{,/claim,/release}` →
+   `VoiceTypingSession`): the browser's open mic captures on the same physical
+   machine as the hotkey, the meeting recorder, and the wake listener, so it
+   claims the same one-at-a-time arbiter rather than listening behind it. The
+   claim is **leased** (20 s, heartbeated at half): a tab that dies stops
+   renewing and the floor frees itself, so a closed browser can never wedge the
+   owner's hotkey. A refused claim answers 409 with the active owner named. The
+   routes are local-only and carry no audio.
+5. **Connector packs**: user-supplied code under `~/.holdspeak/connector_packs/`
    runs **in-process with the user's permissions**. The manifest permission gate
    (`connector_runtime.py`) is an *honesty* mechanism, **not a security sandbox**:
    a malicious pack can call `subprocess.run` directly. Only install packs you
    trust.
-5. **Session steering** (`coder_steering.py` → a this-device tmux pane): typing into
+6. **Session steering** (`coder_steering.py` → a this-device tmux pane): typing into
    a live Coder session is a this-device consequential act (nothing leaves the
    machine), gated by a consent model rather than an egress row. Watching is
    free: the pull-out's peek is read-only, hash-gated, never a keystroke.
@@ -242,7 +252,7 @@ adds implementation detail but is not a second product inventory.
 
 | Egress | Trigger | What leaves | Gate |
 |---|---|---|---|
-| **Cloud meeting intel** (`intel/providers.py` → OpenAI-compatible client) | `intel_provider` = `cloud`, or `auto` falling back | Transcript text (no audio, no embeddings, no activity) | Explicit provider choice. `provider="local"` (default) **never** egresses, locked by `tests/unit/test_intel_egress_invariant.py`; surfaced by `doctor` + `intel_egress` in the runtime status. |
+| **Cloud meeting intel** (`intel/providers.py` → OpenAI-compatible client) | `intel_provider` = `cloud`, or `auto` falling back, to the destination assigned as the meetings **Runs on** (`effective_intel_cloud`) | Transcript text (no audio, no embeddings, no activity) | Explicit provider choice. `provider="local"` (default) **never** egresses, locked by `tests/unit/test_intel_egress_invariant.py`; surfaced by `doctor` + `intel_egress` in the runtime status. |
 | **Deferred-intel failure webhook** (`intel_queue.py`, the `urlopen` send) | User configures `intel_retry_failure_webhook_url` | Queue statistics only (counts, rates), **no transcript** | Opt-in (URL must be set). |
 | **Wake-model download** (`wake_word.py`, first enable) | `wake_word.enabled` flipped on with models absent | Nothing leaves: an inbound fetch of the detection models (~7 MB) from the openWakeWord GitHub releases, once, cached locally | Opt-in (the feature is off by default); stated in the settings copy. Detection itself runs locally and no audio ever egresses. |
 | **Send to Slack** (`slack_export.py` → the gated webhook connector) | User configures `meeting.slack_webhook_url` AND approves one specific send | The meeting digest or follow-up draft, exactly as previewed on the proposal (plain text; no transcript, no audio) | Double opt-in: the URL must be set (consent for exactly its host; the connector refuses any other host before egress) and every send is a separate per-action approval. The webhook URL is treated as a credential: never in proposals, broadcasts, or API responses. |
@@ -255,7 +265,8 @@ adds implementation detail but is not a second product inventory.
 | **Mesh relay** (`intel/mesh_relay.py` → the hub relay queue) | A run against a Runs on destination whose compatibility kind is `meshNode` | The prompt and the result, between the hub and the machine you named (both yours; the worker authenticates with the hub token) | You author the destination, and the node serves only while `holdspeak mesh serve` runs on it (stopping it reads offline within seconds). No key ever transits: the node resolves the run through its own config and env. |
 | **Web runtime responses** | A client requests data | Whatever the API returns (transcripts, action items, etc.) | Loopback by default; token-gated off-loopback. |
 | **Device audio link** | A paired device streams audio | Audio in; status/LCD text out | PSK; same-LAN today. |
-| **Paired dictation delivery** (`POST /api/dictation/remote`) | The owner releases the native dictation control or explicitly sends a preview/recovery draft | Finalized text plus an opaque delivery id to the named desktop; raw audio never crosses | Direct LAN/Tailscale peer, bearer-token gated off-loopback. The hub claims the id before delivery and caches the terminal Receipt; reconnecting with the same request returns that Receipt without typing twice. A different payload under the same id is refused. |
+| **Browser mic capture** (`lib/speakToFill` → `POST /api/dictation/transcribe`) | The owner holds a mic or the Speak room's TALK key in the browser, **or** an open-mic session segments an utterance (`lib/openMic` posts through the same encoder and route) | Nothing leaves the machine: the WAV is posted to the hub on the same origin the page was served from, the hub's own local Whisper transcribes it, and the audio is never persisted (16 MB cap) | No egress point, held or continuous. Off-loopback the origin is the hub itself, token-gated like every other route; the audio never reaches a third party. Segmentation is decided in the browser (`lib/vad`, energy plus hangover, no model and no network), so continuous listening posts one WAV per detected utterance rather than a stream. |
+| **Paired dictation delivery** (`POST /api/dictation/remote`) | The owner releases the native dictation control, releases TALK in the Speak room, or explicitly sends a preview/recovery draft | Finalized text plus an opaque delivery id to the named desktop; raw audio never crosses | Direct LAN/Tailscale peer, bearer-token gated off-loopback. The hub claims the id before delivery and caches the terminal Receipt; reconnecting with the same request returns that Receipt without typing twice. A different payload under the same id is refused. |
 
 Browser history reads (`activity_*`) make **no network calls**; they are
 read-only against local SQLite snapshots. The activity ledger never leaves the
@@ -265,8 +276,11 @@ machine except via the connector CLIs above (entity IDs only).
 
 ## 5. Secrets handling
 
-- **Cloud API key**: read from an environment variable (default `OPENAI_API_KEY`,
-  or a configured name); **never written to config or the DB**.
+- **Cloud API key**: read from an environment variable; **never written to
+  config or the DB**. Since HS-112-01 the variable is per destination
+  (`HOLDSPEAK_PROFILE_<ID>_KEY`); `OPENAI_API_KEY` remains only the hub's
+  fallback when a feature has no destination assigned. A destination never
+  borrows another one's key.
 - **Device PSK**: generated lazily, stored in `config.json`
   (`device_audio.ensure_device_psk`); constant-time comparison; empty PSK fails
   closed.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -259,27 +259,20 @@ Use `openai_compatible` when the model is served somewhere else:
 - LiteLLM
 - OpenAI or another hosted compatible API
 
-The picker path: author the endpoint once as a Runs on destination (the Web
-compatibility route is `/profiles`), then pick it under Dictation → Runtime →
-**Runs on**. The configuration shape below still works when no destination is
-selected:
+The one path: author the endpoint once as a destination under **Settings,
+Models**, then pick it as the dictation **Runs on**. Assigning a destination is
+itself the "run it there" instruction, so the dictation backend follows. The
+key lives in the environment as `HOLDSPEAK_PROFILE_<ID>_KEY`, never in the
+destination.
 
-```json
-{
-  "dictation": {
-    "pipeline": { "enabled": true },
-    "runtime": {
-      "backend": "openai_compatible",
-      "openai_compatible_base_url": "http://127.0.0.1:8000/v1",
-      "openai_compatible_model": "qwen2.5-7b-instruct",
-      "openai_compatible_api_key_env": "OPENAI_API_KEY",
-      "openai_compatible_timeout_seconds": 8
-    }
-  }
-}
-```
+The old `dictation.runtime.openai_compatible_*` fields no longer configure
+anything (HS-112-01). An upgrade reads a configured legacy endpoint once,
+converts it into a destination named `legacy-dictation`, and points dictation
+at it; the legacy key env deliberately does not carry over.
+`dictation.runtime.openai_compatible_timeout_seconds` is not part of the
+destination and still applies.
 
-Known-good endpoint families include llama.cpp server, LM Studio, Ollama's OpenAI bridge, vLLM, LiteLLM, and hosted OpenAI-compatible APIs. HoldSpeak reads the API key from the named environment variable. It does not store the key in the project context files. If the endpoint is unavailable, times out, or returns malformed output, HoldSpeak preserves the original transcript and surfaces the failure in dry-run/readiness output.
+Known-good endpoint families include llama.cpp server, LM Studio, Ollama's OpenAI bridge, vLLM, LiteLLM, and hosted OpenAI-compatible APIs. HoldSpeak reads the destination's API key from `HOLDSPEAK_PROFILE_<ID>_KEY`. It does not store the key in the destination, in the config, or in the project context files. If the endpoint is unavailable, times out, or returns malformed output, HoldSpeak preserves the original transcript and surfaces the failure in dry-run/readiness output.
 
 ## Project Context
 
@@ -429,19 +422,16 @@ Local-first behavior:
 
 Cloud or homelab behavior:
 
-- If you set `meeting.intel_provider` to `cloud` or configure `intel_cloud_base_url`, meeting text may be sent to that endpoint for analysis.
-- The picker path: author the endpoint once as a Runs on destination (the Web compatibility route is `/profiles`), then pick it under Settings → **Runs on**.
+- If you set `meeting.intel_provider` to `cloud` (or `auto`, which can fall back to it), meeting text may be sent to the destination you picked for analysis.
+- The one path: author the endpoint once as a destination under **Settings, Models**, then pick it as the meetings **Runs on**. The `intel_cloud_*` fields are dead (HS-112-01).
 - Use `holdspeak doctor` from the same shell environment to verify endpoint, model, TLS, DNS, and authentication; its Runs on line names the destination each pipeline resolves to.
 
-Example cloud/homelab config (the fallback shape when no Runs on destination is picked):
+The provider switch itself still lives in config:
 
 ```json
 {
   "meeting": {
     "intel_provider": "cloud",
-    "intel_cloud_model": "qwen2.5-32b-instruct",
-    "intel_cloud_api_key_env": "HOMELAB_INTEL_API_KEY",
-    "intel_cloud_base_url": "http://homelab.local:8000/v1",
     "intel_deferred_enabled": true
   }
 }

--- a/pm/roadmap/holdspeak/phase-112-enough/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-112-enough/current-phase-status.md
@@ -72,11 +72,29 @@ it does not absorb it — it names it in the final summary.
 | HS-112-01 | One dial | in-progress | [story-01-one-dial](./story-01-one-dial.md) | — |
 | HS-112-02 | Speak speaks | in-progress | [story-02-speak-speaks](./story-02-speak-speaks.md) | — (captured; ships with the flip) |
 | HS-112-03 | The architect's desk | in-progress | [story-03-architects-desk](./story-03-architects-desk.md) | — |
-| HS-112-04 | The plain story | backlog | [story-04-plain-story](./story-04-plain-story.md) | — |
+| HS-112-04 | The plain story | in-progress | [story-04-plain-story](./story-04-plain-story.md) | — |
 | HS-112-05 | The sitting walk | backlog | [story-05-walk](./story-05-walk.md) | — |
 | HS-112-06 | The open mic | in-progress | [story-06-open-mic](./story-06-open-mic.md) | — |
 
 ## Where we are
+
+04 BUILT (in-progress pending the fresh-HOME quickstart
+execution, which is 05's walk). HS-112-04 implemented 2026-08-02:
+the README's first screen says what HoldSpeak IS in one paragraph
+(local-first voice desk OS; hold a key or open the mic, words land
+where aimed; one destination list; the badge names what leaves);
+quickstart restructured as the three moves (seed the desk, set the
+dial, hold the key — including the open mic); ~20 stale claims
+corrected across seven docs (the dead intel_cloud_*/
+openai_compatible_* fields pruned from every entry point, the
+retired welcome wizard and Profiles room excised, two false
+"still works" meeting-guide claims fixed); SECURITY gained the
+browser-mic egress row, the audio-floor trust boundary (3.4), and
+the one-WAV-per-utterance clarification. Every claim truth-audited
+to file:line; dead-field grep census 0 in README+GETTING_STARTED;
+doc-drift guards 19 passed; full unit 3522. Named drift for a next
+pass: WEB_DESK.md omits the new mic lamp; welcome.png depicts a
+dead surface.
 
 0/6 flipped; 01, 02, 03, and 06 BUILT (in-progress pending
 live proofs).

--- a/pm/roadmap/holdspeak/phase-112-enough/story-04-plain-story.md
+++ b/pm/roadmap/holdspeak/phase-112-enough/story-04-plain-story.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 112
-- **Status:** backlog
+- **Status:** in-progress
 - **Depends on:** HS-112-01, HS-112-02, HS-112-03
 - **Unblocks:** HS-112-05
 - **Owner:** unassigned


### PR DESCRIPTION
The docs story: the README's first screen says what HoldSpeak IS in one paragraph; the quickstart is the phase's three moves (seed the desk, set the dial, hold the key — including the open mic's ambient leg); ~20 stale claims corrected across seven docs (dead config fields pruned from every entry point, the retired welcome wizard and Profiles room excised); SECURITY gains the browser-mic egress row, the audio-floor trust boundary, and the one-WAV-per-utterance clarification. Every claim truth-audited to file:line.

Story stays **in-progress**: the flip awaits the three-move quickstart executing verbatim on a fresh HOME — HS-112-05's walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)