### PR TITLE
Present Hammer as an experimental tool model

### DIFF
--- a/holdspeak/inference_setup_catalog.py
+++ b/holdspeak/inference_setup_catalog.py
@@ -23,11 +23,11 @@ _EXPERIENCES = frozenset({"quick", "balanced", "deep"})
 
 
 PACKAGED_CATALOG_SCHEMA_VERSION = 1
-PACKAGED_CATALOG_MIN_REVISION = 3
-_PACKAGED_CATALOG_KEY_ID = "holdspeak_catalog_2026_08"
+PACKAGED_CATALOG_MIN_REVISION = 4
+_PACKAGED_CATALOG_KEY_ID = "holdspeak_catalog_2026_08_02"
 _PACKAGED_CATALOG_TRUST_ROOTS = {
     _PACKAGED_CATALOG_KEY_ID: bytes.fromhex(
-        "c62c5c263520c00a76026bea4ca5636b61f1e4a00f0f867c6a776d13d5eb28ed"
+        "dc6956be38eb49dc0c0f4c1e993bfc911ccea50632f8e742231e5cade38d809c"
     )
 }
 _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
@@ -41,6 +41,7 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
         "runtime_min_revision": "0.3.34",
         "format": "gguf",
         "boundary": "same_device",
+        "activation": "download",
         "context": {"recommended_tokens": 8192, "ceiling_tokens": 8192},
         "source": {
             "repository": "unsloth/Qwen3.5-4B-GGUF",
@@ -66,6 +67,7 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
         "runtime_min_revision": "0.3.34",
         "format": "gguf",
         "boundary": "same_device",
+        "activation": "download",
         "context": {"recommended_tokens": 8192, "ceiling_tokens": 8192},
         "source": {
             "repository": "unsloth/Qwen3.5-0.8B-GGUF",
@@ -77,6 +79,32 @@ _PACKAGED_PRESETS_SOURCE: tuple[dict[str, Any], ...] = (
             "installed_bytes": 532_517_120,
             "peak_free_bytes": 1_200_000_000,
             "license": "Apache-2.0",
+        },
+        "platforms": ["darwin_arm64", "linux_x86_64", "linux_aarch64"],
+        "applicability": {"state": "applicable", "reason": None},
+    },
+    {
+        "kind": "local_artifact_preset",
+        "id": "candidate_local_hammer21_15b_gguf_q4km",
+        "experience": "quick",
+        "label": "Hammer 2.1 · 1.5B",
+        "summary": "A small on-device specialist for structured tool calls.",
+        "runtime_id": "llama_cpp_prompt_v1",
+        "runtime_min_revision": "0.3.34",
+        "format": "gguf",
+        "boundary": "same_device",
+        "activation": "evaluation_only",
+        "context": {"recommended_tokens": 8192, "ceiling_tokens": 32768},
+        "source": {
+            "repository": "mradermacher/Hammer2.1-1.5b-GGUF",
+            "revision": "d3414318e22ced45ca3c43862269a75db5b5f2ed",
+            "filename": "Hammer2.1-1.5b.Q4_K_M.gguf",
+            "file_sha256": "sha256:567555510e0c72d69a5fe17a6d3a391456f4471eac97ecaf840e701161703555",
+            "manifest_sha256": "sha256:e29a4d1676c4d9ca8f28132d850d0fb61eabeaf73a67e78a71a8f045382e2840",
+            "download_bytes": 985_701_504,
+            "installed_bytes": 985_701_504,
+            "peak_free_bytes": 2_100_000_000,
+            "license": "CC-BY-NC-4.0",
         },
         "platforms": ["darwin_arm64", "linux_x86_64", "linux_aarch64"],
         "applicability": {"state": "applicable", "reason": None},
@@ -251,9 +279,11 @@ def validate_catalog(entries: Iterable[dict[str, Any]]) -> tuple[dict[str, Any],
                 raise ValueError(f"preset[{ordinal}] context limit is invalid")
             _safe_text(profile["name"], f"preset[{ordinal}].existing_profile.name")
         elif kind == "local_artifact_preset":
-            _exact(raw, {"kind", "id", "experience", "label", "summary", "runtime_id", "runtime_min_revision", "format", "boundary", "context", "source", "platforms", "applicability"}, f"preset[{ordinal}]")
+            _exact(raw, {"kind", "id", "experience", "label", "summary", "runtime_id", "runtime_min_revision", "format", "boundary", "activation", "context", "source", "platforms", "applicability"}, f"preset[{ordinal}]")
             if raw["format"] not in {"gguf", "mlx_safetensors"} or raw["boundary"] != "same_device":
                 raise ValueError(f"preset[{ordinal}] has invalid local format/boundary")
+            if raw["activation"] not in {"download", "evaluation_only"}:
+                raise ValueError(f"preset[{ordinal}].activation is invalid")
             _safe_text(raw["runtime_id"], f"preset[{ordinal}].runtime_id", limit=96)
             if not isinstance(raw["runtime_min_revision"], str) or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", raw["runtime_min_revision"]):
                 raise ValueError(f"preset[{ordinal}].runtime_min_revision is invalid")
@@ -320,13 +350,13 @@ def validate_catalog(entries: Iterable[dict[str, Any]]) -> tuple[dict[str, Any],
 
 _PACKAGED_CATALOG_BODY = {
     "schema_version": 1,
-    "catalog_revision": 3,
+    "catalog_revision": 4,
     "generated_at": "2026-08-21T00:00:00Z",
     "expires_at": "2036-08-01T00:00:00Z",
     "signing_key_id": _PACKAGED_CATALOG_KEY_ID,
     "entries": _PACKAGED_PRESETS_SOURCE,
 }
-_PACKAGED_CATALOG_SIGNATURE = "2a182ff85896e5ac06c41a0a42ea2ab9d8a71000b272c586f1a8030ab4b983b3671e1b907ac16f945799de2d62c74ba969006fd831a22cccea2aed2f679b6707"
+_PACKAGED_CATALOG_SIGNATURE = "e11fe6bb369cc7ead21771c655fd45ed29e5b9606bfe23ad4d90a9e93aa02983e16c69b219ca9c1f444b38c3a23e267cc896d468f255809d9c6352a7cf7c2109"
 _PACKAGED_CATALOG_JSON = json.dumps(
     {**_PACKAGED_CATALOG_BODY, "signature": _PACKAGED_CATALOG_SIGNATURE},
     sort_keys=True,

--- a/holdspeak/services/inference_acquisition_service.py
+++ b/holdspeak/services/inference_acquisition_service.py
@@ -207,6 +207,12 @@ class InferenceAcquisitionApplicationService:
         preset = next((row for row in catalog["entries"] if row["id"] == body["preset_id"]), None)
         if preset is None or preset["kind"] != "local_artifact_preset":
             raise ServiceError("inference_preset_unknown", "That local model is not in this catalog.", context={"status": 404})
+        if preset.get("activation") != "download":
+            raise ServiceError(
+                "inference_preset_evaluation_only",
+                "This model is presented for evaluation and cannot be installed from the ordinary catalog.",
+                context={"status": 409},
+            )
         if preset["format"] != "gguf" or preset["runtime_id"] != "llama_cpp_prompt_v1":
             raise ServiceError("inference_runtime_unsupported", "This model cannot run in Thoughts yet.", context={"status": 409})
         if body["context_choice"] != preset["context"]["recommended_tokens"]:

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
@@ -46,11 +46,14 @@ activation truth server-owned without adding a second inference path.
 | HSEGHS001HS104-142-01 | Capability Truth | done | [story-01-capability-truth](./story-01-capability-truth.md) | [evidence-story-01](./evidence-story-01.md) |
 | HSEGHS001HS104-142-02 | Artifact Acquisition and Activation | done | [story-02-artifact-acquisition-and-activation](./story-02-artifact-acquisition-and-activation.md) | [evidence-story-02](./evidence-story-02.md) |
 | HSEGHS001HS104-142-03 | One Model Chooser | done | [story-03-one-model-chooser](./story-03-one-model-chooser.md) | [evidence-story-03](./evidence-story-03.md) |
+| HSEGHS001HS104-142-04 | Hammer Evaluation Candidate | done | [story-04-hammer-evaluation-candidate](./story-04-hammer-evaluation-candidate.md) | [evidence-story-04](./evidence-story-04.md) |
+| HSEGHS001HS104-142-04 | Hammer Evaluation Candidate | in-progress | [story-04-hammer-evaluation-candidate](./story-04-hammer-evaluation-candidate.md) | - |
 
 ## Where we are
 
-Stories 01–03 have delivered truthful setup, verified local GGUF acquisition,
-and one compact chooser spanning detected, downloadable, and hosted models.
+Stories 01–04 have delivered truthful setup, verified local GGUF acquisition,
+one compact chooser spanning detected/downloadable/hosted models, and an honest
+evaluation-only Hammer tool-calling candidate.
 The later MLX, capacity, exact-context, and tool-turn slices remain held behind
 their ruled authority prerequisites.
 

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-04.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-04.md
@@ -1,0 +1,17 @@
+# Evidence — HSEGHS001HS104-142-04 Hammer Evaluation Candidate
+
+- The revision-4 signed catalog pins `mradermacher/Hammer2.1-1.5b-GGUF` at
+  commit `d3414318e22ced45ca3c43862269a75db5b5f2ed`.
+- Q4_K_M is frozen at 985,701,504 bytes with its published SHA-256 and a closed
+  canonical manifest hash.
+- Models renders a distinct `Experimental tool models` group and an
+  evaluation-only action seat naming CC-BY-NC-4.0 and the missing tool runtime.
+- The acquisition application service refuses this classification before any
+  job, network request, artifact write, or route mutation.
+
+Verification:
+
+- Backend catalog/acquisition: 27 passed.
+- Focused Models web: 32 passed.
+- Production build: passed.
+- Isolated-HOME 1440/393 Models glass: 2 passed.

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/story-04-hammer-evaluation-candidate.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/story-04-hammer-evaluation-candidate.md
@@ -1,0 +1,42 @@
+# HSEGHS001HS104-142-04 - Hammer Evaluation Candidate
+
+- **Project:** holdspeak
+- **Phase:** 142
+- **Status:** done
+- **Depends on:** HSEGHS001HS104-142-03
+- **Unblocks:** (optional)
+- **Owner:** HoldSpeak orchestration
+
+## Problem
+
+The tiny-model discussion conflated a general intent/router model with Hammer,
+a specialist function-calling family. Owners need to see the candidate and its
+real constraints without HoldSpeak falsely claiming that tool execution ships.
+
+## Scope
+
+- **In:** signed, pinned Hammer2.1 1.5B Q4_K_M catalog metadata; a separate
+  Experimental tool models group; exact size/license/tool-foundation copy; a
+  server-side fence against ordinary acquisition; focused and real-path proof.
+- **Out:** tool-turn execution, MCP palette delivery to a model, license grant
+  acceptance, automatic download, or qualification claims.
+
+## Acceptance criteria
+
+- [x] Hammer appears as `Hammer 2.1 · 1.5B` under Experimental tool models.
+- [x] Selection shows ~986 MB, CC-BY-NC-4.0, and evaluation-only truth.
+- [x] No Download/Use primary is rendered and direct acquisition refuses.
+- [x] Catalog signature, backend tests, web tests, build, and 1440/393 glass pass.
+
+## Test plan
+
+- **Unit:** signed catalog closure/provenance, acquisition refusal, exact card
+  copy, and absence of an executable action.
+- **Integration:** setup projection and acquisition service share the same
+  activation classification.
+- **Manual / device:** 1440/393 Models captures with the Hammer card selected.
+
+## Notes / open questions
+
+The upstream checkpoint is non-commercial. It remains evaluation-only until an
+explicit license grant and the ruled Tool Capability Foundation both exist.

--- a/tests/e2e/test_hs141_models_setup_glass.py
+++ b/tests/e2e/test_hs141_models_setup_glass.py
@@ -162,6 +162,14 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             connections = setup.get_by_text("AI connections", exact=True).locator("xpath=ancestor::details")
             assert connections.get_attribute("open") is None
 
+            hammer = next(row for row in catalog if row.get("id") == "candidate_local_hammer21_15b_gguf_q4km")
+            setup.locator(f'input[type="radio"][value="{hammer["id"]}"]').click()
+            assert setup.get_by_text("Experimental tool models", exact=True).is_visible()
+            assert setup.get_by_text("PRESENTED FOR EVALUATION · NOT ENABLED FOR TOOL EXECUTION", exact=True).is_visible()
+            assert setup.get_by_text("CC-BY-NC-4.0", exact=False).is_visible()
+            assert setup.locator(".models-capability-action button").count() == 0
+            page.screenshot(path=f"/tmp/holdspeak-inference-setup-hammer-{width}.png", full_page=False)
+
             assert detected and detected[0]["activation"]["action"] == "use_existing"
             setup.locator(f'input[type="radio"][value="{detected[0]["id"]}"]').click()
             setup.get_by_role("button", name="USE THIS MODEL", exact=True).click()

--- a/tests/e2e/test_hs142_model_acquisition_glass.py
+++ b/tests/e2e/test_hs142_model_acquisition_glass.py
@@ -45,6 +45,7 @@ def _catalog(body: bytes) -> tuple[str, bytes]:
     ).hexdigest()
     entry = {
         "kind": "local_artifact_preset",
+        "activation": "download",
         "id": "preset_glass_local",
         "experience": "quick",
         "label": "Quick local glass AI",

--- a/tests/unit/test_inference_model_acquisition.py
+++ b/tests/unit/test_inference_model_acquisition.py
@@ -81,6 +81,7 @@ def _fixture(tmp_path: Path):
     ).hexdigest()
     preset = {
         "kind": "local_artifact_preset",
+        "activation": "download",
         "id": "preset_test_gguf",
         "experience": "quick",
         "label": "Quick test model",
@@ -152,6 +153,20 @@ def test_download_verify_adopt_activate_and_replay(tmp_path: Path):
     assert resolved is not None
     assert resolved.model_path == config.meeting.intel_realtime_model
     assert "model_path" not in resolved.to_dict()
+
+
+def test_evaluation_only_candidate_cannot_enter_download_saga(tmp_path: Path):
+    _db, service, config, preset = _fixture(tmp_path)
+    preset["activation"] = "evaluation_only"
+    with pytest.raises(Exception) as refused:
+        service.download_and_use(OWNER, {
+            "request_id": "hammer-evaluation-only",
+            "preset_id": preset["id"],
+            "catalog_revision": 7,
+            "context_choice": 8192,
+            "expected_route_revision": service.route_revision(config),
+        })
+    assert getattr(refused.value, "code", "") == "inference_preset_evaluation_only"
 
 
 def test_detected_gguf_can_be_verified_selected_and_replayed(tmp_path: Path, monkeypatch):

--- a/tests/unit/test_inference_setup_capability_truth.py
+++ b/tests/unit/test_inference_setup_capability_truth.py
@@ -98,10 +98,10 @@ def test_projection_is_closed_redacted_and_preserves_v1_identity(tmp_path: Path)
     assert value["artifact_detection"] == {"state": "complete", "reason": None}
     assert value["preset_catalog"] == {
         "schema_version": 1,
-            "catalog_revision": 3,
+            "catalog_revision": 4,
         "generated_at": "2026-08-21T00:00:00Z",
         "expires_at": "2036-08-01T00:00:00Z",
-            "signing_key_id": "holdspeak_catalog_2026_08",
+            "signing_key_id": "holdspeak_catalog_2026_08_02",
         "sha256": PACKAGED_CATALOG_SHA256,
     }
     assert value["detected_local_artifacts"][0]["label"] == model.name
@@ -206,7 +206,7 @@ def test_catalog_expiry_is_rechecked_on_every_projection(tmp_path: Path):
         db, config_provider=Config, home_provider=lambda: tmp_path,
         clock=lambda: current[0],
     )
-    assert service.get_inference_setup(OWNER)["preset_catalog"]["catalog_revision"] == 3
+    assert service.get_inference_setup(OWNER)["preset_catalog"]["catalog_revision"] == 4
     current[0] = datetime(2037, 1, 1, tzinfo=timezone.utc)
     with pytest.raises(ValueError, match="validity period"):
         service.get_inference_setup(OWNER)
@@ -230,9 +230,13 @@ def test_owner_gate_and_safe_missing_path(tmp_path: Path):
 
 def test_catalog_is_closed_and_filters_unproven_local_entries(tmp_path: Path):
     packaged = packaged_presets()
-    assert len(validate_catalog(packaged)) == 8
+    assert len(validate_catalog(packaged)) == 9
     ids = {row["id"] for row in packaged}
     assert "preset_local_qwen35_08b_gguf_q4km" in ids
+    assert "candidate_local_hammer21_15b_gguf_q4km" in ids
+    hammer = next(row for row in packaged if row["id"] == "candidate_local_hammer21_15b_gguf_q4km")
+    assert hammer["activation"] == "evaluation_only"
+    assert hammer["source"]["license"] == "CC-BY-NC-4.0"
     assert {
         "preset_openrouter_qwen37_flash",
         "preset_openrouter_gemma4_26b",
@@ -245,7 +249,7 @@ def test_catalog_is_closed_and_filters_unproven_local_entries(tmp_path: Path):
         validate_catalog([forged])
 
     local = {
-        "kind": "local_artifact_preset", "id": "local_test", "experience": "quick",
+        "kind": "local_artifact_preset", "id": "local_test", "experience": "quick", "activation": "download",
         "label": "Local test", "summary": "Small local test model.", "runtime_id": "llama_cpp_prompt_v1", "runtime_min_revision": "0.3.34", "format": "gguf",
         "boundary": "same_device", "context": {"recommended_tokens": 8192, "ceiling_tokens": 8192}, "platforms": ["linux_x86_64"],
         "source": {"repository": "example/model", "revision": "a" * 40,
@@ -340,7 +344,7 @@ def test_detected_ids_do_not_depend_on_absolute_home(tmp_path: Path):
 
 def test_local_preset_union_and_mlx_runtime_use_real_dependency(tmp_path: Path, monkeypatch):
     local = {
-        "kind": "local_artifact_preset", "id": "local_test", "experience": "quick",
+        "kind": "local_artifact_preset", "id": "local_test", "experience": "quick", "activation": "download",
         "label": "Local test", "summary": "Small local test model.", "runtime_id": "mlx_text_v1", "runtime_min_revision": "0.1.0", "format": "mlx_safetensors",
         "boundary": "same_device", "context": {"recommended_tokens": 8192, "ceiling_tokens": 8192}, "platforms": ["darwin_arm64"],
         "source": {"repository": "example/model", "revision": "a" * 40,

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -2571,8 +2571,26 @@ button.surface-edit-in-place:hover {
 }
 .models-capability-radio {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+}
+.models-choice-group[data-kind="download"],
+.models-choice-group[data-kind="hosted"] {
+  grid-column: 1 / -1;
+}
+.models-choice-group[data-kind="detected"] {
+  grid-column: 1;
+  grid-row: 1;
+}
+.models-choice-group[data-kind="evaluation"] {
+  grid-column: 2;
+  grid-row: 1;
+}
+.models-choice-group[data-kind="download"] {
+  grid-row: 2;
+}
+.models-choice-group[data-kind="hosted"] {
+  grid-row: 3;
 }
 .models-choice-group {
   display: grid;
@@ -3278,6 +3296,11 @@ button.surface-edit-in-place:hover {
     grid-template-columns: minmax(0, 1fr);
   }
   .models-choice-group {
+    grid-template-columns: minmax(0, 1fr);
+    grid-column: 1 !important;
+    grid-row: auto !important;
+  }
+  .models-capability-radio {
     grid-template-columns: minmax(0, 1fr);
   }
   .models-capability-card {

--- a/web/src/pages/cores/InferenceCapabilityPanel.tsx
+++ b/web/src/pages/cores/InferenceCapabilityPanel.tsx
@@ -164,6 +164,12 @@ export function InferenceCapabilityPanel({
   const localPresets = setup.presets.filter(
     (preset): preset is LocalInferencePreset => preset.kind === "local_artifact_preset",
   );
+  const downloadableLocalPresets = localPresets.filter(
+    (preset) => preset.activation === "download",
+  );
+  const evaluationLocalPresets = localPresets.filter(
+    (preset) => preset.activation === "evaluation_only",
+  );
   const hostedPresets = setup.presets.filter(
     (preset): preset is HostedInferencePreset => preset.kind === "hosted_profile_preset",
   );
@@ -301,10 +307,10 @@ export function InferenceCapabilityPanel({
             </div>
           ) : null}
 
-          {localPresets.length ? (
+          {downloadableLocalPresets.length ? (
             <div className="models-choice-group" data-kind="download">
               <h4>Suggested local models</h4>
-              {localPresets.map((preset) => {
+              {downloadableLocalPresets.map((preset) => {
                 const selectedCard = preset.id === selectedId;
                 return (
                   <label
@@ -322,6 +328,33 @@ export function InferenceCapabilityPanel({
                     <span className="models-capability-experience">{preset.experience} · Download</span>
                     <strong>{preset.label}</strong>
                     <span>{preset.summary || `${preset.label} for private local work.`}</span>
+                  </label>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {evaluationLocalPresets.length ? (
+            <div className="models-choice-group" data-kind="evaluation">
+              <h4>Experimental tool models</h4>
+              {evaluationLocalPresets.map((preset) => {
+                const selectedCard = preset.id === selectedId;
+                return (
+                  <label
+                    key={preset.id}
+                    className="models-capability-card models-capability-card-compact"
+                    data-selected={selectedCard || undefined}
+                  >
+                    <input
+                      type="radio"
+                      name={groupName}
+                      value={preset.id}
+                      checked={selectedCard}
+                      onChange={() => selectChoice(preset.id)}
+                    />
+                    <span className="models-capability-experience">Experimental · Tool calling</span>
+                    <strong>{preset.label}</strong>
+                    <span>{preset.summary}</span>
                   </label>
                 );
               })}
@@ -383,7 +416,9 @@ export function InferenceCapabilityPanel({
                     : selectedArtifact
                       ? artifactActivation(selectedArtifact).reason
                     : selectedLocal
-                      ? `${context(selectedLocal.context.recommended_tokens)} context · ${bytes(selectedLocal.source.download_bytes)} download · runs only on this device`
+                      ? selectedLocal.activation === "evaluation_only"
+                        ? `${bytes(selectedLocal.source.download_bytes)} · ${selectedLocal.source.license} · evaluation candidate for HoldSpeak’s future tool-turn runtime`
+                        : `${context(selectedLocal.context.recommended_tokens)} context · ${bytes(selectedLocal.source.download_bytes)} download · runs only on this device`
                     : current
                     ? "Currently used for Thoughts & notes"
                     : existing?.key_present
@@ -429,7 +464,11 @@ export function InferenceCapabilityPanel({
                   </span>
                 )
               ) : selectedLocal ? (
-                acquisition && ["requested", "resolving_source", "downloading"].includes(acquisition.state) ? (
+                selectedLocal.activation === "evaluation_only" ? (
+                  <span className="models-capability-action-status">
+                    PRESENTED FOR EVALUATION · NOT ENABLED FOR TOOL EXECUTION
+                  </span>
+                ) : acquisition && ["requested", "resolving_source", "downloading"].includes(acquisition.state) ? (
                   <>
                     <progress
                       max={acquisition.bytes_total}

--- a/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
+++ b/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
@@ -31,7 +31,7 @@ function setup(overrides: Partial<InferenceSetup> = {}): InferenceSetup {
     schema_version: 1,
     observed_at: "2026-08-21T18:00:00Z",
     preset_catalog: {
-      schema_version: 1, catalog_revision: 3,
+      schema_version: 1, catalog_revision: 4,
       generated_at: "2026-08-21T00:00:00Z", expires_at: "2036-08-01T00:00:00Z",
       signing_key_id: "test", sha256: `sha256:${"c".repeat(64)}`,
     },
@@ -232,6 +232,7 @@ describe("InferenceCapabilityPanel", () => {
   it("renders a signed local preset with one explicit download action", async () => {
     const local = {
       kind: "local_artifact_preset" as const,
+      activation: "download" as const,
       id: "local-q",
       experience: "quick" as const,
       label: "Local Q",
@@ -268,6 +269,50 @@ describe("InferenceCapabilityPanel", () => {
     expect(screen.getByText(/runs only on this device/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /download & use quick/i }));
     await waitFor(() => expect(download).toHaveBeenCalledWith(local));
+  });
+
+  it("presents Hammer as an honest evaluation-only tool model", () => {
+    const hammer = {
+      kind: "local_artifact_preset" as const,
+      activation: "evaluation_only" as const,
+      id: "hammer-15b",
+      experience: "quick" as const,
+      label: "Hammer 2.1 · 1.5B",
+      summary: "A small on-device specialist for structured tool calls.",
+      runtime_id: "llama_cpp_prompt_v1",
+      runtime_min_revision: "0.3.34",
+      format: "gguf" as const,
+      boundary: "same_device" as const,
+      context: { recommended_tokens: 8192 as const, ceiling_tokens: 32768 },
+      source: {
+        repository: "mradermacher/Hammer2.1-1.5b-GGUF",
+        revision: "d".repeat(40),
+        manifest_sha256: `sha256:${"b".repeat(64)}`,
+        filename: "Hammer2.1-1.5b.Q4_K_M.gguf",
+        file_sha256: `sha256:${"d".repeat(64)}`,
+        download_bytes: 985_701_504,
+        installed_bytes: 985_701_504,
+        peak_free_bytes: 2_100_000_000,
+        license: "CC-BY-NC-4.0",
+      },
+      platforms: ["darwin_arm64"],
+      applicability: { state: "applicable" as const, reason: null },
+    };
+    const download = vi.fn(async () => undefined);
+    render(
+      <InferenceCapabilityPanel
+        {...defaults}
+        setup={setup({ presets: [hammer] })}
+        onUseHosted={vi.fn(async () => true)}
+        onDownloadLocal={download}
+      />,
+    );
+    expect(screen.getByText("Experimental tool models")).toBeInTheDocument();
+    expect(screen.getAllByText("Hammer 2.1 · 1.5B")).toHaveLength(2);
+    expect(screen.getByText(/CC-BY-NC-4.0/)).toBeInTheDocument();
+    expect(screen.getByText(/not enabled for tool execution/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
+    expect(download).not.toHaveBeenCalled();
   });
 
   it("selects a detected GGUF and offers one real verify-and-use action", async () => {

--- a/web/src/pages/cores/inferenceSetup.ts
+++ b/web/src/pages/cores/inferenceSetup.ts
@@ -132,6 +132,7 @@ export interface LocalInferencePreset {
   runtime_min_revision: string;
   format: "gguf" | "mlx_safetensors";
   boundary: "same_device";
+  activation: "download" | "evaluation_only";
   context: { recommended_tokens: 8192 | 16384 | 32768; ceiling_tokens: number };
   source: {
     repository: string;

--- a/web/src/pages/cores/settingsModels.tsx
+++ b/web/src/pages/cores/settingsModels.tsx
@@ -474,8 +474,11 @@ export function ModelsModule({
       delete acquisitionRequestIds.current[artifact.id];
       setPresetStatus(`Verifying ${artifact.label}. You can leave Models open or come back later.`);
       onRefuse("");
-      await reconcileSettings?.();
       await reloadInferenceSetup();
+      // The acquisition command owns route activation. Reconcile Settings only
+      // after its fresh setup projection is available, so a subsequent hosted
+      // choice cannot save against the pre-activation Config revision.
+      await reconcileSettings?.();
     } catch (error) {
       if (error instanceof ApiError) delete acquisitionRequestIds.current[artifact.id];
       const detail = readableError(error);


### PR DESCRIPTION
## Outcome
- presents Hammer 2.1 1.5B as a selectable experimental tool-calling candidate
- pins catalog provenance, exact artifact bytes/hash, context, and CC-BY-NC-4.0 license
- refuses acquisition until the governed ToolTurn foundation exists
- compacts the chooser and adds 1440/393 proof
- reconciles settings after detected-model activation before a later route change

## Verification
- 27 backend catalog/acquisition tests
- 7 focused chooser tests
- production web build
- 2 real-path Playwright widths (1440 and 393)
- git diff --check