### PR TITLE
Replace the model catalog with a setup wizard

### DIFF
--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
@@ -47,13 +47,13 @@ activation truth server-owned without adding a second inference path.
 | HSEGHS001HS104-142-02 | Artifact Acquisition and Activation | done | [story-02-artifact-acquisition-and-activation](./story-02-artifact-acquisition-and-activation.md) | [evidence-story-02](./evidence-story-02.md) |
 | HSEGHS001HS104-142-03 | One Model Chooser | done | [story-03-one-model-chooser](./story-03-one-model-chooser.md) | [evidence-story-03](./evidence-story-03.md) |
 | HSEGHS001HS104-142-04 | Hammer Evaluation Candidate | done | [story-04-hammer-evaluation-candidate](./story-04-hammer-evaluation-candidate.md) | [evidence-story-04](./evidence-story-04.md) |
-| HSEGHS001HS104-142-04 | Hammer Evaluation Candidate | in-progress | [story-04-hammer-evaluation-candidate](./story-04-hammer-evaluation-candidate.md) | - |
+| HSEGHS001HS104-142-05 | Model Setup Wizard | done | [story-05-model-setup-wizard](./story-05-model-setup-wizard.md) | [evidence-story-05](./evidence-story-05.md) |
 
 ## Where we are
 
-Stories 01–04 have delivered truthful setup, verified local GGUF acquisition,
-one compact chooser spanning detected/downloadable/hosted models, and an honest
-evaluation-only Hammer tool-calling candidate.
+Stories 01–05 have delivered truthful setup, verified local GGUF acquisition,
+an honest evaluation-only Hammer candidate, and a calm three-step chooser that
+never renders the complete model catalog at once.
 The later MLX, capacity, exact-context, and tool-turn slices remain held behind
 their ruled authority prerequisites.
 

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-05.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-05.md
@@ -1,0 +1,17 @@
+# Evidence — HSEGHS001HS104-142-05 Model Setup Wizard
+
+- Models now opens on a three-step Location → Model → Review flow.
+- Device, OpenRouter, and Tool experiments are mutually exclusive views; the
+  browser never mounts the entire catalog wall at once.
+- Full model names and explanations wrap. The old ellipsis/nowrap rules were
+  removed.
+- Review contains the selected model and the sole lawful action; Change model
+  and Change location navigate backward without mutation.
+
+Verification:
+
+- Focused Models component: 7 passed.
+- Production web build: passed.
+- Isolated-HOME 1440/393 Models glass: 2 passed.
+- Screenshots inspected for initial Location and Hammer Review states at both
+  widths.

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/story-05-model-setup-wizard.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/story-05-model-setup-wizard.md
@@ -1,0 +1,45 @@
+# HSEGHS001HS104-142-05 - Model Setup Wizard
+
+- **Project:** holdspeak
+- **Phase:** 142
+- **Status:** done
+- **Depends on:** HSEGHS001HS104-142-03
+- **Unblocks:** pleasant local/hosted/tool candidate selection
+- **Owner:** product
+
+## Problem
+
+The one-screen model catalog made every detected, suggested, hosted, and
+experimental choice compete at once. Compact cards truncated exact model names
+and turned truthful setup into a scanning exercise instead of a decision.
+
+## Scope
+
+- **In:** Replace the catalog wall with a three-step location/model/review
+  wizard, wrap full model names, preserve one action seat, and prove the
+  interaction at 1440 and 393.
+- **Out:** New catalog entries, recommendation authority, runtime execution, or
+  changes to server-owned setup facts.
+
+## Acceptance criteria
+
+- [x] Only one of device, OpenRouter, or tool-experiment choices is visible at
+  a time.
+- [x] The model list and action seat never coexist with the full catalog.
+- [x] Exact model labels wrap and never use ellipsis.
+- [x] Location, model, and review are keyboard-operable and selection alone
+  never mutates settings or starts a download.
+- [x] Review exposes at most one lawful primary action.
+- [x] Real 1440/393 walks cover detected local, Hammer, and hosted choices.
+
+## Test plan
+
+- **Unit:** focused `InferenceCapabilityPanel` behavior and action tests.
+- **Integration:** production web build plus isolated Models setup glass.
+- **Manual / device:** inspect all three wizard states at desktop and narrow
+  width for wrapping, focus, and information density.
+
+## Notes / open questions
+
+No server authority changed. The wizard filters the existing authoritative
+projection and delegates every mutation to the same application commands.

--- a/tests/e2e/test_hs141_models_setup_glass.py
+++ b/tests/e2e/test_hs141_models_setup_glass.py
@@ -119,23 +119,22 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             catalog = projection["presets"]
             detected = projection["detected_local_artifacts"]
             choices = [*detected, *catalog]
+            setup.get_by_role("tab", name="This device", exact=False).click()
             radios = setup.get_by_role("radiogroup", name="AI choices").get_by_role("radio")
-            assert radios.count() == len(choices)
+            # The chooser is a wizard: only the active location's models are
+            # mounted, never the entire catalog wall at once.
+            assert 0 < radios.count() < len(choices)
             if choices:
-                expected = next(
-                    (row for row in hosted if row["existing_profile"]["target_id"] == projection["current_routes"]["thoughts"]["target_id"]),
-                    choices[0],
+                expected_radio = setup.locator(
+                    '.models-capability-radio input[type="radio"]:checked'
                 )
-                expected_radio = setup.locator(f'input[type="radio"][value="{expected["id"]}"]')
+                assert expected_radio.count() == 1
                 assert expected_radio.is_checked()
-                if len(choices) > 1:
-                    expected_index = choices.index(expected)
-                    next_row = choices[(expected_index + 1) % len(choices)]
+                if radios.count() > 1:
                     expected_radio.focus()
                     expected_radio.press("ArrowRight")
-                    assert setup.locator(
-                        f'input[type="radio"][value="{next_row["id"]}"]'
-                    ).is_checked()
+                    setup.get_by_text("Review and use", exact=True).wait_for()
+                    assert setup.locator(".models-capability-radio").count() == 0
                     assert (
                         _api(page, "GET", "/api/settings")["thoughts"][
                             "inference_target_id"
@@ -155,22 +154,31 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             if width == 1440:
                 seat_box = setup.locator(".models-capability-action").bounding_box()
                 body_box = surface_body.bounding_box()
-                selected_box = setup.locator(".models-capability-card[data-selected]").bounding_box()
-                assert seat_box and body_box and selected_box
-                assert selected_box["y"] >= body_box["y"]
+                assert seat_box and body_box
+                assert seat_box["y"] >= body_box["y"]
                 assert seat_box["y"] + seat_box["height"] <= body_box["y"] + body_box["height"]
             connections = setup.get_by_text("AI connections", exact=True).locator("xpath=ancestor::details")
             assert connections.get_attribute("open") is None
 
+            setup.get_by_role("button", name="Change model", exact=True).click()
+            setup.get_by_role("button", name="Change location", exact=True).click()
             hammer = next(row for row in catalog if row.get("id") == "candidate_local_hammer21_15b_gguf_q4km")
+            setup.get_by_role("tab", name="Tool experiments", exact=False).click()
+            hammer_label = setup.get_by_text(hammer["label"], exact=True)
+            assert hammer_label.evaluate(
+                "element => { const style = getComputedStyle(element); return style.whiteSpace !== 'nowrap' && style.textOverflow !== 'ellipsis'; }"
+            )
             setup.locator(f'input[type="radio"][value="{hammer["id"]}"]').click()
-            assert setup.get_by_text("Experimental tool models", exact=True).is_visible()
+            assert setup.get_by_text("Review and use", exact=True).is_visible()
             assert setup.get_by_text("PRESENTED FOR EVALUATION · NOT ENABLED FOR TOOL EXECUTION", exact=True).is_visible()
             assert setup.get_by_text("CC-BY-NC-4.0", exact=False).is_visible()
             assert setup.locator(".models-capability-action button").count() == 0
             page.screenshot(path=f"/tmp/holdspeak-inference-setup-hammer-{width}.png", full_page=False)
 
             assert detected and detected[0]["activation"]["action"] == "use_existing"
+            setup.get_by_role("button", name="Change model", exact=True).click()
+            setup.get_by_role("button", name="Change location", exact=True).click()
+            setup.get_by_role("tab", name="This device", exact=False).click()
             setup.locator(f'input[type="radio"][value="{detected[0]["id"]}"]').click()
             setup.get_by_role("button", name="USE THIS MODEL", exact=True).click()
             setup.get_by_text("Ready · in use for Thoughts", exact=True).wait_for(timeout=10000)
@@ -183,6 +191,9 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
 
             if hosted:
                 chosen = hosted[-1]
+                setup.get_by_role("button", name="Change model", exact=True).click()
+                setup.get_by_role("button", name="Change location", exact=True).click()
+                setup.get_by_role("tab", name="OpenRouter", exact=False).click()
                 radio = setup.locator(f'input[type="radio"][value="{chosen["id"]}"]')
                 radio.click()
                 key = setup.get_by_label("OpenRouter key")

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -2532,6 +2532,20 @@ button.surface-edit-in-place:hover {
   color: var(--text);
   font: 600 13px / 1.35 var(--font-sans);
 }
+.models-device-inline {
+  margin-top: 10px !important;
+  color: var(--text-muted);
+  font: 500 10px / 1.35 var(--font-mono) !important;
+}
+.models-device-inline strong {
+  color: var(--text);
+}
+.models-device-inline-status {
+  display: block;
+  margin-top: 4px;
+  color: var(--warning);
+  font: 600 9px / 1.3 var(--font-mono);
+}
 .models-capability-device,
 .models-capability-choices {
   padding: 12px;
@@ -2571,26 +2585,11 @@ button.surface-edit-in-place:hover {
 }
 .models-capability-radio {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 9px;
-}
-.models-choice-group[data-kind="download"],
-.models-choice-group[data-kind="hosted"] {
-  grid-column: 1 / -1;
-}
-.models-choice-group[data-kind="detected"] {
-  grid-column: 1;
-  grid-row: 1;
-}
-.models-choice-group[data-kind="evaluation"] {
-  grid-column: 2;
-  grid-row: 1;
-}
-.models-choice-group[data-kind="download"] {
-  grid-row: 2;
-}
-.models-choice-group[data-kind="hosted"] {
-  grid-row: 3;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 6px;
+  max-height: 128px;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 .models-choice-group {
   display: grid;
@@ -2618,24 +2617,148 @@ button.surface-edit-in-place:hover {
   background: var(--desk-window-well);
 }
 .models-capability-card.models-capability-card-compact {
-  min-height: 60px;
+  min-height: 68px;
   gap: 4px;
-  padding: 10px 10px 10px 34px;
+  padding: 10px 14px 10px 40px;
 }
 .models-capability-card-compact > strong,
 .models-capability-card-compact > span:not(.models-capability-experience) {
   display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 .models-capability-card.models-capability-card-compact > input {
   top: 12px;
   left: 11px;
 }
 .models-capability-card.models-capability-card-compact[data-selected] {
-  min-height: 60px;
+  min-height: 68px;
   background: color-mix(in srgb, var(--accent) 5%, var(--desk-window-well));
+}
+.models-wizard-step {
+  display: grid;
+  gap: 9px;
+  padding: 10px 0 12px;
+  border-top: 1px solid var(--border);
+}
+.models-wizard-progress {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: var(--border);
+}
+.models-wizard-progress li {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  min-height: 34px;
+  padding: 6px 9px;
+  color: var(--text-muted);
+  background: var(--desk-window-well);
+  font: 600 10px / 1.2 var(--font-mono);
+}
+.models-wizard-progress li > span {
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border);
+  font-size: 8px;
+}
+.models-wizard-progress li[data-current] {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 7%, var(--desk-window-well));
+}
+.models-wizard-progress li[data-current] > span,
+.models-wizard-progress li[data-done] > span {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.models-wizard-heading {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+.models-wizard-heading > span {
+  display: grid;
+  place-items: center;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  border: 1px solid color-mix(in srgb, var(--accent) 70%, var(--border));
+  color: var(--accent);
+  background: var(--desk-window-well);
+  font: 700 10px / 1 var(--font-mono);
+}
+.models-wizard-heading > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.models-wizard-back {
+  margin-left: auto;
+  min-height: 32px;
+  padding: 5px 9px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: transparent;
+  font: 600 9px / 1 var(--font-mono);
+  cursor: pointer;
+}
+.models-wizard-back:hover,
+.models-wizard-back:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+}
+.models-wizard-heading strong {
+  color: var(--text);
+  font: 650 13px / 1.2 var(--font-sans);
+}
+.models-wizard-heading small {
+  color: var(--text-muted);
+  font: 400 10px / 1.35 var(--font-sans);
+}
+.models-wizard-review-heading {
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.models-source-choices {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+.models-source-choices > button {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  min-height: 54px;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  color: var(--text);
+  text-align: left;
+  background: var(--desk-window-well);
+  cursor: pointer;
+}
+.models-source-choices > button[aria-selected="true"] {
+  border-color: var(--accent);
+  box-shadow: inset 3px 0 0 var(--accent);
+  background: color-mix(in srgb, var(--accent) 6%, var(--desk-window-well));
+}
+.models-source-choices > button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.models-source-choices strong {
+  font: 650 12px / 1.2 var(--font-sans);
+}
+.models-source-choices span {
+  color: var(--text-muted);
+  font: 500 9px / 1.3 var(--font-mono);
 }
 .models-choice-detail {
   display: grid;
@@ -2713,7 +2836,7 @@ button.surface-edit-in-place:hover {
   align-items: end;
   gap: 12px;
   min-height: 76px;
-  margin-top: 0;
+  margin-top: 8px;
   padding: 12px;
   border: 1px solid var(--border);
   background: var(--surface-2);
@@ -3302,6 +3425,23 @@ button.surface-edit-in-place:hover {
   }
   .models-capability-radio {
     grid-template-columns: minmax(0, 1fr);
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
+  }
+  .models-source-choices {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .models-wizard-progress li {
+    justify-content: center;
+    padding-inline: 4px;
+    font-size: 9px;
+  }
+  .models-wizard-back {
+    min-height: 44px;
+  }
+  .models-source-choices > button {
+    min-height: 48px;
   }
   .models-capability-card {
     min-height: 52px;

--- a/web/src/pages/cores/InferenceCapabilityPanel.tsx
+++ b/web/src/pages/cores/InferenceCapabilityPanel.tsx
@@ -10,6 +10,7 @@ import type {
 } from "./inferenceSetup";
 
 type ExistingTarget = { id: string; key_present: boolean };
+type ChoiceMode = "device" | "hosted" | "experimental";
 
 function bytes(value: number | null): string {
   if (value == null || !Number.isFinite(value) || value < 0) return "Unknown";
@@ -91,6 +92,8 @@ export function InferenceCapabilityPanel({
 }) {
   const groupName = useId();
   const [selectedId, setSelectedId] = useState("");
+  const [choiceMode, setChoiceMode] = useState<ChoiceMode>("device");
+  const [wizardStep, setWizardStep] = useState<1 | 2 | 3>(1);
   const [key, setKey] = useState("");
 
   useEffect(() => {
@@ -112,13 +115,20 @@ export function InferenceCapabilityPanel({
     const currentArtifact = setup.detected_local_artifacts.find(
       (artifact) => artifact.configured_for_thoughts,
     );
-    setSelectedId(
-      (prior) =>
+    setSelectedId((prior) => {
+      const next =
         currentPreset?.id || currentArtifact?.id ||
-        (choices.some((choice) => choice.id === prior)
-          ? prior
-          : choices[0].id),
-    );
+        (choices.some((choice) => choice.id === prior) ? prior : choices[0].id);
+      const preset = setup.presets.find((choice) => choice.id === next);
+      setChoiceMode(
+        preset?.kind === "hosted_profile_preset"
+          ? "hosted"
+          : preset?.kind === "local_artifact_preset" && preset.activation === "evaluation_only"
+            ? "experimental"
+            : "device",
+      );
+      return next;
+    });
   }, [setup]);
 
   if (loading && !setup) {
@@ -173,6 +183,16 @@ export function InferenceCapabilityPanel({
   const hostedPresets = setup.presets.filter(
     (preset): preset is HostedInferencePreset => preset.kind === "hosted_profile_preset",
   );
+  const deviceChoices: Array<InferenceSetupArtifact | LocalInferencePreset> = [
+    ...setup.detected_local_artifacts,
+    ...downloadableLocalPresets,
+  ];
+  const visibleChoices: Array<InferenceSetupArtifact | InferencePreset> =
+    choiceMode === "hosted"
+      ? hostedPresets
+      : choiceMode === "experimental"
+        ? evaluationLocalPresets
+        : deviceChoices;
   const acquisition = selectedLocal
     ? (setup.acquisitions ?? []).find((row) => row.preset_id === selectedLocal.id) || null
     : selectedArtifact
@@ -182,6 +202,24 @@ export function InferenceCapabilityPanel({
   const selectChoice = (id: string) => {
     setSelectedId(id);
     setKey("");
+  };
+
+  const chooseMode = (mode: ChoiceMode) => {
+    const choices =
+      mode === "hosted"
+        ? hostedPresets
+        : mode === "experimental"
+          ? evaluationLocalPresets
+          : deviceChoices;
+    if (!choices.length) return;
+    setChoiceMode(mode);
+    selectChoice(choices.some((choice) => choice.id === selectedId) ? selectedId : choices[0].id);
+    setWizardStep(2);
+  };
+
+  const reviewChoice = (id: string) => {
+    selectChoice(id);
+    setWizardStep(3);
   };
 
   return (
@@ -197,6 +235,19 @@ export function InferenceCapabilityPanel({
             Choose a private local model or a configured connection. A local
             download starts only when you explicitly ask.
           </p>
+          <p className="models-device-inline">
+            <strong>{hardwareLine(setup)}</strong>
+            {setup.detected_local_artifacts.length
+              ? ` · ${setup.detected_local_artifacts.length} local model${setup.detected_local_artifacts.length === 1 ? "" : "s"} found`
+              : ""}
+          </p>
+          {!setup.detected_local_artifacts.length ? (
+            <span className="models-device-inline-status">
+              {setup.artifact_detection.state === "complete"
+                ? "No local AI detected"
+                : `Local AI inspection ${setup.artifact_detection.state === "partial" ? "incomplete" : "unavailable"}`}
+            </span>
+          ) : null}
         </div>
         <div
           className="models-current-route"
@@ -217,48 +268,6 @@ export function InferenceCapabilityPanel({
       </section>
 
       <section
-        className="models-capability-device"
-        aria-labelledby="models-device-title"
-      >
-        <header>
-          <div>
-            <p className="models-setup-kicker">This device</p>
-            <h3 id="models-device-title">{hardwareLine(setup)}</h3>
-          </div>
-          {setup.hardware.detection.reason ? (
-            <p>{setup.hardware.detection.reason}</p>
-          ) : null}
-        </header>
-        {setup.detected_local_artifacts.length ? (
-          <p className="models-device-summary">
-            <strong>{setup.detected_local_artifacts.length} local model{setup.detected_local_artifacts.length === 1 ? "" : "s"} found.</strong>{" "}
-            Choose one below to see what HoldSpeak can use now.
-          </p>
-        ) : setup.artifact_detection.state === "complete" ? (
-          <div className="models-capability-empty">
-            <strong>No local AI detected</strong>
-            <p>
-              You can keep using a configured connection or add an existing
-              model in Advanced.
-            </p>
-          </div>
-        ) : (
-          <div className="models-capability-empty">
-            <strong>
-              Local AI inspection{" "}
-              {setup.artifact_detection.state === "partial"
-                ? "incomplete"
-                : "unavailable"}
-            </strong>
-            <p>
-              {setup.artifact_detection.reason ||
-                "This hub could not verify whether local AI is present."}
-            </p>
-          </div>
-        )}
-      </section>
-
-      <section
         className="models-capability-choices"
         aria-labelledby="models-choices-title"
       >
@@ -270,128 +279,132 @@ export function InferenceCapabilityPanel({
             changes nothing.
           </p>
         </header>
-        <div
-          className="models-capability-radio"
-          role="radiogroup"
-          aria-label="AI choices"
-        >
-          {setup.detected_local_artifacts.length ? (
-            <div className="models-choice-group" data-kind="detected">
-              <h4>Already on this device</h4>
-              {setup.detected_local_artifacts.map((artifact) => {
-                const selectedCard = artifact.id === selectedId;
-                return (
-                  <label
-                    key={artifact.id}
-                    className="models-capability-card models-capability-card-compact"
-                    data-selected={selectedCard || undefined}
-                  >
-                    <input
-                      type="radio"
-                      name={groupName}
-                      value={artifact.id}
-                      checked={selectedCard}
-                      onChange={() => selectChoice(artifact.id)}
-                    />
-                    <span className="models-capability-experience">
-                      {artifact.format === "gguf" ? "On device · GGUF" : "On device · MLX"}
-                    </span>
-                    <strong>{artifact.label}</strong>
-                    <span>
-                      <span>{supportLabel(artifact.thought_support.state)}</span>
-                      {` · ${bytes(artifact.size_bytes)}`}
-                    </span>
-                  </label>
-                );
-              })}
+        <ol className="models-wizard-progress" aria-label={`Setup step ${wizardStep} of 3`}>
+          {["Location", "Model", "Review"].map((label, index) => (
+            <li key={label} data-current={wizardStep === index + 1 || undefined} data-done={wizardStep > index + 1 || undefined}>
+              <span>{index + 1}</span>{label}
+            </li>
+          ))}
+        </ol>
+        {wizardStep === 1 ? <div className="models-wizard-step">
+          <div className="models-wizard-heading">
+            <span>1</span>
+            <div>
+              <strong>Where should it run?</strong>
+              <small>Show one kind of AI at a time.</small>
             </div>
-          ) : null}
+          </div>
+          <div className="models-source-choices" role="tablist" aria-label="AI location">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={choiceMode === "device"}
+              disabled={!deviceChoices.length}
+              onClick={() => chooseMode("device")}
+            >
+              <strong>This device</strong>
+              <span>{deviceChoices.length} available or suggested</span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={choiceMode === "hosted"}
+              disabled={!hostedPresets.length}
+              onClick={() => chooseMode("hosted")}
+            >
+              <strong>OpenRouter</strong>
+              <span>{hostedPresets.length} curated choices</span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={choiceMode === "experimental"}
+              disabled={!evaluationLocalPresets.length}
+              onClick={() => chooseMode("experimental")}
+            >
+              <strong>Tool experiments</strong>
+              <span>{evaluationLocalPresets.length} evaluation candidate</span>
+            </button>
+          </div>
+        </div> : null}
 
-          {downloadableLocalPresets.length ? (
-            <div className="models-choice-group" data-kind="download">
-              <h4>Suggested local models</h4>
-              {downloadableLocalPresets.map((preset) => {
-                const selectedCard = preset.id === selectedId;
+        {wizardStep === 2 ? <div className="models-wizard-step">
+          <div className="models-wizard-heading">
+            <span>2</span>
+            <div>
+              <strong>
+                {choiceMode === "hosted"
+                  ? "Choose an OpenRouter model"
+                  : choiceMode === "experimental"
+                    ? "Experimental tool models"
+                    : "Choose a model on this device"}
+              </strong>
+              <small>Selection is harmless. Nothing runs or downloads yet.</small>
+            </div>
+            <button type="button" className="models-wizard-back" onClick={() => setWizardStep(1)}>
+              Change location
+            </button>
+          </div>
+          {visibleChoices.length ? (
+            <div
+              className="models-capability-radio"
+              role="radiogroup"
+              aria-label="AI choices"
+            >
+              {visibleChoices.map((choice) => {
+                const artifact = "thought_support" in choice
+                  ? (choice as InferenceSetupArtifact)
+                  : null;
+                const preset = artifact ? null : (choice as InferencePreset);
+                const selectedCard = choice.id === selectedId;
+                const eyebrow = artifact
+                  ? `${artifact.format.toUpperCase()} · ${supportLabel(artifact.thought_support.state)}`
+                  : preset?.kind === "hosted_profile_preset"
+                    ? `${preset.experience} · Cloud`
+                    : preset?.activation === "evaluation_only"
+                      ? "Experimental · Tool calling"
+                      : `${preset?.experience} · Download`;
+                const detail = artifact
+                  ? `${bytes(artifact.size_bytes)} · ${artifact.activation.reason}`
+                  : preset?.summary || `${preset?.label} through OpenRouter.`;
                 return (
                   <label
-                    key={preset.id}
+                    key={choice.id}
                     className="models-capability-card models-capability-card-compact"
                     data-selected={selectedCard || undefined}
+                    onClick={() => reviewChoice(choice.id)}
                   >
                     <input
                       type="radio"
                       name={groupName}
-                      value={preset.id}
+                      value={choice.id}
                       checked={selectedCard}
-                      onChange={() => selectChoice(preset.id)}
+                      onChange={() => reviewChoice(choice.id)}
                     />
-                    <span className="models-capability-experience">{preset.experience} · Download</span>
-                    <strong>{preset.label}</strong>
-                    <span>{preset.summary || `${preset.label} for private local work.`}</span>
+                    <span className="models-capability-experience">{eyebrow}</span>
+                    <strong>{choice.label}</strong>
+                    <span>{detail}</span>
                   </label>
                 );
               })}
             </div>
-          ) : null}
-
-          {evaluationLocalPresets.length ? (
-            <div className="models-choice-group" data-kind="evaluation">
-              <h4>Experimental tool models</h4>
-              {evaluationLocalPresets.map((preset) => {
-                const selectedCard = preset.id === selectedId;
-                return (
-                  <label
-                    key={preset.id}
-                    className="models-capability-card models-capability-card-compact"
-                    data-selected={selectedCard || undefined}
-                  >
-                    <input
-                      type="radio"
-                      name={groupName}
-                      value={preset.id}
-                      checked={selectedCard}
-                      onChange={() => selectChoice(preset.id)}
-                    />
-                    <span className="models-capability-experience">Experimental · Tool calling</span>
-                    <strong>{preset.label}</strong>
-                    <span>{preset.summary}</span>
-                  </label>
-                );
-              })}
-            </div>
-          ) : null}
-
-          {hostedPresets.length ? (
-            <div className="models-choice-group" data-kind="hosted">
-              <h4>OpenRouter</h4>
-              {hostedPresets.map((preset) => {
-                const selectedCard = preset.id === selectedId;
-                return (
-                  <label
-                    key={preset.id}
-                    className="models-capability-card models-capability-card-compact"
-                    data-selected={selectedCard || undefined}
-                  >
-                    <input
-                      type="radio"
-                      name={groupName}
-                      value={preset.id}
-                      checked={selectedCard}
-                      onChange={() => selectChoice(preset.id)}
-                    />
-                    <span className="models-capability-experience">{preset.experience} · Cloud</span>
-                    <strong>{preset.label}</strong>
-                    <span>{preset.summary || `${preset.label} through OpenRouter.`}</span>
-                  </label>
-                );
-              })}
-            </div>
-          ) : setup.detected_local_artifacts.length || localPresets.length ? null : (
+          ) : (
             <div className="models-capability-empty">
-              <strong>No model choices are available on this hub</strong>
-              <p>Refresh Models after configuring a runtime or connection.</p>
+              <strong>No choices are available here</strong>
+              <p>Choose another location or refresh Models after configuring a runtime.</p>
             </div>
           )}
+        </div> : null}
+        {wizardStep === 3 ? <>
+        <div className="models-wizard-heading models-wizard-review-heading">
+          <span>3</span>
+          <div>
+            <strong>Review and use</strong>
+              <small>The only action for the selected model appears below.</small>
+            </div>
+            <button type="button" className="models-wizard-back" onClick={() => setWizardStep(2)}>
+              Change model
+            </button>
         </div>
         <div className="models-capability-action" aria-live="polite">
           {selected || selectedArtifact ? (
@@ -530,6 +543,7 @@ export function InferenceCapabilityPanel({
             </span>
           )}
         </div>
+        </> : null}
         {status ? (
           <p className="models-preset-status" role="status">
             {status}

--- a/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
+++ b/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
@@ -146,6 +146,7 @@ describe("InferenceCapabilityPanel", () => {
         onUseHosted={onUseHosted}
       />,
     );
+    fireEvent.click(screen.getByRole("tab", { name: /^OpenRouter/i }));
     await waitFor(() =>
       expect(screen.getByRole("radio", { name: /deep choice/i })).toBeChecked(),
     );
@@ -265,7 +266,9 @@ describe("InferenceCapabilityPanel", () => {
         onDownloadLocal={download}
       />,
     );
-    expect(screen.getAllByText("Local Q")).toHaveLength(2);
+    fireEvent.click(screen.getByRole("tab", { name: /^This device/i }));
+    fireEvent.click(screen.getByRole("radio", { name: /Local Q/i }));
+    expect(screen.getByText("Local Q")).toBeInTheDocument();
     expect(screen.getByText(/runs only on this device/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /download & use quick/i }));
     await waitFor(() => expect(download).toHaveBeenCalledWith(local));
@@ -307,8 +310,10 @@ describe("InferenceCapabilityPanel", () => {
         onDownloadLocal={download}
       />,
     );
-    expect(screen.getByText("Experimental tool models")).toBeInTheDocument();
-    expect(screen.getAllByText("Hammer 2.1 · 1.5B")).toHaveLength(2);
+    fireEvent.click(screen.getByRole("tab", { name: /^Tool experiments/i }));
+    fireEvent.click(screen.getByRole("radio", { name: /Hammer 2.1/i }));
+    expect(screen.getByText("Review and use")).toBeInTheDocument();
+    expect(screen.getByText("Hammer 2.1 · 1.5B")).toBeInTheDocument();
     expect(screen.getByText(/CC-BY-NC-4.0/)).toBeInTheDocument();
     expect(screen.getByText(/not enabled for tool execution/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
@@ -342,8 +347,10 @@ describe("InferenceCapabilityPanel", () => {
         onUseExisting={useExisting}
       />,
     );
+    fireEvent.click(screen.getByRole("tab", { name: /^This device/i }));
     expect(screen.getByRole("radio", { name: /Qwen3-4B-Q6_K/ })).toBeChecked();
-    expect(screen.getByRole("heading", { name: "Already on this device" })).toBeInTheDocument();
+    expect(screen.getByText("Choose a model on this device")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: /Qwen3-4B-Q6_K/ }));
     fireEvent.click(screen.getByRole("button", { name: "USE THIS MODEL" }));
     await waitFor(() => expect(useExisting).toHaveBeenCalledWith(artifact));
   });
@@ -357,6 +364,8 @@ describe("InferenceCapabilityPanel", () => {
         onUseHosted={failed}
       />,
     );
+    fireEvent.click(screen.getByRole("tab", { name: /^OpenRouter/i }));
+    fireEvent.click(screen.getByRole("radio", { name: /deep choice/i }));
     const key = screen.getByLabelText("OpenRouter key");
     fireEvent.change(key, { target: { value: "sentinel-secret" } });
     fireEvent.click(screen.getByRole("button", { name: "ADD & USE DEEP" }));


### PR DESCRIPTION
## Outcome
- replaces the all-at-once model wall with Location → Model → Review
- shows only one model category at a time
- removes ellipsis and wraps complete model names/details
- keeps exactly one lawful action in the final review step
- preserves server-owned setup and existing mutation commands

## Verification
- focused Models component: 7 passed
- production web build: passed
- isolated-HOME Models glass at 1440 and 393: 2 passed
- screenshots inspected for initial and Hammer review states
- git diff --check