### PR TITLE
Phase 113 Wave 1: Static desk, real editor, compositor

### DIFF
--- a/web/design-tokens.json
+++ b/web/design-tokens.json
@@ -809,6 +809,16 @@
         "doc": "snap tiles clear the dock band"
       },
       {
+        "name": "--desk-work-top",
+        "value": "var(--desk-snap-top)",
+        "doc": "the working band begins below the system bar"
+      },
+      {
+        "name": "--desk-work-bottom",
+        "value": "var(--desk-snap-bottom)",
+        "doc": "the working band ends above the dock"
+      },
+      {
         "name": "--glow-meeting",
         "value": "{primitive.color.glowpool.meeting}"
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,12 @@
       "name": "holdspeak-web",
       "version": "0.0.1",
       "dependencies": {
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-markdown": "^6.5.1",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/language-data": "^6.5.2",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.7",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@use-gesture/react": "^10.3.1",
@@ -388,6 +394,396 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.1.tgz",
+      "integrity": "sha512-6re5avCNfyRMIoi3XNjbEfQM1vTeVD3JS3g/Fyegyso/eoANFM71Cyvbb66LDyYtQLMEcRFlzioywCqDo9SlLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
+      "integrity": "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
+      "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1028,6 +1424,189 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.6.tgz",
+      "integrity": "sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.5.tgz",
+      "integrity": "sha512-PrlQ8glBdWS5UOqgnFCmPxAJbhuOhb0WoDnSAXiNQPjivlDujhuUQ1K/fxyk2vFoq4VTBgFtFZOc8sOpiYjz5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.7.2.tgz",
+      "integrity": "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+      "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@pixi/colord": {
       "version": "2.9.6",
@@ -2041,6 +2620,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -3123,6 +3708,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -3452,6 +4043,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,12 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-markdown": "^6.5.1",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.7",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@use-gesture/react": "^10.3.1",

--- a/web/src/desk/components/DeskEditor.tsx
+++ b/web/src/desk/components/DeskEditor.tsx
@@ -1,0 +1,147 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { markdown, markdownKeymap } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, placeholder } from "@codemirror/view";
+import { deskEditorTheme, deskMarkdownHighlighting } from "./deskEditorTheme";
+
+export interface DeskEditorHandle {
+  insertAtCursor(text: string): void;
+}
+
+interface DeskEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  autoFocus?: boolean;
+  onEscape?: () => void;
+  placeholder?: string;
+  className?: string;
+  minHeight?: string;
+  ariaLabel?: string;
+  onModEnter?: () => void;
+}
+
+export const DeskEditor = forwardRef<DeskEditorHandle, DeskEditorProps>(
+  function DeskEditor(
+    {
+      value,
+      onChange,
+      autoFocus = false,
+      onEscape,
+      placeholder: placeholderText,
+      className,
+      minHeight = "120px",
+      ariaLabel,
+      onModEnter,
+    },
+    forwardedRef,
+  ) {
+    const host = useRef<HTMLDivElement | null>(null);
+    const viewRef = useRef<EditorView | null>(null);
+    const onChangeRef = useRef(onChange);
+    const onEscapeRef = useRef(onEscape);
+    const onModEnterRef = useRef(onModEnter);
+
+    onChangeRef.current = onChange;
+    onEscapeRef.current = onEscape;
+    onModEnterRef.current = onModEnter;
+
+    useImperativeHandle(forwardedRef, () => ({
+      insertAtCursor(text) {
+        const view = viewRef.current;
+        if (!view) return;
+        const { from, to } = view.state.selection.main;
+        view.dispatch({ changes: { from, to, insert: text } });
+        view.focus();
+      },
+    }), []);
+
+    useEffect(() => {
+      if (!host.current) return;
+      const view = new EditorView({
+        state: EditorState.create({
+          doc: value,
+          extensions: [
+            history(),
+            markdown(),
+            deskEditorTheme,
+            deskMarkdownHighlighting,
+            keymap.of([
+              {
+                key: "Escape",
+                run(editor) {
+                  const selection = editor.state.selection.main;
+                  if (!selection.empty) {
+                    editor.dispatch({ selection: { anchor: selection.head } });
+                  } else {
+                    onEscapeRef.current?.();
+                  }
+                  return true;
+                },
+              },
+              {
+                key: "Mod-Enter",
+                run() {
+                  if (!onModEnterRef.current) return false;
+                  onModEnterRef.current();
+                  return true;
+                },
+              },
+              indentWithTab,
+              ...defaultKeymap,
+              ...historyKeymap,
+              ...markdownKeymap,
+            ]),
+            EditorView.domEventHandlers({
+              keydown(event) {
+                if (event.key !== "Escape") return false;
+                event.preventDefault();
+                event.stopPropagation();
+                return false;
+              },
+            }),
+            EditorView.updateListener.of((update) => {
+              if (update.docChanged) onChangeRef.current(update.state.doc.toString());
+            }),
+            ...(ariaLabel ? [EditorView.contentAttributes.of({ "aria-label": ariaLabel })] : []),
+            ...(placeholderText ? [placeholder(placeholderText)] : []),
+          ],
+        }),
+        parent: host.current,
+      });
+      viewRef.current = view;
+      if (autoFocus) view.focus();
+
+      return () => {
+        view.destroy();
+        viewRef.current = null;
+      };
+      // This editor deliberately initializes once. Prop synchronization lives below.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+      const view = viewRef.current;
+      if (!view || value === view.state.doc.toString()) return;
+      const { from, to } = view.state.selection.main;
+      const nextCursor = Math.min(value.length, Math.max(0, from));
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: value },
+        selection: { anchor: nextCursor, head: Math.min(value.length, to) },
+      });
+    }, [value]);
+
+    return (
+      <div
+        ref={host}
+        className={["desk-code-editor", className].filter(Boolean).join(" ")}
+        style={{ "--desk-editor-min-height": minHeight } as React.CSSProperties}
+      />
+    );
+  },
+);

--- a/web/src/desk/components/DeskWindow.tsx
+++ b/web/src/desk/components/DeskWindow.tsx
@@ -30,8 +30,6 @@ import { DESK_WINDOW, DESK_Z } from "../../lib/tokens.gen";
 
 /** Viewport margin windows are clamped inside. */
 const MARGIN = DESK_WINDOW.margin;
-/** Minimum visible head strip so a window can always be grabbed back. */
-const GRAB = DESK_WINDOW.grab;
 /** The desk-window z band (see the ladder note in desk.css). */
 const Z_BASE = DESK_Z.windowBase;
 /** Cascade step when several default-corner windows are open at once. */
@@ -39,6 +37,24 @@ const CASCADE = DESK_WINDOW.cascade;
 
 /** The window head strip considered for title-bar occlusion (px). */
 const HEAD = 44;
+
+/** The usable desktop is one contract: below the system bar, above the dock.
+ * CSS owns the dimensions so shell changes cannot make window physics drift. */
+function workBand() {
+  const fallback = {
+    top: DESK_WINDOW.snapTop,
+    bottom: DESK_WINDOW.snapBottom,
+  };
+  if (typeof window === "undefined" || typeof document === "undefined")
+    return fallback;
+  const style = getComputedStyle(document.documentElement);
+  const top = parseFloat(style.getPropertyValue("--desk-work-top"));
+  const bottom = parseFloat(style.getPropertyValue("--desk-work-bottom"));
+  return {
+    top: Number.isFinite(top) ? top : fallback.top,
+    bottom: Number.isFinite(bottom) ? bottom : fallback.bottom,
+  };
+}
 
 /** HS-97-02 — the open-placement engine. A window opening without a
  * persisted rect lands FULLY inside the working band (below the chrome,
@@ -53,8 +69,7 @@ export function placeWindow(
   minW = 320,
   minH = 220,
 ): PanelRect {
-  const top = DESK_WINDOW.snapTop;
-  const bottom = DESK_WINDOW.snapBottom;
+  const { top, bottom } = workBand();
   const w = Math.max(minW, Math.min(seed.w, vw - MARGIN * 2));
   const h = Math.max(minH, Math.min(seed.h, Math.max(minH, vh - top - bottom)));
   const maxX = Math.max(MARGIN, vw - MARGIN - w);
@@ -114,8 +129,7 @@ export function clampIntoBand(
   minW = 320,
   minH = 220,
 ): PanelRect {
-  const top = DESK_WINDOW.snapTop;
-  const bottom = DESK_WINDOW.snapBottom;
+  const { top, bottom } = workBand();
   const w = Math.max(minW, Math.min(r.w, vw - MARGIN * 2));
   const h = Math.max(minH, Math.min(r.h, Math.max(minH, vh - top - bottom)));
   const x = Math.min(Math.max(r.x, MARGIN), Math.max(MARGIN, vw - MARGIN - w));
@@ -134,8 +148,7 @@ export function snapForPointer(
 ): PanelRect | null {
   const EDGE = 26;
   const CORNER = 150;
-  const top = DESK_WINDOW.snapTop; // below the chrome band
-  const bottom = DESK_WINDOW.snapBottom; // clear of the dock band
+  const { top, bottom } = workBand(); // below chrome, clear of dock
   const halfW = Math.floor((vw - MARGIN * 3) / 2);
   const halfH = Math.floor((vh - top - bottom - MARGIN) / 2);
   const left = px <= CORNER;
@@ -230,8 +243,9 @@ export function exposeLayout(
   vw: number,
   vh: number,
 ): PanelRect[] {
-  const top = DESK_WINDOW.snapTop + 8;
-  const bottom = DESK_WINDOW.snapBottom + 8;
+  const band = workBand();
+  const top = band.top + 8;
+  const bottom = band.bottom + 8;
   const GAP = 18;
   const cols = Math.max(1, Math.ceil(Math.sqrt(count)));
   const rows = Math.max(1, Math.ceil(count / cols));
@@ -258,15 +272,11 @@ export function exposeLayout(
 function clampRect(r: PanelRect, minW: number, minH: number): PanelRect {
   const vw = window.innerWidth || 1280;
   const vh = window.innerHeight || 800;
-  let w = Math.min(Math.max(r.w, minW), vw - MARGIN * 2);
-  let h = Math.min(Math.max(r.h, minH), vh - MARGIN * 2);
-  const x = Math.min(Math.max(r.x, MARGIN - w + GRAB), vw - GRAB);
-  const y = Math.min(Math.max(r.y, MARGIN), vh - 48);
-  // Keep the resize grip reachable: a window dragged toward an edge
-  // shrinks to fit the viewport (floored at its minimum) rather than
-  // sliding its bottom-right corner off-screen.
-  w = Math.max(minW, Math.min(w, vw - MARGIN - x));
-  h = Math.max(minH, Math.min(h, vh - MARGIN - y));
+  const { top, bottom } = workBand();
+  const w = Math.max(minW, Math.min(r.w, vw - MARGIN * 2));
+  const h = Math.max(minH, Math.min(r.h, Math.max(minH, vh - top - bottom)));
+  const x = Math.min(Math.max(r.x, MARGIN), Math.max(MARGIN, vw - MARGIN - w));
+  const y = Math.min(Math.max(r.y, top), Math.max(top, vh - bottom - h));
   return { x, y, w, h };
 }
 
@@ -283,6 +293,41 @@ export interface DeskWindowOptions {
    * desk object). The window seats itself beside it and the open/close
    * motion flies out of and back into it — spatial, not a side dock. */
   origin?: { x: number; y: number } | null;
+}
+
+let resizeClampUsers = 0;
+let resizeClampTimer: ReturnType<typeof setTimeout> | undefined;
+
+function reClampOpenWindows() {
+  const state = useDesk.getState();
+  for (const { id } of registrySnapshot) {
+    const rect = state.panelRects[id];
+    if (!rect || state.panelMax.includes(id)) continue;
+    const clamped = clampRect(rect, 320, 220);
+    if (
+      clamped.x !== rect.x ||
+      clamped.y !== rect.y ||
+      clamped.w !== rect.w ||
+      clamped.h !== rect.h
+    )
+      state.setPanelRect(id, clamped, state.panelSaved.includes(id));
+  }
+}
+
+function onWindowResize() {
+  clearTimeout(resizeClampTimer);
+  resizeClampTimer = setTimeout(reClampOpenWindows, 150);
+}
+
+function subscribeResizeClamp() {
+  if (resizeClampUsers++ === 0)
+    window.addEventListener("resize", onWindowResize);
+  return () => {
+    if (--resizeClampUsers === 0) {
+      window.removeEventListener("resize", onWindowResize);
+      clearTimeout(resizeClampTimer);
+    }
+  };
 }
 
 /** The desk-window physics (Phase 93). Module-private since HS-95-02:
@@ -371,7 +416,7 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
         const cap = Math.max(
           minH,
           Math.round(
-            ((vh - DESK_WINDOW.snapTop - DESK_WINDOW.snapBottom) * 78) / 100,
+            ((vh - workBand().top - workBand().bottom) * 78) / 100,
           ),
         );
         if (Number.isFinite(mh) && mh > seed.h)
@@ -426,6 +471,13 @@ function useDeskWindow(id: string, opts: DeskWindowOptions = {}) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, open]);
+
+  // One compositor listener re-seats open windows after a viewport change.
+  // The 150ms debounce keeps browser resize storms out of the layout path.
+  useEffect(() => {
+    if (!open || typeof window === "undefined") return;
+    return subscribeResizeClamp();
+  }, [open]);
 
   // Round 9 — growth settles with motion: a content-sized card whose
   // material arrives async (a meeting detail, a relationships fetch)
@@ -1257,10 +1309,10 @@ export function DeskWindowFrame(props: DeskWindowFrameProps) {
       ? { zIndex: (win.style.zIndex as number) ?? 42 }
       : maxed
         ? {
-            top: 54,
-            left: 10,
-            right: 10,
-            bottom: 10,
+            top: "var(--desk-work-top)",
+            left: MARGIN,
+            right: MARGIN,
+            bottom: "var(--desk-work-bottom)",
             width: "auto",
             height: "auto",
             maxHeight: "none",

--- a/web/src/desk/components/InlineEditor.tsx
+++ b/web/src/desk/components/InlineEditor.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useDesk } from "../store";
 import type { WorldObject } from "../world";
 import type { UnitPos } from "../store";
+import { DeskEditor, type DeskEditorHandle } from "./DeskEditor";
 import { MicButton } from "./MicButton";
 import {
   buildLinearGraph,
@@ -36,6 +37,7 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
   const items = useDesk((s) => s.items);
   const profiles = useDesk((s) => s.profiles);
   const ref = useRef<HTMLDivElement | null>(null);
+  const bodyEditorRef = useRef<DeskEditorHandle | null>(null);
   const save = useDebouncedSave(o.kind === "kb" ? "kb" : o.kind, o.id);
   const [more, setMore] = useState(false);
 
@@ -95,8 +97,6 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
       if (e.key === "Escape") closeEditor();
     };
     document.addEventListener("keydown", onKey);
-    // Focus the first field on open.
-    ref.current?.querySelector<HTMLInputElement>("input, textarea")?.focus();
     return () => document.removeEventListener("keydown", onKey);
   }, []);
 
@@ -153,11 +153,13 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
               placeholder="Title"
               onChange={(e) => set("title", "title", e.target.value)}
             />
-            <textarea
-              rows={7}
+            <DeskEditor
+              ref={bodyEditorRef}
               value={f.body}
               placeholder="Write"
-              onChange={(e) => set("body", "body_markdown", e.target.value)}
+              autoFocus
+              onEscape={closeEditor}
+              onChange={(value) => set("body", "body_markdown", value)}
             />
             <input
               value={f.tags}
@@ -167,11 +169,21 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
           </>
         )}
         {o.kind === "kb" && (
-          <input
-            value={f.name}
-            placeholder="Name"
-            onChange={(e) => set("name", "name", e.target.value)}
-          />
+          <>
+            <input
+              value={f.name}
+              placeholder="Name"
+              onChange={(e) => set("name", "name", e.target.value)}
+            />
+            <DeskEditor
+              ref={bodyEditorRef}
+              value={f.body}
+              placeholder="Write"
+              autoFocus
+              onEscape={closeEditor}
+              onChange={(value) => set("body", "body_markdown", value)}
+            />
+          </>
         )}
         {o.kind === "workflow" && (
           <>
@@ -353,12 +365,9 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
           <MicButton
             draftScope={`inline:${o.kind}:${o.id}`}
             onText={(t) => {
-              // Fill the primary text field for the kind: a note's body,
-              // otherwise the name/title.
-              if (o.kind === "note") {
-                set("body", "body_markdown", (f.body ? f.body + " " : "") + t);
-              } else if (o.kind === "kb") {
-                set("name", "name", (f.name ? f.name + " " : "") + t);
+              // Notes and Knowledge bodies receive dictation at the editor cursor.
+              if (o.kind === "note" || o.kind === "kb") {
+                bodyEditorRef.current?.insertAtCursor(t);
               } else {
                 set(
                   "systemPrompt",

--- a/web/src/desk/components/Pullout.tsx
+++ b/web/src/desk/components/Pullout.tsx
@@ -3,7 +3,7 @@
 // world stays alive behind it; "Open full" is the ONE navigation on the
 // desk; Escape or ✕ closes (it is a desk window — it survives clicks
 // elsewhere and can be moved, resized, and raised).
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 // @ts-ignore — shared ESM module (see ../sprites.d.ts)
 import { spriteUrl } from "../sprites";
 import { apiRequest } from "../../lib/api";
@@ -11,6 +11,7 @@ import { useDurableDraft } from "../../lib/durableDraft";
 import { useDesk } from "../store";
 import { openSurfaceOr } from "../shell";
 import { parseLinearGraph, stepLabel } from "../graph";
+import { DeskEditor, type DeskEditorHandle } from "./DeskEditor";
 import { MicButton } from "./MicButton";
 import { AgentAvatar } from "./AgentAvatar";
 import { lineage } from "../lineage";
@@ -117,6 +118,7 @@ export function Pullout({
   // card. Escape reverts; Done (or ⌘Enter) commits through the real PUT.
   const [editingBody, setEditingBody] = useState(false);
   const [bodyDraft, setBodyDraft] = useState("");
+  const bodyEditorRef = useRef<DeskEditorHandle | null>(null);
   const startBodyEdit = () => {
     setBodyDraft(String((o.ref as any).bodyMarkdown || ""));
     setEditingBody(true);
@@ -486,23 +488,17 @@ export function Pullout({
             if (o.kind === "note" && editingBody)
               return (
                 <section>
-                  <textarea
-                    className="desk-pullout-editbox"
-                    aria-label={`${o.title} content`}
+                  <DeskEditor
+                    ref={bodyEditorRef}
+                    className="desk-pullout-markdown-editor"
+                    ariaLabel={`${o.title} content`}
                     value={bodyDraft}
                     autoFocus
-                    rows={Math.max(6, bodyDraft.split("\n").length + 1)}
+                    minHeight={`${Math.max(6, bodyDraft.split("\n").length + 1) * 1.55}em`}
                     placeholder="Write"
-                    onChange={(e) => setBodyDraft(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Escape") {
-                        e.stopPropagation();
-                        setEditingBody(false);
-                      } else if (e.key === "Enter" && e.metaKey) {
-                        e.preventDefault();
-                        commitBodyEdit();
-                      }
-                    }}
+                    onChange={setBodyDraft}
+                    onEscape={() => setEditingBody(false)}
+                    onModEnter={commitBodyEdit}
                   />
                 </section>
               );
@@ -1024,9 +1020,7 @@ export function Pullout({
               <MicButton
                 label="Hold to fill"
                 draftScope={`card-edit:${o.id}`}
-                onText={(t) =>
-                  setBodyDraft((current) => (current ? `${current} ${t}` : t))
-                }
+                onText={(text) => bodyEditorRef.current?.insertAtCursor(text)}
               />
               <button
                 type="button"

--- a/web/src/desk/components/SessionPullout.tsx
+++ b/web/src/desk/components/SessionPullout.tsx
@@ -345,6 +345,13 @@ function FactoryControls() {
               placeholder={attachedSession || undefined}
               autoFocus
               onChange={setNewName}
+              onKeyDown={(event) => {
+                if (event.key !== "Escape") return;
+                event.preventDefault();
+                event.stopPropagation();
+                setNewName("");
+                setRenaming(false);
+              }}
             />
             <TransportKey
               compact
@@ -457,6 +464,12 @@ function SteerComposer() {
           rows={2}
           placeholder="Steer"
           onChange={(e) => setText(e.target.value)}
+          onKeyDown={(event) => {
+            if (event.key !== "Escape") return;
+            event.preventDefault();
+            event.stopPropagation();
+            setText("");
+          }}
         />
         <TransportKey
           compact
@@ -648,7 +661,15 @@ export function SessionPullout() {
     // A desk window closes deliberately (✕ or Escape) — never from a stray
     // click elsewhere on the desk; a live peek must survive arranging.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeSession();
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      // Inline rename/compose owns Escape first; their handlers cancel and
+      // stop propagation rather than letting the window consume the key.
+      if (
+        e.target instanceof Element &&
+        e.target.matches(".desk-steer-input, .gadget-string input")
+      )
+        return;
+      closeSession();
     };
     document.addEventListener("keydown", onKey);
     return () => {

--- a/web/src/desk/components/ZoneWindow.tsx
+++ b/web/src/desk/components/ZoneWindow.tsx
@@ -3,7 +3,7 @@
 // and THE WINDOW REMEMBERS — rect (the panel system), view, and sort
 // (`hs.desk.zone-views`). Icons view speaks the world's cell contract;
 // List view is the density altitude (Name / Kind / Modified, sortable).
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 // @ts-ignore — shared ESM module (see ../sprites.d.ts)
 import { spriteUrl } from "../sprites";
 import { useDesk, type ZoneViewPref } from "../store";
@@ -38,6 +38,7 @@ export function ZoneWindow({
     useDesk.getState();
   const zone = (items.directory || []).find((d) => d.id === zoneId);
   const memberIds: string[] = ((zone as any)?.memberIds as string[]) || [];
+  const [selected, setSelected] = useState<string | null>(null);
 
   const members = useMemo(() => {
     const resolved = memberIds
@@ -128,8 +129,10 @@ export function ZoneWindow({
                 key={`${m.kind}:${m.id}`}
                 type="button"
                 role="listitem"
-                className="zone-cell"
-                onClick={(e) =>
+                className={`zone-cell${selected === `${m.kind}:${m.id}` ? " is-selected" : ""}`}
+                aria-selected={selected === `${m.kind}:${m.id}`}
+                onClick={() => setSelected(`${m.kind}:${m.id}`)}
+                onDoubleClick={(e) =>
                   openPullout(m.id, { x: e.clientX, y: e.clientY })
                 }
               >
@@ -158,7 +161,11 @@ export function ZoneWindow({
               {members.map((m) => {
                 const t = memberTime(m);
                 return (
-                  <tr key={`${m.kind}:${m.id}`}>
+                  <tr
+                    key={`${m.kind}:${m.id}`}
+                    className={selected === `${m.kind}:${m.id}` ? "is-selected" : ""}
+                    onClick={() => setSelected(`${m.kind}:${m.id}`)}
+                  >
                     <td className="zone-list-ic">
                       <img
                         src={spriteUrl(m.kind, m.id)}
@@ -171,7 +178,9 @@ export function ZoneWindow({
                       <button
                         type="button"
                         className="zone-list-open"
-                        onClick={(e) =>
+                        aria-selected={selected === `${m.kind}:${m.id}`}
+                        onClick={() => setSelected(`${m.kind}:${m.id}`)}
+                        onDoubleClick={(e) =>
                           openPullout(m.id, { x: e.clientX, y: e.clientY })
                         }
                       >

--- a/web/src/desk/components/deskEditorTheme.ts
+++ b/web/src/desk/components/deskEditorTheme.ts
@@ -1,0 +1,63 @@
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { EditorView } from "@codemirror/view";
+import { tags } from "@lezer/highlight";
+
+export const deskEditorTheme = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "var(--surface-2)",
+      color: "var(--text)",
+      border: "1px solid var(--border)",
+      borderRadius: "var(--radius-sm)",
+      boxShadow: "var(--desk-window-etch)",
+      fontFamily: "var(--font-mono)",
+      fontSize: "var(--font-size-sm)",
+      lineHeight: "1.6",
+    },
+    "&.cm-focused": {
+      borderColor: "var(--field-focus-border)",
+      boxShadow: "var(--desk-window-etch), 0 0 0 2px var(--accent-tint)",
+    },
+    ".cm-scroller": {
+      fontFamily: "inherit",
+      overflow: "auto",
+    },
+    ".cm-content": {
+      minHeight: "var(--desk-editor-min-height, 120px)",
+      padding: "8px 12px",
+      caretColor: "var(--accent)",
+    },
+    ".cm-line": {
+      padding: "0",
+    },
+    ".cm-selectionBackground, ::selection": {
+      backgroundColor: "var(--accent-tint) !important",
+    },
+    ".cm-cursor, .cm-dropCursor": {
+      borderLeftColor: "var(--accent)",
+    },
+    ".cm-placeholder": {
+      color: "var(--text-faint)",
+      fontStyle: "italic",
+    },
+    ".cm-gutters": {
+      display: "none",
+    },
+  },
+  { dark: true },
+);
+
+export const deskMarkdownHighlighting = syntaxHighlighting(
+  HighlightStyle.define([
+    { tag: tags.heading, color: "var(--text)", fontWeight: "700" },
+    { tag: tags.strong, fontWeight: "700" },
+    { tag: tags.emphasis, fontStyle: "italic" },
+    {
+      tag: tags.monospace,
+      color: "var(--info)",
+      backgroundColor: "var(--desk-window-well)",
+    },
+    { tag: [tags.link, tags.url], color: "var(--accent)" },
+    { tag: tags.list, color: "var(--text-faint)" },
+  ]),
+);

--- a/web/src/desk/desk.css
+++ b/web/src/desk/desk.css
@@ -342,8 +342,6 @@
 }
 .desk-next .desk-start-action.is-recording .desk-start-record {
   background: var(--danger-signal);
-  box-shadow: 0 0 8px color-mix(in srgb, var(--danger-signal) 60%, transparent);
-  animation: desk-next-mic-pulse 1.6s ease-in-out infinite;
 }
 .desk-next .desk-create {
   position: relative;
@@ -1299,24 +1297,16 @@
 .desk-next .desk-chip.is-primary:hover {
   background: var(--accent-hover);
 }
-/* the dive camera: the world scales in as the zone's members take the stage */
+/* Dive changes the world contents without scaling pixel art. */
 .desk-next .desk-world {
-  transition:
-    opacity 0.28s var(--ease-standard),
-    transform 0.28s var(--ease-standard);
+  transition: opacity 0.28s var(--ease-standard);
 }
 .desk-next .desk-world.dived {
   animation: desk-next-dive 0.34s var(--ease-standard);
 }
 @keyframes desk-next-dive {
-  0% {
-    opacity: 0;
-    transform: scale(1.06);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
+  0% { opacity: 0; }
+  100% { opacity: 1; }
 }
 .desk-next .desk-surface {
   position: fixed;
@@ -1424,28 +1414,13 @@
   place-items: center;
   cursor: pointer;
   backdrop-filter: none;
-  transition:
-    transform var(--duration-short) var(--ease-standard),
-    border-color var(--duration-short) var(--ease-standard);
+  transition: border-color var(--duration-short) var(--ease-standard);
 }
 .desk-next .desk-rail-avatar:hover {
-  transform: scale(1.08);
   border-color: var(--accent, #ff6b35);
 }
 .desk-next .desk-rail-avatar.open {
   border-color: var(--accent, #ff6b35);
-}
-.desk-next .desk-rail-avatar.working {
-  animation: desk-next-rail-work 1.1s ease-in-out infinite;
-}
-@keyframes desk-next-rail-work {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 var(--accent-glow-strong);
-  }
-  50% {
-    box-shadow: 0 0 0 7px rgba(255, 107, 53, 0);
-  }
 }
 /* HS-111: status indicators — square, no glow */
 .desk-next .desk-rail-egress {
@@ -1525,7 +1500,6 @@
 }
 .desk-next .desk-mic.is-listening {
   border-color: var(--accent, #ff6b35);
-  animation: desk-next-mic-pulse 1.1s ease-in-out infinite;
 }
 .desk-next .desk-mic.is-busy {
   opacity: 0.7;
@@ -1545,15 +1519,6 @@
   color: color-mix(in srgb, var(--danger, #f87171) 65%, var(--text));
   font-size: var(--font-size-xs);
   line-height: 1.35;
-}
-@keyframes desk-next-mic-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 rgba(255, 107, 53, 0.55);
-  }
-  50% {
-    box-shadow: 0 0 0 8px rgba(255, 107, 53, 0);
-  }
 }
 .desk-next .desk-editor-spacer {
   flex: 1;
@@ -3593,20 +3558,6 @@
 .desk-next .desk-dock-chip.is-front {
   background: var(--accent-tint);
   border-color: var(--border-strong);
-}
-/* HS-99-05 — the glyph swells under the pointer (compositor-only). */
-.desk-next .desk-dock-main > span[aria-hidden="true"] {
-  display: inline-block;
-  transition: transform var(--duration-short) var(--ease-quart);
-}
-/* Materials round 2 — dock magnification: chips and launchers swell
-   under the pointer with a distance falloff (JS drives --dock-mag
-   transforms; this transition makes it springy). */
-.desk-next .desk-dock-main,
-.desk-next .desk-dock-launch,
-.desk-next .desk-dock-reset {
-  transform-origin: bottom center;
-  transition: transform var(--duration-short) var(--ease-quart);
 }
 /* HS-110-03: no glyph swell — flat shelf */
 .desk-next .desk-dock-launch {

--- a/web/src/desk/desk.css
+++ b/web/src/desk/desk.css
@@ -754,7 +754,7 @@
 .desk-next .desk-editor input:focus,
 .desk-next .desk-editor textarea:focus,
 .desk-next .desk-editor select:focus {
-  outline: none;
+  outline-color: var(--accent, #ff6b35);
   border-color: var(--accent, #ff6b35);
 }
 .desk-next .desk-editor-head {
@@ -842,7 +842,6 @@
   width: 100%;
   padding: 0;
   border: 0;
-  outline: 0;
   background: transparent;
   color: var(--text);
   font-family: inherit;
@@ -908,6 +907,25 @@
 .desk-next .desk-light:hover svg {
   opacity: 1;
   color: var(--text);
+}
+/* The traffic cluster is the depth signal: colored on the front plane,
+   neutral in the background. */
+.desk-next .desk-window-shell:not(.is-front) .desk-light {
+  background: var(--surface-2);
+  border-color: var(--border);
+}
+.desk-next .desk-window-shell.is-front .desk-light-close {
+  background: var(--danger-signal, #f87171);
+}
+.desk-next .desk-window-shell.is-front .desk-light-min {
+  background: var(--warn, #f2a33c);
+}
+.desk-next .desk-window-shell.is-front .desk-light-max {
+  background: var(--success, #34d399);
+}
+.desk-next .desk-window-shell.is-front .desk-light svg {
+  color: color-mix(in srgb, var(--bg) 78%, transparent);
+  opacity: 0.82;
 }
 .desk-next .is-front .desk-light-close:hover {
   background: var(--gadget-close-fill);
@@ -1242,7 +1260,7 @@
   padding: 8px 0;
 }
 .desk-next .desk-chat-composer textarea:focus {
-  outline: none;
+  outline-color: var(--accent);
 }
 
 .desk-next .runs-on-picker {
@@ -1468,7 +1486,7 @@
   font-size: var(--font-size-sm);
 }
 .desk-next .desk-rail-ask input:focus {
-  outline: none;
+  outline-color: var(--accent, #ff6b35);
   border-color: var(--accent, #ff6b35);
 }
 @media (prefers-reduced-motion: reduce) {
@@ -1917,7 +1935,6 @@
   resize: vertical;
   border: 0;
   background: none;
-  outline: none;
   color: var(--text);
   font-size: var(--font-size-sm);
   font-family: var(--font-mono);
@@ -1997,7 +2014,7 @@
   font-family: var(--font-mono);
 }
 .desk-next .desk-chat-composer input:focus {
-  outline: none;
+  outline-color: var(--accent, #ff6b35);
   border-color: var(--accent, #ff6b35);
 }
 
@@ -2410,7 +2427,7 @@
   line-height: 1.4;
 }
 .desk-next .desk-steer-input:focus {
-  outline: none;
+  outline-color: var(--accent);
   border-color: var(--accent);
 }
 .desk-next .desk-steer-sent {
@@ -4889,7 +4906,6 @@
   min-width: 0;
   background: none;
   border: 0;
-  outline: none;
   color: var(--text);
   font-size: var(--desk-surface-body-size);
 }
@@ -4960,8 +4976,13 @@ body:has(.desk-next .desk-pullout:not(.is-card)) .ambient-qlippy {
   color: var(--text);
 }
 .desk-zone-window .zone-cell:hover,
-.desk-zone-window .zone-cell:focus-visible {
-  background: var(--canvas-raised);
+.desk-zone-window .zone-cell:focus-visible,
+.desk-zone-window .zone-cell.is-selected {
+  background: var(--accent-tint);
+  outline-color: var(--accent);
+}
+.desk-zone-window .zone-list tr.is-selected {
+  background: var(--accent-tint);
 }
 .desk-zone-window .zone-cell img {
   image-rendering: pixelated;

--- a/web/src/desk/gl/__tests__/iconCell.test.ts
+++ b/web/src/desk/gl/__tests__/iconCell.test.ts
@@ -24,8 +24,9 @@ describe("the cell contract (HS-105-01)", () => {
     expect(LIFT).toBe(80); // the selection box
   });
 
-  it("never tilts or fractionally scales an object", () => {
+  it("keeps every object at a neutral rest state", () => {
     const m = objMotion({ kind: "note", id: "x", title: "x", ref: {} as any });
+    expect(m.phase).toBe(0);
     expect(m.tilt).toBe(0);
     expect(m.scale).toBe(1);
   });

--- a/web/src/desk/gl/engine.ts
+++ b/web/src/desk/gl/engine.ts
@@ -1,11 +1,11 @@
 /** HS-95-01 — the GL world engine. One pixi Application draws the whole
- * world layer (zones, objects, selection, drag, ambient motes) from the
- * pure scene model; the desk store stays the only truth and every store
- * write goes through the exact same actions the DOM world called. Per-frame
- * work is transform-only on the GPU scene graph — no DOM layout, no paint.
+ * world layer (zones, objects, selection, drag) from the pure scene model;
+ * the desk store stays the only truth and every store write goes through the
+ * exact same actions the DOM world called. Per-frame work is transform-only
+ * on the GPU scene graph — no DOM layout, no paint.
  *
  * Stacking parity with the DOM world: zones (z 2) draw above resting
- * objects; whatever is dragging rides at z 20; motes drift beneath all. */
+ * objects; whatever is dragging rides at z 20. */
 import {
   Application,
   Container,
@@ -46,7 +46,6 @@ import {
   glowTexture,
   gripTexture,
   loadSprite,
-  moteTexture,
   shadowTexture,
   zonePanelTexture,
   zoneShadowTexture,
@@ -59,7 +58,6 @@ import { spriteUrl as spriteStateUrl } from "../sprites";
 const ACCENT = "#ff6b35";
 const TEXT_COLOR = 0xf2f3f5;
 const TEXT_MUTED = 0x9ba2b0;
-const BOB_SECONDS = 4.6;
 
 interface ObjectNode {
   root: Container;
@@ -69,7 +67,6 @@ interface ObjectNode {
   glowTint: string;
   ring: Graphics;
   sprite: Sprite;
-  highlight: Sprite;
   paper: Sprite | null;
   label: Text;
   labelBg: Graphics;
@@ -82,9 +79,6 @@ interface ObjectNode {
   spriteUrl: string;
   labelText: string;
   ringState: string;
-  bornAt: number;
-  ringBornAt: number;
-  wasNew: boolean;
   data: SceneObject;
 }
 
@@ -101,10 +95,6 @@ interface ZoneNode {
   labelText: string;
   countBadge: Container | null;
   countText: string;
-  lift: number;
-  liftTarget: number;
-  scale: number;
-  scaleTarget: number;
   data: SceneZone;
 }
 
@@ -164,16 +154,8 @@ export class WorldEngine {
   private callbacks: EngineCallbacks;
   private zoneLayer = new Container();
   private objectLayer = new Container();
-  private moteLayer = new Container();
   private objects = new Map<string, ObjectNode>();
   private zones = new Map<string, ZoneNode>();
-  private motes: {
-    sprite: Sprite;
-    x: number;
-    y: number;
-    s: number;
-    drift: number;
-  }[] = [];
   private scene: WorldScene | null = null;
   private drag: DragState = { type: "idle" };
   private hoverKey: string | null = null;
@@ -185,7 +167,6 @@ export class WorldEngine {
   private lastTap: { key: string; t: number; x: number; y: number } | null =
     null;
   private unsubscribers: (() => void)[] = [];
-  private reduceMotion = false;
   private destroyed = false;
   private rectCache: WorldRect | null = null;
   failed = false;
@@ -201,9 +182,6 @@ export class WorldEngine {
   }
 
   async init(): Promise<void> {
-    this.reduceMotion =
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     const app = new Application();
     try {
       await app.init({
@@ -226,9 +204,8 @@ export class WorldEngine {
       return;
     }
     this.app = app;
-    // DOM parity: motes beneath, objects, then zones (z 2) above.
-    app.stage.addChild(this.moteLayer, this.objectLayer, this.zoneLayer);
-    this.seedMotes();
+    // Zones (z 2) draw above resting objects.
+    app.stage.addChild(this.objectLayer, this.zoneLayer);
     this.refreshRect();
     this.rebuild();
     const rebuild = () => this.rebuild();
@@ -252,7 +229,6 @@ export class WorldEngine {
       window.removeEventListener("scroll", onScroll);
       window.removeEventListener("resize", onScroll);
     });
-    app.ticker.add(() => this.tick());
     this.bindPointer();
     // A read-only probe for the production walks (HS-95-01/10): where does
     // each object render, in client px? Lets Playwright drive the canvas
@@ -359,10 +335,6 @@ export class WorldEngine {
     const ring = new Graphics();
     const sprite = new Sprite();
     sprite.anchor.set(0.5);
-    const highlight = new Sprite();
-    highlight.anchor.set(0.5);
-    highlight.blendMode = "add";
-    highlight.alpha = 0;
     const label = new Text({
       text: "",
       style: {
@@ -384,7 +356,7 @@ export class WorldEngine {
     label.anchor.set(0.5, 0);
     const labelBg = new Graphics();
     labelBg.visible = false;
-    lift.addChild(glow, ring, sprite, highlight);
+    lift.addChild(glow, ring, sprite);
     root.addChild(shadow, lift, labelBg, label);
     return {
       root,
@@ -394,7 +366,6 @@ export class WorldEngine {
       glowTint: o.glow,
       ring,
       sprite,
-      highlight,
       paper: null,
       label,
       labelBg,
@@ -407,9 +378,6 @@ export class WorldEngine {
       spriteUrl: "",
       labelText: "",
       ringState: " ",
-      bornAt: performance.now(),
-      ringBornAt: o.isNew ? performance.now() : 0,
-      wasNew: o.isNew,
       data: o,
     };
   }
@@ -428,23 +396,19 @@ export class WorldEngine {
     // small-note differential and the paper ruling overlay died with the
     // mascot scale (the sprite IS the paper at pixel-true size).
     const size = SPRITE;
-    if (node.spriteUrl !== o.sprite) {
-      node.spriteUrl = o.sprite;
-      const tex = loadSprite(o.sprite, (t) => {
-        if (node.spriteUrl === o.sprite) {
-          node.sprite.texture = t;
-          node.highlight.texture = t;
-        }
+    const sprite =
+      this.hoverKey === `obj:${o.key}`
+        ? spriteStateUrl(o.kind, o.id, "sel")
+        : o.sprite;
+    if (node.spriteUrl !== sprite) {
+      node.spriteUrl = sprite;
+      const tex = loadSprite(sprite, (t) => {
+        if (node.spriteUrl === sprite) node.sprite.texture = t;
       });
-      if (tex) {
-        node.sprite.texture = tex;
-        node.highlight.texture = tex;
-      }
+      if (tex) node.sprite.texture = tex;
     }
     node.sprite.width = size;
     node.sprite.height = size;
-    node.highlight.width = size;
-    node.highlight.height = size;
     if (node.paper) {
       node.paper.destroy();
       node.paper = null;
@@ -459,11 +423,11 @@ export class WorldEngine {
     node.glow.height = LIFT + 40;
     // Shadow sits just under the art (art bottom = SPRITE/2).
     node.shadow.position.set(0, SPRITE / 2 + 8);
-    node.shadow.width = 54;
+    node.shadow.width = 70;
     node.shadow.height = 12;
-    // Ring: selected = steady dashed; new = pulsing solid (per-frame).
-    // Redrawn only when its state actually flips — never on drags.
-    const ringState = `${o.selected ? "s" : ""}${o.isNew ? "n" : ""}`;
+    node.shadow.alpha = 0.5;
+    // Selection is the cell: redraw only when its state flips.
+    const ringState = o.selected ? "s" : "";
     if (ringState !== node.ringState) {
       node.ringState = ringState;
       this.drawRing(node, o);
@@ -533,17 +497,13 @@ export class WorldEngine {
     if (o.isNew && !node.newBadge) {
       node.newBadge = makeBadge("NEW", parseColorNum(ACCENT), 0x06121f, 9);
       node.lift.addChild(node.newBadge);
-      if (!node.wasNew) {
-        node.ringBornAt = performance.now();
-        node.wasNew = true;
-      }
     }
     if (node.newBadge) node.newBadge.position.set(half - 10, -half + 2);
     if (!o.isNew && node.newBadge) {
       node.newBadge.destroy({ children: true });
       node.newBadge = null;
-      node.wasNew = false;
     }
+    node.root.alpha = 1;
     node.root.scale.set(o.scale);
   }
 
@@ -586,40 +546,29 @@ export class WorldEngine {
   private setObjectSprite(node: ObjectNode, url: string): void {
     node.spriteUrl = url;
     const tex = loadSprite(url, (t) => {
-      if (node.spriteUrl === url) {
-        node.sprite.texture = t;
-        node.highlight.texture = t;
-      }
+      if (node.spriteUrl === url) node.sprite.texture = t;
     });
-    if (tex) {
-      node.sprite.texture = tex;
-      node.highlight.texture = tex;
-    }
+    if (tex) node.sprite.texture = tex;
   }
 
   private drawRing(node: ObjectNode, o: SceneObject): void {
     // HS-105-01 — selection is the CELL: a rounded-rect box at the lift
-    // bounds (tinted fill + outline), the gate's approved treatment; the
-    // orbiting dashed circle died with the mascot. NEW keeps a pulsing
-    // outline of the same box (alpha animated per-frame in tick()).
+    // bounds (tinted fill + outline), the gate's approved treatment.
     const g = node.ring;
     g.clear();
-    if (!o.selected && !o.isNew) {
+    if (!o.selected) {
       g.visible = false;
       return;
     }
     g.visible = true;
     const half = LIFT / 2;
     const accent = parseColorNum(ACCENT);
-    if (o.selected) {
-      g.roundRect(-half, -half, LIFT, LIFT, 10);
-      g.fill({ color: accent, alpha: 0.1 });
-      g.roundRect(-half, -half, LIFT, LIFT, 10);
-      g.stroke({ width: 1.5, color: accent, alpha: 0.55 });
-    } else {
-      g.roundRect(-half, -half, LIFT, LIFT, 10);
-      g.stroke({ width: 2, color: accent, alpha: 0.85 });
-    }
+    g.roundRect(-half, -half, LIFT, LIFT, 10);
+    g.fill({ color: accent, alpha: 0.1 });
+    g.roundRect(-half, -half, LIFT, LIFT, 10);
+    g.stroke({ width: 1.5, color: accent, alpha: 0.55 });
+    g.alpha = 0.9;
+    g.scale.set(1);
   }
 
   private syncZones(scene: WorldScene, rect: WorldRect): void {
@@ -682,10 +631,6 @@ export class WorldEngine {
       labelText: "",
       countBadge: null,
       countText: "",
-      lift: 0,
-      liftTarget: 0,
-      scale: 1,
-      scaleTarget: 1,
       data: {} as SceneZone,
     };
   }
@@ -702,10 +647,13 @@ export class WorldEngine {
     // y math is unchanged).
     const cx = z.width / 2;
     const cy = LIFT / 2;
-    if (node.spriteUrl !== z.sprite) {
-      node.spriteUrl = z.sprite;
-      const tex = loadSprite(z.sprite, (t) => {
-        if (node.spriteUrl === z.sprite) node.sprite.texture = t;
+    const sprite = emphasized
+      ? spriteStateUrl("directory", z.id, "sel")
+      : z.sprite;
+    if (node.spriteUrl !== sprite) {
+      node.spriteUrl = sprite;
+      const tex = loadSprite(sprite, (t) => {
+        if (node.spriteUrl === sprite) node.sprite.texture = t;
       });
       if (tex) node.sprite.texture = tex;
     }
@@ -718,7 +666,7 @@ export class WorldEngine {
     node.glow.width = LIFT + 40;
     node.glow.height = LIFT + 40;
     node.glow.position.set(cx, cy);
-    node.glow.alpha = emphasized ? 0.85 : 0.5;
+    node.glow.alpha = 0.5;
     node.shadow.position.set(cx, cy + SPRITE / 2 + 8);
     node.shadow.width = 54;
     node.shadow.height = 12;
@@ -743,112 +691,8 @@ export class WorldEngine {
       if (node.countBadge) node.root.addChild(node.countBadge);
     }
     node.countBadge?.position.set(cx + SPRITE / 2 - 4, cy + SPRITE / 2 - 4);
-    node.liftTarget = z.dropReady ? -4 : emphasized ? -2 : 0;
-    node.scaleTarget = z.dropReady ? 1.04 : 1;
     // Rename hides the GL label (the DOM input overlays it).
     node.label.visible = !z.renaming;
-  }
-
-  // ── per-frame (transform-only) ──────────────────────────────────────────
-
-  private seedMotes(): void {
-    const N = 18;
-    for (let i = 0; i < N; i++) {
-      const sprite = new Sprite(moteTexture());
-      sprite.anchor.set(0.5);
-      const r = 0.6 + Math.random() * 1.6;
-      sprite.width = r * 4;
-      sprite.height = r * 4;
-      sprite.alpha = 0.06 + Math.random() * 0.12;
-      this.moteLayer.addChild(sprite);
-      this.motes.push({
-        sprite,
-        x: Math.random(),
-        y: Math.random(),
-        s: 0.006 + Math.random() * 0.014,
-        drift: (Math.random() - 0.5) * 0.01,
-      });
-    }
-  }
-
-  private tick(): void {
-    if (!this.app) return;
-    const now = performance.now();
-    const dt = Math.min(this.app.ticker.deltaMS / 1000, 0.05);
-    const w = this.app.renderer.width / this.app.renderer.resolution;
-    const h = this.app.renderer.height / this.app.renderer.resolution;
-    if (!this.reduceMotion) {
-      for (const m of this.motes) {
-        m.y -= m.s * dt;
-        m.x += m.drift * dt;
-        if (m.y < -0.02) {
-          m.y = 1.02;
-          m.x = Math.random();
-        }
-        m.sprite.position.set(m.x * w, m.y * h);
-      }
-    } else {
-      for (const m of this.motes) m.sprite.position.set(m.x * w, m.y * h);
-    }
-    for (const node of this.objects.values()) {
-      const o = node.data;
-      const settled = o.dragging || o.editing || this.reduceMotion;
-      // The bob: rotate(tilt→-tilt) + translateY(0→-9), 4.6s, phase delay.
-      const frac = settled
-        ? 0
-        : (((now / 1000 - o.phase) % BOB_SECONDS) + BOB_SECONDS) %
-          BOB_SECONDS /
-          BOB_SECONDS;
-      const k = settled ? 0 : (1 - Math.cos(frac * Math.PI * 2)) / 2;
-      node.lift.position.y = -9 * k;
-      node.lift.rotation = ((o.tilt * (1 - 2 * k)) * Math.PI) / 180;
-      node.shadow.scale.x = (1 - 0.2 * k) * (70 / node.shadow.texture.width);
-      node.shadow.alpha = 0.5 - 0.2 * k;
-      // Hover/selection glow levels (DOM: .5 rest, .82 hover, .95 new, .9 editing).
-      const hovered = this.hoverKey === `obj:${o.key}`;
-      node.glow.alpha = o.isNew
-        ? 0.95
-        : o.editing
-          ? 0.9
-          : hovered
-            ? 0.82
-            : o.selected
-              ? 0.55
-              : 0.5;
-      node.highlight.alpha = hovered ? 0.12 : 0;
-      // Materialize: 0.5s overshoot scale-in on spawn.
-      const age = (now - node.bornAt) / 500;
-      if (age < 1 && !this.reduceMotion) {
-        const t = overshoot(Math.min(1, age));
-        node.root.alpha = Math.min(1, age * 2);
-        node.root.scale.set(o.scale * (0.35 + 0.65 * t));
-      } else {
-        node.root.alpha = 1;
-        node.root.scale.set(o.scale);
-      }
-      // The NEW ring pulse: 1.1s ease-out, three beats.
-      if (o.isNew && node.ringBornAt && !o.selected) {
-        const beat = (now - node.ringBornAt) / 1100;
-        if (beat < 3) {
-          const bt = beat % 1;
-          node.ring.visible = true;
-          node.ring.alpha = 0.85 * (1 - bt);
-          node.ring.scale.set(0.7 + 0.85 * bt);
-        } else {
-          node.ring.visible = false;
-        }
-      } else if (o.selected) {
-        node.ring.alpha = 0.9;
-        node.ring.scale.set(1);
-      }
-    }
-    const rect = this.worldRect();
-    for (const node of this.zones.values()) {
-      node.lift += (node.liftTarget - node.lift) * Math.min(1, dt * 14);
-      node.scale += (node.scaleTarget - node.scale) * Math.min(1, dt * 14);
-      node.root.position.y = node.data.u.y * rect.height + node.lift;
-      node.root.scale.set(node.scale);
-    }
   }
 
   // ── input (the DOM world's exact semantics, HS-71-04/05/06) ─────────────
@@ -1321,13 +1165,6 @@ export class WorldEngine {
             ? "text"
             : "default";
   }
-}
-
-function overshoot(t: number): number {
-  // cubic-bezier(0.2, 1.4, 0.4, 1) flavor: fast rise, slight overshoot.
-  const s = 1.70158 * 0.7;
-  const u = t - 1;
-  return u * u * ((s + 1) * u + s) + 1;
 }
 
 function bodyFont(): string {

--- a/web/src/desk/store.ts
+++ b/web/src/desk/store.ts
@@ -51,6 +51,30 @@ export interface PanelRect {
 }
 
 const PANEL_KEY = "hs.desk.panels";
+const PANEL_ORDER_LIMIT = 100;
+
+// A panel id is local storage data, not an executable identifier. Retain
+// legacy panel names while rejecting empty and malformed keys; live panels
+// subsequently present themselves through the compositor registry.
+const isPanelId = (value: unknown): value is string =>
+  typeof value === "string" && /^[A-Za-z0-9:_-]+$/.test(value);
+
+const isPanelRect = (value: unknown): value is PanelRect => {
+  if (!value || typeof value !== "object") return false;
+  const rect = value as PanelRect;
+  return [rect.x, rect.y, rect.w, rect.h].every(Number.isFinite) &&
+    rect.w > 0 && rect.h > 0;
+};
+
+/** Keep z positions inside the window band. `panelOrder` is the store's
+ * z-index source, so retaining its newest 100 ids is equivalent to
+ * renumbering the ladder from its base while preserving relative order. */
+function compactPanelOrder(order: string[]): string[] {
+  const unique = Array.from(new Set(order));
+  return unique.length > PANEL_ORDER_LIMIT
+    ? unique.slice(-PANEL_ORDER_LIMIT)
+    : unique;
+}
 
 /** The persisted window layout (HS-95-02; order since HS-97-03):
  * arranged rects, the stacking order, and maximize. Minimize is
@@ -65,15 +89,27 @@ interface PanelLayout {
 
 export function loadPanelLayout(): PanelLayout {
   try {
-    const raw = JSON.parse(localStorage.getItem(PANEL_KEY) || "{}") || {};
-    if (raw && typeof raw === "object" && raw.rects) {
-      return {
-        rects: raw.rects || {},
-        order: Array.isArray(raw.order) ? raw.order : [],
-        max: Array.isArray(raw.max) ? raw.max : [],
-      };
-    }
-    return { rects: raw, order: [], max: [] };
+    const raw: unknown = JSON.parse(localStorage.getItem(PANEL_KEY) || "{}") || {};
+    const layout = raw as { rects?: unknown; order?: unknown; max?: unknown };
+    const source = raw && typeof raw === "object" && layout.rects ? layout.rects : raw;
+    const rects = Object.fromEntries(
+      Object.entries(source && typeof source === "object" ? source : {}).filter(
+        ([id, rect]) => isPanelId(id) && isPanelRect(rect),
+      ),
+    ) as Record<string, PanelRect>;
+    const order = compactPanelOrder(
+      (Array.isArray(layout.order) ? layout.order : []).filter(
+        (value): value is string => isPanelId(value),
+      ),
+    );
+    const max = Array.from(
+      new Set(
+        (Array.isArray(layout.max) ? layout.max : []).filter(
+          (value): value is string => isPanelId(value),
+        ),
+      ),
+    );
+    return { rects, order, max };
   } catch {
     return { rects: {}, order: [], max: [] };
   }
@@ -1001,8 +1037,10 @@ export const useDesk = create<DeskState>((set, get) => ({
     savePanelLayout(rest, panelSaved, get().panelOrder, get().panelMax);
   },
   focusPanel(id) {
-    const order = get().panelOrder.filter((x) => x !== id);
-    order.push(id);
+    const order = compactPanelOrder([
+      ...get().panelOrder.filter((x) => x !== id),
+      id,
+    ]);
     set({ panelOrder: order });
     savePanelLayout(get().panelRects, get().panelSaved, order, get().panelMax);
   },
@@ -1023,8 +1061,10 @@ export const useDesk = create<DeskState>((set, get) => ({
   },
   restorePanel(id) {
     const panelMin = get().panelMin.filter((x) => x !== id);
-    const order = get().panelOrder.filter((x) => x !== id);
-    order.push(id);
+    const order = compactPanelOrder([
+      ...get().panelOrder.filter((x) => x !== id),
+      id,
+    ]);
     set({ panelMin, panelOrder: order });
     savePanelLayout(get().panelRects, get().panelSaved, order, get().panelMax);
   },
@@ -1033,8 +1073,10 @@ export const useDesk = create<DeskState>((set, get) => ({
     const panelMax = has
       ? get().panelMax.filter((x) => x !== id)
       : [...get().panelMax, id];
-    const order = get().panelOrder.filter((x) => x !== id);
-    order.push(id);
+    const order = compactPanelOrder([
+      ...get().panelOrder.filter((x) => x !== id),
+      id,
+    ]);
     set({ panelMax, panelOrder: order });
     savePanelLayout(get().panelRects, get().panelSaved, order, panelMax);
   },

--- a/web/src/desk/world.ts
+++ b/web/src/desk/world.ts
@@ -143,13 +143,10 @@ export function objUnit(
   };
 }
 
-/** Per-object float phase. HS-105-01: the random tilt and 0.92–1.08 scale
- * jitter died with the mascot scale — pixel art renders integer-true and
- * axis-aligned (the Workbench discipline); the positional bob keeps the
- * desk alive without blurring a single pixel. */
-export function objMotion(o: WorldObject) {
+/** Pixel art is rendered integer-true and axis-aligned at its rest state. */
+export function objMotion(_o: WorldObject) {
   return {
-    phase: -(oh(o.id) * 4.5),
+    phase: 0,
     tilt: 0,
     scale: 1,
   };

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -232,6 +232,8 @@
   --desk-window-cascade: 26px; /* default-corner cascade step */
   --desk-snap-top: 54px; /* snap tiles clear the chrome band */
   --desk-snap-bottom: 52px; /* snap tiles clear the dock band */
+  --desk-work-top: var(--desk-snap-top); /* the working band begins below the system bar */
+  --desk-work-bottom: var(--desk-snap-bottom); /* the working band ends above the dock */
   --glow-meeting: #56C7F5;
   --glow-note: #34D399;
   --glow-kb: #FBBF24;


### PR DESCRIPTION
## Summary

Three Phase 113 stories shipping together — the first wave of **The Forge**.

### HS-113-09: The static desk — kill the animated diorama
- Removed idle icon bob (4.6s cosine cycle on every world icon)
- Replaced hover glow with `_sel` sprite swap (the real Workbench way)
- Removed spawn materialize animation (fractional scaling of pixel art)
- Removed pulsating NEW ring (3-beat expanding ring)
- Removed drawer hover lift+scale (replaced with `_sel` sprite)
- Removed 18 decorative drifting motes
- Removed dive camera fractional scale
- Removed agent-rail hover scale + working halo pulse
- Removed stale dock magnification CSS
- **Net: -264 lines. The desk at rest is now perfectly still.**

### HS-113-02: The real editor — CodeMirror 6 replaces textarea
- Added `@codemirror/*` packages
- Created `DeskEditor` component with markdown syntax highlighting
- Created Desk dark-glass theme from `design-tokens.json` CSS variables
- Wired into `InlineEditor` (note/KB body editing) and `Pullout` (note editing)
- MicButton now inserts at cursor position via CM6 `dispatch`
- Escape clears selection first, then closes editor
- Cmd+Enter saves in Pullout context

### HS-113-10: The compositor — OS-grade window system
- Unified working band with `--desk-work-top` / `--desk-work-bottom` tokens
- Maximize respects dock band (no more overlap)
- Bounded z-index ladder with compaction at 100 windows
- Viewport resize re-clamps open windows (150ms debounce)
- Persisted panel data validated on load (drops corrupt/stale entries)
- Zone window items: single-click selects, double-click opens (Desk Grammar law)
- SessionPullout Escape bubbling fixed (cancels local edit first)
- Focus-visible restored on all composer controls (removed `outline: none`)
- Active/inactive traffic lights on window title bars

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] 509/509 Vitest tests pass (2 pre-existing DeskListView pagination timeouts under jsdom)
- [x] `npm run build` passes
- [ ] Visual walk on running hub: desk at rest is still, icons use `_sel` on hover, editor shows markdown highlighting, windows respect dock band

🤖 Generated with [Claude Code](https://claude.com/claude-code)