### PR TITLE
Repair Phase 142 integration contracts

### DIFF
--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-01.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-01.md
@@ -150,3 +150,21 @@ The replacement still executes the real browser, Workbench, API, kernel,
 context picker, Stop/result race, composite answer, and restart paths at 1440
 and 393. Context application and MCP authority remain covered by their focused
 backend suites.
+
+### Post-merge integration contract repair — 2026-08-21
+
+The full macOS integration job found two test contracts that predated the
+production coordinator admission seam and current first-value recovery copy.
+Both were corrected and rerun directly:
+
+```text
+uv run pytest -q \
+  tests/integration/test_refinement_coordinator_kernel.py::test_real_kernel_turn_reaches_review_then_answer_does_not_auto_chain \
+  tests/integration/test_web_welcome_wizard.py::test_basic_value_precedes_optional_runs_on_setup -vv
+2 passed in 0.49s
+```
+
+The coordinator proof now binds the production Ask factory to its exact test
+broker instead of accidentally entering the scripted-claim seam. The welcome
+proof asserts that first-value custody precedes the failure-only Setup door,
+without resurrecting the retired Runs-on setup copy.

--- a/tests/integration/test_refinement_coordinator_kernel.py
+++ b/tests/integration/test_refinement_coordinator_kernel.py
@@ -8,7 +8,6 @@ from fastapi.testclient import TestClient
 from holdspeak.db import Database, reset_database
 from holdspeak.kernel.runtime import _configure
 from holdspeak.principals import Principal, PrincipalKind
-from holdspeak.services.ask_service import AskService
 from holdspeak.services.refinement_coordinator import RefinementCoordinator
 from holdspeak.services.refinement_thought_service import (
     INBOX_DIRECTORY_ID,
@@ -44,9 +43,11 @@ async def test_real_kernel_turn_reaches_review_then_answer_does_not_auto_chain(t
     engine = _ScriptedEngine()
     broker = _configure(db)
     monkeypatch.setattr(broker.inference_runner, "_engine_factory", lambda _revision, **_kw: engine)
-    coordinator = RefinementCoordinator(
-        db, ask_factory=lambda: AskService(db, broker=broker)
-    )
+    monkeypatch.setattr("holdspeak.kernel.runtime._service", lambda: broker)
+    # Keep the coordinator on its real default-admission seam and bind the
+    # production AskService factory to this test's exact broker. The injected
+    # ask_factory seam deliberately carries a scripted test claim.
+    coordinator = RefinementCoordinator(db)
     await coordinator.start()
     service = RefinementThoughtService(db)
     thought = service.create(

--- a/tests/integration/test_web_welcome_wizard.py
+++ b/tests/integration/test_web_welcome_wizard.py
@@ -34,11 +34,12 @@ def test_welcome_is_the_same_one_step_first_value_surface_as_the_desk() -> None:
 def test_basic_value_precedes_optional_runs_on_setup() -> None:
     first_words = (_REPO / "web/src/desk/components/FirstWords.tsx").read_text()
     assert "Dictate one sentence" in first_words
-    basic_value = first_words.index("Dictation is ready on this machine.")
-    optional_runs = first_words.index("Configure rewrite destination")
-    assert basic_value < optional_runs
-    # HS-95-07: the Runs on affordance opens in-world through the shell.
-    assert 'openSurfaceOr("configure-runs-on", "/profiles")' in first_words
+    basic_value = first_words.index("Keep as Note")
+    optional_setup = first_words.index('openSurfaceOr("configure-setup", "/setup")')
+    assert basic_value < optional_setup
+    # Setup remains a failure-only recovery door after the first-value actions;
+    # Models/destination choice no longer competes with the initial sentence.
+    assert "failureContract?.setup" in first_words
 
 
 def test_first_dictation_retains_editable_text_and_all_recovery_doors() -> None:


### PR DESCRIPTION
## Outcome

Repairs the two stale integration-test contracts found by the full macOS run after Phase 142 Story 01 merged.

## Fixes

- binds the production coordinator/Ask factory to the test's exact scripted broker instead of entering the fake-claim seam
- updates the first-value ordering assertion to the current failure-only Setup recovery door and removes retired Runs-on copy assumptions
- records the focused rerun in Story 01 evidence

## Verification

`2 passed in 0.49s` for the two exact failed integration tests.
