### PR TITLE
Replace model wizard with task-first picker

### DIFF
--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/current-phase-status.md
@@ -48,12 +48,13 @@ activation truth server-owned without adding a second inference path.
 | HSEGHS001HS104-142-03 | One Model Chooser | done | [story-03-one-model-chooser](./story-03-one-model-chooser.md) | [evidence-story-03](./evidence-story-03.md) |
 | HSEGHS001HS104-142-04 | Hammer Evaluation Candidate | done | [story-04-hammer-evaluation-candidate](./story-04-hammer-evaluation-candidate.md) | [evidence-story-04](./evidence-story-04.md) |
 | HSEGHS001HS104-142-05 | Model Setup Wizard | done | [story-05-model-setup-wizard](./story-05-model-setup-wizard.md) | [evidence-story-05](./evidence-story-05.md) |
+| HSEGHS001HS104-142-06 | Task-First Model Picker | done | [story-06-task-first-model-picker](./story-06-task-first-model-picker.md) | [evidence-story-06](./evidence-story-06.md) |
 
 ## Where we are
 
-Stories 01–05 have delivered truthful setup, verified local GGUF acquisition,
-an honest evaluation-only Hammer candidate, and a calm three-step chooser that
-never renders the complete model catalog at once.
+Stories 01–06 have delivered truthful setup, verified local GGUF acquisition,
+an honest evaluation-only Hammer candidate, and a compact task-first model
+picker that puts choices and the sole action in the first useful viewport.
 The later MLX, capacity, exact-context, and tool-turn slices remain held behind
 their ruled authority prerequisites.
 

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-06.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/evidence-story-06.md
@@ -1,0 +1,27 @@
+# Evidence - HSEGHS001HS104-142-06
+
+- **Story:** HSEGHS001HS104-142-06 - Task-First Model Picker
+- **Status:** done
+- **Date:** 2026-08-21
+
+## Proof
+
+# Evidence — HSEGHS001HS104-142-06
+
+## Outcome
+
+Replaced the three-step model setup wizard with one compact task-first master/detail picker. The first useful viewport now contains source filters, model rows, selected truth, and the sole action. Full names wrap; setup issues and per-job routing are disclosed.
+
+## Verification
+
+- Focused Vitest: 2 files, 32 tests passed.
+- Production Vite build passed.
+- Isolated-HOME Playwright glass: 1440×900 and 393×900, 2 tests passed.
+- `git diff --check` passed.
+
+## Visual evidence
+
+- `/tmp/holdspeak-inference-setup-1440.png`
+- `/tmp/holdspeak-inference-setup-393.png`
+- `/tmp/holdspeak-inference-setup-hammer-1440.png`
+- `/tmp/holdspeak-inference-setup-hammer-393.png`

--- a/pm/roadmap/holdspeak/phase-142-inference-instrument/story-06-task-first-model-picker.md
+++ b/pm/roadmap/holdspeak/phase-142-inference-instrument/story-06-task-first-model-picker.md
@@ -1,0 +1,51 @@
+# HSEGHS001HS104-142-06 - Task-First Model Picker
+
+- **Project:** holdspeak
+- **Phase:** 142
+- **Status:** done
+- **Depends on:** HSEGHS001HS104-142-05
+- **Unblocks:** a direct, comprehensible model setup path
+- **Owner:** Codex
+
+## Problem
+
+The three-step Models wizard spent most of its viewport explaining setup instead
+of letting an owner choose a model. It duplicated headings, hid useful choices
+below introductory prose, truncated model names, and separated selection from
+the action with an unnecessary review step.
+
+## Scope
+
+- **In:** Replace the wizard with one task-first master/detail picker; keep
+  source filters, all server-projected choices, full wrapping names, one stable
+  action seat, compact status truth, collapsed setup issues and job routing,
+  and exact 1440/393 behavior.
+- **Out:** New models, recommendation policy, download authority, MLX execution,
+  or any browser-authored capability/readiness fact.
+
+## Acceptance criteria
+
+- [x] The first useful viewport begins with `Choose a model` and the model list,
+  not a hero, progress rail, location step, or review screen.
+- [x] `This device`, `OpenRouter`, and `Experimental` filter one persistent list;
+  selecting a row is inert until the owner invokes the sole action.
+- [x] Full model names wrap and never ellipsize; detected models use compact rows.
+- [x] Desktop shows list, selected detail, and action together; mobile shows at
+  least three rows and an in-surface action panel without horizontal overflow.
+- [x] Visible copy is limited to decision facts, current truth, and direct verbs;
+  setup issues and per-job administration remain disclosed.
+- [x] Focused component tests, production build, and isolated-HOME 1440/393
+  browser glass pass.
+
+## Test plan
+
+- **Unit:** focused `InferenceCapabilityPanel` and Models settings suites.
+- **Integration:** production Vite build.
+- **Manual / device:** isolated-HOME Playwright glass at 1440×900 and 393×900,
+  including source switching, full-name wrapping, one action seat, 44px mobile
+  targets, secret non-leak, and no horizontal overflow.
+
+## Notes / open questions
+
+The server remains the sole source of catalog, hardware, detection, readiness,
+and activation truth. This story changes presentation and copy, not authority.

--- a/tests/e2e/test_hs141_models_setup_glass.py
+++ b/tests/e2e/test_hs141_models_setup_glass.py
@@ -91,17 +91,17 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             _api(page, "PUT", "/api/setup/onboarding", {"disposition": "completed"})
             page.goto(f"{url}/profiles", wait_until="load")
 
-            heading = page.get_by_role("heading", name="Choose your AI", exact=True)
+            heading = page.locator("#models-capability-title")
             heading.wait_for(timeout=10000)
             setup = page.locator(".models-setup")
             projection = _api(page, "GET", "/api/inference/setup")["setup"]
             assert setup.get_by_text("This device", exact=True).first.is_visible()
-            assert setup.get_by_text("Choose AI for each job", exact=True).is_visible()
+            assert setup.get_by_text("Models by job", exact=True).is_visible()
             assert setup.get_by_text("Runs on", exact=True).count() == 0
-            assert setup.get_by_role("heading", name="Choose an experience", exact=True).is_visible()
-            assert setup.get_by_text(projection["current_thought_deployment"]["target"]["name"], exact=True).first.is_visible()
+            assert setup.get_by_role("heading", name="Choose a model", exact=True).is_visible()
+            assert setup.get_by_text("Not configured", exact=True).is_visible()
             body = setup.inner_text()
-            for forbidden in ["Ready to configure", "Recommended", str(home), "/Users/"]:
+            for forbidden in ["Choose your AI", "Choose an experience", "Where should it run", "Review and use", "Ready to configure", "Recommended", str(home), "/Users/"]:
                 assert forbidden not in body
             surface_body = page.locator(".desk-settings-window .desk-surface-body")
             if width == 393:
@@ -121,8 +121,8 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             choices = [*detected, *catalog]
             setup.get_by_role("tab", name="This device", exact=False).click()
             radios = setup.get_by_role("radiogroup", name="AI choices").get_by_role("radio")
-            # The chooser is a wizard: only the active location's models are
-            # mounted, never the entire catalog wall at once.
+            # The active source owns one compact list; the complete catalog is
+            # never mounted as a wall of cards.
             assert 0 < radios.count() < len(choices)
             if choices:
                 expected_radio = setup.locator(
@@ -131,10 +131,13 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
                 assert expected_radio.count() == 1
                 assert expected_radio.is_checked()
                 if radios.count() > 1:
+                    before = expected_radio.get_attribute("value")
                     expected_radio.focus()
                     expected_radio.press("ArrowRight")
-                    setup.get_by_text("Review and use", exact=True).wait_for()
-                    assert setup.locator(".models-capability-radio").count() == 0
+                    assert setup.locator(
+                        '.models-capability-radio input[type="radio"]:checked'
+                    ).get_attribute("value") != before
+                    assert setup.locator(".models-capability-radio").count() == 1
                     assert (
                         _api(page, "GET", "/api/settings")["thoughts"][
                             "inference_target_id"
@@ -145,9 +148,9 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             detection = projection["artifact_detection"]["state"]
             if not projection["detected_local_artifacts"]:
                 if detection == "complete":
-                    assert setup.get_by_text("No local AI detected", exact=True).is_visible()
+                    assert setup.get_by_text("0 detected", exact=False).is_visible()
                 else:
-                    assert setup.get_by_text(f"Local AI inspection {'incomplete' if detection == 'partial' else 'unavailable'}", exact=True).is_visible()
+                    assert setup.get_by_text(f"Scan {detection}", exact=False).is_visible()
 
             primary = setup.locator(".models-capability-action button")
             assert primary.count() <= 1
@@ -160,28 +163,23 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
             connections = setup.get_by_text("AI connections", exact=True).locator("xpath=ancestor::details")
             assert connections.get_attribute("open") is None
 
-            setup.get_by_role("button", name="Change model", exact=True).click()
-            setup.get_by_role("button", name="Change location", exact=True).click()
             hammer = next(row for row in catalog if row.get("id") == "candidate_local_hammer21_15b_gguf_q4km")
-            setup.get_by_role("tab", name="Tool experiments", exact=False).click()
-            hammer_label = setup.get_by_text(hammer["label"], exact=True)
+            setup.get_by_role("tab", name="Experimental", exact=False).click()
+            hammer_label = setup.locator(".models-capability-card strong", has_text=hammer["label"])
             assert hammer_label.evaluate(
                 "element => { const style = getComputedStyle(element); return style.whiteSpace !== 'nowrap' && style.textOverflow !== 'ellipsis'; }"
             )
             setup.locator(f'input[type="radio"][value="{hammer["id"]}"]').click()
-            assert setup.get_by_text("Review and use", exact=True).is_visible()
-            assert setup.get_by_text("PRESENTED FOR EVALUATION · NOT ENABLED FOR TOOL EXECUTION", exact=True).is_visible()
+            assert setup.get_by_text("Evaluation only · tool execution isn’t available yet.", exact=True).is_visible()
             assert setup.get_by_text("CC-BY-NC-4.0", exact=False).is_visible()
             assert setup.locator(".models-capability-action button").count() == 0
             page.screenshot(path=f"/tmp/holdspeak-inference-setup-hammer-{width}.png", full_page=False)
 
             assert detected and detected[0]["activation"]["action"] == "use_existing"
-            setup.get_by_role("button", name="Change model", exact=True).click()
-            setup.get_by_role("button", name="Change location", exact=True).click()
             setup.get_by_role("tab", name="This device", exact=False).click()
             setup.locator(f'input[type="radio"][value="{detected[0]["id"]}"]').click()
-            setup.get_by_role("button", name="USE THIS MODEL", exact=True).click()
-            setup.get_by_text("Ready · in use for Thoughts", exact=True).wait_for(timeout=10000)
+            setup.get_by_role("button", name="USE MODEL", exact=True).click()
+            setup.get_by_text("In use", exact=True).wait_for(timeout=10000)
             used = _api(page, "GET", "/api/inference/setup")["setup"]
             acquisition = next(row for row in used["acquisitions"] if row["preset_id"] == detected[0]["id"])
             assert acquisition["state"] == "ready"
@@ -191,26 +189,24 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
 
             if hosted:
                 chosen = hosted[-1]
-                setup.get_by_role("button", name="Change model", exact=True).click()
-                setup.get_by_role("button", name="Change location", exact=True).click()
                 setup.get_by_role("tab", name="OpenRouter", exact=False).click()
                 radio = setup.locator(f'input[type="radio"][value="{chosen["id"]}"]')
                 radio.click()
                 key = setup.get_by_label("OpenRouter key")
                 key.fill("glass-only-openrouter-key")
-                action = setup.get_by_role("button", name=f"ADD & USE {chosen['experience'].upper()}", exact=True)
+                action = setup.get_by_role("button", name="CONNECT & USE", exact=True)
                 action.click()
                 page.wait_for_timeout(1200)
                 assert key.count() == 0 or key.input_value() == "", setup.inner_text()
                 config = _api(page, "GET", "/api/settings")
                 assert config["thoughts"]["inference_target_id"] == chosen["existing_profile"]["target_id"]
-                setup.get_by_text("IN USE FOR THOUGHTS", exact=True).wait_for(timeout=10000)
+                setup.get_by_text("IN USE", exact=True).wait_for(timeout=10000)
                 targets = _api(page, "GET", "/api/inference-targets")["targets"]
                 selected = next(row for row in targets if row["id"] == chosen["existing_profile"]["target_id"])
                 assert selected["model"] == chosen["existing_profile"]["model"]
                 assert selected["secret"] == {"required": True, "present": True}
                 assert "glass-only-openrouter-key" not in str(targets)
-                assert setup.get_by_text("IN USE FOR THOUGHTS", exact=True).is_visible()
+                assert setup.get_by_text("IN USE", exact=True).is_visible()
                 assert setup.locator(".models-capability-action button").count() == 0
                 page.screenshot(path=f"/tmp/holdspeak-inference-setup-configured-{width}.png", full_page=False)
 

--- a/web/src/desk/surface/surface.css
+++ b/web/src/desk/surface/surface.css
@@ -2906,6 +2906,205 @@ button.surface-edit-in-place:hover {
   color: var(--accent);
   font: 600 9px / 1.2 var(--font-mono);
 }
+
+/* HS-142-06: the model picker is a task surface, not a setup brochure. */
+.models-model-picker {
+  border: 1px solid var(--border);
+  background: var(--desk-window-well);
+  box-shadow: inset 1px 1px 0 var(--etch-light);
+}
+.models-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 50px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.models-picker-header h2,
+.models-model-picker-main h3 {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-sans);
+}
+.models-picker-header h2 { font-size: 19px; }
+.models-model-picker-main h3 { font-size: 15px; }
+.models-picker-header .models-current-route {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  max-width: min(52%, 520px);
+  min-height: 30px;
+  padding: 5px 9px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--warning);
+  background: var(--surface-2);
+}
+.models-picker-header .models-current-route[data-available] { border-left-color: var(--success); }
+.models-picker-header .models-current-route > span { flex: 0 0 auto; }
+.models-picker-header .models-current-route > strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+.models-model-picker-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 330px;
+  min-height: 360px;
+}
+.models-model-picker-main {
+  display: grid;
+  align-content: start;
+  gap: 9px;
+  min-width: 0;
+  padding: 13px 14px 14px;
+}
+.models-model-picker .models-source-choices {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+.models-model-picker .models-source-choices > button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 38px;
+  padding: 7px 9px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  text-align: center;
+  background: transparent;
+}
+.models-model-picker .models-source-choices > button[aria-selected="true"] {
+  border-bottom-color: var(--accent);
+  box-shadow: none;
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+.models-model-picker .models-source-choices span {
+  display: grid;
+  place-items: center;
+  min-width: 19px;
+  height: 19px;
+  border: 1px solid var(--border);
+  font-size: 8px;
+}
+.models-picker-facts {
+  margin: 0;
+  color: var(--text-muted);
+  font: 500 9px / 1.3 var(--font-mono);
+}
+.models-model-picker .models-capability-radio {
+  max-height: clamp(260px, 44vh, 520px);
+  gap: 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+  overflow-y: auto;
+}
+.models-model-picker .models-capability-card.models-capability-card-compact {
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-rows: auto auto;
+  column-gap: 12px;
+  min-height: 62px;
+  padding: 10px 12px 10px 38px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+}
+.models-model-picker .models-capability-card.models-capability-card-compact[data-selected] {
+  min-height: 62px;
+  box-shadow: inset 3px 0 0 var(--accent);
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+.models-model-picker .models-capability-card-compact > strong {
+  grid-column: 1;
+  grid-row: 1;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  font-size: 13px;
+}
+.models-model-picker .models-capability-card-compact > span {
+  grid-column: 1;
+  grid-row: 2;
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+  font: 400 10px / 1.3 var(--font-sans);
+}
+.models-model-picker .models-capability-card-compact > small {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: center;
+  color: var(--text-muted);
+  white-space: nowrap;
+  font: 600 9px / 1.2 var(--font-mono);
+}
+.models-model-detail {
+  position: relative;
+  min-width: 0;
+  border-left: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.models-model-detail .models-capability-action {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  min-height: 0;
+  margin: 0;
+  padding: 16px;
+  border: 0;
+  background: transparent;
+}
+.models-model-detail .models-capability-action > div {
+  gap: 4px;
+}
+.models-model-detail .models-capability-action > div > span {
+  color: var(--text-muted);
+  font: 600 9px / 1.2 var(--font-mono);
+  text-transform: uppercase;
+}
+.models-model-detail .models-capability-action > div > strong {
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font: 650 17px / 1.25 var(--font-sans);
+}
+.models-selected-summary {
+  color: var(--text-muted);
+  font: 500 10px / 1.45 var(--font-mono);
+}
+.models-model-detail .models-capability-action > button,
+.models-model-detail .models-capability-action > label,
+.models-model-detail .models-capability-action-status {
+  width: 100%;
+  justify-self: stretch;
+}
+.models-model-detail .models-capability-action-status {
+  min-height: 0;
+  color: var(--warning);
+  font: 600 10px / 1.4 var(--font-sans);
+  letter-spacing: 0;
+  text-transform: none;
+}
+details.models-capability-limits {
+  display: block;
+  padding: 0;
+}
+details.models-capability-limits > summary {
+  min-height: 38px;
+  padding: 10px 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: 600 10px / 1.2 var(--font-mono);
+}
+details.models-capability-limits > div {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  border-top: 1px solid var(--border);
+}
 .models-setup-intro {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(220px, max-content);
@@ -3396,6 +3595,66 @@ button.surface-edit-in-place:hover {
   }
 }
 @container surface (max-width: 559.9px) {
+  .models-picker-header {
+    min-height: 44px;
+    padding: 7px 10px;
+  }
+  .models-picker-header h2 { font-size: 16px; }
+  .models-picker-header .models-current-route {
+    max-width: 68%;
+    min-height: 28px;
+  }
+  .models-model-picker-body {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 0;
+  }
+  .models-model-picker-main {
+    padding: 10px;
+  }
+  .models-model-picker .models-source-choices {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .models-model-picker .models-source-choices > button {
+    min-height: 44px;
+    padding-inline: 4px;
+  }
+  .models-model-picker .models-source-choices strong {
+    font-size: 10px;
+  }
+  .models-model-picker .models-capability-radio {
+    max-height: 42vh;
+    overflow-y: auto;
+  }
+  .models-model-picker .models-capability-card.models-capability-card-compact {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 64px;
+    padding-right: 10px;
+  }
+  .models-model-picker .models-capability-card-compact > small {
+    grid-column: 1;
+    grid-row: 3;
+    margin-top: 3px;
+    white-space: normal;
+  }
+  .models-model-detail {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    border-top: 1px solid var(--border);
+    border-left: 0;
+    box-shadow: 0 -8px 18px color-mix(in srgb, #000 36%, transparent);
+  }
+  .models-model-detail .models-capability-action {
+    position: static;
+    gap: 8px;
+    padding: 11px;
+  }
+  .models-model-detail .models-capability-action > div > strong {
+    font-size: 14px;
+  }
+  details.models-capability-limits > div {
+    grid-template-columns: minmax(0, 1fr);
+  }
   .models-capability-intro {
     grid-template-columns: minmax(0, 1fr);
     padding: 15px 14px;

--- a/web/src/pages/cores/InferenceCapabilityPanel.tsx
+++ b/web/src/pages/cores/InferenceCapabilityPanel.tsx
@@ -24,6 +24,27 @@ function context(value: number): string {
     : `${value.toLocaleString()} tokens`;
 }
 
+function modelLabel(choice: InferencePreset | InferenceSetupArtifact): string {
+  return choice.label
+    .replace(/^OpenRouter · /, "")
+    .replace(/^Quick local Qwen$/, "Quick Qwen")
+    .replace(/^Tiny local Qwen$/, "Tiny Qwen");
+}
+
+function modelSummary(preset: InferencePreset): string {
+  const summaries: Record<string, string> = {
+    preset_local_qwen35_4b_gguf_q4km: "Fast everyday model.",
+    preset_local_qwen35_08b_gguf_q4km: "Lightweight intent and routing.",
+    preset_openrouter_qwen3_8b: "Fast everyday model.",
+    preset_openrouter_qwen35_35b_a3b: "General reasoning.",
+    preset_openrouter_qwen38_27b: "Harder reasoning and synthesis.",
+    preset_openrouter_qwen37_flash: "Fast, economical everyday model.",
+    preset_openrouter_gemma4_26b: "Writing and synthesis.",
+    preset_openrouter_qwen3_coder_next: "Technical planning and code.",
+  };
+  return summaries[preset.id] || preset.summary;
+}
+
 function hardwareLine(setup: InferenceSetup): string {
   const { capability, detection } = setup.hardware;
   if (detection.state === "unavailable") return "Hardware details unavailable";
@@ -93,7 +114,6 @@ export function InferenceCapabilityPanel({
   const groupName = useId();
   const [selectedId, setSelectedId] = useState("");
   const [choiceMode, setChoiceMode] = useState<ChoiceMode>("device");
-  const [wizardStep, setWizardStep] = useState<1 | 2 | 3>(1);
   const [key, setKey] = useState("");
 
   useEffect(() => {
@@ -134,15 +154,15 @@ export function InferenceCapabilityPanel({
   if (loading && !setup) {
     return (
       <section className="models-capability-opening" aria-busy="true">
-        <span>Reading this hub…</span>
+        <span>Loading models…</span>
       </section>
     );
   }
   if (error || !setup) {
     return (
       <section className="models-capability-opening" role="alert">
-        <strong>Could not read this hub’s AI setup.</strong>
-        <p>{error || "The setup projection is unavailable."}</p>
+        <strong>Models couldn’t load.</strong>
+        <p>{error || "Try again."}</p>
         <Button variant="primary" onClick={onRetry}>
           TRY AGAIN
         </Button>
@@ -155,6 +175,14 @@ export function InferenceCapabilityPanel({
     deployment.execution_revision?.schema_version === 2
       ? deployment.execution_revision.model
       : deployment.target.model;
+  const routePreset = setup.presets.find(
+    (preset) =>
+      preset.kind === "hosted_profile_preset" &&
+      preset.existing_profile.target_id === setup.current_routes.thoughts.target_id,
+  );
+  const routeArtifact = setup.detected_local_artifacts.find(
+    (artifact) => artifact.configured_for_thoughts,
+  );
   const selected: InferencePreset | null =
     setup.presets.find((preset) => preset.id === selectedId) || null;
   const selectedArtifact =
@@ -198,6 +226,9 @@ export function InferenceCapabilityPanel({
     : selectedArtifact
       ? (setup.acquisitions ?? []).find((row) => row.preset_id === selectedArtifact.id) || null
       : null;
+  const selectedArtifactActivation = selectedArtifact
+    ? artifactActivation(selectedArtifact)
+    : null;
 
   const selectChoice = (id: string) => {
     setSelectedId(id);
@@ -211,234 +242,136 @@ export function InferenceCapabilityPanel({
         : mode === "experimental"
           ? evaluationLocalPresets
           : deviceChoices;
-    if (!choices.length) return;
     setChoiceMode(mode);
-    selectChoice(choices.some((choice) => choice.id === selectedId) ? selectedId : choices[0].id);
-    setWizardStep(2);
-  };
-
-  const reviewChoice = (id: string) => {
-    selectChoice(id);
-    setWizardStep(3);
+    selectChoice(
+      choices.length
+        ? choices.some((choice) => choice.id === selectedId)
+          ? selectedId
+          : choices[0].id
+        : "",
+    );
   };
 
   return (
     <>
       <section
-        className="models-capability-intro"
+        className="models-model-picker"
         aria-labelledby="models-capability-title"
       >
-        <div>
-          <p className="models-setup-kicker">AI setup</p>
-          <h2 id="models-capability-title">Choose your AI</h2>
-          <p>
-            Choose a private local model or a configured connection. A local
-            download starts only when you explicitly ask.
-          </p>
-          <p className="models-device-inline">
-            <strong>{hardwareLine(setup)}</strong>
-            {setup.detected_local_artifacts.length
-              ? ` · ${setup.detected_local_artifacts.length} local model${setup.detected_local_artifacts.length === 1 ? "" : "s"} found`
-              : ""}
-          </p>
-          {!setup.detected_local_artifacts.length ? (
-            <span className="models-device-inline-status">
-              {setup.artifact_detection.state === "complete"
-                ? "No local AI detected"
-                : `Local AI inspection ${setup.artifact_detection.state === "partial" ? "incomplete" : "unavailable"}`}
-            </span>
-          ) : null}
-        </div>
-        <div
-          className="models-current-route"
-          data-available={deployment.execution_support.executable || undefined}
-        >
-          <span>Thoughts &amp; notes</span>
-          <strong>
-            {deployment.target.name}
-            {routeModel ? ` · ${routeModel}` : ""}
-          </strong>
-          <small>
-            {deployment.execution_support.executable
-              ? "Available for Thoughts"
-              : deployment.execution_support.reason ||
-                "Not available for Thoughts"}
-          </small>
-        </div>
-      </section>
-
-      <section
-        className="models-capability-choices"
-        aria-labelledby="models-choices-title"
-      >
-        <header>
-          <p className="models-setup-kicker">Thoughts &amp; notes</p>
-          <h3 id="models-choices-title">Choose an experience</h3>
-          <p>
-            These choices come from this hub’s verified catalog. Selecting one
-            changes nothing.
-          </p>
+        <header className="models-picker-header">
+          <h2 id="models-capability-title">Choose a model</h2>
+          <div
+            className="models-current-route"
+            data-available={deployment.execution_support.executable || undefined}
+            title={deployment.execution_support.reason || undefined}
+          >
+            <span>Thoughts</span>
+            <strong>
+              {deployment.execution_support.executable
+                ? routePreset
+                  ? modelLabel(routePreset)
+                  : routeArtifact
+                    ? modelLabel(routeArtifact)
+                    : routeModel || deployment.target.name
+                : "Not configured"}
+            </strong>
+          </div>
         </header>
-        <ol className="models-wizard-progress" aria-label={`Setup step ${wizardStep} of 3`}>
-          {["Location", "Model", "Review"].map((label, index) => (
-            <li key={label} data-current={wizardStep === index + 1 || undefined} data-done={wizardStep > index + 1 || undefined}>
-              <span>{index + 1}</span>{label}
-            </li>
-          ))}
-        </ol>
-        {wizardStep === 1 ? <div className="models-wizard-step">
-          <div className="models-wizard-heading">
-            <span>1</span>
-            <div>
-              <strong>Where should it run?</strong>
-              <small>Show one kind of AI at a time.</small>
-            </div>
-          </div>
-          <div className="models-source-choices" role="tablist" aria-label="AI location">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={choiceMode === "device"}
-              disabled={!deviceChoices.length}
-              onClick={() => chooseMode("device")}
-            >
-              <strong>This device</strong>
-              <span>{deviceChoices.length} available or suggested</span>
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={choiceMode === "hosted"}
-              disabled={!hostedPresets.length}
-              onClick={() => chooseMode("hosted")}
-            >
-              <strong>OpenRouter</strong>
-              <span>{hostedPresets.length} curated choices</span>
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={choiceMode === "experimental"}
-              disabled={!evaluationLocalPresets.length}
-              onClick={() => chooseMode("experimental")}
-            >
-              <strong>Tool experiments</strong>
-              <span>{evaluationLocalPresets.length} evaluation candidate</span>
-            </button>
-          </div>
-        </div> : null}
 
-        {wizardStep === 2 ? <div className="models-wizard-step">
-          <div className="models-wizard-heading">
-            <span>2</span>
-            <div>
-              <strong>
-                {choiceMode === "hosted"
-                  ? "Choose an OpenRouter model"
-                  : choiceMode === "experimental"
-                    ? "Experimental tool models"
-                    : "Choose a model on this device"}
-              </strong>
-              <small>Selection is harmless. Nothing runs or downloads yet.</small>
+        <div className="models-model-picker-body">
+          <div className="models-model-picker-main">
+            <div className="models-source-choices" role="tablist" aria-label="Model source">
+              <button type="button" role="tab" aria-selected={choiceMode === "device"} onClick={() => chooseMode("device")}>
+                <strong>This device</strong><span>{deviceChoices.length}</span>
+              </button>
+              <button type="button" role="tab" aria-selected={choiceMode === "hosted"} disabled={!hostedPresets.length} onClick={() => chooseMode("hosted")}>
+                <strong>OpenRouter</strong><span>{hostedPresets.length}</span>
+              </button>
+              <button type="button" role="tab" aria-selected={choiceMode === "experimental"} disabled={!evaluationLocalPresets.length} onClick={() => chooseMode("experimental")}>
+                <strong>Experimental</strong><span>{evaluationLocalPresets.length}</span>
+              </button>
             </div>
-            <button type="button" className="models-wizard-back" onClick={() => setWizardStep(1)}>
-              Change location
-            </button>
+
+            {choiceMode === "device" ? (
+              <p className="models-picker-facts">
+                {hardwareLine(setup)} · {setup.detected_local_artifacts.length} detected · {downloadableLocalPresets.length} to download
+                {setup.artifact_detection.state === "complete"
+                  ? ""
+                  : ` · Scan ${setup.artifact_detection.state}`}
+              </p>
+            ) : null}
+
+            {visibleChoices.length ? (
+              <div className="models-capability-radio" role="radiogroup" aria-label="AI choices">
+                {visibleChoices.map((choice) => {
+                  const artifact = "thought_support" in choice ? (choice as InferenceSetupArtifact) : null;
+                  const preset = artifact ? null : (choice as InferencePreset);
+                  const selectedCard = choice.id === selectedId;
+                  const meta = artifact
+                    ? `${artifact.format.toUpperCase()} · ${bytes(artifact.size_bytes)}`
+                    : preset?.kind === "hosted_profile_preset"
+                      ? `${preset.experience} · ${context(preset.context.working_ceiling_tokens)}`
+                      : preset?.activation === "evaluation_only"
+                        ? `${bytes(preset.source.download_bytes)} · ${context(preset.context.recommended_tokens)}`
+                        : `${preset?.experience} · ${bytes(preset?.source.download_bytes ?? 0)} · ${context(preset?.context.recommended_tokens ?? 8192)}`;
+                  const descriptor = artifact
+                    ? supportLabel(artifact.thought_support.state)
+                    : preset?.kind === "local_artifact_preset" && preset.activation === "evaluation_only"
+                      ? "Tool calling"
+                    : preset ? modelSummary(preset) : "Configured connection";
+                  return (
+                    <label key={choice.id} className="models-capability-card models-capability-card-compact" data-selected={selectedCard || undefined}>
+                      <input type="radio" name={groupName} value={choice.id} checked={selectedCard} onChange={() => selectChoice(choice.id)} />
+                      <strong>{modelLabel(choice)}</strong>
+                      <span>{descriptor}</span>
+                      <small>{meta}</small>
+                    </label>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="models-capability-empty"><strong>No models here</strong></div>
+            )}
           </div>
-          {visibleChoices.length ? (
-            <div
-              className="models-capability-radio"
-              role="radiogroup"
-              aria-label="AI choices"
-            >
-              {visibleChoices.map((choice) => {
-                const artifact = "thought_support" in choice
-                  ? (choice as InferenceSetupArtifact)
-                  : null;
-                const preset = artifact ? null : (choice as InferencePreset);
-                const selectedCard = choice.id === selectedId;
-                const eyebrow = artifact
-                  ? `${artifact.format.toUpperCase()} · ${supportLabel(artifact.thought_support.state)}`
-                  : preset?.kind === "hosted_profile_preset"
-                    ? `${preset.experience} · Cloud`
-                    : preset?.activation === "evaluation_only"
-                      ? "Experimental · Tool calling"
-                      : `${preset?.experience} · Download`;
-                const detail = artifact
-                  ? `${bytes(artifact.size_bytes)} · ${artifact.activation.reason}`
-                  : preset?.summary || `${preset?.label} through OpenRouter.`;
-                return (
-                  <label
-                    key={choice.id}
-                    className="models-capability-card models-capability-card-compact"
-                    data-selected={selectedCard || undefined}
-                    onClick={() => reviewChoice(choice.id)}
-                  >
-                    <input
-                      type="radio"
-                      name={groupName}
-                      value={choice.id}
-                      checked={selectedCard}
-                      onChange={() => reviewChoice(choice.id)}
-                    />
-                    <span className="models-capability-experience">{eyebrow}</span>
-                    <strong>{choice.label}</strong>
-                    <span>{detail}</span>
-                  </label>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="models-capability-empty">
-              <strong>No choices are available here</strong>
-              <p>Choose another location or refresh Models after configuring a runtime.</p>
-            </div>
-          )}
-        </div> : null}
-        {wizardStep === 3 ? <>
-        <div className="models-wizard-heading models-wizard-review-heading">
-          <span>3</span>
-          <div>
-            <strong>Review and use</strong>
-              <small>The only action for the selected model appears below.</small>
-            </div>
-            <button type="button" className="models-wizard-back" onClick={() => setWizardStep(2)}>
-              Change model
-            </button>
-        </div>
-        <div className="models-capability-action" aria-live="polite">
-          {selected || selectedArtifact ? (
-            <>
-              <div>
-                <strong>{selected?.label || selectedArtifact?.label}</strong>
-                <span>
+
+          <aside className="models-model-detail" aria-live="polite">
+            <div className="models-capability-action">
+              {selected || selectedArtifact ? (
+                <>
+                  <div>
+                    <strong>{selected ? modelLabel(selected) : selectedArtifact ? modelLabel(selectedArtifact) : ""}</strong>
+                  </div>
+                  <span className="models-selected-summary">
                   {acquisition
                     ? acquisition.state === "downloading"
                       ? `Downloading ${bytes(acquisition.transport_bytes)} of ${bytes(acquisition.bytes_total)}`
                       : acquisition.state === "verifying"
                         ? selectedArtifact
-                          ? "Verifying this model’s complete contents…"
+                          ? "Verifying…"
                           : "Verifying the published checksum…"
                         : acquisition.state === "installing"
                           ? selectedArtifact
-                            ? "Making this the local AI for Thoughts…"
-                            : "Installing verified model bytes…"
+                            ? "Installing…"
+                            : "Installing…"
                           : acquisition.state === "ready" && acquisition.activation_state === "in_use"
-                            ? "Ready · in use for Thoughts"
+                            ? "In use"
                             : acquisition.error?.message || acquisition.state
                     : selectedArtifact
-                      ? artifactActivation(selectedArtifact).reason
+                      ? selectedArtifactActivation?.state === "current"
+                        ? "In use"
+                        : selectedArtifactActivation?.action === "use_existing"
+                          ? "Verified before use."
+                          : selectedArtifactActivation?.reason
                     : selectedLocal
                       ? selectedLocal.activation === "evaluation_only"
-                        ? `${bytes(selectedLocal.source.download_bytes)} · ${selectedLocal.source.license} · evaluation candidate for HoldSpeak’s future tool-turn runtime`
-                        : `${context(selectedLocal.context.recommended_tokens)} context · ${bytes(selectedLocal.source.download_bytes)} download · runs only on this device`
+                        ? `${bytes(selectedLocal.source.download_bytes)} · ${context(selectedLocal.context.recommended_tokens)} · ${selectedLocal.source.license}`
+                        : `Local · ${context(selectedLocal.context.recommended_tokens)} · ${bytes(selectedLocal.source.download_bytes)} download`
                     : current
-                    ? "Currently used for Thoughts & notes"
+                    ? "In use"
                     : existing?.key_present
-                      ? `Already configured · ${context(selectedHosted?.context.working_ceiling_tokens || 8192)} working context`
-                      : `Requires an OpenRouter key · ${context(selectedHosted?.context.working_ceiling_tokens || 8192)} working context`}
+                      ? `OpenRouter · ${context(selectedHosted?.context.working_ceiling_tokens || 8192)}`
+                      : `OpenRouter key required · ${context(selectedHosted?.context.working_ceiling_tokens || 8192)}`}
                 </span>
-              </div>
               {selectedHosted && !current && !targetsLoading && !existing?.key_present ? (
                 <label>
                   <span>OpenRouter key</span>
@@ -453,33 +386,33 @@ export function InferenceCapabilityPanel({
               ) : null}
               {selectedArtifact ? (
                 acquisition && ["requested", "resolving_source"].includes(acquisition.state) ? (
-                  <span className="models-capability-action-status">PREPARING VERIFICATION…</span>
+                  <span className="models-capability-action-status">PREPARING…</span>
                 ) : acquisition && ["verifying", "installing"].includes(acquisition.state) ? (
                   <span className="models-capability-action-status">
-                    {acquisition.state === "verifying" ? "VERIFYING…" : "MAKING IT AVAILABLE…"}
+                    {acquisition.state === "verifying" ? "VERIFYING…" : "INSTALLING…"}
                   </span>
                 ) : acquisition?.state === "ready" && acquisition.activation_state === "in_use" ? (
-                  <span className="models-capability-action-status">IN USE FOR THOUGHTS</span>
-                ) : artifactActivation(selectedArtifact).action === "use_existing" ? (
+                  <span className="models-capability-action-status">IN USE</span>
+                ) : selectedArtifactActivation?.action === "use_existing" ? (
                   <Button
                     variant="primary"
                     disabled={Boolean(busyPresetId)}
                     loading={busyPresetId === selectedArtifact.id}
                     onClick={() => void onUseExisting?.(selectedArtifact)}
                   >
-                    {acquisition?.state === "failed" ? "TRY AGAIN" : "USE THIS MODEL"}
+                    {acquisition?.state === "failed" ? "TRY AGAIN" : "USE MODEL"}
                   </Button>
                 ) : (
                   <span className="models-capability-action-status">
                     {selectedArtifact.configured_for_thoughts
-                      ? "IN USE FOR THOUGHTS"
-                      : artifactActivation(selectedArtifact).reason.toUpperCase()}
+                      ? "IN USE"
+                      : selectedArtifactActivation?.reason.toUpperCase()}
                   </span>
                 )
               ) : selectedLocal ? (
                 selectedLocal.activation === "evaluation_only" ? (
                   <span className="models-capability-action-status">
-                    PRESENTED FOR EVALUATION · NOT ENABLED FOR TOOL EXECUTION
+                    Evaluation only · tool execution isn’t available yet.
                   </span>
                 ) : acquisition && ["requested", "resolving_source", "downloading"].includes(acquisition.state) ? (
                   <>
@@ -499,7 +432,7 @@ export function InferenceCapabilityPanel({
                     {acquisition.state === "verifying" ? "VERIFYING…" : "INSTALLING…"}
                   </span>
                 ) : acquisition?.state === "ready" && acquisition.activation_state === "in_use" ? (
-                  <span className="models-capability-action-status">IN USE FOR THOUGHTS</span>
+                  <span className="models-capability-action-status">IN USE</span>
                 ) : (
                   <Button
                     variant="primary"
@@ -507,16 +440,16 @@ export function InferenceCapabilityPanel({
                     loading={busyPresetId === selectedLocal.id}
                     onClick={() => void onDownloadLocal?.(selectedLocal)}
                   >
-                    {acquisition?.state === "failed" ? "TRY AGAIN" : `DOWNLOAD & USE ${selectedLocal.experience.toUpperCase()}`}
+                    {acquisition?.state === "failed" ? "TRY AGAIN" : "DOWNLOAD & USE"}
                   </Button>
                 )
               ) : current ? (
                 <span className="models-capability-action-status">
-                  IN USE FOR THOUGHTS
+                  IN USE
                 </span>
               ) : targetsLoading ? (
                 <span className="models-capability-action-status">
-                  READING SAVED CONNECTION…
+                  LOADING CONNECTION…
                 </span>
               ) : canUse ? (
                 <Button
@@ -528,12 +461,12 @@ export function InferenceCapabilityPanel({
                   }}
                 >
                   {existing?.key_present
-                    ? `USE ${selectedHosted?.experience.toUpperCase()}`
-                    : `ADD & USE ${selectedHosted?.experience.toUpperCase()}`}
+                    ? "USE MODEL"
+                    : "CONNECT & USE"}
                 </Button>
               ) : (
                 <span className="models-capability-action-status">
-                  ENTER A KEY TO CONTINUE
+                  ENTER AN OPENROUTER KEY
                 </span>
               )}
             </>
@@ -542,8 +475,9 @@ export function InferenceCapabilityPanel({
               NO MODEL SELECTED
             </span>
           )}
+            </div>
+          </aside>
         </div>
-        </> : null}
         {status ? (
           <p className="models-preset-status" role="status">
             {status}
@@ -552,18 +486,18 @@ export function InferenceCapabilityPanel({
       </section>
 
       {setup.limitations.length ? (
-        <section
-          className="models-capability-limits"
-          aria-label="AI setup limitations"
-        >
-          {setup.limitations.map((limitation) => (
-            <article key={limitation.code}>
-              <strong>{limitation.title}</strong>
-              <p>{limitation.detail}</p>
-              <small>{limitation.repair.label}</small>
-            </article>
-          ))}
-        </section>
+        <details className="models-capability-limits">
+          <summary>{setup.limitations.length} setup {setup.limitations.length === 1 ? "issue" : "issues"}</summary>
+          <div>
+            {setup.limitations.map((limitation) => (
+              <article key={limitation.code}>
+                <strong>{limitation.title}</strong>
+                <p>{limitation.detail}</p>
+                <small>{limitation.repair.label}</small>
+              </article>
+            ))}
+          </div>
+        </details>
       ) : null}
     </>
   );

--- a/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
+++ b/web/src/pages/cores/__tests__/InferenceCapabilityPanel.test.tsx
@@ -191,10 +191,8 @@ describe("InferenceCapabilityPanel", () => {
         onUseHosted={onUseHosted}
       />,
     );
-    expect(
-      screen.getByText("Local AI inspection unavailable"),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("No local AI detected")).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: /^This device/i }));
+    expect(screen.getByText(/0 detected · 0 to download · Scan unavailable/)).toBeInTheDocument();
 
     rerender(
       <InferenceCapabilityPanel
@@ -205,7 +203,8 @@ describe("InferenceCapabilityPanel", () => {
         onUseHosted={onUseHosted}
       />,
     );
-    expect(screen.getByText("No local AI detected")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /^This device/i }));
+    expect(screen.getByText(/0 detected · 0 to download$/)).toBeInTheDocument();
   });
 
   it("uses executable support, never configured-path readiness, for Thought availability", () => {
@@ -226,7 +225,7 @@ describe("InferenceCapabilityPanel", () => {
         onUseHosted={vi.fn(async () => true)}
       />,
     );
-    expect(screen.getByText("llama.cpp is not available.")).toBeInTheDocument();
+    expect(screen.getByTitle("llama.cpp is not available.")).toBeInTheDocument();
     expect(screen.queryByText("Available for Thoughts")).toBeNull();
   });
 
@@ -268,9 +267,9 @@ describe("InferenceCapabilityPanel", () => {
     );
     fireEvent.click(screen.getByRole("tab", { name: /^This device/i }));
     fireEvent.click(screen.getByRole("radio", { name: /Local Q/i }));
-    expect(screen.getByText("Local Q")).toBeInTheDocument();
-    expect(screen.getByText(/runs only on this device/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /download & use quick/i }));
+    expect(screen.getAllByText("Local Q")).toHaveLength(2);
+    expect(screen.getByText(/Local · 8K/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /download & use/i }));
     await waitFor(() => expect(download).toHaveBeenCalledWith(local));
   });
 
@@ -310,12 +309,11 @@ describe("InferenceCapabilityPanel", () => {
         onDownloadLocal={download}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: /^Tool experiments/i }));
+    fireEvent.click(screen.getByRole("tab", { name: /^Experimental/i }));
     fireEvent.click(screen.getByRole("radio", { name: /Hammer 2.1/i }));
-    expect(screen.getByText("Review and use")).toBeInTheDocument();
-    expect(screen.getByText("Hammer 2.1 · 1.5B")).toBeInTheDocument();
+    expect(screen.getAllByText("Hammer 2.1 · 1.5B")).toHaveLength(2);
     expect(screen.getByText(/CC-BY-NC-4.0/)).toBeInTheDocument();
-    expect(screen.getByText(/not enabled for tool execution/i)).toBeInTheDocument();
+    expect(screen.getByText(/tool execution isn’t available yet/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
     expect(download).not.toHaveBeenCalled();
   });
@@ -349,9 +347,8 @@ describe("InferenceCapabilityPanel", () => {
     );
     fireEvent.click(screen.getByRole("tab", { name: /^This device/i }));
     expect(screen.getByRole("radio", { name: /Qwen3-4B-Q6_K/ })).toBeChecked();
-    expect(screen.getByText("Choose a model on this device")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("radio", { name: /Qwen3-4B-Q6_K/ }));
-    fireEvent.click(screen.getByRole("button", { name: "USE THIS MODEL" }));
+    fireEvent.click(screen.getByRole("button", { name: "USE MODEL" }));
     await waitFor(() => expect(useExisting).toHaveBeenCalledWith(artifact));
   });
 
@@ -368,7 +365,7 @@ describe("InferenceCapabilityPanel", () => {
     fireEvent.click(screen.getByRole("radio", { name: /deep choice/i }));
     const key = screen.getByLabelText("OpenRouter key");
     fireEvent.change(key, { target: { value: "sentinel-secret" } });
-    fireEvent.click(screen.getByRole("button", { name: "ADD & USE DEEP" }));
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT & USE" }));
     await waitFor(() => expect(failed).toHaveBeenCalled());
     expect(key).toHaveValue("sentinel-secret");
 
@@ -380,7 +377,7 @@ describe("InferenceCapabilityPanel", () => {
         onUseHosted={succeeded}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "ADD & USE DEEP" }));
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT & USE" }));
     await waitFor(() => expect(key).toHaveValue(""));
   });
 });

--- a/web/src/pages/cores/__tests__/settingsModels.test.tsx
+++ b/web/src/pages/cores/__tests__/settingsModels.test.tsx
@@ -405,14 +405,11 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
     await screen.findByDisplayValue("LAN llama");
 
     expect(
-      screen.getByRole("heading", { name: "Choose your AI" }),
+      screen.getByRole("heading", { name: "Choose a model" }),
     ).toBeInTheDocument();
     expect(screen.getAllByText(/This device/).length).toBeGreaterThan(0);
-    expect(screen.getByText("Choose AI for each job")).toBeInTheDocument();
+    expect(screen.getByText("Models by job")).toBeInTheDocument();
     expect(screen.queryByText("Runs on")).toBeNull();
-    expect(
-      screen.getByRole("heading", { name: "Choose an experience" }),
-    ).toBeInTheDocument();
     const connections = screen.getByText("AI connections").closest("details");
     expect(connections).not.toHaveAttribute("open");
     expect(container.querySelector(".models-destinations")).toHaveAttribute(
@@ -423,12 +420,8 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
       container.querySelector(".models-destination-matrix"),
     ).toBeInTheDocument();
     expect(container.querySelector(".dest-card")).toBeNull();
-    expect(
-      container.querySelector(".models-capability-intro"),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector(".models-capability-device"),
-    ).toBeInTheDocument();
+    expect(container.querySelector(".models-model-picker")).toBeInTheDocument();
+    expect(container.querySelector(".models-capability-intro")).toBeNull();
     expect(container.querySelector(".models-job-routing")).toBeInTheDocument();
     expect(apiFetch).not.toHaveBeenCalledWith("/api/setup/hub-default-summary");
     expect(apiFetch).not.toHaveBeenCalledWith("/api/setup/runtime-options");
@@ -438,7 +431,7 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
     render(
       <ModelsModule settings={settings} update={vi.fn()} onRefuse={vi.fn()} />,
     );
-    expect(await screen.findByText("Pocket GGUF")).toBeInTheDocument();
+    expect((await screen.findAllByText("Pocket GGUF")).length).toBeGreaterThan(0);
     expect(screen.getByText("Used by Thoughts now")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /download|check local/i }),
@@ -458,17 +451,15 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
         onRefuse={vi.fn()}
       />,
     );
-    await screen.findByRole("heading", { name: "Choose an experience" });
+    await screen.findByRole("heading", { name: "Choose a model" });
+    fireEvent.click(screen.getByRole("tab", { name: /^OpenRouter/i }));
     const balanced = screen.getByRole("radio", { name: /Balanced Qwen/ });
-    await waitFor(() =>
-      expect(screen.getByRole("radio", { name: /Pocket GGUF/ })).toBeChecked(),
-    );
     fireEvent.click(balanced);
     expect(balanced).toBeChecked();
     fireEvent.change(screen.getByPlaceholderText("sk-or-v1-…"), {
       target: { value: "not-a-real-openrouter-key" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "ADD & USE BALANCED" }));
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT & USE" }));
 
     await waitFor(() =>
       expect(apiFetch).toHaveBeenCalledWith("/api/inference-targets", {
@@ -515,10 +506,11 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
         onRefuse={vi.fn()}
       />,
     );
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenRouter/i }));
     fireEvent.click(await screen.findByRole("radio", { name: /Deep Qwen/ }));
     const key = screen.getByLabelText("OpenRouter key");
     fireEvent.change(key, { target: { value: "durability-sentinel" } });
-    fireEvent.click(screen.getByRole("button", { name: "ADD & USE DEEP" }));
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT & USE" }));
     await waitFor(() => expect(commitMany).toHaveBeenCalledTimes(1));
     expect(key).toHaveValue("durability-sentinel");
     expect(screen.queryByText("IN USE FOR THOUGHTS")).toBeNull();
@@ -537,10 +529,11 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
         onRefuse={vi.fn()}
       />,
     );
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenRouter/i }));
     fireEvent.click(await screen.findByRole("radio", { name: /Deep Qwen/ }));
     const key = screen.getByLabelText("OpenRouter key");
     fireEvent.change(key, { target: { value: "cas-refusal-sentinel" } });
-    fireEvent.click(screen.getByRole("button", { name: "ADD & USE DEEP" }));
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT & USE" }));
     expect(
       await screen.findByText(
         "Could not save the Thoughts choice. Your key is still here.",
@@ -554,7 +547,7 @@ describe("Models destination workbench (HS-139 beauty pass)", () => {
     render(
       <ModelsModule settings={settings} update={vi.fn()} onRefuse={vi.fn()} />,
     );
-    await screen.findByRole("heading", { name: "Choose an experience" });
+    await screen.findByRole("heading", { name: "Choose a model" });
     fireEvent.click(screen.getByText("AI connections"));
     expect(
       screen.getByText("AI connections").closest("details"),

--- a/web/src/pages/cores/settingsModels.tsx
+++ b/web/src/pages/cores/settingsModels.tsx
@@ -422,7 +422,7 @@ export function ModelsModule({
         );
         return false;
       }
-      setPresetStatus(`${preset.label} selected for Thoughts & notes.`);
+      setPresetStatus("");
       onRefuse("");
       await reload();
       await reloadInferenceSetup();
@@ -987,12 +987,8 @@ export function ModelsModule({
         onCancelAcquisition={cancelLocalAcquisition}
       />
 
-      <div className="models-job-routing">
-        <GadgetGroup label="Choose AI for each job">
-          <p className="models-section-help">
-            Most people can leave these on This device. A connection here
-            changes only that job.
-          </p>
+      <FoldGadget title="Models by job" token="optional" className="models-job-routing">
+        <GadgetGroup>
           {pointerRow(
             "Thoughts & notes",
             ["thoughts", "inference_target_id"],
@@ -1005,7 +1001,7 @@ export function ModelsModule({
           )}
           {meetingsBlock}
         </GadgetGroup>
-      </div>
+      </FoldGadget>
 
       <FoldGadget
         title="AI connections"


### PR DESCRIPTION
## What changed

- replaced the three-step model setup wizard with a compact task-first model picker
- put source filters, model rows, selected truth, and one action in the first useful viewport
- made full model names wrap and collapsed setup issues and per-job routing
- rewrote visible copy around choice, comparison, and action
- preserved server-owned catalog/readiness truth and existing activation paths

## Why

The previous wizard spent most of the viewport narrating setup, hid the useful choices below the fold, and added a review step to a two-click task.

## Validation

- focused Vitest: 2 files, 32 tests passed
- production Vite build passed
- isolated-HOME Playwright at 1440×900 and 393×900: 2 tests passed
- `git diff --check` passed
