### PR TITLE
Unify model selection and activate local GGUFs

### DIFF
--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -9,7 +9,7 @@ and the clients that call it (extracted from the real call sites in
 `web/src` and `apple/`). "server only" means no in-repo client calls
 it today.
 
-Routes: 515 (plus static mounts). iOS-consumed: 89. Web-consumed: 405.
+Routes: 516 (plus static mounts). iOS-consumed: 89. Web-consumed: 406.
 
 ## device_audio_ws
 
@@ -771,6 +771,7 @@ Routes: 515 (plus static mounts). iOS-consumed: 89. Web-consumed: 405.
 | Method | Path | Consumers |
 |---|---|---|
 | POST | `/api/inference/acquisitions/download-and-use` | web |
+| POST | `/api/inference/acquisitions/use-existing` | web |
 | GET | `/api/inference/acquisitions/{job_id}` | web |
 | POST | `/api/inference/acquisitions/{job_id}/cancel` | web |
 | GET | `/api/inference/setup` | web |

--- a/docs/MCP_SIDECAR.md
+++ b/docs/MCP_SIDECAR.md
@@ -81,13 +81,16 @@ admitted inference path and returns the answer with its receipt.
 `ask.cancel` cancels an in-flight invocation. `ask.keep` persists an
 answer as a desk artifact (not model-invoking).
 
-### inference (2 tools)
+### inference (3 tools)
 
 Owner-only durable local-model setup. `inference.download_and_use` records one
 stable command, resolves a signed catalogue source, downloads bounded bytes,
 verifies the published digest, adopts the content-addressed artifact, and then
-attempts the narrow Thoughts-route activation. `inference.cancel_model_acquisition`
-cancels only before verification begins. Both use the same application service,
+attempts the narrow Thoughts-route activation. `inference.use_existing_model`
+freshly resolves a projected local GGUF, verifies its complete contents, adopts
+it without exposing its locator, and activates it through the same ledger.
+`inference.cancel_model_acquisition` cancels only before verification begins.
+All three use the same application service,
 receipts, and refusal codes as HTTP; model/agent principals receive no authority
 through these tools.
 

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -2557,6 +2557,16 @@
       ]
     },
     {
+      "path": "/api/inference/acquisitions/use-existing",
+      "methods": [
+        "POST"
+      ],
+      "module": "web.routes.setup",
+      "consumers": [
+        "web"
+      ]
+    },
+    {
       "path": "/api/inference/acquisitions/{job_id}",
       "methods": [
         "GET"

--- a/holdspeak/inference_setup_catalog.py
+++ b/holdspeak/inference_setup_catalog.py
@@ -23,11 +23,11 @@ _EXPERIENCES = frozenset({"quick", "balanced", "deep"})
 
 
 PACKAGED_CATALOG_SCHEMA_VERSION = 1
-PACKAGED_CATALOG_MIN_REVISION = 2
-_PACKAGED_CATALOG_KEY_ID = "holdspeak_catalog_2026_03"
+PACKAGED_CATALOG_MIN_REVISION = 3
+_PACKAGED_CATALOG_KEY_ID = "holdspeak_catalog_2026_08"
 _PACKAGED_CATALOG_TRUST_ROOTS = {
     _PACKAGED_CATALOG_KEY_ID: bytes.fromhex(
-        "bbd7a874461c9038e03cba19a6c2749e0f4188c288bd480e48617d016e1d0299"
+        "c62c5c263520c00a76026bea4ca5636b61f1e4a00f0f867c6a776d13d5eb28ed"
     )
 }
 _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
@@ -36,6 +36,7 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
         "id": "preset_local_qwen35_4b_gguf_q4km",
         "experience": "quick",
         "label": "Quick local Qwen",
+        "summary": "Fast local Thought interviews and everyday writing.",
         "runtime_id": "llama_cpp_prompt_v1",
         "runtime_min_revision": "0.3.34",
         "format": "gguf",
@@ -56,10 +57,36 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
         "applicability": {"state": "applicable", "reason": None},
     },
     {
+        "kind": "local_artifact_preset",
+        "id": "preset_local_qwen35_08b_gguf_q4km",
+        "experience": "quick",
+        "label": "Tiny local Qwen",
+        "summary": "A 0.8B local model for intent, routing, and lightweight work.",
+        "runtime_id": "llama_cpp_prompt_v1",
+        "runtime_min_revision": "0.3.34",
+        "format": "gguf",
+        "boundary": "same_device",
+        "context": {"recommended_tokens": 8192, "ceiling_tokens": 8192},
+        "source": {
+            "repository": "unsloth/Qwen3.5-0.8B-GGUF",
+            "revision": "6ab461498e2023f6e3c1baea90a8f0fe38ab64d0",
+            "filename": "Qwen3.5-0.8B-Q4_K_M.gguf",
+            "file_sha256": "sha256:bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517",
+            "manifest_sha256": "sha256:ec6d18c20bccb7db96fd368b275ce3017d84046e8573b1ebc7854bed83ce348b",
+            "download_bytes": 532_517_120,
+            "installed_bytes": 532_517_120,
+            "peak_free_bytes": 1_200_000_000,
+            "license": "Apache-2.0",
+        },
+        "platforms": ["darwin_arm64", "linux_x86_64", "linux_aarch64"],
+        "applicability": {"state": "applicable", "reason": None},
+    },
+    {
         "kind": "hosted_profile_preset",
         "id": "preset_openrouter_qwen3_8b",
         "experience": "quick",
         "label": "OpenRouter · Quick Qwen",
+        "summary": "A small, fast Qwen for short Notes and everyday work.",
         "provider_adapter": "openai_compatible",
         "model_id": "qwen/qwen3-8b",
         "boundary": "external_service",
@@ -81,6 +108,7 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
         "id": "preset_openrouter_qwen35_35b_a3b",
         "experience": "balanced",
         "label": "OpenRouter · Balanced Qwen",
+        "summary": "Strong general reasoning without using a giant model.",
         "provider_adapter": "openai_compatible",
         "model_id": "qwen/qwen3.5-35b-a3b",
         "boundary": "external_service",
@@ -102,6 +130,7 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
         "id": "preset_openrouter_qwen38_27b",
         "experience": "deep",
         "label": "OpenRouter · Deep Qwen",
+        "summary": "Deeper cloud reasoning for harder synthesis.",
         "provider_adapter": "openai_compatible",
         "model_id": "qwen/qwen3.8-27b",
         "boundary": "external_service",
@@ -114,6 +143,72 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
             "kind": "openAICompatible",
             "base_url": "https://openrouter.ai/api/v1",
             "model": "qwen/qwen3.8-27b",
+            "context_limit": 262_144,
+            "requires_key": True,
+        },
+    },
+    {
+        "kind": "hosted_profile_preset",
+        "id": "preset_openrouter_qwen37_flash",
+        "experience": "quick",
+        "label": "OpenRouter · Qwen Flash",
+        "summary": "The quickest economical Qwen choice for everyday work.",
+        "provider_adapter": "openai_compatible",
+        "model_id": "qwen/qwen3.7-flash",
+        "boundary": "external_service",
+        "secret_requirement": "profile_key",
+        "context": {"support": "bounded", "working_ceiling_tokens": 16_384},
+        "applicability": {"state": "applicable", "reason": None},
+        "existing_profile": {
+            "target_id": "preset_openrouter_qwen37_flash",
+            "name": "OpenRouter · Qwen Flash",
+            "kind": "openAICompatible",
+            "base_url": "https://openrouter.ai/api/v1",
+            "model": "qwen/qwen3.7-flash",
+            "context_limit": 1_000_000,
+            "requires_key": True,
+        },
+    },
+    {
+        "kind": "hosted_profile_preset",
+        "id": "preset_openrouter_gemma4_26b",
+        "experience": "balanced",
+        "label": "OpenRouter · Gemma 4",
+        "summary": "A capable Gemma 4 alternative for writing and synthesis.",
+        "provider_adapter": "openai_compatible",
+        "model_id": "google/gemma-4-26b-a4b-it",
+        "boundary": "external_service",
+        "secret_requirement": "profile_key",
+        "context": {"support": "bounded", "working_ceiling_tokens": 32_768},
+        "applicability": {"state": "applicable", "reason": None},
+        "existing_profile": {
+            "target_id": "preset_openrouter_gemma4_26b",
+            "name": "OpenRouter · Gemma 4",
+            "kind": "openAICompatible",
+            "base_url": "https://openrouter.ai/api/v1",
+            "model": "google/gemma-4-26b-a4b-it",
+            "context_limit": 262_144,
+            "requires_key": True,
+        },
+    },
+    {
+        "kind": "hosted_profile_preset",
+        "id": "preset_openrouter_qwen3_coder_next",
+        "experience": "deep",
+        "label": "OpenRouter · Coding Qwen",
+        "summary": "A coding-focused Qwen for technical plans and implementation.",
+        "provider_adapter": "openai_compatible",
+        "model_id": "qwen/qwen3-coder-next",
+        "boundary": "external_service",
+        "secret_requirement": "profile_key",
+        "context": {"support": "bounded", "working_ceiling_tokens": 32_768},
+        "applicability": {"state": "applicable", "reason": None},
+        "existing_profile": {
+            "target_id": "preset_openrouter_qwen3_coder_next",
+            "name": "OpenRouter · Coding Qwen",
+            "kind": "openAICompatible",
+            "base_url": "https://openrouter.ai/api/v1",
+            "model": "qwen/qwen3-coder-next",
             "context_limit": 262_144,
             "requires_key": True,
         },
@@ -143,7 +238,7 @@ def validate_catalog(entries: Iterable[dict[str, Any]]) -> tuple[dict[str, Any],
             raise ValueError(f"preset[{ordinal}] must be an object")
         kind = raw.get("kind")
         if kind == "hosted_profile_preset":
-            _exact(raw, {"kind", "id", "experience", "label", "provider_adapter", "model_id", "boundary", "secret_requirement", "context", "applicability", "existing_profile"}, f"preset[{ordinal}]")
+            _exact(raw, {"kind", "id", "experience", "label", "summary", "provider_adapter", "model_id", "boundary", "secret_requirement", "context", "applicability", "existing_profile"}, f"preset[{ordinal}]")
             if raw["provider_adapter"] != "openai_compatible" or raw["boundary"] != "external_service" or raw["secret_requirement"] != "profile_key":
                 raise ValueError(f"preset[{ordinal}] has unsupported hosted authority")
             if not isinstance(raw["model_id"], str) or not _MODEL_ID.fullmatch(raw["model_id"]):
@@ -156,7 +251,7 @@ def validate_catalog(entries: Iterable[dict[str, Any]]) -> tuple[dict[str, Any],
                 raise ValueError(f"preset[{ordinal}] context limit is invalid")
             _safe_text(profile["name"], f"preset[{ordinal}].existing_profile.name")
         elif kind == "local_artifact_preset":
-            _exact(raw, {"kind", "id", "experience", "label", "runtime_id", "runtime_min_revision", "format", "boundary", "context", "source", "platforms", "applicability"}, f"preset[{ordinal}]")
+            _exact(raw, {"kind", "id", "experience", "label", "summary", "runtime_id", "runtime_min_revision", "format", "boundary", "context", "source", "platforms", "applicability"}, f"preset[{ordinal}]")
             if raw["format"] not in {"gguf", "mlx_safetensors"} or raw["boundary"] != "same_device":
                 raise ValueError(f"preset[{ordinal}] has invalid local format/boundary")
             _safe_text(raw["runtime_id"], f"preset[{ordinal}].runtime_id", limit=96)
@@ -212,6 +307,7 @@ def validate_catalog(entries: Iterable[dict[str, Any]]) -> tuple[dict[str, Any],
         if raw.get("experience") not in _EXPERIENCES:
             raise ValueError(f"preset[{ordinal}].experience is invalid")
         _safe_text(raw.get("label"), f"preset[{ordinal}].label")
+        _safe_text(raw.get("summary"), f"preset[{ordinal}].summary", limit=200)
         _exact(raw["context"], {"support", "working_ceiling_tokens"}, f"preset[{ordinal}].context") if kind == "hosted_profile_preset" else None
         if kind == "hosted_profile_preset" and (raw["context"]["support"] != "bounded" or type(raw["context"]["working_ceiling_tokens"]) is not int or not 1 <= raw["context"]["working_ceiling_tokens"] <= raw["existing_profile"]["context_limit"]):
             raise ValueError(f"preset[{ordinal}].context is invalid")
@@ -224,13 +320,13 @@ def validate_catalog(entries: Iterable[dict[str, Any]]) -> tuple[dict[str, Any],
 
 _PACKAGED_CATALOG_BODY = {
     "schema_version": 1,
-    "catalog_revision": 2,
+    "catalog_revision": 3,
     "generated_at": "2026-08-21T00:00:00Z",
     "expires_at": "2036-08-01T00:00:00Z",
     "signing_key_id": _PACKAGED_CATALOG_KEY_ID,
     "entries": _PACKAGED_PRESETS_SOURCE,
 }
-_PACKAGED_CATALOG_SIGNATURE = "fdaede8d7878745afa5a740b4b3814a14363c5d8dd99aa3867e349ff827237348ba52e423a6a3b850cf03e364f2eb4ac085d7cd81ec4961990114ddb3af37a01"
+_PACKAGED_CATALOG_SIGNATURE = "2a182ff85896e5ac06c41a0a42ea2ab9d8a71000b272c586f1a8030ab4b983b3671e1b907ac16f945799de2d62c74ba969006fd831a22cccea2aed2f679b6707"
 _PACKAGED_CATALOG_JSON = json.dumps(
     {**_PACKAGED_CATALOG_BODY, "signature": _PACKAGED_CATALOG_SIGNATURE},
     sort_keys=True,

--- a/holdspeak/mcp/families/inference.py
+++ b/holdspeak/mcp/families/inference.py
@@ -43,6 +43,20 @@ TOOLS = [
         },
         ["request_id", "job_id", "expected_revision"],
     ),
+    _tool(
+        "inference.use_existing_model",
+        "Verify and use one local GGUF projected by inference setup.",
+        {
+            "request_id": {"type": "string"},
+            "detected_artifact_id": {"type": "string"},
+            "context_choice": {"type": "integer", "enum": [8192]},
+            "expected_route_revision": {"type": "string"},
+        },
+        [
+            "request_id", "detected_artifact_id", "context_choice",
+            "expected_route_revision",
+        ],
+    ),
 ]
 
 
@@ -63,4 +77,6 @@ def dispatch(name: str, arguments: dict[str, Any], principal: Principal) -> Any:
             "expected_revision": arguments["expected_revision"],
         }
         return _service().cancel(principal, str(arguments["job_id"]), body)
+    if name == "inference.use_existing_model":
+        return _service().use_existing(principal, dict(arguments))
     raise LookupError(name)

--- a/holdspeak/services/inference_acquisition_service.py
+++ b/holdspeak/services/inference_acquisition_service.py
@@ -74,6 +74,10 @@ def _safe_error(code: str) -> tuple[str, str]:
             "The model is downloaded and verified, but Thoughts changed AI while it downloaded.",
             "Choose Use for Thoughts when you are ready.",
         ),
+        "model_existing_invalid": (
+            "That local model changed or could not be verified.",
+            "Check the file, then refresh Models and try again.",
+        ),
     }
     return messages.get(code, ("Model setup stopped.", "Try again or choose another model."))
 
@@ -97,6 +101,7 @@ class InferenceAcquisitionApplicationService:
         catalog_provider: Callable[[], dict[str, Any]] | None = None,
         source_url_builder: Callable[[dict[str, Any]], str] | None = None,
         allowed_download_host: Callable[[str], bool] | None = None,
+        home_provider: Callable[[], Path] = Path.home,
         auto_recover: bool = True,
     ) -> None:
         self._db = db
@@ -114,6 +119,7 @@ class InferenceAcquisitionApplicationService:
             or host.endswith(".hf.co")
             or host.endswith(".huggingface.co")
         )
+        self._home_provider = home_provider
         self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="holdspeak-model")
         self._submitted: set[str] = set()
         self._submitted_lock = threading.Lock()
@@ -287,6 +293,177 @@ class InferenceAcquisitionApplicationService:
         acquisition = self._get(job_id)
         return {"acquisition": acquisition, "receipt": self._receipt(acquisition), "setup": self._setup.get_inference_setup(principal)}
 
+    def use_existing(self, principal: Principal, body: dict[str, Any]) -> dict[str, Any]:
+        """Verify and activate one freshly re-resolved detected GGUF."""
+        self._require_owner(principal)
+        allowed = {
+            "request_id", "detected_artifact_id", "context_choice",
+            "expected_route_revision",
+        }
+        if not isinstance(body, dict) or set(body) != allowed:
+            raise ServiceError(
+                "inference_existing_request_invalid",
+                "Use existing model has an invalid request shape.",
+                context={"status": 400},
+            )
+        request_id = str(body["request_id"] or "").strip()
+        detected_id = str(body["detected_artifact_id"] or "").strip()
+        expected_route = str(body["expected_route_revision"] or "")
+        if (
+            not request_id or len(request_id) > 128
+            or not detected_id.startswith("detected_")
+            or len(detected_id) > 96
+            or type(body["context_choice"]) is not int
+            or body["context_choice"] != 8192
+            or not expected_route
+        ):
+            raise ServiceError(
+                "inference_existing_request_invalid",
+                "Use existing model has invalid fields.", context={"status": 400},
+            )
+        payload = {
+            "request_id": request_id,
+            "detected_artifact_id": detected_id,
+            "context_choice": body["context_choice"],
+            "expected_route_revision": expected_route,
+        }
+        request_sha = _sha(payload)
+        with self._db._connection() as conn:
+            replay = conn.execute(
+                "SELECT job_id,request_sha256 FROM inference_model_acquisitions WHERE request_id=?",
+                (request_id,),
+            ).fetchone()
+        if replay is not None:
+            if str(replay["request_sha256"]) != request_sha:
+                raise ServiceError(
+                    "request_payload_mismatch",
+                    "That request id was already used for different model setup.",
+                    context={"status": 409},
+                )
+            acquisition = self._get(str(replay["job_id"]))
+            return {
+                "acquisition": acquisition,
+                "receipt": self._receipt(acquisition),
+                "setup": self._setup.get_inference_setup(principal),
+            }
+        config = self._config_provider()
+        if expected_route != _route_revision(config):
+            raise ServiceError(
+                "inference_route_stale",
+                "Thoughts changed AI. Check the current route and try again.",
+                context={"status": 409},
+            )
+        from .inference_setup_service import (
+            _this_machine_from_config,
+            resolve_detected_local_artifact,
+        )
+
+        candidate = resolve_detected_local_artifact(
+            home=self._home_provider(),
+            current_target=_this_machine_from_config(config),
+            artifact_id=detected_id,
+        )
+        if candidate is None:
+            raise ServiceError(
+                "inference_detected_artifact_stale",
+                "That detected model is no longer available. Refresh Models.",
+                context={"status": 409},
+            )
+        if candidate["format"] != "gguf":
+            raise ServiceError(
+                "inference_runtime_unsupported",
+                "MLX Thought execution is not installed yet.",
+                context={"status": 409},
+            )
+        path = Path(candidate["path"])
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            raise ServiceError(
+                "inference_detected_artifact_stale",
+                "That detected model is no longer available. Refresh Models.",
+                context={"status": 409},
+            ) from exc
+        plan = {
+            "kind": "existing_local_file",
+            "filename": path.name,
+            "local_locator": str(path),
+            "size": int(stat.st_size),
+            "mtime_ns": int(stat.st_mtime_ns),
+            "runtime_id": "llama_cpp_prompt_v1",
+            # Existing GGUF activation uses the long-established pinned local
+            # engine seam; it does not require the newer acquisition-only
+            # runtime features used by packaged downloads.
+            "runtime_min_revision": "0.3.16",
+            "format": "gguf",
+            "architecture": "gguf",
+            "model_identity": str(candidate["label"]).removesuffix(".gguf"),
+            "context_ceiling": 8192,
+        }
+        plan_sha = _sha(plan)
+        source_claim_sha = _sha({
+            "kind": plan["kind"], "locator": plan["local_locator"],
+            "size": plan["size"], "mtime_ns": plan["mtime_ns"],
+        })
+        job_id = "acq_" + hashlib.sha256(request_id.encode("utf-8")).hexdigest()[:32]
+        created = _now()
+        with self._db._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            replay = conn.execute(
+                "SELECT job_id,request_sha256 FROM inference_model_acquisitions WHERE request_id=?",
+                (request_id,),
+            ).fetchone()
+            if replay is not None:
+                if str(replay["request_sha256"]) != request_sha:
+                    conn.rollback()
+                    raise ServiceError(
+                        "request_payload_mismatch",
+                        "That request id was already used for different model setup.",
+                        context={"status": 409},
+                    )
+                conn.commit()
+                acquisition = self._get(str(replay["job_id"]))
+                return {
+                    "acquisition": acquisition,
+                    "receipt": self._receipt(acquisition),
+                    "setup": self._setup.get_inference_setup(principal),
+                }
+            active = conn.execute(
+                """SELECT job_id FROM inference_model_acquisitions
+                    WHERE source_claim_sha256=?
+                      AND state IN ('requested','resolving_source','downloading','verifying','installing')
+                    ORDER BY created_at ASC LIMIT 1""",
+                (source_claim_sha,),
+            ).fetchone()
+            if active is not None:
+                conn.commit()
+                acquisition = self._get(str(active["job_id"]))
+                return {
+                    "acquisition": acquisition,
+                    "receipt": self._receipt(acquisition),
+                    "setup": self._setup.get_inference_setup(principal),
+                }
+            conn.execute(
+                """INSERT INTO inference_model_acquisitions
+                   (job_id,request_id,request_sha256,preset_id,catalog_revision,
+                    source_plan_json,source_plan_sha256,source_claim_sha256,state,
+                    bytes_total,expected_route_revision,created_at,updated_at)
+                   VALUES (?,?,?,?,0,?,?,?,'requested',?,?,?,?)""",
+                (
+                    job_id, request_id, request_sha, detected_id,
+                    _canonical(plan), plan_sha, source_claim_sha, plan["size"],
+                    expected_route, created, created,
+                ),
+            )
+            conn.commit()
+        self._submit(job_id)
+        acquisition = self._get(job_id)
+        return {
+            "acquisition": acquisition,
+            "receipt": self._receipt(acquisition),
+            "setup": self._setup.get_inference_setup(principal),
+        }
+
     def get_acquisition(self, principal: Principal, job_id: str) -> dict[str, Any]:
         self._require_owner(principal)
         acquisition = self._get(job_id)
@@ -411,6 +588,9 @@ class InferenceAcquisitionApplicationService:
             if _sha(plan) != str(row["source_plan_sha256"]):
                 self._transition(job_id, "indeterminate", error_code="source_plan_integrity", error_message="The saved download plan is damaged.")
                 return
+            if plan.get("kind") == "existing_local_file":
+                self._run_existing(job_id, plan)
+                return
             self._transition(job_id, "resolving_source")
             if self._cancelled(job_id):
                 raise _Cancelled
@@ -473,6 +653,9 @@ class InferenceAcquisitionApplicationService:
                 shutil.rmtree(staging, ignore_errors=True)
             self._transition(job_id, "cancelled")
         except OSError as exc:
+            if plan.get("kind") == "existing_local_file":
+                self._fail(job_id, "model_existing_invalid")
+                return
             code = "model_download_disk" if getattr(exc, "errno", None) == 28 else "model_download_network"
             part = self._partial_file(job_id)
             resumable = bool(
@@ -482,7 +665,68 @@ class InferenceAcquisitionApplicationService:
             )
             self._fail(job_id, code, resumable=resumable)
         except Exception:
-            self._fail(job_id, "model_download_network")
+            self._fail(
+                job_id,
+                "model_existing_invalid"
+                if plan.get("kind") == "existing_local_file"
+                else "model_download_network",
+            )
+
+    def _run_existing(self, job_id: str, plan: dict[str, Any]) -> None:
+        self._transition(job_id, "resolving_source")
+        if self._cancelled(job_id):
+            raise _Cancelled
+        path = Path(str(plan["local_locator"]))
+        if path.is_symlink() or not path.is_file():
+            raise OSError("detected model is no longer a regular file")
+        stat = path.stat()
+        if (
+            int(stat.st_size) != int(plan["size"])
+            or int(stat.st_mtime_ns) != int(plan["mtime_ns"])
+        ):
+            raise OSError("detected model changed before verification")
+        self._transition(job_id, "verifying")
+        digest = self._hash_file(path)
+        with path.open("rb") as handle:
+            if handle.read(4) != b"GGUF":
+                raise OSError("detected model is not GGUF")
+        post = path.stat()
+        if (
+            int(post.st_size) != int(plan["size"])
+            or int(post.st_mtime_ns) != int(plan["mtime_ns"])
+        ):
+            raise OSError("detected model changed during verification")
+        sha = "sha256:" + digest
+        manifest = {
+            "files": [{"path": plan["filename"], "sha256": sha, "size": plan["size"]}],
+        }
+        manifest_sha = _sha(manifest)
+        execution_plan = {
+            **plan,
+            "sha256": sha,
+            "manifest_sha256": manifest_sha,
+            "repository": "Existing local model",
+            "revision": sha,
+        }
+        self._transition(job_id, "installing", verified_bytes=int(plan["size"]))
+        artifact_id = "artifact_" + manifest_sha.removeprefix("sha256:")
+        now = _now()
+        with self._db._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """INSERT OR IGNORE INTO inference_model_artifacts
+                   (artifact_id,format,source_kind,source_repository,
+                    source_revision,manifest_json,manifest_sha256,
+                    installed_bytes,state,local_locator,created_at,verified_at)
+                   VALUES (?,?,?,?,?,?,?,?, 'verified',?,?,?)""",
+                (
+                    artifact_id, "gguf", "existing_local_file",
+                    "Existing local model", sha, _canonical(manifest),
+                    manifest_sha, plan["size"], str(path), now, now,
+                ),
+            )
+            conn.commit()
+        self._activate(job_id, artifact_id, path, execution_plan)
 
     def _download(self, job_id: str, plan: dict[str, Any], part: Path) -> None:
         url = self._source_url_builder(plan)
@@ -574,7 +818,8 @@ class InferenceAcquisitionApplicationService:
             model=str(plan["model_identity"]), runtime_id=str(plan["runtime_id"]),
             runtime_revision=runtime_revision, artifact_id=artifact_id,
             manifest_sha256=str(plan["manifest_sha256"]), format="gguf",
-            architecture="qwen3.5", context_ceiling=int(plan["context_ceiling"]),
+            architecture=str(plan.get("architecture") or "gguf"),
+            context_ceiling=int(plan["context_ceiling"]),
             capability_sha256=capability_sha,
         )
         config.meeting.intel_realtime_model = str(final_file)
@@ -583,7 +828,12 @@ class InferenceAcquisitionApplicationService:
         now = _now()
         deployment_id = "deployment_" + artifact_id.removeprefix("artifact_")[:24]
         receipt = {
-            "kind": "download_and_use", "artifact_id": artifact_id,
+            "kind": (
+                "use_existing_model"
+                if plan.get("kind") == "existing_local_file"
+                else "download_and_use"
+            ),
+            "artifact_id": artifact_id,
             "deployment_id": deployment_id, "deployment_revision_id": revision.id,
             "route": "thoughts", "activated_at": now,
         }

--- a/holdspeak/services/inference_setup_service.py
+++ b/holdspeak/services/inference_setup_service.py
@@ -302,7 +302,53 @@ def _valid_mlx(path: Path) -> bool:
         return False
 
 
-def inspect_local_artifacts(*, home: Path, current_target: InferenceTarget) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+def _artifact_size(path: Path) -> int:
+    try:
+        if path.is_file():
+            return int(path.stat().st_size)
+        total = 0
+        with os.scandir(path) as iterator:
+            for ordinal, child in enumerate(iterator):
+                if ordinal >= _MAX_DIRECTORY_ENTRIES:
+                    break
+                if child.is_file(follow_symlinks=False):
+                    total += int(child.stat(follow_symlinks=False).st_size)
+        return total
+    except OSError:
+        return 0
+
+
+def _detected_artifact_id(format_id: str, path: Path, _ordinal: int) -> str:
+    """Return a public, path-independent scan identity (never a locator).
+
+    The ordinal is deliberately ignored: adding another model must not make an
+    already-rendered choice resolve to a different file.  A bounded content
+    prefix makes the ID independent of the owner's home path and filesystem
+    timestamps; activation still performs full content verification before
+    registering anything executable.
+    """
+    try:
+        size = _artifact_size(path)
+        if path.is_file():
+            with path.open("rb") as handle:
+                prefix = handle.read(_MAX_MLX_CONFIG_BYTES)
+        else:
+            config = path / "config.json"
+            with config.open("rb") as handle:
+                prefix = handle.read(_MAX_MLX_CONFIG_BYTES)
+        scan_facts = str(size).encode("ascii") + b"\0" + prefix
+    except OSError:
+        scan_facts = b"unavailable"
+    digest = hashlib.sha256()
+    digest.update((format_id + "\0" + path.name + "\0").encode("utf-8"))
+    digest.update(scan_facts)
+    return "detected_" + digest.hexdigest()[:20]
+
+
+def _scan_local_artifact_candidates(
+    *, home: Path, current_target: InferenceTarget,
+) -> tuple[list[tuple[str, Path]], dict[str, Any]]:
+    """Boundedly inspect local model roots while retaining locators in-process."""
     configured_raw = str(getattr(current_target.deployment, "model_path", "") or "").strip()
     configured = Path(configured_raw).expanduser() if configured_raw else None
     found: list[tuple[str, Path]] = []
@@ -362,28 +408,11 @@ def inspect_local_artifacts(*, home: Path, current_target: InferenceTarget) -> t
     for format_id, path in found:
         key = str(path.absolute())
         unique[key] = (format_id, path)
-    rows: list[dict[str, Any]] = []
     configured_row = unique.pop(str(configured.absolute()), None) if configured is not None else None
     ordered = ([configured_row] if configured_row is not None else []) + sorted(
         unique.values(), key=lambda item: (item[1].name.casefold(), str(item[1]))
     )
-    for ordinal, (format_id, path) in enumerate(ordered[0:_MAX_DETECTED]):
-        is_configured = configured is not None and path.absolute() == configured.absolute()
-        if format_id == "mlx_safetensors":
-            support = {"state": "unsupported", "reason": "MLX is not executable by Thoughts yet."}
-        elif is_configured and current_target.ready:
-            support = {"state": "current_v1", "reason": "This is the configured v1 Thought model."}
-        else:
-            support = {"state": "candidate", "reason": "Detected locally but not verified as the current Thought deployment."}
-        rows.append({
-            "id": "detected_" + hashlib.sha256(
-                (format_id + "\0" + path.name + "\0" + str(ordinal)).encode("utf-8")
-            ).hexdigest()[:20],
-            "label": _public_text(path.name, "Local model"),
-            "format": format_id,
-            "configured_for_thoughts": is_configured,
-            "thought_support": support,
-        })
+    ordered = ordered[0:_MAX_DETECTED]
     capped = len(unique) > _MAX_DETECTED or traversal_capped
     if scanned == 0:
         detection = {"state": "unavailable", "reason": "Local model folders could not be inspected."}
@@ -391,7 +420,81 @@ def inspect_local_artifacts(*, home: Path, current_target: InferenceTarget) -> t
         detection = {"state": "partial", "reason": "Some local model facts could not be inspected." if failures else f"Only the first {_MAX_DETECTED} local models are shown."}
     else:
         detection = {"state": "complete", "reason": None}
+    return ordered, detection
+
+
+def inspect_local_artifacts(
+    *,
+    home: Path,
+    current_target: InferenceTarget,
+    gguf_executable: bool = True,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    ordered, detection = _scan_local_artifact_candidates(
+        home=home, current_target=current_target,
+    )
+    configured_raw = str(getattr(current_target.deployment, "model_path", "") or "").strip()
+    configured = Path(configured_raw).expanduser() if configured_raw else None
+    rows: list[dict[str, Any]] = []
+    for ordinal, (format_id, path) in enumerate(ordered[0:_MAX_DETECTED]):
+        is_configured = configured is not None and path.absolute() == configured.absolute()
+        if format_id == "mlx_safetensors":
+            support = {"state": "unsupported", "reason": "MLX is not executable by Thoughts yet."}
+            activation = {
+                "state": "unsupported", "action": "none", "context_tokens": None,
+                "reason": "MLX Thought execution is not installed yet.",
+            }
+        elif is_configured and current_target.ready:
+            support = {"state": "current_v1", "reason": "This is the configured v1 Thought model."}
+            activation = {
+                "state": "current", "action": "none",
+                "context_tokens": min(max(int(current_target.context_limit or 8192), 1), 32768),
+                "reason": "Thoughts already use this model.",
+            }
+        elif gguf_executable:
+            support = {"state": "candidate", "reason": "Detected locally and ready to verify for Thoughts."}
+            activation = {
+                "state": "available", "action": "use_existing", "context_tokens": 8192,
+                "reason": "HoldSpeak will verify this file before using it.",
+            }
+        else:
+            support = {"state": "candidate", "reason": "Detected locally, but llama.cpp support is unavailable."}
+            activation = {
+                "state": "unavailable", "action": "none", "context_tokens": None,
+                "reason": "Install llama.cpp support before using this GGUF.",
+            }
+        rows.append({
+            "id": _detected_artifact_id(format_id, path, ordinal),
+            "label": _public_text(path.name, "Local model"),
+            "format": format_id,
+            "size_bytes": _artifact_size(path),
+            "configured_for_thoughts": is_configured,
+            "thought_support": support,
+            "activation": activation,
+        })
     return rows, detection
+
+
+def resolve_detected_local_artifact(
+    *, home: Path, current_target: InferenceTarget, artifact_id: str,
+) -> dict[str, Any] | None:
+    """Resolve one projected scan id to a private locator after fresh inspection."""
+    ordered, _detection = _scan_local_artifact_candidates(
+        home=home, current_target=current_target,
+    )
+    for ordinal, (format_id, path) in enumerate(ordered):
+        if _detected_artifact_id(format_id, path, ordinal) != artifact_id:
+            continue
+        try:
+            return {
+                "id": artifact_id,
+                "format": format_id,
+                "label": _public_text(path.name, "Local model"),
+                "path": path,
+                "size_bytes": _artifact_size(path),
+            }
+        except OSError:
+            return None
+    return None
 
 
 def _execution_support(
@@ -472,7 +575,15 @@ class InferenceSetupApplicationService:
         hardware = inspect_hardware(home=home, now=now)
         runtimes = inspect_runtimes(apple_silicon=hardware["capability"]["apple_silicon"])
         source, configured_target_id, target = _thought_target(self._db, config)
-        artifacts, artifact_detection = inspect_local_artifacts(home=home, current_target=target)
+        llama_ready = any(
+            row["id"] == "llama_cpp_prompt_v1"
+            and row["availability"]["state"] == "available"
+            and row["thought_support"]["state"] == "supported"
+            for row in runtimes
+        )
+        artifacts, artifact_detection = inspect_local_artifacts(
+            home=home, current_target=target, gguf_executable=llama_ready,
+        )
         execution_support = _execution_support(target, artifacts, runtimes)
         runtime_ids = {row["id"] for row in runtimes if row["availability"]["state"] == "available"}
         platform_id = f'{hardware["capability"]["system"]}_{hardware["capability"]["architecture"]}'

--- a/holdspeak/web/routes/setup.py
+++ b/holdspeak/web/routes/setup.py
@@ -154,6 +154,23 @@ def build_setup_router(ctx: WebContext) -> APIRouter:
         except Exception as exc:
             return error_500(exc, log, "Failed to start model acquisition")
 
+    @router.post("/api/inference/acquisitions/use-existing")
+    async def api_inference_use_existing(request: Request) -> Any:
+        try:
+            if inference_acquisition is None:
+                raise ServiceError("inference_acquisition_unavailable", "Local model setup is unavailable on this hub.", context={"status": 503})
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ServiceError("inference_existing_request_invalid", "Expected a JSON object.", context={"status": 400})
+            return JSONResponse(
+                inference_acquisition.use_existing(request.state.principal, body),
+                status_code=202,
+            )
+        except ServiceError as exc:
+            return _inference_error(exc)
+        except Exception as exc:
+            return error_500(exc, log, "Failed to use existing local model")
+
     @router.get("/api/inference/acquisitions/{job_id}")
     async def api_inference_acquisition(job_id: str, request: Request) -> Any:
         try:

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
@@ -45,13 +45,14 @@ activation truth server-owned without adding a second inference path.
 |---|---|---|---|---|
 | HSEGHS001HS104-142-01 | Capability Truth | done | [story-01-capability-truth](./story-01-capability-truth.md) | [evidence-story-01](./evidence-story-01.md) |
 | HSEGHS001HS104-142-02 | Artifact Acquisition and Activation | done | [story-02-artifact-acquisition-and-activation](./story-02-artifact-acquisition-and-activation.md) | [evidence-story-02](./evidence-story-02.md) |
+| HSEGHS001HS104-142-03 | One Model Chooser | done | [story-03-one-model-chooser](./story-03-one-model-chooser.md) | [evidence-story-03](./evidence-story-03.md) |
 
 ## Where we are
 
-Stories 01 and 02 have delivered truthful setup plus explicit, verified local
-GGUF acquisition and activation through the existing runner. The later MLX,
-capacity, exact-context, and tool-turn slices remain held behind their ruled
-authority prerequisites.
+Stories 01–03 have delivered truthful setup, verified local GGUF acquisition,
+and one compact chooser spanning detected, downloadable, and hosted models.
+The later MLX, capacity, exact-context, and tool-turn slices remain held behind
+their ruled authority prerequisites.
 
 ## Active risks
 

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-03.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-03.md
@@ -1,0 +1,32 @@
+# Evidence — HSEGHS001HS104-142-03 One Model Chooser
+
+## Delivered
+
+- One compact radiogroup contains detected local artifacts, signed local
+  suggestions, and six OpenRouter choices, with one stable action seat.
+- A detected GGUF is resolved server-side from a path-private scan identity,
+  fully verified, adopted, captured as an immutable execution revision, and
+  selected for Thoughts through one idempotent owner command.
+- The signed catalog now includes a pinned Qwen3.5 0.8B Q4_K_M utility choice
+  for intent, routing, and lightweight work. It is not presented as a quality
+  substitute for the main Thought model.
+- MLX remains visible but truthfully non-actionable until its execution slice.
+- HTTP and MCP call the same application service; setup/API surfaces contain
+  neither local locators nor provider secrets.
+
+## Verification
+
+- Focused backend/API/MCP suite: 36 passed.
+- Focused Models/Settings web suite: 31 passed.
+- Production web build: passed (existing chunk-size warnings only).
+- Isolated-HOME real-path glass at 1440×900 and 393×900: 2 passed.
+- Glass activates a detected GGUF, changes to an OpenRouter preset, proves one
+  visible action seat, keyboard-inert selection, 44px mobile controls, no
+  horizontal overflow, and no path/key leakage.
+
+## Visual evidence
+
+- `/tmp/holdspeak-inference-setup-1440.png`
+- `/tmp/holdspeak-inference-setup-393.png`
+- `/tmp/holdspeak-inference-setup-configured-1440.png`
+- `/tmp/holdspeak-inference-setup-configured-393.png`

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/story-03-one-model-chooser.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/story-03-one-model-chooser.md
@@ -1,0 +1,46 @@
+# HSEGHS001HS104-142-03 - One Model Chooser
+
+- **Project:** holdspeak
+- **Phase:** 142
+- **Status:** done
+- **Depends on:** HSEGHS001HS104-142-02
+- **Unblocks:** (optional)
+- **Owner:** HoldSpeak orchestration
+
+## Problem
+
+Models currently renders detected local artifacts as oversized, dead inventory
+cards and renders suggested downloads/hosted choices in a separate chooser.
+Owners cannot select an already-present GGUF and can easily miss the catalog.
+
+## Scope
+
+- **In:** one compact selectable model chooser; server-owned activation of an
+  existing detected GGUF; exact unsupported MLX truth; a pinned tiny Qwen local
+  option; a broader current OpenRouter catalog; HTTP/MCP parity; 1440/393 glass.
+- **Out:** MLX Thought execution, automatic recommendation claims, utility-route
+  execution distinct from Thoughts, silent downloads, or model-authored setup.
+
+## Acceptance criteria
+
+- [x] Detected, downloadable, and hosted models participate in one radiogroup
+  and one stable action seat; unselected rows remain compact.
+- [x] A projected detected GGUF can be selected and activated through one
+  owner-only idempotent application command without exposing its locator.
+- [x] MLX remains selectable for explanation but exposes no false Use action.
+- [x] The signed catalog includes a pinned ~1B local Qwen and at least five
+  current OpenRouter choices with outcome-first copy and exact model Details.
+- [x] Backend/API/MCP, focused web tests, and isolated 1440/393 glass pass.
+
+## Test plan
+
+- **Unit:** detected-ref resolution/privacy, existing-file hash/adoption/replay,
+  route conflict/runtime refusal, catalog signatures, chooser state/copy.
+- **Integration:** reciprocal HTTP/MCP command envelopes and setup refresh.
+- **Manual / device:** real existing GGUF activation plus compact chooser at
+  1440/393 with one action seat, keyboard selection, and no overflow.
+
+## Notes / open questions
+
+The ~1B preset is a fast local option suitable for intent/lightweight work, not
+a claim that a separate utility-routing subsystem ships in this story.

--- a/tests/e2e/test_hs141_models_setup_glass.py
+++ b/tests/e2e/test_hs141_models_setup_glass.py
@@ -39,16 +39,37 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
     from playwright.sync_api import sync_playwright
     import holdspeak.config as config_module
     import holdspeak.db.core as db_core
+    import holdspeak.services.inference_acquisition_service as acquisition_module
+    import holdspeak.services.inference_setup_service as setup_module
     from holdspeak.db import reset_database
     from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
 
     home = tmp_path / "home"
     home.mkdir()
+    existing_model = home / "Models" / "gguf" / "Qwen3-4B-Existing-Q6_K.gguf"
+    existing_model.parent.mkdir(parents=True)
+    existing_model.write_bytes(b"GGUF" + b"glass-existing-model")
     browser_cache = Path(os.environ.get("PLAYWRIGHT_BROWSERS_PATH", Path.home() / "Library/Caches/ms-playwright"))
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(browser_cache))
     monkeypatch.setattr(config_module, "CONFIG_FILE", home / ".holdspeak" / "config.json")
     monkeypatch.setattr(db_core, "DEFAULT_DB_PATH", tmp_path / "holdspeak.db")
+    original_package_revision = setup_module._package_revision
+    monkeypatch.setattr(
+        setup_module,
+        "_package_revision",
+        lambda distribution, fallback: "0.3.34"
+        if distribution == "llama-cpp-python"
+        else original_package_revision(distribution, fallback),
+    )
+    original_runtime_version = acquisition_module.importlib.metadata.version
+    monkeypatch.setattr(
+        acquisition_module.importlib.metadata,
+        "version",
+        lambda distribution: "0.3.34"
+        if distribution == "llama-cpp-python"
+        else original_runtime_version(distribution),
+    )
     reset_database()
 
     server = MeetingWebServer(
@@ -96,18 +117,20 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
 
             hosted = [row for row in projection["presets"] if row["kind"] == "hosted_profile_preset"]
             catalog = projection["presets"]
+            detected = projection["detected_local_artifacts"]
+            choices = [*detected, *catalog]
             radios = setup.get_by_role("radiogroup", name="AI choices").get_by_role("radio")
-            assert radios.count() == len(catalog)
-            if catalog:
+            assert radios.count() == len(choices)
+            if choices:
                 expected = next(
                     (row for row in hosted if row["existing_profile"]["target_id"] == projection["current_routes"]["thoughts"]["target_id"]),
-                    catalog[0],
+                    choices[0],
                 )
                 expected_radio = setup.locator(f'input[type="radio"][value="{expected["id"]}"]')
                 assert expected_radio.is_checked()
-                if len(catalog) > 1:
-                    expected_index = catalog.index(expected)
-                    next_row = catalog[(expected_index + 1) % len(catalog)]
+                if len(choices) > 1:
+                    expected_index = choices.index(expected)
+                    next_row = choices[(expected_index + 1) % len(choices)]
                     expected_radio.focus()
                     expected_radio.press("ArrowRight")
                     assert setup.locator(
@@ -139,6 +162,17 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             connections = setup.get_by_text("AI connections", exact=True).locator("xpath=ancestor::details")
             assert connections.get_attribute("open") is None
 
+            assert detected and detected[0]["activation"]["action"] == "use_existing"
+            setup.locator(f'input[type="radio"][value="{detected[0]["id"]}"]').click()
+            setup.get_by_role("button", name="USE THIS MODEL", exact=True).click()
+            setup.get_by_text("Ready · in use for Thoughts", exact=True).wait_for(timeout=10000)
+            used = _api(page, "GET", "/api/inference/setup")["setup"]
+            acquisition = next(row for row in used["acquisitions"] if row["preset_id"] == detected[0]["id"])
+            assert acquisition["state"] == "ready"
+            assert acquisition["activation_state"] == "in_use"
+            assert str(home) not in str(used)
+            assert setup.locator(".models-capability-action button").count() == 0
+
             if hosted:
                 chosen = hosted[-1]
                 radio = setup.locator(f'input[type="radio"][value="{chosen["id"]}"]')
@@ -147,10 +181,11 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
                 key.fill("glass-only-openrouter-key")
                 action = setup.get_by_role("button", name=f"ADD & USE {chosen['experience'].upper()}", exact=True)
                 action.click()
-                setup.get_by_text(f"{chosen['label']} selected for Thoughts & notes.", exact=True).wait_for()
-                assert key.count() == 0 or key.input_value() == ""
+                page.wait_for_timeout(1200)
+                assert key.count() == 0 or key.input_value() == "", setup.inner_text()
                 config = _api(page, "GET", "/api/settings")
                 assert config["thoughts"]["inference_target_id"] == chosen["existing_profile"]["target_id"]
+                setup.get_by_text("IN USE FOR THOUGHTS", exact=True).wait_for(timeout=10000)
                 targets = _api(page, "GET", "/api/inference-targets")["targets"]
                 selected = next(row for row in targets if row["id"] == chosen["existing_profile"]["target_id"])
                 assert selected["model"] == chosen["existing_profile"]["model"]

--- a/tests/unit/test_inference_model_acquisition.py
+++ b/tests/unit/test_inference_model_acquisition.py
@@ -23,6 +23,7 @@ from holdspeak.principals import Principal, PrincipalKind
 from holdspeak.mcp import resources
 from holdspeak.mcp.families import inference as inference_mcp
 from holdspeak.services.inference_acquisition_service import InferenceAcquisitionApplicationService
+from holdspeak.services.inference_setup_service import InferenceSetupApplicationService
 from holdspeak.services.setup_service import SetupService
 from holdspeak.web.context import WebContext
 from holdspeak.web.routes.setup import build_setup_router
@@ -83,6 +84,7 @@ def _fixture(tmp_path: Path):
         "id": "preset_test_gguf",
         "experience": "quick",
         "label": "Quick test model",
+        "summary": "Fast local test model.",
         "runtime_id": "llama_cpp_prompt_v1",
         "runtime_min_revision": "0.3.16",
         "format": "gguf",
@@ -150,6 +152,81 @@ def test_download_verify_adopt_activate_and_replay(tmp_path: Path):
     assert resolved is not None
     assert resolved.model_path == config.meeting.intel_realtime_model
     assert "model_path" not in resolved.to_dict()
+
+
+def test_detected_gguf_can_be_verified_selected_and_replayed(tmp_path: Path, monkeypatch):
+    model = tmp_path / "Models" / "gguf" / "already-here.gguf"
+    model.parent.mkdir(parents=True)
+    model.write_bytes(b"GGUF" + b"existing-model-bytes")
+    config = Config()
+    db = Database(tmp_path / "holdspeak.db")
+    setup = InferenceSetupApplicationService(
+        db, config_provider=lambda: config, home_provider=lambda: tmp_path,
+    )
+    service = InferenceAcquisitionApplicationService(
+        db,
+        setup_service=setup,
+        model_root=tmp_path / "managed-models",
+        config_provider=lambda: config,
+        config_saver=lambda _config: None,
+        home_provider=lambda: tmp_path,
+        auto_recover=False,
+    )
+    service._submit = lambda _job_id: None
+    monkeypatch.setattr(
+        "holdspeak.services.inference_acquisition_service.importlib.metadata.version",
+        lambda _package: "0.3.34",
+    )
+    projected = setup.get_inference_setup(OWNER)
+    detected = next(row for row in projected["detected_local_artifacts"] if row["label"] == model.name)
+    assert detected["activation"]["action"] == "use_existing"
+    body = {
+        "request_id": "use-existing-one",
+        "detected_artifact_id": detected["id"],
+        "context_choice": 8192,
+        "expected_route_revision": projected["current_routes"]["thoughts"]["revision"],
+    }
+
+    started = service.use_existing(OWNER, body)["acquisition"]
+    service._run(started["id"])
+    complete = service.get_acquisition(OWNER, started["id"])["acquisition"]
+
+    assert complete["state"] == "ready"
+    assert complete["activation_state"] == "in_use"
+    assert complete["verified_bytes"] == model.stat().st_size
+    assert config.meeting.intel_realtime_model == str(model)
+    assert service.use_existing(OWNER, body)["acquisition"]["id"] == complete["id"]
+    monkeypatch.setattr(inference_mcp, "_service", lambda: service)
+    assert inference_mcp.dispatch("inference.use_existing_model", body, OWNER)["acquisition"]["id"] == complete["id"]
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def existing_owner(request: Request, call_next):
+        request.state.principal = OWNER
+        return await call_next(request)
+
+    app.include_router(build_setup_router(WebContext(
+        get_state=lambda: {}, setup_service=SetupService(db),
+        inference_setup_service=setup, inference_acquisition_service=service,
+    )))
+    client = TestClient(app)
+    assert client.post("/api/inference/acquisitions/use-existing", json=body).status_code == 202
+    assert client.post(
+        "/api/inference/acquisitions/use-existing", json={**body, "invented": True},
+    ).status_code == 400
+    with db._connection() as conn:
+        artifact = conn.execute(
+            "SELECT source_kind,local_locator FROM inference_model_artifacts WHERE artifact_id=?",
+            (complete["artifact_id"],),
+        ).fetchone()
+    assert dict(artifact) == {
+        "source_kind": "existing_local_file",
+        "local_locator": str(model),
+    }
+
+    with pytest.raises(Exception) as changed:
+        service.use_existing(OWNER, {**body, "expected_route_revision": "changed"})
+    assert getattr(changed.value, "code", "") == "request_payload_mismatch"
 
 
 def test_changed_request_refuses_and_route_conflict_keeps_verified_artifact(tmp_path: Path):

--- a/tests/unit/test_inference_setup_capability_truth.py
+++ b/tests/unit/test_inference_setup_capability_truth.py
@@ -98,10 +98,10 @@ def test_projection_is_closed_redacted_and_preserves_v1_identity(tmp_path: Path)
     assert value["artifact_detection"] == {"state": "complete", "reason": None}
     assert value["preset_catalog"] == {
         "schema_version": 1,
-        "catalog_revision": 2,
+            "catalog_revision": 3,
         "generated_at": "2026-08-21T00:00:00Z",
         "expires_at": "2036-08-01T00:00:00Z",
-        "signing_key_id": "holdspeak_catalog_2026_03",
+            "signing_key_id": "holdspeak_catalog_2026_08",
         "sha256": PACKAGED_CATALOG_SHA256,
     }
     assert value["detected_local_artifacts"][0]["label"] == model.name
@@ -206,7 +206,7 @@ def test_catalog_expiry_is_rechecked_on_every_projection(tmp_path: Path):
         db, config_provider=Config, home_provider=lambda: tmp_path,
         clock=lambda: current[0],
     )
-    assert service.get_inference_setup(OWNER)["preset_catalog"]["catalog_revision"] == 2
+    assert service.get_inference_setup(OWNER)["preset_catalog"]["catalog_revision"] == 3
     current[0] = datetime(2037, 1, 1, tzinfo=timezone.utc)
     with pytest.raises(ValueError, match="validity period"):
         service.get_inference_setup(OWNER)
@@ -230,8 +230,15 @@ def test_owner_gate_and_safe_missing_path(tmp_path: Path):
 
 def test_catalog_is_closed_and_filters_unproven_local_entries(tmp_path: Path):
     packaged = packaged_presets()
-    assert len(validate_catalog(packaged)) == 4
-    assert len(applicable_presets(platform_id="darwin_arm64", runtime_ids=set())) == 3
+    assert len(validate_catalog(packaged)) == 8
+    ids = {row["id"] for row in packaged}
+    assert "preset_local_qwen35_08b_gguf_q4km" in ids
+    assert {
+        "preset_openrouter_qwen37_flash",
+        "preset_openrouter_gemma4_26b",
+        "preset_openrouter_qwen3_coder_next",
+    } <= ids
+    assert len(applicable_presets(platform_id="darwin_arm64", runtime_ids=set())) == 6
     forged = dict(packaged[0])
     forged["download_url"] = "https://mutable.invalid/latest"
     with pytest.raises(ValueError, match="invalid fields"):
@@ -239,7 +246,7 @@ def test_catalog_is_closed_and_filters_unproven_local_entries(tmp_path: Path):
 
     local = {
         "kind": "local_artifact_preset", "id": "local_test", "experience": "quick",
-        "label": "Local test", "runtime_id": "llama_cpp_prompt_v1", "runtime_min_revision": "0.3.34", "format": "gguf",
+        "label": "Local test", "summary": "Small local test model.", "runtime_id": "llama_cpp_prompt_v1", "runtime_min_revision": "0.3.34", "format": "gguf",
         "boundary": "same_device", "context": {"recommended_tokens": 8192, "ceiling_tokens": 8192}, "platforms": ["linux_x86_64"],
         "source": {"repository": "example/model", "revision": "a" * 40,
                    "filename": "model.gguf", "file_sha256": "sha256:" + "a" * 64,
@@ -334,7 +341,7 @@ def test_detected_ids_do_not_depend_on_absolute_home(tmp_path: Path):
 def test_local_preset_union_and_mlx_runtime_use_real_dependency(tmp_path: Path, monkeypatch):
     local = {
         "kind": "local_artifact_preset", "id": "local_test", "experience": "quick",
-        "label": "Local test", "runtime_id": "mlx_text_v1", "runtime_min_revision": "0.1.0", "format": "mlx_safetensors",
+        "label": "Local test", "summary": "Small local test model.", "runtime_id": "mlx_text_v1", "runtime_min_revision": "0.1.0", "format": "mlx_safetensors",
         "boundary": "same_device", "context": {"recommended_tokens": 8192, "ceiling_tokens": 8192}, "platforms": ["darwin_arm64"],
         "source": {"repository": "example/model", "revision": "a" * 40,
                    "filename": "model.gguf", "file_sha256": "sha256:" + "a" * 64,

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -1083,7 +1083,7 @@ button.surface-edit-in-place:hover {
   align-items: center;
   flex-wrap: wrap;
   gap: 4px 8px;
-  margin-top: 3px;
+  margin-top: 2px;
   color: var(--text-muted);
   font-size: var(--desk-surface-detail-size);
 }
@@ -2448,7 +2448,7 @@ button.surface-edit-in-place:hover {
 .models-setup {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 8px;
   min-width: 0;
 }
 .models-capability-opening,
@@ -2478,7 +2478,7 @@ button.surface-edit-in-place:hover {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(260px, 36%);
   gap: 20px;
-  padding: 20px;
+  padding: 16px;
   background:
     linear-gradient(
       135deg,
@@ -2534,7 +2534,14 @@ button.surface-edit-in-place:hover {
 }
 .models-capability-device,
 .models-capability-choices {
-  padding: 16px;
+  padding: 12px;
+}
+.models-capability-device {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 42%);
+  align-items: center;
+  gap: 12px;
+  padding-block: 9px;
 }
 .models-capability-device > header,
 .models-capability-choices > header {
@@ -2543,6 +2550,12 @@ button.surface-edit-in-place:hover {
   justify-content: space-between;
   gap: 20px;
   margin-bottom: 12px;
+}
+.models-capability-device > header {
+  margin-bottom: 0;
+}
+.models-capability-device h3 {
+  font-size: 15px;
 }
 .models-capability-device h3,
 .models-capability-choices h3 {
@@ -2556,6 +2569,25 @@ button.surface-edit-in-place:hover {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
 }
+.models-capability-radio {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
+}
+.models-choice-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 7px;
+  min-width: 0;
+}
+.models-choice-group > h4 {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--text-muted);
+  font: 700 10px / 1.2 var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
 .models-artifact-list article,
 .models-local-catalog article,
 .models-capability-card {
@@ -2566,6 +2598,44 @@ button.surface-edit-in-place:hover {
   padding: 13px;
   border: 1px solid var(--border);
   background: var(--desk-window-well);
+}
+.models-capability-card.models-capability-card-compact {
+  min-height: 60px;
+  gap: 4px;
+  padding: 10px 10px 10px 34px;
+}
+.models-capability-card-compact > strong,
+.models-capability-card-compact > span:not(.models-capability-experience) {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.models-capability-card.models-capability-card-compact > input {
+  top: 12px;
+  left: 11px;
+}
+.models-capability-card.models-capability-card-compact[data-selected] {
+  min-height: 60px;
+  background: color-mix(in srgb, var(--accent) 5%, var(--desk-window-well));
+}
+.models-choice-detail {
+  display: grid;
+  gap: 3px;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font: 400 10px / 1.35 var(--font-sans);
+}
+.models-device-summary {
+  margin: 0;
+  padding: 9px 11px;
+  border-left: 3px solid var(--accent);
+  color: var(--text-muted);
+  background: var(--desk-window-well);
+  font: 400 11px / 1.45 var(--font-sans);
+}
+.models-device-summary strong {
+  color: var(--text);
 }
 .models-artifact-list strong,
 .models-local-catalog strong,
@@ -2625,7 +2695,7 @@ button.surface-edit-in-place:hover {
   align-items: end;
   gap: 12px;
   min-height: 76px;
-  margin-top: 10px;
+  margin-top: 0;
   padding: 12px;
   border: 1px solid var(--border);
   background: var(--surface-2);
@@ -3193,6 +3263,9 @@ button.surface-edit-in-place:hover {
   .models-capability-choices {
     padding: 12px;
   }
+  .models-capability-device {
+    grid-template-columns: minmax(0, 1fr);
+  }
   .models-capability-device > header,
   .models-capability-choices > header {
     align-items: start;
@@ -3201,8 +3274,10 @@ button.surface-edit-in-place:hover {
   }
   .models-artifact-list,
   .models-local-catalog,
-  .models-capability-radio,
   .models-capability-limits {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .models-choice-group {
     grid-template-columns: minmax(0, 1fr);
   }
   .models-capability-card {

--- a/web/src/pages/cores/InferenceCapabilityPanel.tsx
+++ b/web/src/pages/cores/InferenceCapabilityPanel.tsx
@@ -5,6 +5,7 @@ import type {
   InferenceAcquisition,
   InferencePreset,
   InferenceSetup,
+  InferenceSetupArtifact,
   LocalInferencePreset,
 } from "./inferenceSetup";
 
@@ -48,6 +49,19 @@ function supportLabel(
   }
 }
 
+function artifactActivation(artifact: InferenceSetupArtifact): InferenceSetupArtifact["activation"] {
+  if (artifact.activation) return artifact.activation;
+  if (artifact.configured_for_thoughts) {
+    return { state: "current", action: "none", context_tokens: 8192, reason: "Thoughts already use this model." };
+  }
+  return {
+    state: artifact.format === "gguf" ? "available" : "unsupported",
+    action: artifact.format === "gguf" ? "use_existing" : "none",
+    context_tokens: artifact.format === "gguf" ? 8192 : null,
+    reason: artifact.thought_support.reason || "This model is not available for Thoughts yet.",
+  };
+}
+
 export function InferenceCapabilityPanel({
   setup,
   loading,
@@ -59,6 +73,7 @@ export function InferenceCapabilityPanel({
   onRetry,
   onUseHosted,
   onDownloadLocal,
+  onUseExisting,
   onCancelAcquisition,
 }: {
   setup: InferenceSetup | null;
@@ -71,6 +86,7 @@ export function InferenceCapabilityPanel({
   onRetry(): void;
   onUseHosted(preset: HostedInferencePreset, key: string): Promise<boolean>;
   onDownloadLocal?(preset: LocalInferencePreset): Promise<void>;
+  onUseExisting?(artifact: InferenceSetupArtifact): Promise<void>;
   onCancelAcquisition?(acquisition: InferenceAcquisition): Promise<void>;
 }) {
   const groupName = useId();
@@ -82,7 +98,8 @@ export function InferenceCapabilityPanel({
       setSelectedId("");
       return;
     }
-    if (!setup.presets.length) {
+    const choices = [...setup.detected_local_artifacts, ...setup.presets];
+    if (!choices.length) {
       setSelectedId("");
       return;
     }
@@ -92,12 +109,15 @@ export function InferenceCapabilityPanel({
         preset.kind === "hosted_profile_preset" &&
         preset.existing_profile.target_id === current,
     );
+    const currentArtifact = setup.detected_local_artifacts.find(
+      (artifact) => artifact.configured_for_thoughts,
+    );
     setSelectedId(
       (prior) =>
-        currentPreset?.id ||
-        (setup.presets.some((preset) => preset.id === prior)
+        currentPreset?.id || currentArtifact?.id ||
+        (choices.some((choice) => choice.id === prior)
           ? prior
-          : setup.presets[0].id),
+          : choices[0].id),
     );
   }, [setup]);
 
@@ -127,6 +147,8 @@ export function InferenceCapabilityPanel({
       : deployment.target.model;
   const selected: InferencePreset | null =
     setup.presets.find((preset) => preset.id === selectedId) || null;
+  const selectedArtifact =
+    setup.detected_local_artifacts.find((artifact) => artifact.id === selectedId) || null;
   const selectedHosted = selected?.kind === "hosted_profile_preset" ? selected : null;
   const selectedLocal = selected?.kind === "local_artifact_preset" ? selected : null;
   const existing = selected
@@ -139,9 +161,22 @@ export function InferenceCapabilityPanel({
     selectedHosted?.existing_profile.target_id ===
     setup.current_routes.thoughts.target_id;
   const canUse = Boolean(selectedHosted && (existing?.key_present || key.trim()));
+  const localPresets = setup.presets.filter(
+    (preset): preset is LocalInferencePreset => preset.kind === "local_artifact_preset",
+  );
+  const hostedPresets = setup.presets.filter(
+    (preset): preset is HostedInferencePreset => preset.kind === "hosted_profile_preset",
+  );
   const acquisition = selectedLocal
     ? (setup.acquisitions ?? []).find((row) => row.preset_id === selectedLocal.id) || null
-    : null;
+    : selectedArtifact
+      ? (setup.acquisitions ?? []).find((row) => row.preset_id === selectedArtifact.id) || null
+      : null;
+
+  const selectChoice = (id: string) => {
+    setSelectedId(id);
+    setKey("");
+  };
 
   return (
     <>
@@ -189,18 +224,10 @@ export function InferenceCapabilityPanel({
           ) : null}
         </header>
         {setup.detected_local_artifacts.length ? (
-          <div className="models-artifact-list" aria-label="Detected local AI">
-            {setup.detected_local_artifacts.map((artifact) => (
-              <article key={artifact.id}>
-                <span>{artifact.format === "gguf" ? "GGUF" : "MLX"}</span>
-                <strong>{artifact.label}</strong>
-                <small>{supportLabel(artifact.thought_support.state)}</small>
-                {artifact.thought_support.reason ? (
-                  <p>{artifact.thought_support.reason}</p>
-                ) : null}
-              </article>
-            ))}
-          </div>
+          <p className="models-device-summary">
+            <strong>{setup.detected_local_artifacts.length} local model{setup.detected_local_artifacts.length === 1 ? "" : "s"} found.</strong>{" "}
+            Choose one below to see what HoldSpeak can use now.
+          </p>
         ) : setup.artifact_detection.state === "complete" ? (
           <div className="models-capability-empty">
             <strong>No local AI detected</strong>
@@ -242,84 +269,126 @@ export function InferenceCapabilityPanel({
           role="radiogroup"
           aria-label="AI choices"
         >
-          {setup.presets.length ? (
-            setup.presets.map((preset) => {
-              const selectedCard = preset.id === selectedId;
-              return (
-                <label
-                  key={preset.id}
-                  className="models-capability-card"
-                  data-selected={selectedCard || undefined}
-                >
-                  <input
-                    type="radio"
-                    name={groupName}
-                    value={preset.id}
-                    checked={selectedCard}
-                    onChange={() => {
-                      setSelectedId(preset.id);
-                      setKey("");
-                    }}
-                  />
-                  <span className="models-capability-experience">
-                    {preset.experience}
-                  </span>
-                  <strong>{preset.label}</strong>
-                  {preset.kind === "hosted_profile_preset" ? (
-                    <>
-                      <span>
-                        Hosted · {context(preset.context.working_ceiling_tokens)}{" "}
-                        working ceiling
-                      </span>
-                      <small>Saved Note material may leave this hub.</small>
-                    </>
-                  ) : (
-                    <>
-                      <span>
-                        GGUF · {context(preset.context.recommended_tokens)} context
-                      </span>
-                      <small>Runs only on this device. Note text stays here.</small>
-                      <small>
-                        {bytes(preset.source.download_bytes)} download · {bytes(preset.source.installed_bytes)} installed · {bytes(preset.source.peak_free_bytes)} free required
-                      </small>
-                      <small>
-                        From Hugging Face · {preset.source.repository} · {preset.source.license}
-                      </small>
-                    </>
-                  )}
-                </label>
-              );
-            })
-          ) : (
+          {setup.detected_local_artifacts.length ? (
+            <div className="models-choice-group" data-kind="detected">
+              <h4>Already on this device</h4>
+              {setup.detected_local_artifacts.map((artifact) => {
+                const selectedCard = artifact.id === selectedId;
+                return (
+                  <label
+                    key={artifact.id}
+                    className="models-capability-card models-capability-card-compact"
+                    data-selected={selectedCard || undefined}
+                  >
+                    <input
+                      type="radio"
+                      name={groupName}
+                      value={artifact.id}
+                      checked={selectedCard}
+                      onChange={() => selectChoice(artifact.id)}
+                    />
+                    <span className="models-capability-experience">
+                      {artifact.format === "gguf" ? "On device · GGUF" : "On device · MLX"}
+                    </span>
+                    <strong>{artifact.label}</strong>
+                    <span>
+                      <span>{supportLabel(artifact.thought_support.state)}</span>
+                      {` · ${bytes(artifact.size_bytes)}`}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {localPresets.length ? (
+            <div className="models-choice-group" data-kind="download">
+              <h4>Suggested local models</h4>
+              {localPresets.map((preset) => {
+                const selectedCard = preset.id === selectedId;
+                return (
+                  <label
+                    key={preset.id}
+                    className="models-capability-card models-capability-card-compact"
+                    data-selected={selectedCard || undefined}
+                  >
+                    <input
+                      type="radio"
+                      name={groupName}
+                      value={preset.id}
+                      checked={selectedCard}
+                      onChange={() => selectChoice(preset.id)}
+                    />
+                    <span className="models-capability-experience">{preset.experience} · Download</span>
+                    <strong>{preset.label}</strong>
+                    <span>{preset.summary || `${preset.label} for private local work.`}</span>
+                  </label>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {hostedPresets.length ? (
+            <div className="models-choice-group" data-kind="hosted">
+              <h4>OpenRouter</h4>
+              {hostedPresets.map((preset) => {
+                const selectedCard = preset.id === selectedId;
+                return (
+                  <label
+                    key={preset.id}
+                    className="models-capability-card models-capability-card-compact"
+                    data-selected={selectedCard || undefined}
+                  >
+                    <input
+                      type="radio"
+                      name={groupName}
+                      value={preset.id}
+                      checked={selectedCard}
+                      onChange={() => selectChoice(preset.id)}
+                    />
+                    <span className="models-capability-experience">{preset.experience} · Cloud</span>
+                    <strong>{preset.label}</strong>
+                    <span>{preset.summary || `${preset.label} through OpenRouter.`}</span>
+                  </label>
+                );
+              })}
+            </div>
+          ) : setup.detected_local_artifacts.length || localPresets.length ? null : (
             <div className="models-capability-empty">
-              <strong>No curated hosted choices for this hub</strong>
-              <p>Existing connections remain available below.</p>
+              <strong>No model choices are available on this hub</strong>
+              <p>Refresh Models after configuring a runtime or connection.</p>
             </div>
           )}
         </div>
         <div className="models-capability-action" aria-live="polite">
-          {selected ? (
+          {selected || selectedArtifact ? (
             <>
               <div>
-                <strong>{selected.label}</strong>
+                <strong>{selected?.label || selectedArtifact?.label}</strong>
                 <span>
-                  {selectedLocal && acquisition
+                  {acquisition
                     ? acquisition.state === "downloading"
                       ? `Downloading ${bytes(acquisition.transport_bytes)} of ${bytes(acquisition.bytes_total)}`
                       : acquisition.state === "verifying"
-                        ? "Verifying the published checksum…"
+                        ? selectedArtifact
+                          ? "Verifying this model’s complete contents…"
+                          : "Verifying the published checksum…"
                         : acquisition.state === "installing"
-                          ? "Installing verified model bytes…"
+                          ? selectedArtifact
+                            ? "Making this the local AI for Thoughts…"
+                            : "Installing verified model bytes…"
                           : acquisition.state === "ready" && acquisition.activation_state === "in_use"
                             ? "Ready · in use for Thoughts"
                             : acquisition.error?.message || acquisition.state
+                    : selectedArtifact
+                      ? artifactActivation(selectedArtifact).reason
                     : selectedLocal
-                      ? "Private local model · downloads only on your command"
+                      ? `${context(selectedLocal.context.recommended_tokens)} context · ${bytes(selectedLocal.source.download_bytes)} download · runs only on this device`
                     : current
                     ? "Currently used for Thoughts & notes"
                     : existing?.key_present
-                      ? "Already configured on this hub"
-                      : "Requires an OpenRouter key"}
+                      ? `Already configured · ${context(selectedHosted?.context.working_ceiling_tokens || 8192)} working context`
+                      : `Requires an OpenRouter key · ${context(selectedHosted?.context.working_ceiling_tokens || 8192)} working context`}
                 </span>
               </div>
               {selectedHosted && !current && !targetsLoading && !existing?.key_present ? (
@@ -334,7 +403,32 @@ export function InferenceCapabilityPanel({
                   />
                 </label>
               ) : null}
-              {selectedLocal ? (
+              {selectedArtifact ? (
+                acquisition && ["requested", "resolving_source"].includes(acquisition.state) ? (
+                  <span className="models-capability-action-status">PREPARING VERIFICATION…</span>
+                ) : acquisition && ["verifying", "installing"].includes(acquisition.state) ? (
+                  <span className="models-capability-action-status">
+                    {acquisition.state === "verifying" ? "VERIFYING…" : "MAKING IT AVAILABLE…"}
+                  </span>
+                ) : acquisition?.state === "ready" && acquisition.activation_state === "in_use" ? (
+                  <span className="models-capability-action-status">IN USE FOR THOUGHTS</span>
+                ) : artifactActivation(selectedArtifact).action === "use_existing" ? (
+                  <Button
+                    variant="primary"
+                    disabled={Boolean(busyPresetId)}
+                    loading={busyPresetId === selectedArtifact.id}
+                    onClick={() => void onUseExisting?.(selectedArtifact)}
+                  >
+                    {acquisition?.state === "failed" ? "TRY AGAIN" : "USE THIS MODEL"}
+                  </Button>
+                ) : (
+                  <span className="models-capability-action-status">
+                    {selectedArtifact.configured_for_thoughts
+                      ? "IN USE FOR THOUGHTS"
+                      : artifactActivation(selectedArtifact).reason.toUpperCase()}
+                  </span>
+                )
+              ) : selectedLocal ? (
                 acquisition && ["requested", "resolving_source", "downloading"].includes(acquisition.state) ? (
                   <>
                     <progress
@@ -375,7 +469,7 @@ export function InferenceCapabilityPanel({
               ) : canUse ? (
                 <Button
                   variant="primary"
-                  loading={busyPresetId === selected.id}
+                  loading={busyPresetId === selectedHosted?.id}
                   disabled={Boolean(busyPresetId)}
                   onClick={async () => {
                     if (selectedHosted && await onUseHosted(selectedHosted, key.trim())) setKey("");
@@ -393,7 +487,7 @@ export function InferenceCapabilityPanel({
             </>
           ) : (
             <span className="models-capability-action-status">
-              NO CATALOG ACTION AVAILABLE
+              NO MODEL SELECTED
             </span>
           )}
         </div>

--- a/web/src/pages/cores/SettingsCore.tsx
+++ b/web/src/pages/cores/SettingsCore.tsx
@@ -323,6 +323,25 @@ function SettingsFace({ hero, scope }: CoreProps) {
     debouncedChangesRef.current = [];
     return save(pending);
   };
+  const reconcileSettings = async () => {
+    const reconcile = async () => {
+      try {
+        await readAuthoritativeBase();
+        repaintPending();
+        return true;
+      } catch (error) {
+        setRefusal(readableError(error));
+        writerFencedRef.current = true;
+        return false;
+      }
+    };
+    const next = saveQueue.current.then(reconcile, reconcile);
+    saveQueue.current = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  };
 
   const changeSecret = async (
     secretId: string,
@@ -903,6 +922,7 @@ function SettingsFace({ hero, scope }: CoreProps) {
             update={update}
             updateMany={updateMany}
             commitMany={commitMany}
+            reconcileSettings={reconcileSettings}
             onRefuse={setRefusal}
           />
         );

--- a/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
+++ b/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
@@ -8,6 +8,7 @@ const hosted = (id: string, experience: "quick" | "balanced" | "deep") => ({
   id,
   experience,
   label: `${experience} choice`,
+  summary: `${experience} hosted choice.`,
   provider_adapter: "openai_compatible" as const,
   model_id: `provider/${id}`,
   boundary: "external_service" as const,
@@ -30,7 +31,7 @@ function setup(overrides: Partial<InferenceSetup> = {}): InferenceSetup {
     schema_version: 1,
     observed_at: "2026-08-21T18:00:00Z",
     preset_catalog: {
-      schema_version: 1, catalog_revision: 2,
+      schema_version: 1, catalog_revision: 3,
       generated_at: "2026-08-21T00:00:00Z", expires_at: "2036-08-01T00:00:00Z",
       signing_key_id: "test", sha256: `sha256:${"c".repeat(64)}`,
     },
@@ -234,6 +235,7 @@ describe("InferenceCapabilityPanel", () => {
       id: "local-q",
       experience: "quick" as const,
       label: "Local Q",
+      summary: "Fast intent routing and short Notes.",
       runtime_id: "llama.cpp",
       runtime_min_revision: "0.3.34",
       format: "gguf" as const,
@@ -266,6 +268,39 @@ describe("InferenceCapabilityPanel", () => {
     expect(screen.getByText(/runs only on this device/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /download & use quick/i }));
     await waitFor(() => expect(download).toHaveBeenCalledWith(local));
+  });
+
+  it("selects a detected GGUF and offers one real verify-and-use action", async () => {
+    const useExisting = vi.fn(async () => undefined);
+    const artifact = {
+      id: "detected-local-qwen",
+      label: "Qwen3-4B-Q6_K.gguf",
+      format: "gguf" as const,
+      size_bytes: 2_400_000_000,
+      configured_for_thoughts: false,
+      thought_support: {
+        state: "candidate" as const,
+        reason: "Detected locally and ready to verify for Thoughts.",
+      },
+      activation: {
+        state: "available" as const,
+        action: "use_existing" as const,
+        context_tokens: 8192 as const,
+        reason: "HoldSpeak will verify this file before using it.",
+      },
+    };
+    render(
+      <InferenceCapabilityPanel
+        {...defaults}
+        setup={setup({ detected_local_artifacts: [artifact], presets: [] })}
+        onUseHosted={vi.fn(async () => true)}
+        onUseExisting={useExisting}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: /Qwen3-4B-Q6_K/ })).toBeChecked();
+    expect(screen.getByRole("heading", { name: "Already on this device" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "USE THIS MODEL" }));
+    await waitFor(() => expect(useExisting).toHaveBeenCalledWith(artifact));
   });
 
   it("clears a secret only after confirmed success and retains it on failure", async () => {

--- a/web/src/pages/cores/__tests__/settingsModels.test.tsx
+++ b/web/src/pages/cores/__tests__/settingsModels.test.tsx
@@ -461,7 +461,7 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
     await screen.findByRole("heading", { name: "Choose an experience" });
     const balanced = screen.getByRole("radio", { name: /Balanced Qwen/ });
     await waitFor(() =>
-      expect(screen.getByRole("radio", { name: /Deep Qwen/ })).toBeChecked(),
+      expect(screen.getByRole("radio", { name: /Pocket GGUF/ })).toBeChecked(),
     );
     fireEvent.click(balanced);
     expect(balanced).toBeChecked();
@@ -515,9 +515,7 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
         onRefuse={vi.fn()}
       />,
     );
-    await waitFor(() =>
-      expect(screen.getByRole("radio", { name: /Deep Qwen/ })).toBeChecked(),
-    );
+    fireEvent.click(await screen.findByRole("radio", { name: /Deep Qwen/ }));
     const key = screen.getByLabelText("OpenRouter key");
     fireEvent.change(key, { target: { value: "durability-sentinel" } });
     fireEvent.click(screen.getByRole("button", { name: "ADD & USE DEEP" }));
@@ -539,9 +537,7 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
         onRefuse={vi.fn()}
       />,
     );
-    await waitFor(() =>
-      expect(screen.getByRole("radio", { name: /Deep Qwen/ })).toBeChecked(),
-    );
+    fireEvent.click(await screen.findByRole("radio", { name: /Deep Qwen/ }));
     const key = screen.getByLabelText("OpenRouter key");
     fireEvent.change(key, { target: { value: "cas-refusal-sentinel" } });
     fireEvent.click(screen.getByRole("button", { name: "ADD & USE DEEP" }));

--- a/web/src/pages/cores/inferenceSetup.ts
+++ b/web/src/pages/cores/inferenceSetup.ts
@@ -85,10 +85,17 @@ export interface InferenceSetupArtifact {
   id: string;
   label: string;
   format: "gguf" | "mlx_safetensors";
+  size_bytes: number;
   configured_for_thoughts: boolean;
   thought_support: {
     state: "current_v1" | "unsupported" | "candidate";
     reason: string | null;
+  };
+  activation: {
+    state: "available" | "current" | "unavailable" | "unsupported";
+    action: "use_existing" | "none";
+    context_tokens: 8192 | 16384 | 32768 | null;
+    reason: string;
   };
 }
 
@@ -97,6 +104,7 @@ export interface HostedInferencePreset {
   id: string;
   experience: "quick" | "balanced" | "deep";
   label: string;
+  summary: string;
   provider_adapter: "openai_compatible";
   model_id: string;
   boundary: "external_service";
@@ -119,6 +127,7 @@ export interface LocalInferencePreset {
   id: string;
   experience: "quick" | "balanced" | "deep";
   label: string;
+  summary: string;
   runtime_id: string;
   runtime_min_revision: string;
   format: "gguf" | "mlx_safetensors";
@@ -235,6 +244,26 @@ export async function downloadAndUseLocalPreset(
       preset_id: preset.id,
       catalog_revision: setup.preset_catalog.catalog_revision,
       context_choice: preset.context.recommended_tokens,
+      expected_route_revision: setup.current_routes.thoughts.revision,
+    },
+  });
+  return result.acquisition;
+}
+
+export async function useExistingLocalModel(
+  setup: InferenceSetup,
+  artifact: InferenceSetupArtifact,
+  requestId: string,
+): Promise<InferenceAcquisition> {
+  const result = await apiFetch<{
+    acquisition: InferenceAcquisition;
+    setup: InferenceSetup;
+  }>("/api/inference/acquisitions/use-existing", {
+    method: "POST",
+    json: {
+      request_id: requestId,
+      detected_artifact_id: artifact.id,
+      context_choice: artifact.activation.context_tokens,
       expected_route_revision: setup.current_routes.thoughts.revision,
     },
   });

--- a/web/src/pages/cores/settingsModels.tsx
+++ b/web/src/pages/cores/settingsModels.tsx
@@ -32,10 +32,12 @@ import { InferenceCapabilityPanel } from "./InferenceCapabilityPanel";
 import {
   getInferenceSetup,
   downloadAndUseLocalPreset,
+  useExistingLocalModel,
   cancelInferenceAcquisition,
   type HostedInferencePreset,
   type InferenceAcquisition,
   type InferenceSetup,
+  type InferenceSetupArtifact,
   type LocalInferencePreset,
 } from "./inferenceSetup";
 
@@ -115,6 +117,7 @@ export function ModelsModule({
   update,
   updateMany,
   commitMany,
+  reconcileSettings,
   onRefuse,
 }: {
   settings: SettingsResponse;
@@ -124,6 +127,8 @@ export function ModelsModule({
   updateMany?(changes: Array<[string[], unknown]>): void;
   /** Immediate coherent settings write for actions that must report durable success. */
   commitMany?(changes: Array<[string[], unknown]>): Promise<boolean>;
+  /** Adopt an authoritative settings change made by another application command. */
+  reconcileSettings?(): Promise<boolean>;
   /** The footer receipt bar; "" clears. */
   onRefuse(refusal: string): void;
 }) {
@@ -199,6 +204,7 @@ export function ModelsModule({
       ].includes(prior);
       if (wasActive && job.state === "ready" && job.activation_state === "in_use") {
         setPresetStatus("Ready · in use for Thoughts.");
+        void reconcileSettings?.();
       } else if (wasActive && job.state === "failed") {
         setPresetStatus(job.error?.message || "Model setup stopped. Try again.");
       } else if (wasActive && job.state === "cancelled") {
@@ -212,7 +218,7 @@ export function ModelsModule({
     if (!active) return;
     const timer = window.setTimeout(() => void reloadInferenceSetup(), 700);
     return () => window.clearTimeout(timer);
-  }, [inferenceSetup, reloadInferenceSetup]);
+  }, [inferenceSetup, reloadInferenceSetup, reconcileSettings]);
 
   const put = async (target: Target) => {
     try {
@@ -448,6 +454,30 @@ export function ModelsModule({
       // A typed HTTP response proves whether the server admitted the command.
       // A transport failure is ambiguous, so retain the exact id for replay.
       if (error instanceof ApiError) delete acquisitionRequestIds.current[preset.id];
+      const detail = readableError(error);
+      setPresetStatus(detail);
+      onRefuse(detail);
+    } finally {
+      setPresetBusy(null);
+    }
+  };
+
+  const useExistingModel = async (artifact: InferenceSetupArtifact) => {
+    if (!inferenceSetup) return;
+    setPresetBusy(artifact.id);
+    setPresetStatus("");
+    const requestId =
+      acquisitionRequestIds.current[artifact.id] || crypto.randomUUID();
+    acquisitionRequestIds.current[artifact.id] = requestId;
+    try {
+      await useExistingLocalModel(inferenceSetup, artifact, requestId);
+      delete acquisitionRequestIds.current[artifact.id];
+      setPresetStatus(`Verifying ${artifact.label}. You can leave Models open or come back later.`);
+      onRefuse("");
+      await reconcileSettings?.();
+      await reloadInferenceSetup();
+    } catch (error) {
+      if (error instanceof ApiError) delete acquisitionRequestIds.current[artifact.id];
       const detail = readableError(error);
       setPresetStatus(detail);
       onRefuse(detail);
@@ -950,6 +980,7 @@ export function ModelsModule({
         onRetry={() => void reloadInferenceSetup()}
         onUseHosted={useOpenRouterPreset}
         onDownloadLocal={downloadLocalPreset}
+        onUseExisting={useExistingModel}
         onCancelAcquisition={cancelLocalAcquisition}
       />
 


### PR DESCRIPTION
## What changed

- combines detected GGUF/MLX artifacts, signed local suggestions, and six OpenRouter presets in one compact radio chooser with one action seat
- lets owners select and activate an existing detected GGUF through one idempotent, path-private HTTP/MCP application command
- adds a pinned Qwen3.5 0.8B GGUF suggestion for intent, routing, and lightweight utility work
- safely reconciles Settings authority after local activation before another route change
- keeps MLX visible but truthfully non-actionable until the runtime slice lands

## Why

Detected models were presented as oversized dead inventory, while suggested and hosted models lived elsewhere. Owners could not use a model already on disk, and the chooser obscured both lightweight local options and broader OpenRouter choices.

## Validation

- `36 passed` — focused backend/API/MCP suite
- `31 passed` — focused Models/Settings web suite
- production web build passed
- isolated-HOME Playwright glass at 1440×900 and 393×900: `2 passed`
- scoped TypeScript check reports no errors in the touched Models/Settings files
- `dw` commit contract passed 7/7 and archived story evidence
