### PR TITLE
docs: ORCHESTRATION.md — the Muad'Dib method

### DIFF
--- a/docs/internal/ORCHESTRATION.md
+++ b/docs/internal/ORCHESTRATION.md
@@ -1,0 +1,136 @@
+# Orchestration — the Muad'Dib method
+
+How multi-agent phases run in this repository. The orchestrator is
+Muad'Dib; the implementation agents are the Fedaykin (Terras); the spice
+is the pipeline. Written after Phase 129 (One Grammar: two bug
+screenshots → four audits → eleven stories → thirteen Terras → merged,
+in one day), which is used throughout as the worked example.
+
+## The stance
+
+The orchestrator **decides, briefs, and verifies — it does not write
+product code** during phase execution. Its hands touch: roadmap files
+(authored directly, never delegated), memory, verification harnesses,
+and surgical corrections when a defect sits exactly at a seam it has
+already diagnosed (Phase 129's collector `stale`/`incompatible` fix).
+Everything else is a brief handed to a Terra.
+
+Three duties the orchestrator can never delegate:
+
+1. **The done call.** A Terra's "done" is a claim; the orchestrator
+   verifies on glass (screenshots against the live product) and by
+   running the FULL suites — Terras run only focused tests.
+2. **Scope honesty.** When reality breaks a chartered criterion, the
+   orchestrator amends it VISIBLY (story file + phase decision log +
+   "owner may overrule at the sitting") — never waives it silently.
+3. **The ledger.** Debt discovered mid-phase is counted, triaged
+   against the pre-phase baseline, logged into evidence, and assigned
+   a home. Silence about a red suite is the one unforgivable sin.
+
+## Phase shape: audit → charter → waves → walk
+
+### 1. Audit before charter
+
+A vague mandate ("make it a proper product") never goes straight to
+stories. Fan out **parallel read-only audit agents, one per plane**,
+each with a tight mission and a required report format:
+
+- structural census (code-level, exhaustive tables, file:line for
+  every claim);
+- live behavioral walk (the real running app, screenshots, measured
+  defects — never code-reading alone);
+- grammar/consistency audit against the Constitution;
+- architecture audit ending in a consolidation map and a
+  no-breakage migration order.
+
+Audits change nothing. Their reports are the charter's evidence base,
+and the live walk's shots become the phase's before-pictures.
+
+### 2. Charter from evidence
+
+The orchestrator authors the phase directly (status doc + stories),
+each story citing the audit findings down to file:line, each carrying
+acceptance criteria, an explicit out-scope, and a test plan. Deletion
+before invention: when audits show a correct pattern already exists
+(ZoneWindow's sibling foot; `SurfaceFooter`), the charter canonizes it
+and kills the impostors rather than inventing a new system. The
+charter commits through the gate like any other work.
+
+### 3. Implementation waves
+
+Terras implement in **parallel waves with serialized shipping**:
+
+- **The brief is the craft.** Each Terra gets: the story file, the
+  settled design (decided at charter — Terras implement, they do not
+  redesign), exact file paths and line anchors, the drift warning
+  ("verify anchors — N commits landed since the audit"), the list of
+  files OTHER Terras own right now (do-not-touch), the focused-tests-
+  only rule, and the hold-for-SHIP protocol.
+- **One commit lane.** All Terras share one working tree and branch.
+  They implement freely in parallel but ship one at a time, on an
+  explicit SHIP message from the orchestrator. Staging is by explicit
+  path only — `git add -A` is forbidden, always.
+- **Shared-tree etiquette.** A teammate's mid-edit file may break your
+  typecheck — retry once after 60s before reporting; never "fix"
+  another story's file. A single-file overlap that rides into the
+  earlier commit is documented in the later commit's body, not
+  panicked over.
+- **Honest reporting is rewarded.** A Terra that reports "this item
+  was already fixed by the keystone — no edit needed", "this move is
+  more than placement — backlogging it", or "the walk could not
+  exercise X" has done its job better than one that forces a change.
+
+### 4. Verification between landings
+
+After each keystone lands, the orchestrator: rebuilds, walks the real
+product with measured assertions (bounding boxes, scroll ownership,
+console errors), and runs the full suites the Terras were forbidden
+to run. New failures are triaged **against the pre-phase baseline**
+(same tests, pre-phase commit, same environment — a worktree with a
+properly pinned toolchain): reproduce-on-main = inherited debt for
+the ledger; new = the phase's to fix before anything flips.
+
+### 5. The walk
+
+The exit story re-runs the audit methodology against the finished
+product: every surface, every state, both widths, automated
+assertions, before/after pairs against the audit shots, the full
+check chain captured through `dw evidence capture`, and a reusable
+harness checked into `scripts/`. The walk story cannot be closed by
+unit tests alone and cannot be waived.
+
+### 6. The close
+
+Push, PR, then **watch → read → merge as separate acts**: watch CI to
+conclusion, READ the failures, diff the failure NAMES against main's
+own CI at the fork point. Merge on zero regressions, with the verdict
+posted as a PR comment. A red baseline inherited from main is named
+and ledgered — matching it silently is not an option; matching it
+loudly, with the diff attached, is the house practice made honest.
+
+## The machinery
+
+- **The gate.** Every commit — charter, story, amendment, docs —
+  carries a certified DW contract (`.githooks/dw contract new`, boxes
+  flipped honestly, evidence paired with done-flips). Mid-story
+  commits ship without the evidence file (the gate pairs evidence
+  with FLIPS); the flip commit carries it.
+- **Serialized SHIP.** The orchestrator is the commit-lane semaphore.
+  A Terra holding for SHIP does not stage, capture evidence, flip, or
+  contract.
+- **Background discipline.** Long runs (suites, CI) go under monitors
+  with failure-covering filters; the orchestrator keeps working and
+  is woken by events, never polls.
+- **Memory.** Session state, gotchas, and standing rules land in the
+  orchestrator's memory as they are learned, so the next session's
+  Muad'Dib starts where this one stood.
+
+## What the owner gets
+
+Status reports that lead with the outcome; a scoreboard, not a log;
+judgment calls surfaced as decisions with the evidence attached and
+the overrule explicitly offered; and a sitting exhibit at the end —
+the before-pictures they sent, next to the afters.
+
+*The Terras are the Fedaykin. The spice is the pipeline. It must
+flow — through the gate, every time.*

--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -3,6 +3,10 @@
 > **New here? Read [`HANDOVER.md`](./HANDOVER.md) first** — current state, where to
 > pick up, and the repo conventions that bite (PMO commit gate, write-once
 > evidence, no `Co-Authored-By`, metal-test exclusion).
+>
+> **Orchestrating a phase?** The multi-agent method — audit fleets, charter
+> from evidence, Terra waves with serialized shipping, walks, honest ledgers —
+> is canon at [`docs/internal/ORCHESTRATION.md`](../../../docs/internal/ORCHESTRATION.md).
 
 **Newest update (2026-08-08): Phase 129 — One Grammar — COMPLETE (11/11).**
 The exit walk passes all 38 surfaces with pinned-foot, stationary-head,


### PR DESCRIPTION
The owner asked for the orchestration methodology to be documented. This canonizes the method as practiced in Phase 129 (four audit Terras → evidence-grounded 11-story charter → thirteen implementation Terras with serialized gate shipping → verification walks → honest ledgers → watch/read/merge).

Docs-only: `docs/internal/ORCHESTRATION.md` + a pointer in the roadmap README's new-here block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)