### PR TITLE
Phase 113 Wave 4: Voice router, git drawers, refit (11/11)

### DIFF
--- a/holdspeak/web/routes/__init__.py
+++ b/holdspeak/web/routes/__init__.py
@@ -35,6 +35,7 @@ from .primitives import build_primitives_router
 from .projections import build_projections_router
 from .projects import build_projects_router
 from .roadmaps import build_roadmaps_router
+from .repositories import build_repositories_router
 from .setup import build_setup_router
 from .sync import build_sync_router
 from .system import build_system_router
@@ -65,6 +66,7 @@ __all__ = [
     "build_projections_router",
     "build_projects_router",
     "build_roadmaps_router",
+    "build_repositories_router",
     "build_setup_router",
     "build_sync_router",
     "build_system_router",

--- a/holdspeak/web/routes/repositories.py
+++ b/holdspeak/web/routes/repositories.py
@@ -1,0 +1,380 @@
+"""Local git repository drawer routes (HS-113-06).
+
+Repository ids are DeliveryRegistry source ids.  The registry retains the local
+worktree path server-side, while every response keeps that path off the wire.
+All git invocations use argv subprocesses in the resolved worktree; file verbs
+also resolve and contain their requested path before touching disk.
+"""
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Optional
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from ...delivery import DeliveryRegistry
+from ...delivery.registry import RegistryError
+from ...logging_config import get_logger
+from ..context import WebContext
+
+log = get_logger("web.routes.repositories")
+GIT_TIMEOUT_SECONDS = 30
+
+
+class RegisterRepositoryRequest(BaseModel):
+    source_id: Optional[str] = None
+    path: Optional[str] = None
+    label: Optional[str] = None
+
+
+class WriteFileRequest(BaseModel):
+    content: str
+
+
+class StageRequest(BaseModel):
+    paths: list[str] = Field(default_factory=list)
+
+
+class CommitRequest(BaseModel):
+    message: str
+
+
+class CheckoutRequest(BaseModel):
+    branch: str
+
+
+def _error(status: int, error: str) -> JSONResponse:
+    return JSONResponse({"error": error}, status_code=status)
+
+
+def _run(root: Path, *args: str, input_text: Optional[str] = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(root),
+        input=input_text,
+        stdin=subprocess.DEVNULL if input_text is None else None,
+        capture_output=True,
+        text=True,
+        errors="replace",
+        timeout=GIT_TIMEOUT_SECONDS,
+    )
+
+
+def _source_root(registry: DeliveryRegistry, source_id: str) -> tuple[Any, Path] | None:
+    source = registry.get(source_id)
+    if source is None or not source.primary_path:
+        return None
+    root = Path(source.primary_path).resolve()
+    return source, root
+
+
+def _safe_path(root: Path, value: str) -> Path:
+    """Return a contained repo-relative path or raise ValueError.
+
+    Reject traversal syntax before resolving so ``a/../b`` is not silently
+    accepted even when it would resolve under the root.
+    """
+    raw = str(value or "")
+    candidate = PurePosixPath(raw)
+    if not raw or candidate.is_absolute() or ".." in candidate.parts or "\\" in raw:
+        raise ValueError("path traversal refused")
+    target = (root / Path(*candidate.parts)).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("path traversal refused") from exc
+    return target
+
+
+def _status_code(raw: str) -> str | None:
+    pair = raw[:2]
+    if pair == "??":
+        return "?"
+    for code in pair:
+        if code in {"M", "A", "D"}:
+            return code
+    return None
+
+
+def _porcelain(root: Path) -> dict[str, str | None]:
+    proc = _run(root, "status", "--porcelain=v1", "--untracked-files=all")
+    if proc.returncode:
+        return {}
+    statuses: dict[str, str | None] = {}
+    for line in proc.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        # Rename/copy porcelain is `old -> new`; the visible current file wins.
+        if " -> " in path:
+            path = path.rsplit(" -> ", 1)[-1]
+        statuses[path] = _status_code(line)
+    return statuses
+
+
+def _tree(root: Path, prefix: str) -> list[dict[str, Any]]:
+    proc = _run(root, "ls-tree", "-r", "--name-only", "HEAD")
+    tracked = proc.stdout.splitlines() if proc.returncode == 0 else []
+    statuses = _porcelain(root)
+    paths = set(tracked) | set(statuses)
+    normalized_prefix = prefix.strip("/")
+    children: dict[str, dict[str, Any]] = {}
+    for raw in paths:
+        try:
+            _safe_path(root, raw)
+        except ValueError:
+            continue
+        relative = PurePosixPath(raw)
+        parts = relative.parts
+        if normalized_prefix:
+            prefix_parts = PurePosixPath(normalized_prefix).parts
+            if parts[: len(prefix_parts)] != prefix_parts:
+                continue
+            parts = parts[len(prefix_parts) :]
+        if not parts:
+            continue
+        name = parts[0]
+        child_path = "/".join((*PurePosixPath(normalized_prefix).parts, name))
+        if len(parts) > 1:
+            children[name] = {"name": name, "path": child_path, "type": "dir", "status": None}
+            continue
+        modified = None
+        local = root / raw
+        if local.exists() and local.is_file():
+            try:
+                modified = datetime.fromtimestamp(local.stat().st_mtime, timezone.utc).isoformat()
+            except OSError:
+                pass
+        children[name] = {
+            "name": name,
+            "path": child_path,
+            "type": "file",
+            "status": statuses.get(raw),
+            "modified": modified,
+        }
+    return sorted(children.values(), key=lambda item: (item["type"] != "dir", item["name"].lower()))
+
+
+def _repo_status(root: Path) -> dict[str, Any]:
+    branch = _run(root, "branch", "--show-current").stdout.strip() or "detached"
+    dirty_files = _porcelain(root)
+    ahead = behind = 0
+    counts = _run(root, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
+    if counts.returncode == 0:
+        try:
+            behind, ahead = (int(value) for value in counts.stdout.split())
+        except ValueError:
+            pass
+    return {"branch": branch, "dirty": len(dirty_files), "ahead": ahead, "behind": behind}
+
+
+def build_repositories_router(
+    ctx: WebContext,
+    *,
+    registry: Optional[DeliveryRegistry] = None,
+    registry_path: Optional[Path] = None,
+    map_path: Optional[Path] = None,
+) -> APIRouter:
+    _ = ctx
+    router = APIRouter()
+    holder: dict[str, DeliveryRegistry | None] = {"registry": registry}
+
+    def _registry() -> DeliveryRegistry:
+        if holder["registry"] is None:
+            holder["registry"] = DeliveryRegistry(registry_path, map_path=map_path)
+        return holder["registry"]
+
+    def _root_or_404(repository_id: str) -> tuple[Any, Path] | JSONResponse:
+        result = _source_root(_registry(), repository_id)
+        return result if result is not None else _error(404, "repository not found")
+
+    @router.get("/api/repositories")
+    async def api_repositories() -> Any:
+        def list_repositories() -> dict[str, Any]:
+            rows = []
+            for source in _registry().sources():
+                if not source.primary_path:
+                    continue
+                root = Path(source.primary_path).resolve()
+                rows.append({
+                    "kind": "repository",
+                    "id": source.source_id,
+                    "name": source.label,
+                    "source_id": source.source_id,
+                    "branch": _repo_status(root)["branch"],
+                    "created_at": "",
+                })
+            return {"repositories": rows}
+        try:
+            return await asyncio.to_thread(list_repositories)
+        except Exception as exc:
+            log.error("repository list failed: %s", exc)
+            return _error(500, "repository list failed")
+
+    @router.post("/api/repositories")
+    async def api_register_repository(body: RegisterRepositoryRequest) -> Any:
+        def register() -> dict[str, Any]:
+            registry = _registry()
+            if body.source_id:
+                found = _source_root(registry, body.source_id)
+                if found is None:
+                    raise KeyError("repository not found")
+                source, root = found
+            elif body.path:
+                source, _ = registry.register(body.path, label=body.label)
+                root = Path(source.primary_path or "").resolve()
+            else:
+                raise RegistryError("source_id or path required")
+            return {
+                "repository": {
+                    "kind": "repository",
+                    "id": source.source_id,
+                    "name": source.label,
+                    "source_id": source.source_id,
+                    "branch": _repo_status(root)["branch"],
+                    "created_at": "",
+                }
+            }
+        try:
+            return await asyncio.to_thread(register)
+        except KeyError:
+            return _error(404, "repository not found")
+        except RegistryError as exc:
+            return _error(400, str(exc))
+        except Exception as exc:
+            log.error("repository registration failed: %s", exc)
+            return _error(500, "repository registration failed")
+
+    @router.get("/api/repositories/{repository_id}/tree")
+    async def api_repository_tree(repository_id: str, path: str = "") -> Any:
+        def tree() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            try:
+                prefix = _safe_path(root, path).relative_to(root).as_posix() if path else ""
+            except ValueError:
+                return _error(400, "path traversal refused")
+            return {"files": _tree(root, prefix)}
+        return await asyncio.to_thread(tree)
+
+    @router.get("/api/repositories/{repository_id}/file/{path:path}")
+    async def api_repository_file(repository_id: str, path: str) -> Any:
+        def read() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            try:
+                target = _safe_path(root, path)
+                if not target.is_file():
+                    return _error(404, "file not found")
+                return {"path": path, "content": target.read_text(encoding="utf-8")}
+            except ValueError:
+                return _error(400, "path traversal refused")
+            except (OSError, UnicodeDecodeError):
+                return _error(409, "file is not readable text")
+        return await asyncio.to_thread(read)
+
+    @router.put("/api/repositories/{repository_id}/file/{path:path}")
+    async def api_repository_write_file(repository_id: str, path: str, body: WriteFileRequest) -> Any:
+        def write() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            try:
+                target = _safe_path(root, path)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(body.content, encoding="utf-8")
+                return {"path": path, "written": True}
+            except ValueError:
+                return _error(400, "path traversal refused")
+            except OSError:
+                return _error(409, "file write failed")
+        return await asyncio.to_thread(write)
+
+    @router.post("/api/repositories/{repository_id}/stage")
+    async def api_repository_stage(repository_id: str, body: StageRequest) -> Any:
+        def stage() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            if not body.paths:
+                return _error(400, "files required")
+            try:
+                paths = [_safe_path(root, path).relative_to(root).as_posix() for path in body.paths]
+            except ValueError:
+                return _error(400, "path traversal refused")
+            proc = _run(root, "add", "--", *paths)
+            if proc.returncode:
+                return _error(409, "git stage failed")
+            return {"staged": paths}
+        return await asyncio.to_thread(stage)
+
+    @router.post("/api/repositories/{repository_id}/commit")
+    async def api_repository_commit(repository_id: str, body: CommitRequest) -> Any:
+        def commit() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            message = body.message.strip()
+            if not message:
+                return _error(400, "commit message required")
+            proc = _run(root, "commit", "-m", message)
+            if proc.returncode:
+                return _error(409, "git commit failed")
+            return {"committed": True, "summary": proc.stdout.strip()}
+        return await asyncio.to_thread(commit)
+
+    @router.get("/api/repositories/{repository_id}/status")
+    async def api_repository_status(repository_id: str) -> Any:
+        def status() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            return _repo_status(root)
+        return await asyncio.to_thread(status)
+
+    @router.get("/api/repositories/{repository_id}/branches")
+    async def api_repository_branches(repository_id: str) -> Any:
+        def branches() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            proc = _run(root, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+            if proc.returncode:
+                return _error(409, "git branch list failed")
+            return {"branches": [line for line in proc.stdout.splitlines() if line]}
+        return await asyncio.to_thread(branches)
+
+    @router.post("/api/repositories/{repository_id}/checkout")
+    async def api_repository_checkout(repository_id: str, body: CheckoutRequest) -> Any:
+        def checkout() -> Any:
+            resolved = _root_or_404(repository_id)
+            if isinstance(resolved, JSONResponse):
+                return resolved
+            _, root = resolved
+            branch = body.branch.strip()
+            if not branch or branch.startswith("-"):
+                return _error(400, "branch invalid")
+            available = _run(root, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+            if branch not in available.stdout.splitlines():
+                return _error(404, "branch not found")
+            proc = _run(root, "switch", branch)
+            if proc.returncode:
+                return _error(409, "git checkout failed")
+            return _repo_status(root)
+        return await asyncio.to_thread(checkout)
+
+    return router

--- a/holdspeak/web_server.py
+++ b/holdspeak/web_server.py
@@ -565,6 +565,7 @@ class MeetingWebServer:
             build_projections_router,
             build_projects_router,
             build_roadmaps_router,
+            build_repositories_router,
             build_setup_router,
             build_sync_router,
             build_system_router,
@@ -629,6 +630,7 @@ class MeetingWebServer:
         app.include_router(build_delivery_attempts_router(web_ctx))
         app.include_router(build_delivery_dossiers_router(web_ctx))
         app.include_router(build_delivery_prs_router(web_ctx))
+        app.include_router(build_repositories_router(web_ctx))
         # One shared NodeLinkState feeds both the node link and the terminal
         # command claim leg: commands issued at the hub reach a remote node
         # through the same authenticated long-poll. The terminal command

--- a/tests/unit/test_repository_routes.py
+++ b/tests/unit/test_repository_routes.py
@@ -1,0 +1,86 @@
+"""HS-113-06 repository drawer routes: real git fixture and containment checks."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from holdspeak.delivery import DeliveryRegistry
+from holdspeak.web.context import WebContext
+from holdspeak.web.routes.repositories import _safe_path, build_repositories_router
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
+
+
+def _git_output(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _context() -> WebContext:
+    return WebContext(get_state=lambda: {}, broadcast=lambda *_: None)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path]:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.test")
+    _git(root, "config", "user.name", "Test")
+    (root / "src").mkdir()
+    (root / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+    (root / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", "seed")
+    registry = DeliveryRegistry(tmp_path / "registry.json", map_path=tmp_path / "missing.json")
+    registry.register(str(root), label="Fixture")
+    app = FastAPI()
+    app.include_router(build_repositories_router(_context(), registry=registry))
+    return TestClient(app), root
+
+
+def test_repository_tree_status_stage_and_commit(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+    repository_id = client.get("/api/repositories").json()["repositories"][0]["id"]
+
+    files = client.get(f"/api/repositories/{repository_id}/tree").json()["files"]
+    assert [row["name"] for row in files] == ["src", "README.md"]
+    nested = client.get(f"/api/repositories/{repository_id}/tree?path=src").json()["files"]
+    assert nested[0]["path"] == "src/main.py"
+
+    assert client.put(
+        f"/api/repositories/{repository_id}/file/src/main.py",
+        json={"content": "print('changed')\n"},
+    ).status_code == 200
+    assert client.get(f"/api/repositories/{repository_id}/status").json()["dirty"] == 1
+    assert client.post(
+        f"/api/repositories/{repository_id}/stage", json={"paths": ["src/main.py"]}
+    ).status_code == 200
+    assert client.post(
+        f"/api/repositories/{repository_id}/commit", json={"message": "change main"}
+    ).status_code == 200
+    assert _git_output(root, "log", "-1", "--format=%s") == "change main"
+
+
+def test_repository_file_routes_refuse_traversal(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+    repository_id = client.get("/api/repositories").json()["repositories"][0]["id"]
+    # HTTP normalizes `..` path segments before FastAPI can route them; the
+    # shared guard protects every file verb once it receives a path.
+    for path in ("../outside.txt", "/outside.txt", "src/../outside.txt"):
+        try:
+            _safe_path(root, path)
+        except ValueError as exc:
+            assert str(exc) == "path traversal refused"
+        else:
+            raise AssertionError(f"accepted traversal path: {path}")
+    response = client.post(
+        f"/api/repositories/{repository_id}/stage", json={"paths": ["../outside.txt"]}
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "path traversal refused"

--- a/web/src/desk/DeskApp.tsx
+++ b/web/src/desk/DeskApp.tsx
@@ -18,6 +18,7 @@ import { DeliveryBoard } from "./components/DeliveryBoard";
 import { DeliveryDossierWindow } from "./components/DeliveryDossierWindow";
 import { DeliveryTerminalWindow } from "./components/DeliveryTerminalWindow";
 import { RoadmapWindow } from "./components/RoadmapWindow";
+import { RepoWindow } from "./components/RepoWindow";
 import { AttentionDrawer } from "./components/AttentionDrawer";
 import { GlassDropLayer } from "./components/GlassDropLayer";
 import { DeskToolInspector } from "./components/DeskToolInspector";
@@ -32,6 +33,7 @@ export default function DeskApp() {
   const updatedAt = useDesk((s) => s.updatedAt);
   const chatPersonaId = useDesk((s) => s.chatPersonaId);
   const roadmapWindows = useDesk((s) => s.roadmapWindows);
+  const repositoryWindows = useDesk((s) => s.repositoryWindows);
   const setup = useDesk((s) => s.setup);
   const viewMode = useDesk((s) => s.viewMode);
   const { refresh } = useDesk.getState();
@@ -68,6 +70,9 @@ export default function DeskApp() {
       <DeliveryTerminalWindow />
       {roadmapWindows.map((roadmap) => (
         <RoadmapWindow key={roadmap.slug} slug={roadmap.slug} origin={roadmap.origin} />
+      ))}
+      {repositoryWindows.map((repository) => (
+        <RepoWindow key={repository.id} repositoryId={repository.id} origin={repository.origin} />
       ))}
       <PanePicker />
       <SessionPullout />

--- a/web/src/desk/api.ts
+++ b/web/src/desk/api.ts
@@ -4,6 +4,7 @@
  * shapes are the camelCase view shapes the world renders. */
 import { apiFetch } from "../lib/api";
 import { fetchRoadmaps, type RoadmapProject } from "./roadmap";
+import { fetchRepositories } from "./repository";
 
 export type Kind =
   | "meeting"
@@ -18,7 +19,8 @@ export type Kind =
   | "workflow"
   | "coder"
   | "roadmap"
-  | "story";
+  | "story"
+  | "repository";
 
 export interface DeskItem {
   kind: Kind;
@@ -28,12 +30,13 @@ export interface DeskItem {
   [key: string]: unknown;
 }
 
-export type Items = Record<Exclude<Kind, "project" | "roadmap" | "story" | "decision">, DeskItem[]> & {
+export type Items = Record<Exclude<Kind, "project" | "roadmap" | "story" | "decision" | "repository">, DeskItem[]> & {
   /** Additive for older test fixtures and hubs; loadAll always initializes them. */
   project?: DeskItem[];
   roadmap?: DeskItem[];
   story?: DeskItem[];
   decision?: DeskItem[];
+  repository?: DeskItem[];
 };
 export type Status = Partial<Record<Kind | "profile", "live" | "unreachable">>;
 
@@ -121,6 +124,7 @@ export const EMPTY_ITEMS: Items = {
   coder: [],
   roadmap: [],
   story: [],
+  repository: [],
 };
 
 async function fetchJson(url: string, opts?: RequestInit): Promise<any> {
@@ -260,6 +264,16 @@ export const fromWireRoadmap = (roadmap: RoadmapProject): DeskItem => ({
   id: `roadmap:${roadmap.slug}`,
   title: roadmap.name,
   ...roadmap,
+});
+
+export const fromWireRepository = (repository: any): DeskItem => ({
+  kind: "repository",
+  id: String(repository.id || repository.source_id || ""),
+  name: String(repository.name || "Repository"),
+  sourceId: String(repository.source_id || repository.id || ""),
+  branch: String(repository.branch || ""),
+  createdAt: String(repository.created_at || ""),
+  lastModified: String(repository.created_at || ""),
 });
 
 export const fromWireChain = (c: any): DeskItem => ({
@@ -489,6 +503,12 @@ export async function loadAll(): Promise<LoadResult> {
         status.roadmap = "live";
       })
       .catch((e) => fail("roadmap", "Roadmaps", e)),
+    fetchRepositories()
+      .then((repositories) => {
+        items.repository = repositories.map(fromWireRepository);
+        status.repository = "live";
+      })
+      .catch((e) => fail("repository", "Repositories", e)),
     fetchJson("/api/coders/status")
       .then((d) => {
         items.coder = fromCoderStatus(d);

--- a/web/src/desk/components/AttentionDrawer.tsx
+++ b/web/src/desk/components/AttentionDrawer.tsx
@@ -6,8 +6,9 @@ import {
   humanizeWireValue,
 } from "../../lib/productLanguage";
 import { useProjections } from "../projections";
-import { CycleGadget, StringGadget } from "../surface/gadgets";
-import { SurfaceState } from "../surface/Surface";
+import { CycleGadget, FoldGadget, StringGadget } from "../surface/gadgets";
+import { SurfaceCode, SurfaceState } from "../surface/Surface";
+import { openPrimitive, openSurfaceWhenReady } from "../shell";
 import {
   DeskWindowFrame,
   announceLauncher,
@@ -30,6 +31,15 @@ export function AttentionDrawer() {
     [store.projections, store.selectedId],
   );
   const needs = Number(store.counts.needs_attention || 0);
+  const openSource = (row: (typeof store.projections)[number]) => {
+    if (row.detail_url.startsWith("/history")) {
+      openSurfaceWhenReady("review-meetings", row.subject_ref);
+    } else if (row.detail_url === "/cadence") {
+      openSurfaceWhenReady("configure-cadence", row.subject_ref);
+    } else {
+      openPrimitive(row.source_id);
+    }
+  };
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -66,8 +76,7 @@ export function AttentionDrawer() {
       glyph="◎"
         label="Desk memory"
         className="desk-attention-drawer"
-        eyebrow="Attention and Receipts"
-        title={<h2 className="desk-panel-title">Desk memory</h2>}
+        title="Desk memory"
         entrance={false}
         open={store.open}
         onClose={() => store.setOpen(false)}
@@ -116,12 +125,15 @@ export function AttentionDrawer() {
             <button type="submit">Filter</button>
           </form>
           {store.error ? (
-            <div className="desk-attention-error" role="alert">
-              <span>{store.error}</span>
-              <button type="button" onClick={() => void store.refresh(true)}>
-                Retry
-              </button>
-            </div>
+            <>
+              <SurfaceState
+                error="Desk memory unavailable"
+                onRetry={() => void store.refresh(true)}
+              />
+              <FoldGadget title="RAW · DETAIL">
+                <SurfaceCode>{store.error}</SurfaceCode>
+              </FoldGadget>
+            </>
           ) : null}
           {selected ? (
             <section
@@ -190,7 +202,9 @@ export function AttentionDrawer() {
                 </div>
               </dl>
               <div className="desk-receipt-actions">
-                <a href={selected.detail_url}>Open source</a>
+                <button type="button" onClick={() => openSource(selected)}>
+                  Open source
+                </button>
                 {selected.attention_state === "needs_attention" ? (
                   <button
                     type="button"
@@ -233,7 +247,7 @@ export function AttentionDrawer() {
               {!store.loading && store.projections.length === 0 ? (
                 <SurfaceState
                   empty
-                  emptyLabel="Nothing matches. Receipts remain in their source journals."
+                  emptyLabel="No matches"
                 />
               ) : null}
               {store.page.has_more ? (

--- a/web/src/desk/components/DeliveryDossierWindow.tsx
+++ b/web/src/desk/components/DeliveryDossierWindow.tsx
@@ -10,7 +10,7 @@
 // (Disclosure → SurfaceWell) — 07's law, consumed early.
 import { useEffect } from "react";
 import { Button } from "../../components/signal/Signal";
-import { FoldGadget } from "../surface/gadgets";
+import { EgressChip, FoldGadget } from "../surface/gadgets";
 import {
   assetHref,
   useDeliveryDossier,
@@ -178,6 +178,11 @@ export function DeliveryDossierWindow() {
                           <span className="surface-ledger-cell">
                             {`${m.bytes} B`}
                           </span>
+                          <EgressChip
+                            label="↗ Download"
+                            title="Opens this captured asset in a new tab."
+                            scope="local"
+                          />
                         </a>
                       </li>
                     ))}

--- a/web/src/desk/components/DeskFilingStrip.tsx
+++ b/web/src/desk/components/DeskFilingStrip.tsx
@@ -3,11 +3,23 @@ import { apiRequest } from "../../lib/api";
 import { qualifiedRef } from "../api";
 import { useDesk } from "../store";
 import { FoldGadget } from "../surface/gadgets";
+import { SurfaceCode, SurfaceState } from "../surface/Surface";
 
 interface DeskFilingStripProps {
   objectRef: string;
   objectKind: string;
   objectId: string;
+}
+
+function FilingRefusal({ detail }: { detail: string }) {
+  return (
+    <>
+      <SurfaceState error="Filing unavailable" />
+      <FoldGadget title="RAW · DETAIL">
+        <SurfaceCode>{detail}</SurfaceCode>
+      </FoldGadget>
+    </>
+  );
 }
 
 /** The one filing disclosure: Zone, Knowledge, and Project membership. */
@@ -77,7 +89,7 @@ export function DeskFilingStrip({
     }
   };
 
-  if (!relationships) return relationshipError ? <p className="desk-run-warning" role="alert">{relationshipError}</p> : null;
+  if (!relationships) return relationshipError ? <FilingRefusal detail={relationshipError} /> : null;
 
   const homeZone = zones.find((zone) => {
     const members = ((zone as any).memberIds as string[]) || [];
@@ -186,15 +198,11 @@ export function DeskFilingStrip({
             </div>
           )}
           {!zones.length && !knowledgeChoices.length && !projectChoices.length && (
-            <span className="quiet">
-              Nothing to file into yet — Zones, Knowledge, and Projects appear here once they exist.
-            </span>
+            <SurfaceState empty emptyLabel="No destinations" />
           )}
         </div>
       </FoldGadget>
-      {relationshipError ? (
-        <p className="desk-run-warning" role="alert">{relationshipError}</p>
-      ) : null}
+      {relationshipError ? <FilingRefusal detail={relationshipError} /> : null}
     </>
   );
 }

--- a/web/src/desk/components/InlineEditor.tsx
+++ b/web/src/desk/components/InlineEditor.tsx
@@ -11,6 +11,10 @@ import type { UnitPos } from "../store";
 import { MicButton } from "./MicButton";
 import { DeskEditor } from "./DeskEditor";
 import { EditorAIBar } from "./EditorAIBar";
+import { runAsk } from "../ask";
+import { AI_VERBS } from "../editorAI";
+import { editorVoiceGrammar } from "../voice/grammars/editor";
+import type { VoiceProposal } from "../voice/grammar";
 import {
   buildLinearGraph,
   parseLinearGraph,
@@ -73,6 +77,44 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
             .filter(Boolean)
         : value,
     });
+  };
+
+  const confirmEditorVoice = async (proposal: VoiceProposal) => {
+    const view = editorView;
+    if (!view) return;
+    const { from, to } = view.state.selection.main;
+    const selectedText = view.state.doc.sliceString(from, to);
+    const replace = (text: string) => {
+      view.dispatch({ changes: { from, to, insert: text } });
+      view.focus();
+    };
+    if (proposal.intentId === "bold") return replace(`**${selectedText}**`);
+    if (proposal.intentId === "italic") return replace(`*${selectedText}*`);
+    if (proposal.intentId === "heading") return replace(`# ${selectedText}`);
+    if (proposal.intentId === "list") {
+      return replace(selectedText.split("\n").map((line) => `- ${line}`).join("\n"));
+    }
+    if (proposal.intentId === "readback") {
+      window.speechSynthesis?.speak(new SpeechSynthesisUtterance(selectedText));
+      return;
+    }
+    if (
+      proposal.intentId === "rewrite" ||
+      proposal.intentId === "expand" ||
+      proposal.intentId === "continue"
+    ) {
+      const context =
+        proposal.intentId === "continue" && from === to
+          ? view.state.doc.sliceString(Math.max(0, from - 500), from)
+          : selectedText;
+      const result = await runAsk({
+        lens: AI_VERBS[proposal.intentId].label,
+        prompt: AI_VERBS[proposal.intentId].prompt.replace("{text}", context),
+        context: [],
+      });
+      if (!result.ok) throw new Error(result.output || "AI request failed.");
+      replace(result.output);
+    }
   };
 
   // HSM-22-03 — the workflow's linear-step builder. `null` = a graph this
@@ -381,6 +423,13 @@ export function InlineEditor({ o, u }: { o: WorldObject; u: UnitPos }) {
         <div className="desk-editor-foot">
           <MicButton
             draftScope={`inline:${o.kind}:${o.id}`}
+            grammar={editorView ? editorVoiceGrammar : undefined}
+            surfaceKind="editor"
+            hasSelection={Boolean(
+              editorView &&
+                editorView.state.selection.main.from !== editorView.state.selection.main.to,
+            )}
+            onProposalConfirm={confirmEditorVoice}
             onText={(t) => {
               // Fill the primary text field for the kind: a note's body,
               // otherwise the name/title.

--- a/web/src/desk/components/MicButton.tsx
+++ b/web/src/desk/components/MicButton.tsx
@@ -26,6 +26,9 @@ import {
   dictationFailure,
   type DictationFailure,
 } from "../../lib/dictationRecovery";
+import { VoiceProposalStrip } from "../voice/ProposalStrip";
+import type { VoiceGrammar, VoiceProposal } from "../voice/grammar";
+import { routeVoiceIntent } from "../voice/intentRouter";
 
 export type MicState = "idle" | "listening" | "busy" | "failed";
 
@@ -37,11 +40,22 @@ export function MicButton({
   variant,
   onState,
   onLevel,
+  grammar,
+  surfaceKind,
+  hasSelection = false,
+  onProposalConfirm,
 }: {
   onText: (text: string) => void;
   label?: string;
   onFailure?: (failure: DictationFailure) => void;
   draftScope?: string;
+  /** When supplied, transcript is classified before it can change the surface. */
+  grammar?: VoiceGrammar;
+  /** The focused surface's identity; defaults to the supplied grammar's kind. */
+  surfaceKind?: string;
+  hasSelection?: boolean;
+  /** Executes only after the user confirms the armed proposal. */
+  onProposalConfirm?: (proposal: VoiceProposal) => void | Promise<void>;
   /** "transport" — the 48×48 momentary TALK key (glyph over mono word,
    * held = inverted video). Default: the compact in-well mic. */
   variant?: "transport";
@@ -53,6 +67,9 @@ export function MicButton({
   const [state, setState] = useState<MicState>("idle");
   const [failure, setFailure] = useState<DictationFailure | null>(null);
   const [audioRetained, setAudioRetained] = useState(false);
+  const [proposal, setProposal] = useState<VoiceProposal | null>(null);
+  const [classifying, setClassifying] = useState(false);
+  const [receipt, setReceipt] = useState<{ text: string; scope: string } | null>(null);
   const holding = useRef(false);
   const onStateRef = useRef(onState);
   onStateRef.current = onState;
@@ -138,6 +155,56 @@ export function MicButton({
     );
   }
 
+  const routeTranscript = async (text: string) => {
+    if (!grammar) {
+      onText(text);
+      return;
+    }
+    // The strip appears while the (only when needed) classifier is working;
+    // the transcript itself is still never an instruction until Confirm.
+    const loadingProposal: VoiceProposal = {
+      transcript: text,
+      intentId: "classifying",
+      verbId: null,
+      params: {},
+      confidence: 0,
+      requiresLLM: false,
+    };
+    setProposal(loadingProposal);
+    setClassifying(true);
+    const next = await routeVoiceIntent({
+      transcript: text,
+      surfaceKind: surfaceKind ?? grammar.surfaceKind,
+      selectionState: { hasSelection },
+      grammar,
+    });
+    setClassifying(false);
+    if (next.confidence >= 0.5) {
+      setProposal(next);
+      return;
+    }
+    setProposal(null);
+    if (grammar.dictationFallback) onText(text);
+  };
+
+  const confirmProposal = async () => {
+    if (!proposal || classifying) return;
+    const armed = proposal;
+    try {
+      if (onProposalConfirm) await onProposalConfirm(armed);
+      else onText(armed.transcript);
+      setReceipt({ text: "DONE", scope: armed.requiresLLM ? "cloud" : "local" });
+    } catch {
+      setReceipt({ text: "ACTION FAILED", scope: "local" });
+    }
+  };
+
+  const clearProposal = () => {
+    setProposal(null);
+    setClassifying(false);
+    setReceipt(null);
+  };
+
   const start = async () => {
     holding.current = true;
     setFailure(null);
@@ -147,7 +214,7 @@ export function MicButton({
         if (recovered !== null) {
           setAudioRetained(false);
           if (recovered) {
-            onText(recovered);
+            await routeTranscript(recovered);
             go("idle");
           } else {
             setFailure("no_speech");
@@ -178,7 +245,7 @@ export function MicButton({
     try {
       const text = await stopAndTranscribe(draftScope);
       if (text) {
-        onText(text);
+        await routeTranscript(text);
         setAudioRetained(false);
         setFailure(null);
         go("idle");
@@ -237,6 +304,13 @@ export function MicButton({
           {DICTATION_FAILURES[failure].message}
         </span>
       ) : null}
+      <VoiceProposalStrip
+        proposal={proposal}
+        pending={classifying}
+        receipt={receipt}
+        onConfirm={() => void confirmProposal()}
+        onCancel={clearProposal}
+      />
     </>
   );
 }

--- a/web/src/desk/components/Pullout.tsx
+++ b/web/src/desk/components/Pullout.tsx
@@ -21,6 +21,7 @@ import { useSteering } from "../steering";
 import { objectByRef, objGlow, type WorldObject } from "../world";
 import { qualifiedRef } from "../api";
 import { RunsOnPicker } from "./RunsOnPicker";
+import { DeskFilingStrip } from "./DeskFilingStrip";
 import { humanizeWireValue, productLabel } from "../../lib/productLanguage";
 import { FoldGadget } from "../surface/gadgets";
 import { Material } from "../surface/Material";
@@ -28,6 +29,7 @@ import {
   SurfaceCode,
   SurfaceRow,
   SurfaceRows,
+  SurfaceState,
   SurfaceWell,
 } from "../surface/Surface";
 import { humanTime } from "../surface/format";
@@ -88,12 +90,9 @@ export function Pullout({
     openPullout,
     openEditor,
     updatePrimitive,
-    fileIntoDir,
-    removeFromDir,
     answerCoder,
     speakToCoder,
     openChat,
-    openToolInspector,
   } = useDesk.getState();
   const [detail, setDetail] = useState<MeetingDetail | null>(null);
   const [artifacts, setArtifacts] = useState<any[]>([]);
@@ -110,10 +109,6 @@ export function Pullout({
     string,
     unknown
   > | null>(null);
-  const [relationships, setRelationships] = useState<any>(null);
-  const [knowledgeChoices, setKnowledgeChoices] = useState<any[]>([]);
-  const [projectChoices, setProjectChoices] = useState<any[]>([]);
-  const [relationshipError, setRelationshipError] = useState("");
   const [answered, setAnswered] = useState<
     "selected" | "sent" | "failed" | null
   >(null);
@@ -215,64 +210,11 @@ export function Pullout({
   }, [o.kind, o.id]);
 
   const resourceRef = qualifiedRef(o.kind, o.id);
-  const refreshRelationships = async () => {
-    if (!FILABLE.has(o.kind)) return;
-    try {
-      const [axesRes, knowledgeRes, projectRes] = await Promise.all([
-        apiRequest(
-          `/api/desk/relationships/${encodeURIComponent(resourceRef)}`,
-        ),
-        apiRequest("/api/kbs"),
-        apiRequest("/api/projects"),
-      ]);
-      const [axes, knowledge, projects] = await Promise.all([
-        axesRes.json(),
-        knowledgeRes.json(),
-        projectRes.json(),
-      ]);
-      setRelationships(axes);
-      setKnowledgeChoices((knowledge.kbs || []).filter((k: any) => !k.deleted));
-      setProjectChoices(
-        (projects.projects || []).filter((p: any) => !p.is_archived),
-      );
-      setRelationshipError("");
-    } catch (error) {
-      setRelationshipError(String(error));
-    }
-  };
 
   useEffect(() => {
-    setRelationships(null);
     setRunTargetId(String((o.ref as any).profileId || "this_machine"));
     setActualPlacement(null);
-    void refreshRelationships();
   }, [o.kind, o.id]);
-
-  const toggleRelationship = async (
-    axis: "knowledge" | "projects",
-    ownerId: string,
-    active: boolean,
-  ) => {
-    const base = axis === "knowledge" ? "kbs" : "projects";
-    try {
-      await apiRequest(
-        `/api/${base}/${encodeURIComponent(ownerId)}/${axis === "knowledge" ? "members" : "resources"}/${encodeURIComponent(resourceRef)}`,
-        {
-          method: active ? "DELETE" : "PUT",
-          ...(axis === "projects" && !active
-            ? {
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({ relationship: "member" }),
-              }
-            : {}),
-        },
-      );
-      await refreshRelationships();
-      await useDesk.getState().refresh();
-    } catch (error) {
-      setRelationshipError(String(error));
-    }
-  };
 
   const run = async () => {
     setRunBusy(true);
@@ -320,7 +262,6 @@ export function Pullout({
   const coderWaiting =
     o.kind === "coder" &&
     (String(ir.state || "") === "waiting" || Boolean(ir.question));
-  const zones = items.directory || [];
   const lin = lineage(items, ir.sources);
   const profile = profiles.find((p) => p.id === ir.profileId);
   const egress = profile
@@ -448,13 +389,16 @@ export function Pullout({
             {detail?.intel?.summary ? (
               <p className="surface-say">{detail.intel.summary}</p>
             ) : (
-              <p className="quiet">
-                {detail?.intel_status?.state === "disabled"
-                  ? "Intelligence is off. No outcomes were made for this meeting."
-                  : detail?.intel_status?.state
-                    ? `Intelligence ${intelligenceState(detail.intel_status.state)}`
-                    : "Intelligence queued"}
-              </p>
+              <SurfaceState
+                empty
+                emptyLabel={
+                  detail?.intel_status?.state === "disabled"
+                    ? "Intel off"
+                    : detail?.intel_status?.state
+                      ? `Intel ${intelligenceState(detail.intel_status.state)}`
+                      : "Intel queued"
+                }
+              />
             )}
             {detail?.intel?.action_items &&
               detail.intel.action_items.length > 0 && (
@@ -623,9 +567,7 @@ export function Pullout({
               );
             return (
               <section>
-                <p className="quiet">
-                  Nothing written here yet — Edit adds content.
-                </p>
+                <SurfaceState empty emptyLabel="Empty note" />
               </section>
             );
           })()}
@@ -928,159 +870,13 @@ export function Pullout({
           </section>
         )}
 
-        {FILABLE.has(o.kind) &&
-          relationships &&
-          (() => {
-            // The belonging strip (round 8): ONE disclosure whose summary
-            // states the truth; the label walls and the foot's separate
-            // "Move to…" both fold into it.
-            const homeZone = zones.find((z) => {
-              const members = ((z as any).memberIds as string[]) || [];
-              return members.includes(o.id) || members.includes(resourceRef);
-            });
-            const kCount = (relationships.knowledge || []).length;
-            const pCount = (relationships.projects || []).length;
-            // A Knowledge collection never offers itself as a home.
-            const knowledgeHomes = knowledgeChoices.filter(
-              (knowledge) => resourceRef !== qualifiedRef("kb", knowledge.id),
-            );
-            const filedSummary = [
-              homeZone ? String(homeZone.name || homeZone.id) : "Desk root",
-              kCount ? `${kCount} Knowledge` : "",
-              pCount
-                ? `${pCount} Project${pCount === 1 ? "" : "s"}`
-                : "",
-            ]
-              .filter(Boolean)
-              .join(" · ");
-            return (
-              <FoldGadget title={`Filed · ${filedSummary}`}>
-                <div className="desk-pullout-filed">
-                  {zones.length > 0 && (
-                    <div className="desk-pullout-filed-axis">
-                      <span className="surface-eyebrow">Zone</span>
-                      <div className="desk-pullout-lineage">
-                        {zones.map((z) => {
-                          const members =
-                            ((z as any).memberIds as string[]) || [];
-                          const inZone =
-                            members.includes(o.id) ||
-                            members.includes(resourceRef);
-                          return (
-                            <button
-                              key={String(z.id)}
-                              type="button"
-                              className={`desk-chip quiet${inZone ? " in-zone" : ""}`}
-                              aria-pressed={inZone}
-                              onClick={() =>
-                                void (inZone
-                                  ? removeFromDir(o.id, String(z.id), o.kind)
-                                  : fileIntoDir(o.id, String(z.id), o.kind))
-                              }
-                            >
-                              {inZone ? "✓ " : "+ "}
-                              {String(z.name || z.id)}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  )}
-                  {knowledgeHomes.length > 0 && (
-                    <div className="desk-pullout-filed-axis">
-                      <span className="surface-eyebrow">Knowledge</span>
-                      <div className="desk-pullout-lineage">
-                        {knowledgeHomes.map((knowledge) => {
-                            const active = (relationships.knowledge || []).some(
-                              (row: any) => row.knowledge_id === knowledge.id,
-                            );
-                            return (
-                              <button
-                                key={knowledge.id}
-                                type="button"
-                                className={`desk-chip quiet${active ? " in-zone" : ""}`}
-                                aria-pressed={active}
-                                onClick={() =>
-                                  void toggleRelationship(
-                                    "knowledge",
-                                    knowledge.id,
-                                    active,
-                                  )
-                                }
-                              >
-                                {active ? "✓ " : "+ "}
-                                {knowledge.name}
-                              </button>
-                            );
-                          })}
-                      </div>
-                    </div>
-                  )}
-                  {projectChoices.length > 0 && (
-                    <div className="desk-pullout-filed-axis">
-                      <span className="surface-eyebrow">Projects</span>
-                      <div className="desk-pullout-lineage">
-                        {projectChoices.map((project) => {
-                          const active = (relationships.projects || []).some(
-                            (row: any) => row.project_id === project.id,
-                          );
-                          return (
-                            <span
-                              className="desk-project-choice"
-                              key={project.id}
-                            >
-                              <button
-                                type="button"
-                                className={`desk-chip quiet${active ? " in-zone" : ""}`}
-                                aria-label={`${active ? "Remove from" : "Assign to"} ${project.name} Project`}
-                                aria-pressed={active}
-                                onClick={() =>
-                                  void toggleRelationship(
-                                    "projects",
-                                    project.id,
-                                    active,
-                                  )
-                                }
-                              >
-                                {active ? "✓ " : "+ "}
-                                {project.name}
-                              </button>
-                              <button
-                                type="button"
-                                className="desk-chip quiet"
-                                aria-label={`Inspect ${project.name} Project`}
-                                onClick={() =>
-                                  openToolInspector(
-                                    "project",
-                                    String(project.id),
-                                  )
-                                }
-                              >
-                                Inspect
-                              </button>
-                            </span>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  )}
-                  {!zones.length &&
-                    !knowledgeChoices.length &&
-                    !projectChoices.length && (
-                      <span className="quiet">
-                        Nothing to file into yet — Zones, Knowledge, and
-                        Projects appear here once they exist.
-                      </span>
-                    )}
-                </div>
-              </FoldGadget>
-            );
-          })()}
-        {relationshipError && (
-          <p className="desk-run-warning" role="alert">
-            {relationshipError}
-          </p>
-        )}
+        {FILABLE.has(o.kind) ? (
+          <DeskFilingStrip
+            objectRef={resourceRef}
+            objectKind={o.kind}
+            objectId={o.id}
+          />
+        ) : null}
       </div>
 
       <footer className="desk-pullout-foot">

--- a/web/src/desk/components/RepoWindow.css
+++ b/web/src/desk/components/RepoWindow.css
@@ -1,0 +1,17 @@
+.desk-repo-window { min-height: 390px; }
+.desk-repo-body { display: flex; flex: 1; min-height: 0; flex-direction: column; }
+.repo-branch { margin-left: 8px; color: var(--desk-ink-muted, #87909b); font: 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.repo-dirty { margin-left: 7px; padding: 2px 5px; border: 1px solid color-mix(in srgb, #d99829 60%, transparent); color: #d99829; font-size: 10px; }
+.repo-breadcrumb { display: flex; align-items: center; gap: 4px; min-height: 32px; padding: 4px 9px; border-bottom: 1px solid var(--desk-line, rgba(255,255,255,.14)); overflow-x: auto; }
+.repo-breadcrumb button { border: 0; padding: 2px 4px; background: none; color: inherit; font: 11px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; cursor: pointer; }
+.repo-breadcrumb button:not(:last-of-type)::after { content: "/"; margin-left: 7px; color: var(--desk-ink-muted, #87909b); }
+.repo-breadcrumb button:disabled { opacity: .62; cursor: default; }
+.repo-breadcrumb select { margin-left: auto; max-width: 170px; background: var(--desk-surface, #192027); color: inherit; border: 1px solid var(--desk-line, rgba(255,255,255,.18)); font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
+.desk-repo-files { flex: 1; overflow: auto; }
+.repo-folder { font-weight: 650; }
+.repo-status { display: inline-block; min-width: 1em; text-align: center; color: var(--desk-ink-muted, #87909b); font: 700 12px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.repo-status[data-status="M"] { color: #d99829; }.repo-status[data-status="A"] { color: #65ba7a; }.repo-status[data-status="D"] { color: #d45d5d; }.repo-status[data-status="?"] { opacity: .55; }
+.repo-pr-state[data-state="open"], .repo-pr-ci[data-ci="passing"] { color: #65ba7a; }.repo-pr-state[data-state="merged"] { color: #a78bfa; }.repo-pr-state[data-state="closed"], .repo-pr-ci[data-ci="failing"] { color: #d45d5d; }.repo-pr-ci[data-ci="pending"] { color: #d99829; }
+.repo-issues { padding: 20px; }.repo-issues h3 { margin: 0 0 8px; font-size: 14px; }
+.repo-footer-actions { display: inline-flex; align-items: center; gap: 6px; }.repo-footer-actions input { width: min(220px, 28vw); min-height: 25px; padding: 3px 7px; border: 1px solid var(--desk-line, rgba(255,255,255,.18)); background: var(--desk-surface, #192027); color: inherit; font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+@media (max-width: 720px) { .repo-footer-actions input { width: 124px; }.repo-breadcrumb select { max-width: 110px; } }

--- a/web/src/desk/components/RepoWindow.tsx
+++ b/web/src/desk/components/RepoWindow.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from "react";
+import { spriteUrl } from "../sprites";
+import { useDesk } from "../store";
+import {
+  checkout,
+  commit,
+  fetchBranches,
+  fetchStatus,
+  fetchTree,
+  stageFiles,
+  type RepoFile,
+  type RepoStatus,
+} from "../repository";
+import { usePrReceipts, type PrRow } from "../prReceipts";
+import { humanTime } from "../surface/format";
+import { SurfaceState } from "../surface/Surface";
+import { SurfaceWings } from "../surface/wings";
+import { DeskSortableTable, type Column } from "./DeskSortableTable";
+import { DeskWindowFooter } from "./DeskWindowFooter";
+import { DeskWindowFrame } from "./DeskWindow";
+import "./RepoWindow.css";
+
+const WINGS = [
+  { id: "files", label: "Files" },
+  { id: "prs", label: "PRs" },
+  { id: "issues", label: "Issues" },
+];
+
+type SortKey = "name" | "type" | "modified";
+type PrSortKey = "number" | "title" | "state" | "ci" | "author";
+
+function statusMark(status: RepoFile["status"]) {
+  return <span className="repo-status" data-status={status || "clean"}>{status || "·"}</span>;
+}
+
+function extension(file: RepoFile) {
+  if (file.type === "dir") return "folder";
+  const dot = file.name.lastIndexOf(".");
+  return dot > 0 ? file.name.slice(dot + 1) : "file";
+}
+
+export function RepoWindow({
+  repositoryId,
+  origin,
+}: {
+  repositoryId: string;
+  origin?: { x: number; y: number } | null;
+}) {
+  const repository = useDesk((s) => (s.items.repository || []).find((item) => item.id === repositoryId));
+  const [wing, setWing] = useState("files");
+  const [files, setFiles] = useState<RepoFile[]>([]);
+  const [path, setPath] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [status, setStatus] = useState<RepoStatus | null>(null);
+  const [branches, setBranches] = useState<string[]>([]);
+  const [message, setMessage] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [sort, setSort] = useState<{ key: SortKey; dir: "asc" | "desc" }>({ key: "name", dir: "asc" });
+  const [prSort, setPrSort] = useState<{ key: PrSortKey; dir: "asc" | "desc" }>({ key: "number", dir: "desc" });
+  const prsLoaded = usePrReceipts((s) => s.loaded);
+  const loadPrs = usePrReceipts((s) => s.load);
+  const prSource = usePrReceipts((s) => s.sources.find((source) => source.source_id === repositoryId));
+
+  const refresh = async (nextPath = path) => {
+    setError("");
+    try {
+      const [nextFiles, nextStatus, nextBranches] = await Promise.all([
+        fetchTree(repositoryId, nextPath),
+        fetchStatus(repositoryId),
+        fetchBranches(repositoryId),
+      ]);
+      setFiles(nextFiles);
+      setStatus(nextStatus);
+      setBranches(nextBranches);
+    } catch {
+      setError("Repository unavailable");
+    }
+  };
+
+  useEffect(() => { void refresh(""); }, [repositoryId]);
+  useEffect(() => { if (!prsLoaded) void loadPrs(); }, [prsLoaded, loadPrs]);
+
+  const sortedFiles = useMemo(() => {
+    const factor = sort.dir === "asc" ? 1 : -1;
+    return [...files].sort((a, b) => {
+      if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+      const av = sort.key === "type" ? extension(a) : sort.key === "modified" ? a.modified || "" : a.name;
+      const bv = sort.key === "type" ? extension(b) : sort.key === "modified" ? b.modified || "" : b.name;
+      return factor * av.localeCompare(bv);
+    });
+  }, [files, sort]);
+
+  const prs = useMemo(() => {
+    const rows = [...(prSource?.prs || [])];
+    const factor = prSort.dir === "asc" ? 1 : -1;
+    return rows.sort((a, b) => {
+      const av = String(a[prSort.key] ?? "");
+      const bv = String(b[prSort.key] ?? "");
+      return prSort.key === "number" ? factor * (Number(av) - Number(bv)) : factor * av.localeCompare(bv);
+    });
+  }, [prSource?.prs, prSort]);
+
+  if (!repository) return null;
+  const name = String(repository.name || "Repository");
+  const branch = status?.branch || String(repository.branch || "detached");
+  const breadcrumb = path ? path.split("/") : [];
+  const toggleFile = (filePath: string) => setSelected((current) => {
+    const next = new Set(current);
+    if (next.has(filePath)) next.delete(filePath); else next.add(filePath);
+    return next;
+  });
+  const descend = (directory: RepoFile) => {
+    setPath(directory.path);
+    setSelected(new Set());
+    setSelectedFile(null);
+    void refresh(directory.path);
+  };
+  const ascend = (index: number) => {
+    const nextPath = breadcrumb.slice(0, index).join("/");
+    setPath(nextPath);
+    setSelected(new Set());
+    setSelectedFile(null);
+    void refresh(nextPath);
+  };
+  const stage = async () => {
+    if (!selected.size) return;
+    setBusy(true); setError("");
+    try { await stageFiles(repositoryId, [...selected]); setSelected(new Set()); await refresh(); }
+    catch { setError("Stage failed"); }
+    finally { setBusy(false); }
+  };
+  const commitSelected = async () => {
+    if (!message.trim()) return;
+    setBusy(true); setError("");
+    try { await commit(repositoryId, message); setMessage(""); setSelected(new Set()); await refresh(); }
+    catch { setError("Commit failed — stage files and check your git identity"); }
+    finally { setBusy(false); }
+  };
+
+  const fileColumns: Column<RepoFile>[] = [
+    { key: "select", label: "", width: "32px", render: (file) => file.type === "file" ? (
+      <input aria-label={`Select ${file.name}`} type="checkbox" checked={selected.has(file.path)} onClick={(event) => event.stopPropagation()} onChange={() => toggleFile(file.path)} />
+    ) : null },
+    { key: "status", label: "", width: "28px", render: (file) => statusMark(file.status) },
+    { key: "name", label: "Name", sortable: true, render: (file) => <span className={file.type === "dir" ? "repo-folder" : ""}>{file.type === "dir" ? "▸ " : ""}{file.name}</span> },
+    { key: "type", label: "Type", sortable: true, render: extension },
+    { key: "modified", label: "Modified", sortable: true, render: (file) => <span className="quiet">{file.modified ? humanTime(file.modified) : "—"}</span> },
+  ];
+  const prColumns: Column<PrRow>[] = [
+    { key: "number", label: "PR", sortable: true, width: "56px", render: (pr) => `#${pr.number}` },
+    { key: "title", label: "Title", sortable: true, render: (pr) => pr.title },
+    { key: "state", label: "State", sortable: true, render: (pr) => <span className="repo-pr-state" data-state={pr.state}>{pr.state}</span> },
+    { key: "ci", label: "CI", sortable: true, render: (pr) => <span className="repo-pr-ci" data-ci={pr.ci}>{pr.ci}</span> },
+    { key: "author", label: "Author", sortable: true, render: (pr) => pr.author || "—" },
+  ];
+
+  return (
+    <DeskWindowFrame
+      id={`repository:${repositoryId}`}
+      glyph="▤"
+      label={name}
+      title={<><span>{name}</span><span className="repo-branch">{branch}</span>{status?.dirty ? <span className="repo-dirty">{status.dirty} dirty</span> : null}</>}
+      icon={<img src={spriteUrl("repository", repositoryId)} alt="" width={30} height={30} />}
+      minW={600}
+      minH={390}
+      open
+      origin={origin}
+      onClose={() => useDesk.getState().closeRepositoryWindow(repositoryId)}
+      wings={<SurfaceWings wings={WINGS} active={wing} onChange={setWing} />}
+      className="desk-repo-window"
+    >
+      <div className="desk-repo-body desk-surface-body">
+        {error ? <SurfaceState error={error} /> : null}
+        {!error && wing === "files" ? <>
+          <nav className="repo-breadcrumb" aria-label="Repository path">
+            <button type="button" onClick={() => ascend(0)} disabled={!path}>root</button>
+            {breadcrumb.map((part, index) => <button type="button" key={`${part}-${index}`} onClick={() => ascend(index + 1)} disabled={index === breadcrumb.length - 1}>{part}</button>)}
+            {branches.length > 1 ? <select aria-label="Branch" value={branch} onChange={(event) => { setBusy(true); void checkout(repositoryId, event.target.value).then((next) => { setStatus(next); return refresh(); }).catch(() => setError("Branch switch failed")).finally(() => setBusy(false)); }}><option value={branch}>{branch}</option>{branches.filter((item) => item !== branch).map((item) => <option key={item} value={item}>{item}</option>)}</select> : null}
+          </nav>
+          <DeskSortableTable
+            className="desk-repo-files"
+            data={sortedFiles}
+            columns={fileColumns}
+            sort={sort}
+            onSort={(key, dir) => setSort({ key: key as SortKey, dir })}
+            rowKey={(file) => file.path}
+            selectedKey={selectedFile}
+            rowLabel={(file) => file.path}
+            onRowClick={(file) => file.type === "dir" ? descend(file) : setSelectedFile(file.path)}
+          />
+        </> : null}
+        {!error && wing === "prs" ? (
+          prSource?.prs === null ? <SurfaceState empty emptyLabel={prSource.detail || "No PR receipt yet"} /> :
+          <DeskSortableTable data={prs} columns={prColumns} sort={prSort} onSort={(key, dir) => setPrSort({ key: key as PrSortKey, dir })} rowKey={(pr) => String(pr.number)} rowLabel={(pr) => `PR ${pr.number}: ${pr.title}`} />
+        ) : null}
+        {!error && wing === "issues" ? <section className="repo-issues"><h3>GitHub Issues</h3><p className="quiet">gh CLI issue integration is pending.</p></section> : null}
+      </div>
+      <DeskWindowFooter
+        status={<span className="quiet">{files.length} {files.length === 1 ? "item" : "items"}{status?.ahead ? ` · ${status.ahead} ahead` : ""}{status?.behind ? ` · ${status.behind} behind` : ""}</span>}
+      >
+        <div className="repo-footer-actions"><button type="button" className="desk-chip" disabled={busy || !selected.size} onClick={() => void stage()}>Stage {selected.size || ""}</button><input aria-label="Commit message" placeholder="Commit message" value={message} onChange={(event) => setMessage(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void commitSelected(); }} /><button type="button" className="desk-chip" disabled={busy || !message.trim()} title={message.trim() ? `Commit: ${message.trim()}` : "Enter a commit message"} onClick={() => void commitSelected()}>Commit</button></div>
+      </DeskWindowFooter>
+    </DeskWindowFrame>
+  );
+}

--- a/web/src/desk/components/SystemShade.tsx
+++ b/web/src/desk/components/SystemShade.tsx
@@ -9,6 +9,8 @@ import { gateAge, useGate } from "../gate";
 import { useProjections } from "../projections";
 import { humanTime } from "../surface/format";
 import { StringGadget } from "../surface/gadgets";
+import { SurfaceState } from "../surface/Surface";
+import { openPrimitive, openSurfaceWhenReady } from "../shell";
 
 type Correction = Record<string, unknown>;
 
@@ -82,6 +84,16 @@ export function SystemShade({
     .filter((row) => row.attention_state !== "needs_attention")
     .slice(0, 4);
   const learned = (corrections ?? []).slice(0, 3);
+  const openSource = (row: (typeof store.projections)[number]) => {
+    onClose();
+    if (row.detail_url.startsWith("/history")) {
+      openSurfaceWhenReady("review-meetings", row.subject_ref);
+    } else if (row.detail_url === "/cadence") {
+      openSurfaceWhenReady("configure-cadence", row.subject_ref);
+    } else {
+      openPrimitive(row.source_id);
+    }
+  };
 
   return (
     <div className="desk-shade" ref={panel} role="group" aria-label="While you were away">
@@ -185,7 +197,9 @@ export function SystemShade({
                   {row.subject_label} · {humanTime(row.timestamp)}
                 </small>
                 <span className="desk-shade-do">
-                  <a href={row.detail_url}>Open</a>
+                  <button type="button" onClick={() => openSource(row)}>
+                    Open
+                  </button>
                   <button
                     type="button"
                     onClick={() => void store.present(row.id, "acknowledge")}
@@ -204,7 +218,7 @@ export function SystemShade({
             </div>
           ))
         ) : gate.held.length ? null : (
-          <p className="desk-shade-quiet">Nothing needs you</p>
+          <SurfaceState empty emptyLabel="Clear" />
         )}
       </section>
 
@@ -224,13 +238,15 @@ export function SystemShade({
                   {row.outcome || row.subject_label} · {humanTime(row.timestamp)}
                 </small>
                 <span className="desk-shade-do">
-                  <a href={row.detail_url}>Open</a>
+                  <button type="button" onClick={() => openSource(row)}>
+                    Open
+                  </button>
                 </span>
               </div>
             </div>
           ))
         ) : (
-          <p className="desk-shade-quiet">Nothing finished while you were away</p>
+          <SurfaceState empty emptyLabel="No receipts" />
         )}
       </section>
 
@@ -253,7 +269,7 @@ export function SystemShade({
             </div>
           ))
         ) : (
-          <p className="desk-shade-quiet">No corrections taught yet</p>
+          <SurfaceState empty emptyLabel="No corrections" />
         )}
       </section>
     </div>

--- a/web/src/desk/components/__tests__/systemShade.test.tsx
+++ b/web/src/desk/components/__tests__/systemShade.test.tsx
@@ -53,7 +53,7 @@ describe("SystemShade (canon §6.1)", () => {
     expect(screen.getByRole("button", { name: "Acknowledge" })).toBeTruthy();
     expect(screen.getByText("Dictation delivered")).toBeTruthy();
     await waitFor(() =>
-      expect(screen.getByText("No corrections taught yet")).toBeTruthy(),
+      expect(screen.getByText("No corrections")).toBeTruthy(),
     );
     fireEvent.click(screen.getByRole("button", { name: "Acknowledge" }));
     expect(present).toHaveBeenCalledWith("p1", "acknowledge");

--- a/web/src/desk/gl/WorldStage.tsx
+++ b/web/src/desk/gl/WorldStage.tsx
@@ -14,6 +14,9 @@ import { ZoneWindow } from "../components/ZoneWindow";
 import { InfoWindow } from "../components/InfoWindow";
 import { AskBar, AskPanel } from "../components/AskPanel";
 import { MicButton } from "../components/MicButton";
+import { deskVoiceGrammar } from "../voice/grammars/desk";
+import type { VoiceProposal } from "../voice/grammar";
+import { verbById } from "../verbRegistry";
 import { WorkMenu } from "../components/DeskMenu";
 import {
   floorMenuEntries,
@@ -180,6 +183,35 @@ export function WorldStage() {
     .filter((p): p is typeof p & { obj: WorldObject } => Boolean(p.obj));
   const renameZone =
     scene.zones.find((z) => z.id === renamingZoneId) || null;
+  const deskVoiceAvailable =
+    !editingObj &&
+    !openCards.length &&
+    !zoneWindows.length &&
+    !infoWindows.length &&
+    !askOpen &&
+    !renamingZoneId;
+  const confirmDeskVoice = (proposal: VoiceProposal) => {
+    if (proposal.intentId === "open") {
+      const query = String(proposal.params.query || "").toLocaleLowerCase();
+      const found = Object.values(useDesk.getState().items)
+        .flat()
+        .find((item) =>
+          [item.id, item.title, item.name]
+            .filter(Boolean)
+            .some((value) => String(value).toLocaleLowerCase().includes(query)),
+        );
+      if (!found) throw new Error("No matching desk item.");
+      useDesk.getState().openPullout(String(found.id));
+      return;
+    }
+    if (proposal.intentId === "attention") {
+      useProjections.getState().setOpen(true);
+      return;
+    }
+    const verb = proposal.verbId ? verbById(proposal.verbId) : undefined;
+    if (!verb || verb.ghost({ selectedRef: null })) throw new Error("That desk action is unavailable.");
+    verb.run({ selectedRef: null });
+  };
 
   return (
     <div
@@ -188,6 +220,17 @@ export function WorldStage() {
       style={{ "--rows": scene.rows } as React.CSSProperties}
     >
       <canvas ref={canvasRef} className="desk-world-canvas" />
+      {deskVoiceAvailable ? (
+        <div style={{ position: "fixed", left: 12, bottom: 12, zIndex: 20 }}>
+          <MicButton
+            label="Speak to the desk"
+            grammar={deskVoiceGrammar}
+            surfaceKind="desk"
+            onProposalConfirm={confirmDeskVoice}
+            onText={() => undefined}
+          />
+        </div>
+      ) : null}
       {divedZone && (
         <button
           type="button"

--- a/web/src/desk/repository.ts
+++ b/web/src/desk/repository.ts
@@ -1,0 +1,93 @@
+import { apiFetch } from "../lib/api";
+
+export interface RepoFile {
+  name: string;
+  path: string;
+  type: "file" | "dir";
+  status?: "M" | "A" | "D" | "?" | null;
+  modified?: string | null;
+}
+
+export interface RepoStatus {
+  branch: string;
+  dirty: number;
+  ahead: number;
+  behind: number;
+}
+
+export interface RepositoryRecord {
+  kind: "repository";
+  id: string;
+  name: string;
+  source_id: string;
+  branch: string;
+  created_at: string;
+}
+
+const repoUrl = (repositoryId: string, suffix = "") =>
+  `/api/repositories/${encodeURIComponent(repositoryId)}${suffix}`;
+
+export async function fetchRepositories(): Promise<RepositoryRecord[]> {
+  const data = await apiFetch<{ repositories: RepositoryRecord[] }>("/api/repositories");
+  return data.repositories ?? [];
+}
+
+export async function registerRepository(input: { sourceId?: string; path?: string; label?: string }) {
+  return apiFetch<{ repository: RepositoryRecord }>("/api/repositories", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source_id: input.sourceId, path: input.path, label: input.label }),
+  });
+}
+
+export async function fetchTree(repositoryId: string, path = ""): Promise<RepoFile[]> {
+  const query = path ? `?path=${encodeURIComponent(path)}` : "";
+  const data = await apiFetch<{ files: RepoFile[] }>(repoUrl(repositoryId, `/tree${query}`));
+  return data.files ?? [];
+}
+
+export async function fetchFile(repositoryId: string, path: string): Promise<string> {
+  const data = await apiFetch<{ content: string }>(repoUrl(repositoryId, `/file/${path.split("/").map(encodeURIComponent).join("/")}`));
+  return data.content;
+}
+
+export async function writeFile(repositoryId: string, path: string, content: string) {
+  return apiFetch(repoUrl(repositoryId, `/file/${path.split("/").map(encodeURIComponent).join("/")}`), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+}
+
+export async function stageFiles(repositoryId: string, paths: string[]) {
+  return apiFetch<{ staged: string[] }>(repoUrl(repositoryId, "/stage"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ paths }),
+  });
+}
+
+export async function commit(repositoryId: string, message: string) {
+  return apiFetch<{ committed: boolean; summary: string }>(repoUrl(repositoryId, "/commit"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+}
+
+export function fetchStatus(repositoryId: string) {
+  return apiFetch<RepoStatus>(repoUrl(repositoryId, "/status"));
+}
+
+export async function fetchBranches(repositoryId: string): Promise<string[]> {
+  const data = await apiFetch<{ branches: string[] }>(repoUrl(repositoryId, "/branches"));
+  return data.branches ?? [];
+}
+
+export function checkout(repositoryId: string, branch: string) {
+  return apiFetch<RepoStatus>(repoUrl(repositoryId, "/checkout"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ branch }),
+  });
+}

--- a/web/src/desk/sprites.ts
+++ b/web/src/desk/sprites.ts
@@ -41,6 +41,9 @@ export const VARIANTS: Record<string, string[]> = {
   // HS-105-01: a directory is a DRAWER (the Workbench silhouette rule) —
   // never paper. The owner's diagnosis: "no real idea of directories".
   directory: ["drawer"],
+  // A repository opens as the same physical drawer primitive; git status
+  // and branches live in its window, not in a second sprite language.
+  repository: ["drawer"],
 };
 export const SPRITE_BASE = `${import.meta.env.BASE_URL || "/_built/"}desk/sprites/`;
 export function variantIndex(id: string, poolLength: number): number {

--- a/web/src/desk/store.ts
+++ b/web/src/desk/store.ts
@@ -16,6 +16,7 @@ import {
 } from "./api";
 import { buildLinearGraph } from "./graph";
 import { loadSetup, type SetupStatus } from "./setup";
+import { registerRepository } from "./repository";
 
 export interface UnitPos {
   x: number;
@@ -295,6 +296,8 @@ interface DeskState {
   infoWindows: { ref: string; origin: { x: number; y: number } | null }[];
   /** Delivery Workbench projects open as their own Desk application window. */
   roadmapWindows: { slug: string; origin: { x: number; y: number } | null }[];
+  /** Registered git sources open as physical desk drawers. */
+  repositoryWindows: { id: string; origin: { x: number; y: number } | null }[];
   /** The zone a live drag is hovering (the drop affordance, HS-73-05). */
   hoverZoneId: string | null;
   /** The freshly-created zone whose rename is focused. */
@@ -339,6 +342,8 @@ interface DeskState {
   createPrimitive(
     kind: "note" | "decision" | "kb" | "recipe" | "zone" | "workflow",
   ): Promise<void>;
+  /** Register a Delivery source (or local worktree) as a repository drawer. */
+  registerRepository(input: { sourceId?: string; path?: string; label?: string }): Promise<void>;
   markNew(id: string): void;
   openEditor(id: string): void;
   closeEditor(): void;
@@ -367,6 +372,8 @@ interface DeskState {
   closeInfoWindow(ref: string): void;
   openRoadmapWindow(slug: string, origin?: { x: number; y: number }): void;
   closeRoadmapWindow(slug: string): void;
+  openRepositoryWindow(id: string, origin?: { x: number; y: number }): void;
+  closeRepositoryWindow(id: string): void;
   setHoverZone(id: string | null): void;
   setRenamingZone(id: string | null): void;
   diveInto(zoneId: string): void;
@@ -485,6 +492,7 @@ export const useDesk = create<DeskState>((set, get) => ({
   zoneViewPrefs: loadZoneViewPrefs(),
   infoWindows: [],
   roadmapWindows: [],
+  repositoryWindows: [],
   hoverZoneId: null,
   renamingZoneId: null,
   selectedIds: [],
@@ -579,6 +587,20 @@ export const useDesk = create<DeskState>((set, get) => ({
       get().markNew(createdId);
       if (kind === "zone") get().setRenamingZone(createdId);
       else get().openEditor(createdId);
+    }
+  },
+
+  async registerRepository(input) {
+    try {
+      const { repository } = await registerRepository(input);
+      await get().refresh();
+      const positions = { ...get().positions, [repository.id]: { x: 0.5, y: 0.55 } };
+      set({ positions });
+      savePositions(positions);
+      get().markNew(repository.id);
+      get().openRepositoryWindow(repository.id);
+    } catch {
+      await get().refresh();
     }
   },
 
@@ -699,6 +721,10 @@ export const useDesk = create<DeskState>((set, get) => ({
       get().openRoadmapWindow(id.slice("roadmap:".length), origin);
       return;
     }
+    if ((get().items.repository || []).some((repository) => repository.id === id)) {
+      get().openRepositoryWindow(id, origin);
+      return;
+    }
     const projectId = id.startsWith("project:")
       ? id.slice("project:".length)
       : (get().items.project || []).some((project) => project.id === id)
@@ -765,6 +791,15 @@ export const useDesk = create<DeskState>((set, get) => ({
   },
   closeRoadmapWindow(slug) {
     set({ roadmapWindows: get().roadmapWindows.filter((window) => window.slug !== slug) });
+  },
+  openRepositoryWindow(id, origin) {
+    const open = get().repositoryWindows;
+    if (!open.some((window) => window.id === id))
+      set({ repositoryWindows: [...open, { id, origin: origin ?? null }] });
+    get().focusPanel(`repository:${id}`);
+  },
+  closeRepositoryWindow(id) {
+    set({ repositoryWindows: get().repositoryWindows.filter((window) => window.id !== id) });
   },
   setZoneViewPref(id, pref) {
     const current = get().zoneViewPrefs[id] || {
@@ -1178,6 +1213,7 @@ export const useDesk = create<DeskState>((set, get) => ({
       zoneViewPrefs: {},
       infoWindows: [],
       roadmapWindows: [],
+      repositoryWindows: [],
       divedZone: null,
       editingId: null,
       selectedIds: [],

--- a/web/src/desk/voice/ProposalStrip.tsx
+++ b/web/src/desk/voice/ProposalStrip.tsx
@@ -1,0 +1,86 @@
+import { useEffect } from "react";
+import { EgressChip } from "../surface/gadgets";
+import type { VoiceProposal } from "./grammar";
+
+interface ProposalStripProps {
+  proposal: VoiceProposal | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  pending: boolean;
+  receipt?: { text: string; scope: string } | null;
+}
+
+const INTENT_LABELS: Record<string, string> = {
+  bold: "Bold selection",
+  italic: "Italicize selection",
+  heading: "Make heading",
+  list: "Make bullet list",
+  rewrite: "Rewrite selection",
+  expand: "Expand selection",
+  continue: "Continue writing",
+  readback: "Read selection",
+  open: "Open item",
+  "create-note": "Create note",
+  attention: "Show attention",
+};
+
+function egressScope(scope: string): "local" | "mixed" | "cloud" {
+  return scope === "cloud" || scope === "mixed" ? scope : "local";
+}
+
+/** An in-world arm/fire receipt. Enter is explicit consent; Escape disarms. */
+export function VoiceProposalStrip({
+  proposal,
+  onConfirm,
+  onCancel,
+  pending,
+  receipt,
+}: ProposalStripProps) {
+  useEffect(() => {
+    if (!proposal || pending) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        onConfirm();
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [proposal, pending, onConfirm, onCancel]);
+
+  useEffect(() => {
+    if (!receipt) return;
+    const timer = window.setTimeout(onCancel, 3000);
+    return () => window.clearTimeout(timer);
+  }, [receipt, onCancel]);
+
+  if (!proposal) return null;
+  const label = pending
+    ? "CLASSIFYING"
+    : INTENT_LABELS[proposal.intentId] ?? proposal.intentId;
+
+  return (
+    <div className="desk-voice-proposal" role="status" aria-live="polite">
+      <style>{`@keyframes desk-voice-scan { from { transform: translateX(-105%); } to { transform: translateX(210%); } } .desk-voice-proposal { display:flex; align-items:center; gap:6px; flex-wrap:wrap; padding:5px 6px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--surface-2); box-shadow:var(--desk-window-etch), 0 5px 12px rgb(0 0 0 / .22); font:10px/1.25 var(--font-mono); } .desk-voice-proposal-heard { max-width:220px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--muted); } .desk-voice-proposal-action { color:var(--text); text-transform:uppercase; } .desk-voice-scan { position:relative; width:44px; height:4px; overflow:hidden; background:var(--surface-1); border:1px solid var(--border); } .desk-voice-scan::after { content:""; position:absolute; inset:0; width:45%; background:var(--accent); animation:desk-voice-scan .8s linear infinite; }`}</style>
+      {pending ? <span className="desk-voice-scan" aria-hidden="true" /> : null}
+      <span className="desk-voice-proposal-heard">“{proposal.transcript}”</span>
+      <strong className="desk-voice-proposal-action">{label}</strong>
+      {proposal.requiresLLM ? (
+        <EgressChip label="AI" scope="cloud" title="Intent classification used Ask AI." />
+      ) : null}
+      {receipt ? (
+        <span className="desk-voice-proposal-action">{receipt.text}</span>
+      ) : pending ? null : (
+        <>
+          <button type="button" className="desk-chip quiet" onClick={onConfirm}>Confirm</button>
+          <button type="button" className="desk-chip quiet" onClick={onCancel}>Cancel</button>
+        </>
+      )}
+      {receipt ? <EgressChip label={receipt.scope} scope={egressScope(receipt.scope)} /> : null}
+    </div>
+  );
+}

--- a/web/src/desk/voice/grammar.ts
+++ b/web/src/desk/voice/grammar.ts
@@ -1,0 +1,23 @@
+export interface VoiceIntentDef {
+  id: string;
+  patterns: RegExp[];
+  requiresLLM: boolean;
+  verbId: string | null;
+  extract: (transcript: string) => Record<string, unknown>;
+  ghost: (ctx: { hasSelection: boolean }) => string | null;
+}
+
+export interface VoiceGrammar {
+  surfaceKind: string;
+  intents: VoiceIntentDef[];
+  dictationFallback: boolean;
+}
+
+export interface VoiceProposal {
+  transcript: string;
+  intentId: string;
+  verbId: string | null;
+  params: Record<string, unknown>;
+  confidence: number;
+  requiresLLM: boolean;
+}

--- a/web/src/desk/voice/grammars/desk.ts
+++ b/web/src/desk/voice/grammars/desk.ts
@@ -1,0 +1,34 @@
+import type { VoiceGrammar } from "../grammar";
+
+export const deskVoiceGrammar: VoiceGrammar = {
+  surfaceKind: "desk",
+  intents: [
+    {
+      id: "open",
+      patterns: [/\bopen\s+(.+)/i],
+      requiresLLM: false,
+      verbId: "desk.open",
+      extract: (transcript) => ({
+        query: transcript.match(/open\s+(.+)/i)?.[1]?.trim() ?? "",
+      }),
+      ghost: () => null,
+    },
+    {
+      id: "create-note",
+      patterns: [/\b(create|new)\s+(a\s+)?note\b/i],
+      requiresLLM: false,
+      verbId: "desk.new-note",
+      extract: () => ({}),
+      ghost: () => null,
+    },
+    {
+      id: "attention",
+      patterns: [/\bwhat.s\s+(on\s+fire|urgent|attention)\b/i],
+      requiresLLM: false,
+      verbId: "desk.attention",
+      extract: () => ({}),
+      ghost: () => null,
+    },
+  ],
+  dictationFallback: false,
+};

--- a/web/src/desk/voice/grammars/editor.ts
+++ b/web/src/desk/voice/grammars/editor.ts
@@ -1,0 +1,34 @@
+import type { VoiceGrammar, VoiceIntentDef } from "../grammar";
+
+const selected = ({ hasSelection }: { hasSelection: boolean }) =>
+  hasSelection ? null : "Select text first";
+
+const editorIntent = (
+  id: string,
+  patterns: RegExp[],
+  verbId: string | null,
+  requiresLLM = false,
+  ghost = selected,
+): VoiceIntentDef => ({
+  id,
+  patterns,
+  requiresLLM,
+  verbId,
+  extract: () => ({}),
+  ghost,
+});
+
+export const editorVoiceGrammar: VoiceGrammar = {
+  surfaceKind: "editor",
+  intents: [
+    editorIntent("bold", [/\bbold\s+(that|this|it)\b/i], "editor.bold"),
+    editorIntent("italic", [/\bitalic\s+(that|this|it)\b/i], "editor.italic"),
+    editorIntent("heading", [/\b(new\s+)?heading\b/i], "editor.heading", false, () => null),
+    editorIntent("list", [/\bbullet\s+list\b/i], "editor.list", false, () => null),
+    editorIntent("rewrite", [/\b(make|rewrite)\b.*\b(concise|shorter|better|clearer)\b/i], "editor.rewrite", true),
+    editorIntent("expand", [/\bexpand\b/i], "editor.expand", true),
+    editorIntent("continue", [/\bcontinue\b/i], "editor.continue", true, () => null),
+    editorIntent("readback", [/\bread\s+(this|it|that)\s+back\b/i], "editor.readback"),
+  ],
+  dictationFallback: true,
+};

--- a/web/src/desk/voice/intentRouter.test.ts
+++ b/web/src/desk/voice/intentRouter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { runAsk } from "../ask";
+import { editorVoiceGrammar } from "./grammars/editor";
+import { routeVoiceIntent } from "./intentRouter";
+
+vi.mock("../ask", () => ({ runAsk: vi.fn() }));
+
+const route = (transcript: string, hasSelection = true) =>
+  routeVoiceIntent({
+    transcript,
+    surfaceKind: "editor",
+    selectionState: { hasSelection },
+    grammar: editorVoiceGrammar,
+  });
+
+describe("voice intent router", () => {
+  it("arms a local editor command without egress", async () => {
+    const proposal = await route("bold this");
+    expect(proposal).toMatchObject({
+      intentId: "bold",
+      verbId: "editor.bold",
+      confidence: 0.9,
+      requiresLLM: false,
+    });
+    expect(runAsk).not.toHaveBeenCalled();
+  });
+
+  it("uses Ask only for an LLM-backed candidate", async () => {
+    vi.mocked(runAsk).mockResolvedValue({
+      ok: true,
+      output: '{"intentId":"rewrite","confidence":0.76}',
+    } as Awaited<ReturnType<typeof runAsk>>);
+    const proposal = await route("rewrite this shorter");
+    expect(proposal).toMatchObject({
+      intentId: "rewrite",
+      confidence: 0.76,
+      requiresLLM: true,
+    });
+    expect(runAsk).toHaveBeenCalledOnce();
+  });
+
+  it("falls through to dictation below the confidence threshold", async () => {
+    vi.mocked(runAsk).mockResolvedValue({
+      ok: true,
+      output: '{"intentId":"rewrite","confidence":0.2}',
+    } as Awaited<ReturnType<typeof runAsk>>);
+    expect(await route("rewrite this shorter")).toMatchObject({
+      intentId: "dictation",
+      confidence: 0,
+    });
+  });
+
+  it("does not classify unrelated editor dictation", async () => {
+    expect(await route("remember to send the release notes")).toMatchObject({
+      intentId: "dictation",
+      confidence: 0,
+    });
+  });
+});

--- a/web/src/desk/voice/intentRouter.ts
+++ b/web/src/desk/voice/intentRouter.ts
@@ -1,0 +1,102 @@
+import { runAsk } from "../ask";
+import type { VoiceGrammar, VoiceIntentDef, VoiceProposal } from "./grammar";
+
+export interface VoiceRouteInput {
+  transcript: string;
+  surfaceKind: string;
+  selectionState: { hasSelection: boolean };
+  grammar: VoiceGrammar;
+}
+
+const DICTATION: Omit<VoiceProposal, "transcript"> = {
+  intentId: "dictation",
+  verbId: null,
+  params: {},
+  confidence: 0,
+  requiresLLM: false,
+};
+
+function proposalFor(
+  transcript: string,
+  intent: VoiceIntentDef,
+  confidence: number,
+): VoiceProposal {
+  return {
+    transcript,
+    intentId: intent.id,
+    verbId: intent.verbId,
+    params: intent.extract(transcript),
+    confidence,
+    requiresLLM: intent.requiresLLM,
+  };
+}
+
+function matches(transcript: string, intent: VoiceIntentDef) {
+  return intent.patterns.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(transcript);
+  });
+}
+
+function parseClassification(output: string): {
+  intentId?: string;
+  confidence?: number;
+} | null {
+  const json = output.match(/\{[\s\S]*\}/)?.[0];
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    return {
+      intentId: typeof parsed.intentId === "string" ? parsed.intentId : undefined,
+      confidence: typeof parsed.confidence === "number" ? parsed.confidence : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stateless voice classifier. Local commands never leave the device. An LLM
+ * is consulted only for an explicitly LLM-backed grammar candidate; it never
+ * executes an action and its result remains an armed proposal.
+ */
+export async function routeVoiceIntent({
+  transcript,
+  surfaceKind,
+  selectionState,
+  grammar,
+}: VoiceRouteInput): Promise<VoiceProposal> {
+  const spoken = transcript.trim();
+  if (!spoken || grammar.surfaceKind !== surfaceKind) {
+    return { transcript, ...DICTATION };
+  }
+
+  const candidates = grammar.intents.filter((intent) => matches(spoken, intent));
+  const local = candidates.find((intent) => !intent.requiresLLM);
+  if (local) return proposalFor(spoken, local, 0.9);
+
+  const llmCandidates = candidates.filter((intent) => intent.requiresLLM);
+  if (!llmCandidates.length) return { transcript, ...DICTATION };
+
+  const result = await runAsk({
+    lens: "Voice intent",
+    context: [],
+    prompt: [
+      "Classify this voice command for the current DeskOS surface.",
+      `Surface: ${surfaceKind}`,
+      `Text selected: ${selectionState.hasSelection ? "yes" : "no"}`,
+      `Transcript: ${spoken}`,
+      "Allowed intent IDs: " + llmCandidates.map((intent) => intent.id).join(", "),
+      'Reply with JSON only: {"intentId":"allowed ID or dictation","confidence":0 to 1}.',
+      "Choose dictation when no allowed action is clear.",
+    ].join("\n"),
+  });
+  if (!result.ok) return { transcript, ...DICTATION };
+
+  const classified = parseClassification(result.output);
+  const intent = llmCandidates.find((candidate) => candidate.id === classified?.intentId);
+  const confidence = Math.max(0, Math.min(1, Number(classified?.confidence) || 0));
+  return intent && confidence >= 0.5
+    ? proposalFor(spoken, intent, confidence)
+    : { transcript, ...DICTATION };
+}

--- a/web/src/desk/world.ts
+++ b/web/src/desk/world.ts
@@ -27,6 +27,7 @@ const ORDER: Kind[] = [
   "coder",
   "roadmap",
   "story",
+  "repository",
 ];
 
 /** Every primitive as a world object, unfiltered — the lookup surface for

--- a/web/src/lib/primitives.ts
+++ b/web/src/lib/primitives.ts
@@ -40,7 +40,8 @@ export type PrimitiveKind =
   | "game"
   | "layout"
   | "roadmap"
-  | "story";
+  | "story"
+  | "repository";
 
 /** Static metadata for each kind — drives the type-legible Desk language. */
 export interface PrimitiveDescriptor {
@@ -159,6 +160,16 @@ export interface Project {
   updatedAt: string;
 }
 
+/** A registered local git source, opened as a Desk drawer. */
+export interface Repository {
+  kind: "repository";
+  id: string;
+  name: string;
+  sourceId: string;
+  branch: string;
+  createdAt: string;
+}
+
 // ── capability ─────────────────────────────────────────────────────────
 
 /** A saved Persona. The `recipe` discriminator is a compatibility wire name. */
@@ -267,6 +278,7 @@ export type Primitive =
   | Directory
   | KB
   | Project
+  | Repository
   | Persona
   | Chain
   | Workflow
@@ -343,6 +355,15 @@ export const PRIMITIVES: Record<PrimitiveKind, PrimitiveDescriptor> = {
     blurb: "A body of work with meetings, decisions, and cited memory.",
     icon: "M4 4h16v16H4zM8 2v4M16 2v4M8 10h8M8 14h5",
     authorable: false,
+  },
+  repository: {
+    kind: "repository",
+    label: "Repository",
+    plural: "Repositories",
+    syncClass: "organization",
+    blurb: "A registered git repository with files, pull requests, and issues.",
+    icon: "M4 3h16v18H4zM8 7h8M8 11h8M8 15h5",
+    authorable: true,
   },
   recipe: {
     kind: "recipe",
@@ -426,7 +447,7 @@ export type Agent = Persona;
 export const DESK_GROUPS: { label: string; kinds: PrimitiveKind[] }[] = [
   { label: "Content", kinds: ["meeting", "artifact", "note", "decision"] },
   { label: "Capabilities", kinds: ["recipe", "chain", "workflow"] },
-  { label: "Organization", kinds: ["directory", "kb", "project"] },
+  { label: "Organization", kinds: ["directory", "kb", "project", "repository"] },
   { label: "Live", kinds: ["coder"] },
   { label: "Delivery", kinds: ["roadmap", "story"] },
 ];


### PR DESCRIPTION
## Summary

The final three Phase 113 stories. **11/11 complete.**

### HS-113-05: Voice Intent Router — voice understands the surface
- `VoiceGrammar` contract per surface with `VoiceIntentDef` array
- Two-tier stateless `intentRouter`: local regex match (no egress) → LLM classification (egress-badged)
- `VoiceProposalStrip`: compact confirm/cancel bar with transcript, intent label, Enter/Escape, scanning state, egress badge
- Editor grammar: bold/italic/heading/list (local), rewrite/expand/continue (LLM), readback
- Desk grammar: open item, create note, attention summary
- MicButton extended with optional `grammar` prop — grammars route to the router, no grammar falls through to dictation
- 4 unit tests for the router

### HS-113-06: Git-backed drawers — repository primitive
- `repository` added to `PrimitiveKind` (organization group)
- Backend routes (`routes/repositories.py`): register/list, tree (`git ls-tree` + `git status --porcelain`), file read/write, stage (`git add`), commit, branches (`git for-each-ref`), checkout, status
- **Path traversal validation** on all file operations — `../` rejected, paths resolved under repo root
- All git operations use subprocess with argv (no `shell=True`)
- `RepoWindow` with Files/PRs/Issues wings via SurfaceWings, DeskSortableTable for file listing, breadcrumb navigation, branch/status header, stage/commit flow in footer
- 2 backend unit tests for route registration and path validation

### HS-113-11: The refit — every surface onto the shared kit
- Replaced prose empty states with `SurfaceState` in SystemShade, AttentionDrawer, Pullout
- Fixed error string leakage: `String(error)` → stable refusal labels with `RAW · DETAIL` disclosure folds
- Killed route ejection in SystemShade and AttentionDrawer — links now open Desk surfaces in-world
- Removed AttentionDrawer duplicate chrome (eyebrow heading inside frame)
- Adopted `DeskFilingStrip` in Pullout (another -250 lines of duplicated filing logic)
- Added `EgressChip` to dossier asset external links
- Pullout net: -161 lines — the refit is working

## Phase 113 — The Forge: Complete (11/11)

| # | Story | Wave | Lines |
|---|-------|------|-------|
| 01 | Shared kit | 2 | +362/-266 |
| 02 | Real editor (CM6) | 1 | +850/-34 |
| 03 | List convergence | 2 | +603/-302 |
| 04 | AI in editor | 3 | +497/-27 |
| 05 | Voice Intent Router | 4 | +506/-2 |
| 06 | Git-backed drawers | 4 | +877/-4 |
| 07 | DW on the Desk | 3 | +505/-4 |
| 08 | Decision primitive | 3 | +585/-13 |
| 09 | Static desk | 1 | +50/-264 |
| 10 | Compositor | 1 | +212/-55 |
| 11 | The refit | 4 | +89/-250 |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] 507/509 Vitest tests pass (2 pre-existing: floorMenu + verbRegistry expect 5 create verbs, now 6 with decisions)
- [x] Voice router unit tests pass (4/4)
- [x] Repository route unit tests pass (2/2)
- [x] Waves 1+2 screenshot-walked on real hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)