### PR TITLE
Handle older settings payloads

### DIFF
--- a/web/src/pages/cores/SettingsCore.tsx
+++ b/web/src/pages/cores/SettingsCore.tsx
@@ -69,6 +69,30 @@ const ROTATABLE_SECRETS = new Set([
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
+
+/** Apply one settings transaction even when an older payload lacks a new section. */
+export function mergeSettingsChanges(
+  source: SettingsResponse,
+  changes: Array<[string[], unknown]>,
+): SettingsResponse {
+  const draft = clone(source);
+  for (const [path, next] of changes) {
+    if (!path.length) continue;
+    let cursor = draft as Record<string, unknown>;
+    path.forEach((part, index) => {
+      if (index === path.length - 1) {
+        cursor[part] = next;
+        return;
+      }
+      const child = cursor[part];
+      if (!child || typeof child !== "object" || Array.isArray(child)) {
+        cursor[part] = {};
+      }
+      cursor = cursor[part] as Record<string, unknown>;
+    });
+  }
+  return draft;
+}
 /* HS-101 round 4 — the glass never wears wire keys: curated names
  * for the fields people actually meet, an acronym dictionary for the
  * rest. */
@@ -189,14 +213,7 @@ function SettingsFace({ hero, scope }: CoreProps) {
     }
   };
   const updateMany = (changes: Array<[string[], unknown]>) => {
-    const draft = clone(resource.data);
-    for (const [path, next] of changes) {
-      let cursor = draft;
-      path.forEach((part, index) => {
-        if (index === path.length - 1) cursor[part] = next;
-        else cursor = cursor[part] as Record<string, unknown>;
-      });
-    }
+    const draft = mergeSettingsChanges(resource.data, changes);
     resource.setData(draft);
     setRefusal("");
     clearTimeout(saveTimer.current);

--- a/web/src/pages/cores/__tests__/SettingsCore.test.ts
+++ b/web/src/pages/cores/__tests__/SettingsCore.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { mergeSettingsChanges } from "../SettingsCore";
+
+describe("SettingsCore atomic settings writer", () => {
+  it("creates a newly introduced settings section in an older payload", () => {
+    const legacy = {
+      meeting: { intel_provider: "local" },
+      dictation: { runtime: { backend: "auto" } },
+    } as never;
+
+    const merged = mergeSettingsChanges(legacy, [
+      [["thoughts", "inference_target_id"], "preset_openrouter_qwen3_8b"],
+    ]);
+
+    expect(merged).toMatchObject({
+      meeting: { intel_provider: "local" },
+      dictation: { runtime: { backend: "auto" } },
+      thoughts: { inference_target_id: "preset_openrouter_qwen3_8b" },
+    });
+    expect(legacy).not.toHaveProperty("thoughts");
+  });
+
+  it("creates every missing intermediate object for a coupled local choice", () => {
+    const merged = mergeSettingsChanges({} as never, [
+      [["meeting", "intel_realtime_model"], "/Models/qwen.gguf"],
+      [["thoughts", "inference_target_id"], null],
+      [["dictation", "runtime", "backend"], "llama_cpp"],
+    ]);
+
+    expect(merged).toMatchObject({
+      meeting: { intel_realtime_model: "/Models/qwen.gguf" },
+      thoughts: { inference_target_id: null },
+      dictation: { runtime: { backend: "llama_cpp" } },
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- make the atomic settings writer create missing intermediate sections
- preserve the source payload while applying coupled settings changes
- add exact regressions for a pre-Thoughts settings payload and fully empty nested settings

## Root cause

The OpenRouter target and secret were created successfully, but selecting the preset attempted to write thoughts.inference_target_id into an older settings object with no thoughts section. Safari surfaced that nested assignment failure as the minified undefined-object error.

## Validation

- 27 focused Settings and model-setup UI tests passed
- isolated-HOME model setup glass passed at 1440 and 393
- production Vite build passed
- Delivery Workbench short contract passed