### PR TITLE
Charter Phase 143 intelligence assignments

### DIFF
--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -8,7 +8,22 @@
 > from evidence, Terra waves with serialized shipping, walks, honest ledgers —
 > is canon at [`docs/internal/ORCHESTRATION.md`](../../../docs/internal/ORCHESTRATION.md).
 
-**Newest update (2026-08-20): Phase 141 — From Thought to Work — ACTIVE
+**Newest update (2026-08-21): Phase 143 — The Intelligence Router — PLANNING.**
+The full execution charter is ready: one server-owned capability registry,
+reusable immutable model profiles with hub-local bindings, sparse ordered
+Assignments, frozen per-run route plans, and durable disposition-driven
+fallback above the existing `InferenceRunner` waist. It generalizes the proven
+meeting/speech plan pattern across Thoughts, writing, meetings, background,
+agents, Workbenches, Recipes, and future tool turns. Owner settings separate
+**Model Library** (what is available) from **Assignments** (which models do
+which jobs), so adding a model never silently changes a job. The default UI
+stays bounded as capabilities grow; ordered fallbacks are edited in one atomic
+sheet and local-to-cloud expansion is explicit. Fourteen recipe-like stories,
+the repository census, architecture contract, owner experience, migration law,
+kill criteria, and chaos/glass matrix are in the
+[Phase 143 record](./phase-143-intelligence-router/current-phase-status.md).
+
+**Previous update (2026-08-20): Phase 141 — From Thought to Work — ACTIVE
 (6/9).** Raw custody, bounded resume continuity, the first owner-facing Develop
 bridge, and the no-model completion/reopen path are done. The Chair now starts a local thought directly; every
 ordinary Note—including Phase 140's first kept Note—can become the same
@@ -901,6 +916,7 @@ canon, canon wins.
 | 140 | The First Sentence: one obvious first-value act on the Chair, a useful editable result, in-place recovery, then a furnished six-drawer reveal with explicitly attachable Everyday context. | in-progress (5/6) | [phase-140-the-first-sentence](./phase-140-the-first-sentence/) |
 | 141 | From Thought to Work: preserve rough speech, develop it through one owner-triggered grounded question at a time, then freeze typed local or GitHub-backed outcomes on the existing authority and receipt spine. | in-progress (6/9) | [phase-141-from-thought-to-work](./phase-141-from-thought-to-work/) |
 | 142 | Make AI capability, runtime, artifact, route, and readiness truth server-owned before adding acquisition or new execution paths. | active | [phase-142-inference-instrument](./phase-142-inference-instrument/) |
+| 143 | Route every AI workload through one server-owned capability assignment to reusable model profiles, with ordered qualified fallbacks, frozen execution truth, and the Model Library + Assignments owner system. | planning | [phase-143-intelligence-router](./phase-143-intelligence-router/) |
 
 (Status values: `planning`, `in-progress`, `done`, `paused`, `cancelled`.)
 

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/architecture-contract.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/architecture-contract.md
@@ -1,0 +1,581 @@
+# Phase 143 architecture contract — profiles, assignments, and fallback
+
+**Status:** ratified charter authority (owner and architecture review,
+2026-08-21).
+**Depends on:** Phase 130 placement truth, Phase 131 one admission path, and
+Phase 142 inference setup/artifact/deployment truth. Story 09 implements the
+Tool Capability Foundation contract ruled in
+`proposals/inference-catalog-and-context-policy.md` before tool routing ships.
+
+## Decision
+
+HoldSpeak will have one reusable model library and one server-owned capability
+assignment system.
+
+* A **model profile revision** describes reusable execution intent: the model
+  or artifact identity, provider/runtime family, context support, and governed
+  capability evidence. It contains no key, local path, or live readiness.
+* A **profile binding** is hub-local configuration that binds one exact model
+  profile revision to an exact deployment head/revision, secret slot, and
+  readiness observation. Every execution still captures the existing immutable
+  `DeploymentRevision`; this phase does not create a second execution registry.
+* A **capability** describes one typed job HoldSpeak may ask intelligence to do.
+  It declares requirements, operation/result contracts, and owner-facing group.
+* An **assignment** (`InferenceAssignment@1`) connects a capability or capability group to an ordered
+  profile chain. The first entry is primary; later entries are fallbacks.
+* A **route plan** (`InferenceRoutePlan@1`) is the immutable, content-free resolution of an assignment
+  for one parent turn/session/job. It contains exact deployment revisions and
+  fallback law. No engine, adapter, or browser resolves a profile after freeze.
+* A **fallback controller** advances the frozen plan only for a closed,
+  explicitly eligible terminal disposition. Every provider-reaching try remains
+  a separately admitted and receipted `inference.invoke@1` child.
+
+There is no second inference gateway, deployment-revision registry, tool
+authority, or browser-authored routing truth.
+
+`CapabilityRoutePolicy` is prose for assignment policy, not another persisted
+type. `ResolvedCapabilityRoutePlan` is prose for a resolved route, not another
+table/DTO. The only canonical persisted names are `InferenceAssignment@1` and
+`InferenceRoutePlan@1`.
+
+## The owner vocabulary
+
+Owner glass uses **Models**, **Providers**, and **Assignments**.
+
+* **Models** — intelligence available to HoldSpeak.
+* **Providers** — OpenRouter, Anthropic, OpenAI-compatible endpoints, private
+  servers, paired devices, and their credential/readiness facts.
+* **Assignments** — which models do which HoldSpeak jobs, including fallbacks.
+
+Primary UI does not say target, route revision, adapter, profile ID, deployment
+revision, or `openAICompatible`. Those remain technical Details terms.
+
+## Canonical capability registry
+
+The server owns a versioned, deterministic registry. Feature modules register
+definitions at composition time; the web client never invents a capability.
+
+```text
+InferenceCapabilityDefinition@1 {
+  id, revision, label, group_id, group_label, description,
+  operation_contract {name, version, definition_origin},
+  input_modalities[], output_kind, output_schema_sha256,
+  context_support: exact|bounded|unavailable,
+  requires {structured_output, structured_tools, vision, audio,
+            minimum_context_tokens, capability_classes[]},
+  allowed_boundaries[], permitted_retry_policy_ids[], default_retry_policy_id,
+  fallback_dispositions[], owner_visibility,
+  source_module, schema_sha256
+}
+```
+
+IDs are stable ASCII slugs. Definitions are recursively closed, canonically
+encoded, hash-bound, and duplicate/confusable IDs refuse startup. Removing or
+changing a requirement is a new definition revision. An invocation freezes the
+exact definition revision and schema hash.
+
+### Bootstrap taxonomy
+
+| Group | Capability IDs | Existing seam |
+|---|---|---|
+| Thoughts & notes | `thought.interview`, `thought.synthesis`, `ask.answer` | refinement coordinator, Ask service |
+| Writing & dictation | `speech.intent_classify`, `speech.rewrite`, `speech.punctuate` | `speech_session.plan` |
+| Speech recognition | `speech.transcribe`; internal `speech.preload` | Whisper session plans; `speech.preload` is lifecycle work with `owner_visibility=internal`, never an assignable row |
+| Meetings | `meeting.live_analysis`, `meeting.bookmark_label`, `meeting.auto_title`, `meeting.deferred_analysis`, `meeting.plugin.<id>` | `MeetingIntelPlan` |
+| Agents & tools | `agent.plan`, `agent.tool_turn`, `agent.code`, `workbench.item`, `recipe.run`, `recipe.chat`, `voice.reference_resolve` | parent runners and admitted children |
+| Background | `background.rails_summary`, `background.cadence_draft`, `decision.promotion_draft`, `delivery.pr_review_draft` | bounded service principals |
+
+Plugin capabilities join through a bounded registry adapter and carry the
+plugin definition revision. Arbitrary runtime strings cannot create a route.
+
+## Profile, binding, and deployment authority
+
+The phase reuses Phase 142's model artifact, deployment head, and immutable
+`DeploymentRevision` laws.
+
+```text
+ModelProfileRevision@2 {
+  profile_id, revision, sha256, label,
+  provider_family, runtime_family, model_or_artifact_identity,
+  supported_modalities[], context_support,
+  tokenizer_template_requirements,
+  capability_manifest {revision, sha256, claims[]},
+  safe_presentation, created_at
+}
+
+ProfileBinding@1 {
+  binding_id, revision, profile_id, profile_revision,
+  deployment_head_id, deployment_revision_id,
+  secret_slot?, endpoint_binding?, local_artifact_binding?, enabled,
+  configuration_revision, readiness_observation_id, updated_at
+}
+```
+
+A local downloaded artifact, existing GGUF/MLX model, OpenRouter model,
+Anthropic model, private OpenAI-compatible model, paired device, or mesh node
+can become a profile only through its canonical setup/application service. Its
+hub-specific path, endpoint, secret, and readiness become a binding, not profile
+identity. Secrets remain in the existing profile key store. Absolute local
+locators, tokens, and endpoint credentials never enter profile revisions,
+assignments, route plans, ordinary projections, sync, or receipts.
+
+Profile readiness is observation, not immutable execution proof. Assignment
+save validates compatibility against current profile evidence and an enabled
+binding; invocation resolution validates again and freezes an exact
+`DeploymentRevision`. Historical v1 `ProfileRecord` rows adapt to one legacy
+profile revision plus one local binding without changing their stored bytes.
+
+`ProfileService` and its replacement application methods enforce OWNER at the
+service boundary. HTTP's default principal is not authority. AGENT and
+MODEL_TURN cannot enumerate, probe, create, update, delete, bind, or assign
+profiles through HTTP, MCP, or direct service calls.
+
+## Assignment hierarchy and precedence
+
+Assignments are sparse overrides, never a capability × model matrix.
+
+```text
+invocation override
+  -> subject override (Thought / Workbench / Agent / Recipe / Project)
+  -> exact capability assignment
+  -> capability-group assignment
+  -> global AI assignment
+```
+
+The first defined assignment wins as a whole ordered chain. Layers are not
+concatenated. `Use default` deletes the sparse override and the projection
+always names the effective chain and the layer it inherited from.
+
+The first slice is hub-local. V2 model-profile revisions, bindings,
+assignments/routes, readiness, hardware, credentials, artifact locators, and
+fallback execution do not sync. Historical v1 profile/deployment bytes and
+immutable nonsecret deployment revision metadata retain only their already
+ruled receipt-resolution sync law. Sync import never creates a v2 profile,
+binding, readiness fact, assignment, acquisition, probe, or invocation.
+
+```text
+InferenceAssignment@1 {
+  id, scope {kind, subject_id?}, capability_id|group_id|global,
+  entries[] {ordinal, profile_id, profile_revision?},
+  retry_policy_id?, revision, created_at, updated_at
+}
+```
+
+Entries are unique and bounded (initial maximum four). Saving is one atomic CAS
+over the entire ordered chain; dragging/reordering never autosaves partial
+order. Empty chains are forbidden. Deleting the final fallback leaves the
+primary; clearing the assignment means inherit.
+
+An exact-capability assignment may select one policy permitted by that
+capability. Group/global assignments primarily store the chain and resolve each
+capability with its own default policy. They may store a policy override only
+when the server proves the exact policy revision is permitted by every affected
+capability. The server projects the compatibility/policy intersection; the
+browser never computes it.
+
+At resolution, an inherited chain that cannot satisfy the exact capability
+produces named `no_compatible_assignment`; entries never silently disappear or
+become fallback skips. **Use default** previews the effective
+capability-specific chain/policy before clearing an override. Registry growth
+cannot retroactively bless a group/global assignment: any new incompatible
+capability appears as a visible issue until the owner repairs or overrides it.
+
+### Fresh and upgraded default law
+
+A fresh hub with no assignment projects **No default model** and one repair,
+**Choose default**. Adding, downloading, detecting, or connecting the first
+model never assigns it. The server may project an exact starter bundle, but it
+is applied only by one explicit **Apply setup** action whose preview names every
+group chain and boundary.
+
+Upgrade maps each valid legacy primary into a one-leg assignment for its exact
+family, preserving effective behavior. Missing or dangling legacy targets do
+not guess a replacement; they project **No default model** or a group issue and
+one **Choose model** repair. With no effective route, invocation refuses before
+planning/egress as `no_assignment`; non-AI work remains available.
+
+## Compatibility and qualification
+
+An assignment entry is structurally compatible only when its durable profile
+claims can satisfy the capability. Whether it is executable for a particular
+operation is decided later by that operation's private admitted-request plan.
+Structural compatibility requires:
+
+* capability definition and operation/result schema revision;
+* profile claims the required modalities and structured dialect;
+* the deployment declares `exact|bounded` context support capable of planning
+  this operation; actual material fit is not guessed during assignment save;
+* tool-bearing work has an executable Tool Capability Foundation and an exact
+  qualified deployment manifest; offline evaluation alone is insufficient;
+* the profile boundary is one the capability can lawfully use.
+
+Per-operation preflight eligibility then observes binding enabled/current, exact
+deployment resolution, placement/egress/principal policy, credential presence,
+artifact/runtime readiness, resource leases, revocation, and the exact material
+fit. These volatile facts never change profile identity.
+
+Runtime lease/capacity pressure is exclusively an operation-time observation
+classified `local_capacity_unavailable`. It is never assignment-save
+compatibility and cannot prevent saving an otherwise compatible chain.
+
+The assignment editor filters normal choices to compatible profiles and
+normally excludes unavailable bindings, but shows a configured entry that later
+becomes incompatible/unavailable in place with one repair. A server projection
+may explicitly mark a compatible unavailable candidate `savable_with_repair`;
+the UI must show that issue before Save. Direct HTTP/MCP calls cannot save an
+incompatible or unprojected chain.
+
+## Frozen route plan
+
+Every inference parent freezes one content-free route plan before child
+admission. It freezes capability, ordered deployments, boundaries, and policy,
+but never future material. One-shot operations atomically freeze the route plan
+and a private admitted-request plan from their immutable material snapshot.
+Long-lived meeting/speech/tool parents freeze the route chain at parent
+admission; each later child/model step freezes a new private request plan from
+that child's immutable material before its ServiceContract admission.
+
+```text
+InferenceRoutePlan@1 {
+  id, sha256, capability {id, revision, schema_sha256},
+  source {assignment_id, assignment_revision, inherited_from},
+  entries[] {
+    ordinal, profile_id, profile_revision, binding_revision,
+    deployment_revision_id, capability_manifest_sha256,
+    boundary, context_support
+  },
+  retry_policy {id, revision, sha256, per_entry_attempts, total_attempts,
+                eligible_dispositions[]},
+  operation_policy_revision, created_at, deadline_at
+}
+```
+
+```text
+OperationAdmittedRouteRequestPlan@1 {
+  id, sha256, route_plan_id, operation_id, material_snapshot_sha256,
+  entries[] {
+    route_leg_ordinal,
+    eligibility: executable|known_preflight_unavailable|known_context_overflow,
+    reason_code?, admitted_request_id?, admitted_request_sha256?,
+    context_plan_sha256?, serialized_request_sha256?
+  },
+  created_at, deadline_at
+}
+```
+
+The private operation plan retains every configured leg and its frozen
+eligibility. Only executable legs carry admitted-request references. All legs
+are evaluated against the same immutable material snapshot; different
+tokenizers/templates may yield different valid serializations. Fallback never
+rereads, summarizes, truncates, or changes owner material after primary failure.
+A known planning-time overflow may advance only to an already exact-planned
+larger leg under explicit policy. Any post-admission tokenizer, template,
+serialization, context, or deployment drift is integrity refusal and cannot
+retry or fall back.
+
+The route and private operation plans store IDs, hashes, boundaries, budgets,
+eligibility, and revisions—not prompts,
+Note bodies, transcript text, audio, tool results, keys, or local paths. The
+kernel parent snapshot carries their summaries/hashes. Every child repeats the
+exact route plan ID, operation request-plan ID, leg ordinal, deployment
+revision, and physical-attempt ordinal. Durable private references suffice for
+restart without exposing owner material through the route projection.
+
+Changing a profile, assignment, capability definition, policy, or model while
+a run is active affects the next parent only. It never retargets an admitted
+child. Replay adopts the same receipt; it does not resolve current settings.
+
+## Retry and fallback law
+
+Retry means another physical attempt on the same frozen entry. Fallback means
+advancing to the next frozen entry. Both consume bounded parent budgets and
+create new admitted/receipted children.
+
+The server owns an immutable, canonically hashed retry-policy registry:
+
+```text
+InferenceRetryPolicyDefinition@1 {
+  id, revision, sha256, permitted_capability_ids[],
+  per_entry_attempts, total_physical_attempts, deadline_ms,
+  token_budget?, cost_budget?, tool_call_budget?,
+  retryable_dispositions[], fallback_dispositions[]
+}
+```
+
+A capability declares its permitted policy IDs and one default. An assignment
+may select only from that set; the route freezes the exact policy revision and
+hash. Policy selection never broadens capability boundary/tool/effect authority.
+
+Default budgets are conservative and capability-specific. The platform does
+not hard-code “three attempts everywhere.” A typical text/tool capability may
+allow two attempts on the primary and one on each fallback, with a hard total,
+deadline, token, cost, and tool-call ceiling.
+
+### Disposition table
+
+| Disposition | Same-entry retry | Next fallback | Law |
+|---|---:|---:|---|
+| `preflight_unavailable` | no | only when the frozen policy explicitly allows `skip_unavailable` and the next entry is currently eligible | zero physical call; receipt names skip |
+| `known_no_generation_transient` | bounded yes | yes after retry budget | failure proven before request send, or explicit provider no-generation response such as 429 |
+| `dispatch_outcome_unknown` | no | no | disconnect/read timeout after send or any state where generation may have occurred |
+| `provider_permanent` | no | policy may allow | authentication/config failure normally nominates repair instead |
+| `invalid_typed_output` | one corrective attempt if declared | yes to another schema-qualified entry | raw invalid output never publishes |
+| `invalid_tool_call` | bounded corrective model step | yes only to another tool-qualified entry | tool args never execute before validation |
+| `context_overflow` | no | only to a frozen entry with a larger provable envelope | a smaller model is never offered as repair |
+| `local_capacity_unavailable` | no | only when boundary policy permits the next entry | no silent local→cloud crossing |
+| `tool_unavailable_or_stale` | no model retry by default | only when failure is model/tool-dialect-specific and next entry is qualified; service outage is not repaired by a different model | typed tool result may allow a limited final answer |
+| `permission_denied` / `policy_refused` | no | no | model choice cannot manufacture authority |
+| `owner_cancelled` / `deadline_exhausted` | no | no | terminal winner fences later work |
+| `physical_outcome_unknown` / `effect_indeterminate` | no | no | never risk duplicate provider/effect execution; aliases classify to the same terminal family as dispatch-outcome-unknown |
+| `owner_terminal` | no | no | expected stop/edit/completion is not failure |
+
+Fallback can change privacy boundary only when the owner saved that exact chain
+with the boundary disclosure visible. The receipt names every attempted/skipped
+entry and actual egress. A local fallback is used only when it meets the same
+capability contract; “local” is not a waiver for tools, context, or schemas.
+
+### Tool-bearing fallback
+
+`Ask` or generic model prose never authorizes an effect. Tool turns use the
+server-owned `ToolTurnController`, durable private capability lease, and
+separately admitted model/tool children ruled in the catalog/context proposal.
+
+* A malformed native tool call may consume a corrective model step and then
+  advance to another **tool-qualified** model.
+* A read-only tool's typed unavailable result may be fed to the same/fallback
+  model only within the frozen lease and aggregate budgets.
+* A tool service/network failure is not automatically a model failure.
+* A receipted effect is adopted, never repeated by a fallback model.
+* Unknown effect completion, permission denial, approval refusal, Stop, or
+  lease expiry terminalizes the turn without model fallback.
+* Parallel read results retain provider-call ordinal order when replanned for a
+  fallback deployment; completion order never changes request identity.
+
+## Controller and durable evidence
+
+One `InferenceFallbackController` lives above `InferenceRunner`; engines and
+provider adapters never loop, retry, or choose another deployment internally.
+
+```text
+resolve assignment -> freeze plan -> reserve entry/attempt
+  -> admit InferenceRunner child -> receipt
+  -> classify closed disposition under plan policy
+  -> terminalize OR reserve next attempt/entry
+```
+
+```text
+inference_route_plans
+  plan_id, plan_sha256, capability_id/revision, assignment_id/revision,
+  entries_json, retry_policy_json, state, deadline_at, created_at
+
+inference_route_attempts
+  plan_id, route_leg_ordinal, physical_attempt_ordinal, child_invocation_id,
+  deployment_revision_id, state, disposition, receipt_id,
+  reserved_at, terminal_at
+```
+
+Reservation, Stop fencing, terminal election, and budget decrement happen in
+one transaction/CAS. Crash with an unreceipted physical call becomes
+indeterminate and never blind-replays. Restart may reconcile durable receipts;
+it cannot reconstruct a plan from current Config/profile state.
+
+Route-leg ordinal and physical-attempt ordinal are distinct. A provider dialect
+compatibility child may consume another physical attempt on leg 1 without
+colliding with the first physical attempt on leg 2.
+
+The controller owns a durable attempt-reservation authority; `InferenceRunner`
+remains the physical waist. Before admitting a primary, same-leg retry, or
+provider-dialect compatibility child, Runner requests/resumes an exact
+reservation `{plan_id, leg_ordinal, physical_attempt_ordinal, purpose}` from the
+controller. That transaction validates Stop/deadline/terminal state and debits
+the frozen total/per-leg budget. Runner cannot mint an unbudgeted compatibility
+child, and the controller never constructs an engine or invokes a provider.
+Legacy one-leg callers use an adapter reservation until their parent migrates.
+
+## Application and transport boundary
+
+`InferenceRoutingApplicationService` owns registry, assignment, plan, and
+receipt projections. Feature services ask it to resolve/freeze; HTTP, MCP, and
+Desk call the same methods.
+
+```text
+get_model_library() -> {library}
+get_assignments() -> {assignments}
+get_capability(id) -> {capability}
+get_assignment(scope, capability_or_group) -> {assignment}
+set_assignment(request_id, expected_revision, scope, subject,
+               capability_or_group, entries[], retry_policy_id) ->
+               {receipt, assignments}
+clear_assignment(...) -> {receipt, assignments}
+resolve_assignment_preview(scope, subject, capability) -> {resolution}
+get_route_receipt(plan_id) -> {route_receipt}
+```
+
+All DTOs and request bodies are recursively closed and versioned. Mutations use
+stable request IDs, payload hashes, and narrow assignment revisions. Replays
+return immutable effect evidence plus a fresh projection; changed payloads
+refuse. Resources and tools are OWNER-only and absent from MODEL_TURN. Events
+are advisory; GET reconstructs current truth.
+
+## Owner experience
+
+Settings contains two jobs:
+
+1. **Models** — download local models, register existing artifacts, connect
+   OpenRouter/Anthropic/custom providers, inspect readiness, and test synthetic
+   input. Adding a model makes it available; it does not silently rewrite every
+   assignment.
+2. **Assignments** — choose which models perform HoldSpeak jobs.
+
+The default Assignments glass stays bounded as capabilities grow:
+
+```text
+Assignments                                      1 issue
+Default for AI work       Quick Qwen → Deep Qwen
+Thoughts & notes          Uses default · Quick Qwen → Deep Qwen
+Writing & dictation       Tiny Qwen → Quick Qwen
+Speech recognition        This device
+Meetings                  This device → Deep Qwen
+Agents & tools            Uses default · Quick Qwen → Deep Qwen
+Background                Uses default · Quick Qwen → Deep Qwen
+Show task overrides
+```
+
+The stable roster is exactly those seven assignment rows. Each inheriting group
+also names its effective chain. **Show task overrides** reveals capability
+leaves with the initial filter **Overrides & issues**. Adding the twentieth
+capability does not lengthen default glass. Internal lifecycle capabilities
+such as `speech.preload` never appear.
+
+Clicking a row opens one editor/sheet:
+
+```text
+Writing & dictation
+○ Use default   Quick Qwen → Deep Qwen
+● Custom
+1  Tiny Qwen                    Ready
+2  Quick Qwen        Fallback  Ready
+   Add fallback
+Fallbacks run only for the failure types shown in Details.
+Cancel                           Save assignment
+```
+
+The model chooser reuses the task-first library picker and filters by server
+compatibility. Reordering supports drag and Move up/down. One atomic Save is
+the sole primary. Cloud boundary changes show one terse warning beside the
+affected entry. Broken saved entries remain visible with one repair.
+
+Subject surfaces reuse `AssignmentSummary`/`AssignmentEditor`:
+
+```text
+Model  Uses Thoughts default · Quick Qwen + 1 fallback   Change
+```
+
+They never implement their own selector or mutate global defaults. In-flight
+work continues under its frozen plan; the changed summary says **Next run**.
+
+### Owner-visible runtime truth
+
+* `Quick Qwen failed. Trying Deep Qwen (2 of 3)…`
+* `Deep Qwen completed this after Quick Qwen failed.`
+* `All 3 models failed. This task didn’t complete.` — only when all three made
+  physical attempts and produced known failures; skipped entries get exact
+  skipped/unavailable copy.
+* `Quick Qwen refused this run. No fallback was attempted.`
+* `Cancelled. No fallback was attempted.`
+* `We can’t confirm whether Quick Qwen ran. No fallback was attempted.`
+* `Fallback 2 can send this Note and attached context to OpenRouter.` The
+  material noun is capability-specific: transcript, audio, or tool-result data
+  is named when that is the projected input.
+
+No copy claims a fallback until the controller durably reserves that entry.
+
+## Migration and deletion law
+
+The phase begins with a generated pointer/resolver/dispatch census. Existing
+Config and object fields remain authoritative until their capability family
+migrates once. Each migration has one marker and mapping, then consumers stop
+reading the old pointer; indefinite dual-read/dual-write is forbidden.
+
+The existing `MeetingIntelPlan` ordered-revision implementation is the proved
+pattern to generalize, not a second permanent plan type. During migration it may
+adapt from the canonical plan, but after its family crosses, capability route
+resolution has one source.
+
+Legacy profile records remain reusable identities. Mutable `InferenceTarget`
+resolution ends before admission; immutable `DeploymentRevision` remains the
+runner contract. Workbench/Recipe/Agent inheritance is migrated without
+changing its visible effective destination until the owner edits an assignment.
+
+The existing mutable `inference.run` target-resolution path is retired or made
+a legacy adapter that produces one frozen one-leg plan before admission. The
+existing workflow labels `fallbackOnDevice` and `retryThenQueue` are not model
+fallback—they currently carry input forward—and must be renamed or removed
+rather than treated as precedent.
+
+Deleting a profile refuses while referenced by any assignment, active route
+plan, acquisition/deployment head, or historical artifact requirement. The
+repair lists assignments that must change. Soft deletion cannot erase receipt
+resolution.
+
+## Performance and accessibility budgets
+
+* Models/Assignments shell from cache: next frame, under 100 ms.
+* Local authoritative projection: target under 300 ms.
+* Open assignment editor/model chooser: under 100 ms.
+* Save acknowledgement: under 300 ms on local hub.
+* Route resolution before admission: target under 10 ms p95 from local SQLite;
+  no network, model load, provider probe, or artifact scan.
+* Fallback decision after terminal receipt: under 50 ms before next child
+  admission; physical provider latency is reported separately.
+* 393px: all targets at least 44px, no horizontal overflow, model names wrap,
+  sticky Save stays inside the sheet, and ordering works without drag.
+* Keyboard: arrows/select in model lists; Move up/down for order; Escape returns
+  focus; Mod+Enter invokes the one focused primary only.
+
+## Kill criteria
+
+The phase cannot close if any of the following remains:
+
+1. A capability resolves a mutable profile after admission.
+2. An engine/provider adapter performs a hidden retry or fallback.
+3. A physical model call bypasses `InferenceRunner`.
+4. An unknown/indeterminate/effectful outcome advances fallback.
+5. Local→cloud fallback occurs without a saved visible boundary crossing.
+6. A tool-incompatible deployment can be saved or selected for required tools.
+7. Browser code invents capability compatibility, readiness, or fallback law.
+8. Config and the assignment store remain competing authority after migration.
+9. The default UI grows one permanent row per capability or becomes a matrix.
+10. HTTP/MCP/Desk produce different assignment, plan, attempt, or receipt truth.
+11. Sync import starts/resumes inference or rewrites hub-local assignments.
+12. A receipt cannot explain primary, attempts, fallback reason, actual model,
+    boundary, and terminal outcome without reading current settings.
+
+## Required adversarial matrix
+
+Tests must cover at least:
+
+* every registry definition and every production inference call site belongs to
+  exactly one capability; unknown/confusable/unregistered IDs refuse;
+* precedence at every layer, clear-to-inherit, dangling subject, concurrent CAS,
+  changed-payload replay, and unrelated-assignment concurrency;
+* profile edit/removal, capability revision, schema drift, runtime/artifact
+  replacement, credential loss, and readiness changes before/after plan freeze;
+* every disposition row above at budget −1/equality/+1, including Stop/result,
+  deadline/result, restart, and lost-response races;
+* provider failure on primary then local success; local capacity skip to a
+  visibly authorized cloud entry; forbidden boundary crossing refusal;
+* malformed tool call correction, tool-qualified fallback, tool service outage,
+  effect receipt adoption, unknown effect completion, and permission denial;
+* exact context fit under different fallback tokenizers without reusing
+  provider-native serialization; no silent truncation;
+* two concurrent plans sharing a profile, local runtime lease pressure, route
+  edit while active, and no DispatchContext cross-bind;
+* HTTP/MCP reciprocal fixtures, owner denial, MODEL_TURN non-discovery, event
+  loss then GET, restart receipt reconstruction, and sync zero egress;
+* fresh and upgraded databases, every legacy pointer family, no dual authority,
+  and a generated zero-bypass census;
+* 1440/393/200%-zoom glass for library, provider connection, assignment groups,
+  leaf overrides, compatible chooser, reorder, broken entry, boundary warning,
+  fallback progress/success/exhaustion/refusal/indeterminate, focus, screen
+  reader names, reduced motion, and no overflow.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/delivery-map.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/delivery-map.md
@@ -1,0 +1,43 @@
+# Phase 143 delivery map
+
+This is the implementation routing table. Story files own exact acceptance;
+this map names the likely code seams and the gate that prevents authority forks.
+
+| Story | Primary implementation seams | Required gate |
+|---|---|---|
+| 01 Census | `holdspeak/inference_targets.py`, `holdspeak/services/profile_service.py`, `holdspeak/kernel/{inference,inference_runner}.py`, `holdspeak/{meeting_session,speech_session}/`, Config, Workbench/Recipe/Agent/background callers | Generated capability/pointer/resolver/physical-leaf inventory equals reviewed fixture |
+| 02 Registry | new `holdspeak/inference_capabilities.py`; composition in server/runtime/plugin setup | Unknown/duplicate/confusable capability refuses startup; every call site mapped |
+| 03 Profiles | existing `profile_service.py`, `target_profile.py`, `deployment_revisions.py`, setup/acquisition services, schema/migrations | OWNER at service boundary; no new revision registry; no path/secret sync |
+| 04 Assignments | new routing application/service + DB repository/schema; legacy Config/subject adapters | Atomic ordered-chain CAS; no dual authority after family marker |
+| 05 Plans | new immutable route-plan DTO/repository/resolver beside `inference_runner.py` | Zero-write/network resolution; mutation after freeze cannot retarget |
+| 06 Controller | new route controller/ledger; existing parent-run and inference outcome seams | Every physical try is a unique admitted child; forbidden dispositions create zero egress |
+| 07 Thoughts/writing | refinement coordinator/application, Ask service, speech intent/rewrite/punctuate, Workbench UI | Visible next chain frozen with reservation; old pointer no longer read |
+| 08 Meetings/speech/background | `meeting_session/intel_*`, `speech_session/*`, Rails, cadence, decisions, delivery | Preserve history/restart; distinct leg/attempt ordinals; generated fork census zero |
+| 09 Tools | implement ruled ToolTurn controller/private lease/ledgers, then routing application | Lease never expands; effects adopt once; unknown completion never falls back |
+| 10 Agents/workflows | Workbench/Recipe services, agents, sequences/workflows, mutable `kernel/inference.py` | Shared resolver only; `inference.run` cannot late-route physical work |
+| 11 Parity/sync | web routes, `mcp/{tools,resources,server}.py`, `sync_service.py`, inventories | Golden HTTP/MCP parity; non-owner nondiscovery; sync zero egress |
+| 12 Library/providers | `InferenceCapabilityPanel.tsx`, `settingsModels.tsx`, setup/profile/provider services | Add/connect/download changes zero assignments; secret/path sentinel |
+| 13 Assignments UX | new shared web assignment model/components/controller and reuse in subject surfaces | Bounded overview, one atomic editor, 1440/393/a11y one-primary glass |
+| 14 Closeout | unit/integration/E2E fixtures, schema/API/MCP inventories, evidence ledger | Every architecture kill criterion disproved on real application paths |
+
+## Delivery waves
+
+1. **Authority:** 01 → parallel 02/03 → 04 → 05 → 06.
+2. **First usable vertical:** 07 + 11 foundations + 12/13 minimal Library and
+   Thoughts assignment. This is the first shippable route-chain product.
+3. **Horizontal adoption:** 08, then 09 when Tool Capability Foundation exists,
+   then 10. Families land with one-way migration markers, never a big-bang flag.
+4. **Close:** complete 11–13 parity/glass and run 14 chaos.
+
+## Standard story evidence
+
+Every implementation story records:
+
+* changed authority/schema and migration/replay behavior;
+* focused unit and integration commands with counts;
+* one-path and legacy-pointer census deltas;
+* HTTP/MCP/sync/privacy results where applicable;
+* 1440/393/200% captures for visible work;
+* known inherited failures separated from story-caused failures;
+* `git diff --check`, production build, API/MCP/schema inventories, and `dw
+  check holdspeak` at the appropriate gate.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/owner-experience.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/owner-experience.md
@@ -1,0 +1,202 @@
+# Phase 143 owner experience — Model Library and Assignments
+
+**Status:** normative product contract.
+
+## The two jobs
+
+Settings has two peer destinations:
+
+1. **Model Library** answers “What intelligence is available?” It downloads,
+   detects, verifies, connects, and tests models/providers. Adding something to
+   the library changes zero assignments.
+2. **Assignments** answers “Which intelligence does each HoldSpeak job use?” It
+   edits ordered compatible model chains with explicit fallback boundaries.
+
+Never combine these into `Download & use`, `Connect & use`, or `Use model` once
+the library exists. The lawful commands are `Download`, `Add to library`,
+`Connect`, and `Add model`. Success says: **Added to the Model Library.
+Assignments are unchanged.** A quiet **Choose where to use it** may open
+Assignments.
+
+A fresh hub with no assignment says **No default model** and offers **Choose
+default**. Adding the first model does not change that. A server-projected
+starter bundle may be applied only through one explicit **Apply setup** action
+that previews every group and boundary. An upgrade preserves each valid legacy
+primary as a one-leg assignment; missing/dangling targets remain named issues.
+
+## Model Library
+
+The compact task-first picker remains the library foundation:
+
+```text
+Model Library                         7 ready · 1 needs attention
+All (10) | This device (3) | Connected (4) | Available (3)
+
+○ Quick Qwen             Fast everyday model.       2.5 GB · 8K
+● Balanced Qwen          General reasoning.          6.0 GB · 16K
+○ Deep Qwen              Harder reasoning.          17.0 GB · 32K
+
+Balanced Qwen
+Local · 6.0 GB · 16K
+Strong Thought interviews and everyday writing.
+                                             Download
+```
+
+Detected, installed, downloadable, and connected models—including Anthropic,
+OpenRouter, private, paired, and mesh-backed models—share one row grammar.
+Full names wrap; only route summaries may truncate. Rows are flat separators,
+not large cards. Details holds filenames, revisions, quantization, source proof,
+runtime, and technical compatibility. A broken configured model stays visible
+with one repair.
+
+**Add model** opens four entries: **Download from catalog**, **Connect hosted
+model**, **Define endpoint**, and **Use model file**. Each returns to this one
+library inventory and changes no assignment. Providers is a focused disclosure
+for endpoints, secrets, and readiness. It is
+not another assignment surface. OpenRouter, Anthropic, custom
+OpenAI-compatible, private, paired, and future providers use the same canonical
+profile/binding application service.
+
+The sole action follows selected truth: downloadable **Download**; existing
+file **Add to library**; hosted profile **Connect**; custom endpoint **Add
+model**; active **Ready** as status, not a command. A connection check is quiet
+and synthetic. Failure keeps the draft/key in the focused form and offers one
+exact **Try again** or repair. Success clears secrets only after durable
+confirmation and says assignments are unchanged.
+
+## Assignments overview
+
+The default page height is bounded even if the registry grows to 100 jobs:
+
+```text
+Assignments                                      1 issue
+Default for AI work       Quick Qwen → Deep Qwen
+Thoughts & notes          Uses default · Quick Qwen → Deep Qwen
+Writing & dictation       Tiny Qwen → Quick Qwen
+Speech recognition        This device
+Meetings                  This device → Deep Qwen
+Agents & tools            Uses default · Quick Qwen → Deep Qwen
+Background                Uses default · Quick Qwen → Deep Qwen
+Show task overrides
+```
+
+The roster is exactly those seven assignment rows. Each summary is one 48–56 px row: owner-facing group label, effective named
+chain, and at most one actionable status. Show the first two models plus `+N`.
+Never show a select in every row. Issues sort to the top with one **Fix**.
+
+**Show task overrides** opens capability leaves whose default filter is
+**Overrides & issues**. **All tasks** reveals the complete owner-visible registry,
+grouped under Thoughts, Writing & dictation, Speech recognition, Meetings,
+Agents & tools, and Background. Adding a capability never adds permanent
+default-screen chrome.
+
+## Assignment editor
+
+Clicking any summary opens one side sheet on desktop and one full-width sheet
+on narrow screens:
+
+```text
+Writing & dictation
+
+○ Use default   Quick Qwen → Deep Qwen
+● Custom
+
+1  Tiny Qwen                         Ready      ⋯
+2  Quick Qwen       Fallback         Ready      ⋯
+   Add fallback
+
+Fallbacks run only after the failure types shown in Details.
+Cancel                                  Save assignment
+```
+
+The model chooser reuses Model Library rows but the server filters compatible
+choices for the exact capability revision. Reordering supports drag and
+accessible Move up/Move down. The owner edits a draft and performs one atomic,
+revision-checked **Save assignment**. There is no fallback toggle and no
+per-slot autosave.
+
+Adding a cloud leg shows one line adjacent to it: **Fallback 2 can send this
+Note and attached context to OpenRouter.** The material noun changes for the
+capability. Incompatible or newly broken saved entries remain in place,
+with a specific repair. Raw IDs, filenames, target/profile terminology, and
+deployment revisions stay in Details.
+
+## Inheritance on product surfaces
+
+Workbench, Thoughts, Agents, Recipes, and Projects reuse the same summary and
+editor contract:
+
+```text
+Model   Uses Thoughts default · Quick Qwen + 1 fallback     Change
+```
+
+`Use default` always names the resolved chain. It never displays opaque
+`Automatic` or `Default`. Changing an override affects the next reservation;
+the in-flight receipt remains frozen and the UI labels the new chain **Next
+run**. No feature builds a private target selector.
+
+Before **Use default** clears a leaf/subject override, the sheet previews the
+effective chain and retry behavior for that exact capability. Group/global rows
+show server-projected compatibility issues across their member capabilities;
+the browser never guesses that one chain or retry policy fits the group.
+
+## Runtime truth
+
+Exact copy follows durable controller state:
+
+* `Quick Qwen failed. Trying Deep Qwen (2 of 3)…`
+* `Deep Qwen completed this after Quick Qwen failed.`
+* `All 3 models failed. This task didn’t complete.` only when all three made a
+  physical attempt and failed; skipped entries use distinct copy.
+* `Quick Qwen refused this run. No fallback was attempted.`
+* `Cancelled. No fallback was attempted.`
+* `We can’t confirm whether Quick Qwen ran. No fallback was attempted.`
+* `Quick Qwen can’t run right now. No model was started.`
+* `Deep Qwen needs an OpenRouter key.`
+* `Hammer can’t run Thought development yet.`
+
+The UI never claims fallback before a later leg is durably reserved. A fallback
+that actually completed is always disclosed. A preflight-unavailable primary
+does not imply fallback unless the saved server policy explicitly permits that
+disposition.
+
+## 1440 and 393 composition
+
+At 1440, Model Library uses a list plus 320 px detail pane. The selected row,
+details, and sole command seat all intersect the visible Desk working band
+without scrolling under the dock. Assignments uses the bounded summary list;
+its editor is a side sheet. At 393, initial `scrollTop` is zero; title, library
+status, source tabs, and at least three model rows intersect the viewport before
+scrolling. Both sheets reserve footer space, keep the selected action above the
+Desk dock with zero overlap, and meet the same intersection law at 200% zoom.
+The assignment sheet shows name, order, readiness, boundary warning, and Save
+without horizontal scrolling. Every target is at least 44 px and close restores
+exact focus.
+
+## Keyboard and accessibility
+
+* Model lists and assignment choices are labelled radiogroups; arrows move
+  selection and selection never executes.
+* Reorder exposes Move up/down commands and announces the new ordinal.
+* Escape closes chooser/editor and restores exact focus.
+* Mod+Enter invokes the sole primary only in the focused surface.
+* Status/progress uses semantic live regions with coarse updates.
+* Reduced motion, 200% zoom, screen-reader names, and full keyboard operation
+  preserve all authority truth.
+
+## Rejection criteria
+
+Reject the implementation if any is true:
+
+1. Capabilities and models become two permanently visible matrix axes.
+2. Adding the twentieth capability increases the default page height.
+3. Adding/downloading/connecting a model silently changes an assignment.
+4. A feature owns a duplicate model selector instead of the shared editor.
+5. A saved entry is hidden merely because it became unavailable.
+6. A browser infers compatibility, readiness, or fallback eligibility.
+7. Order changes autosave one slot at a time.
+8. `Default` or `Automatic` appears without the effective named chain.
+9. A local-to-cloud boundary crossing is silent.
+10. Success/error copy misstates whether fallback occurred.
+11. Raw IDs, paths, endpoints, or secrets appear on ordinary glass.
+12. There is more than one visible primary in a library/editor state.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/repository-census.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/repository-census.md
@@ -1,0 +1,78 @@
+# Phase 143 repository census — routing before consolidation
+
+**Captured:** 2026-08-21 from merged `main` after Phase 142 Story 06.
+**Purpose:** charter evidence; implementation stories must refresh anchors.
+
+## Existing authorities and proved patterns
+
+| Plane | Current authority / seam | Evidence | Phase 143 consequence |
+|---|---|---|---|
+| Mutable destination | `ProfileRecord` plus built-in `this_machine`; `InferenceTarget` resolves readiness/placement | `holdspeak/inference_targets.py` | preserve profile identity; remove post-freeze mutable reads |
+| Immutable execution | content-addressed `DeploymentRevision` v1/v2 consumed by `InferenceRunner` | `holdspeak/deployment_revisions.py`, `holdspeak/kernel/inference_runner.py` | sole executable revision registry remains |
+| Local artifacts/deployments | Phase 142 artifact ledger and mutable `inference_deployments` heads | `holdspeak/services/inference_acquisition_service.py`, `holdspeak/services/inference_setup_service.py` | profiles point to deployment heads; do not duplicate artifact/runtime truth |
+| Thoughts pointer | `Config.thoughts.inference_target_id` | `holdspeak/config/integrations.py`, `holdspeak/inference_targets.py` | migrate to `thought.interview`/`thought.synthesis` assignments |
+| Dictation pointer | `Config.dictation.runtime.profile_id` plus runtime knobs | `holdspeak/config/model.py`, `holdspeak/intel/providers.py` | split intent/rewrite/punctuation capabilities; keep runtime policy typed |
+| Meeting pointer | `Config.meeting.intel_profile_id` plus local/auto/cloud legacy placement | `holdspeak/config/meeting.py`, `holdspeak/intel/providers.py` | migrate meeting capability family, not one blunt pointer |
+| Background pointer | `Config.rails_observer.profile_id`; Cadence uses bounded service inference | `holdspeak/config/integrations.py`, `holdspeak/services/cadence_service.py`, `holdspeak/web_server.py` | explicit background capability assignments |
+| Workbench/Recipe precedence | Workbench profile → Recipe profile → default; frozen revision rebuilt from one transaction | `holdspeak/deployment_revisions.py:resolve_workbench_deployment_revision` | preserve visible result through sparse subject assignments |
+| Meeting ordered fallbacks | `MeetingIntelPlan` freezes ordered deployment revisions per capability; engine fallback disabled | `holdspeak/meeting_session/intel_plan.py`, `intel_child.py` | proved template for canonical route plans/controller |
+| Speech capabilities | transcribe/preload/intent/rewrite/punctuate are already stable constants | `holdspeak/speech_session/plan.py` | seed canonical registry; keep speech vs text requirements distinct |
+| Meeting capabilities | live analysis, bookmark, title, deferred analysis, plugins, Whisper | `holdspeak/meeting_session/intel_plan.py` | seed canonical registry and adapters |
+| Tool authority | future `ToolTurnController`/private lease ruled; owner MCP sidecar forbidden | `proposals/inference-catalog-and-context-policy.md` | required prerequisite for executable tool-aware fallback |
+| Admission waist | every physical model call is `inference.invoke@1` through `InferenceRunner` | Phase 131 census and `tests/unit/test_one_path_census.py` | expand census; controller remains above runner |
+
+## Fragmentation visible today
+
+The repository-wide pointer census contains hundreds of `profile_id`,
+`inference_target_id`, `intel_profile_id`, deployment revision, and target
+references across Config, database objects, services, web types, tests, and
+docs. Not all are routing authority; Story 01 must classify each as:
+
+1. mutable assignment pointer;
+2. immutable execution evidence;
+3. display/projection only;
+4. credential/provider identity;
+5. unrelated use of the word profile; or
+6. dead/legacy path to delete.
+
+Known duplicated owner controls include Models by job, meeting intelligence
+placement, Workbench/Recipe model selectors, Agent destinations, and background
+assistance. They must converge on one Assignment editor rather than receive new
+fallback controls independently.
+
+## Existing fallbacks/retries that require classification
+
+| Mechanism | Current truth | Required treatment |
+|---|---|---|
+| Meeting local→cloud | frozen as real second revision in `MeetingIntelPlan`; each provider attempt is a child | adapt into canonical plan/controller without regression |
+| Deferred meeting retries | new admitted parent/attempt with exponential schedule | remain scheduling retry; do not conflate with same-turn model fallback |
+| Dictation lexical fallback | deterministic non-model degradation on classifier failure | preserve as product fallback, but do not misreport as model profile fallback |
+| Provider dialect retry | may create a winning attempt beneath current adapters | census and make physical attempt cardinality explicit; no hidden second HTTP call |
+| Ask/Thought terminal retry | new owner-visible turn/invocation | distinguish explicit Try again from automatic route fallback |
+| Tool result limitation | design-only until Tool Capability Foundation executes | no executable claim before prerequisite story |
+
+## Initial owner-facing capability groups
+
+Default Assignments glass is intentionally stable at five summary rows:
+
+* Default for AI work
+* Thoughts & notes
+* Writing & dictation
+* Meetings
+* Agents & tools
+
+Background tasks and every leaf capability exist in the searchable override
+disclosure. Issues and explicit overrides rise into default glass. Capability
+count may grow without permanent-screen growth.
+
+## Audit commands for Story 01
+
+```bash
+rg -n 'profile_id|inference_target_id|intel_profile_id|target_profile|deployment_revision_id' holdspeak web/src tests
+rg -n 'CAPABILITY_|capability=' holdspeak -g '*.py'
+rg -n 'run_prompt|InferenceRunner|inference.invoke|build_intel|provider' holdspeak -g '*.py'
+rg -n 'fallback|retry|attempt_ordinal|indeterminate|cancel' holdspeak -g '*.py'
+```
+
+The story converts these reads into checked-in generated fixtures and AST/static
+guards. This hand census is orientation, not the close gate.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/current-phase-status.md
@@ -1,0 +1,109 @@
+# Phase 143 - The Intelligence Router
+
+**Last updated:** 2026-08-21.
+
+## Goal
+
+Make every HoldSpeak AI workload resolve through one server-owned capability
+route to a reusable model profile, with ordered qualified fallbacks, frozen
+execution truth, and one delightful owner system: Model Library plus
+Assignments.
+
+## Scope
+
+- **In:** Canonical capability registry; immutable model-profile revisions and
+  hub-local bindings; ordered capability assignments; frozen route plans;
+  durable retry/fallback control; migration of Thoughts, writing, speech,
+  meetings, background, tools, agents, Workbenches, Recipes, and workflows;
+  HTTP/MCP parity; Model Library, Providers, and Assignments owner surfaces;
+  restart/privacy/sync/accessibility/chaos proof.
+- **Out:** A second inference gateway or deployment-revision registry; ambient
+  model access to owner MCP; silent model installation/assignment; browser-owned
+  compatibility or retry law; synced active routes/bindings; hidden retries;
+  fallback after unknown physical/effect completion.
+
+## Exit criteria (evidence required)
+
+- [ ] Every production inference call site belongs to one versioned capability.
+- [ ] Every execution freezes one immutable route plan before first egress.
+- [ ] Every physical generation remains a separately admitted `InferenceRunner`
+  / `inference.invoke@1` child.
+- [ ] Ordered fallback advances only for a closed eligible disposition and its
+  receipt explains every leg, child, boundary, and terminal outcome.
+- [ ] Config/profile/subject legacy pointers have one-way migrations and no
+  competing authority remains after each family crosses.
+- [ ] Adding/downloading/connecting a model changes zero assignments.
+- [ ] Model Library and bounded Assignments glass pass at 1440, 393, and 200%
+  zoom with keyboard/screen-reader/reduced-motion proof.
+- [ ] HTTP/MCP parity, OWNER boundary, hub-local sync, restart, privacy, schema,
+  API inventory, one-path census, full tests, and production build are green.
+- [ ] All kill criteria in `assets/architecture-contract.md` have production-path
+  evidence in Story 14's write-once ledger.
+
+## Story status
+
+| ID | Story | Status | Story file | Evidence |
+|---|---|---|---|---|
+| HSEGHS001HS104-143-01 | Capability and Route Census | ready | [story-01-capability-route-census](./story-01-capability-route-census.md) | - |
+| HSEGHS001HS104-143-02 | Canonical Capability Registry | backlog | [story-02-canonical-capability-registry](./story-02-canonical-capability-registry.md) | - |
+| HSEGHS001HS104-143-03 | Reusable Model Profile Authority | backlog | [story-03-reusable-model-profile-authority](./story-03-reusable-model-profile-authority.md) | - |
+| HSEGHS001HS104-143-04 | Assignment Store and Resolver | backlog | [story-04-assignment-store-resolver](./story-04-assignment-store-resolver.md) | - |
+| HSEGHS001HS104-143-05 | Frozen Route Plans | backlog | [story-05-frozen-route-plans](./story-05-frozen-route-plans.md) | - |
+| HSEGHS001HS104-143-06 | Fallback Controller and Failure Law | backlog | [story-06-fallback-controller-failure-law](./story-06-fallback-controller-failure-law.md) | - |
+| HSEGHS001HS104-143-07 | Thoughts Ask and Writing Adoption | backlog | [story-07-thoughts-ask-writing-adoption](./story-07-thoughts-ask-writing-adoption.md) | - |
+| HSEGHS001HS104-143-08 | Meetings Speech and Background Adoption | backlog | [story-08-meetings-speech-background-adoption](./story-08-meetings-speech-background-adoption.md) | - |
+| HSEGHS001HS104-143-09 | Tool Capability Foundation and Safe Routing | backlog | [story-09-tool-turn-routing-safe-fallback](./story-09-tool-turn-routing-safe-fallback.md) | - |
+| HSEGHS001HS104-143-10 | Agents Workbenches and Recipes Adoption | backlog | [story-10-agents-workbenches-recipes-adoption](./story-10-agents-workbenches-recipes-adoption.md) | - |
+| HSEGHS001HS104-143-11 | HTTP MCP Sync and Compatibility | backlog | [story-11-http-mcp-sync-compatibility](./story-11-http-mcp-sync-compatibility.md) | - |
+| HSEGHS001HS104-143-12 | Model Library and Providers | backlog | [story-12-model-library-providers](./story-12-model-library-providers.md) | - |
+| HSEGHS001HS104-143-13 | Capability Assignments Experience | backlog | [story-13-capability-assignments-experience](./story-13-capability-assignments-experience.md) | - |
+| HSEGHS001HS104-143-14 | Chaos Glass and Closeout | backlog | [story-14-chaos-glass-closeout](./story-14-chaos-glass-closeout.md) | - |
+
+## Where we are
+
+The architecture and owner-experience contracts are ratified for planning. A
+horizontal repository audit found the existing lawful foundation—immutable
+`DeploymentRevision`, `InferenceRunner`, and meeting/speech frozen plans—and
+the forks that must be removed: mutable Profile/Target conflation, unguarded
+transport-neutral profile authority, scattered Config/subject pointers,
+late-routing `inference.run`, raw-SQL Workbench resolution, fake workflow
+fallback labels, and path-bearing profile sync.
+
+Story 01 is ready to turn the audit into generated census gates. Stories 02–06
+then establish the registry, profile/binding authority, assignments, frozen
+plans, and controller before any product family migrates. Stories 07–10 migrate
+all callers in bounded waves. Stories 11–13 ship parity and the two owner jobs:
+Model Library and Assignments. Story 14 is the cross-product chaos/glass gate.
+
+Normative assets: [architecture contract](./assets/architecture-contract.md),
+[owner experience](./assets/owner-experience.md), [repository census](./assets/repository-census.md),
+and [delivery map](./assets/delivery-map.md).
+
+## Active risks
+
+| Risk | Likelihood | Mitigation | Stop signal |
+|---|---|---|---|
+| A fallback array is added to Config/ProfileRecord | high | Require profile/binding/assignment/plan separation | Any child resolves mutable target state after admission |
+| Existing pointer families remain competing authorities | high | Generated census plus one-way family migration markers | A migrated caller still reads/writes its legacy pointer |
+| Retry/fallback duplicates or hides provider calls | high | Durable controller above InferenceRunner; separate leg/attempt ordinals | A physical leaf lacks its own admitted child/receipt |
+| Tool/model fallback repeats or expands an effect | high | Independent frozen ToolTurn lease and receipt adoption | Unknown/effectful result advances the model chain |
+| Granular routing becomes a matrix/wizard | medium | Bounded group rows plus searchable overrides and one sheet | Default page height grows with capability count |
+| Model setup silently rewrites jobs | medium | Separate Model Library from Assignments | Add/connect/download changes an assignment revision |
+| Local binding data leaks through sync/DTO | medium | Hub-local bindings and reciprocal privacy fixtures | New path/secret/private endpoint appears in sync/public DTO |
+
+## Decisions made (this phase)
+
+- 2026-08-21 - Use Model Library + Assignments as the owner ontology; setup makes intelligence available and never silently assigns it - avoids a conflated wizard and hidden route mutation - owner ruling.
+- 2026-08-21 - Separate immutable `ModelProfileRevision@2`, hub-local `ProfileBinding`, ordered `InferenceAssignment@1`, and frozen `InferenceRoutePlan@1` - prevents mutable profile/readiness/secret state from becoming execution identity; alternate policy/resolved-plan labels are non-persisted prose only - architecture audit.
+- 2026-08-21 - Keep existing `DeploymentRevision` and `InferenceRunner` as the only execution revision/gateway - extends HoldSpeak's mature substrate rather than creating a parallel stack - one-path law.
+- 2026-08-21 - Generalize MeetingIntelPlan/SpeechPlan's frozen ordered-revision pattern; distinguish route-leg and physical-attempt ordinals - preserves proven restart behavior and prevents dialect/fallback ordinal collision - repository census.
+- 2026-08-21 - Assignments are sparse capability/group/subject overrides with ordered qualified fallbacks and an atomic Save - scales without a matrix and keeps inheritance explainable - product/architecture ruling.
+- 2026-08-21 - Tool fallback cannot expand the independent capability lease or repeat/guess an effect; unknown completion stops - maintains YOLO speed inside explicit owner intent and policy - tool authority ruling.
+
+## Decisions deferred
+
+- The exact first shippable migration wave after Story 06 may split Thoughts from writing if implementation evidence shows separate database migrations are safer; default remains Story 07 together.
+- Whether `known_pre_dispatch_unavailable` advances by default is deferred to the capability policy fixture; default is **no advance** until explicitly enabled and owner-visible.
+- Tool-turn delivery remains gated on Story 09 Part A implementing the
+  separately ruled Tool Capability Foundation. The shared owner surface ships
+  first for migrated Thoughts; later groups activate only with Stories 08–10.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-01-capability-route-census.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-01-capability-route-census.md
@@ -1,0 +1,46 @@
+# HSEGHS001HS104-143-01 - Capability and Route Census
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** ready
+- **Depends on:** none
+- **Unblocks:** 143-02 through 143-14
+- **Owner:** unassigned
+
+## Problem
+
+HoldSpeak currently resolves intelligence through Config pointers, ProfileRecord fields, Workbench/Recipe inheritance, MeetingIntelPlan, SpeechPlan, and several direct call sites. We need a generated, reviewable baseline before replacing any authority.
+
+## Scope
+
+### In
+
+- Generate a complete capability, pointer, resolver, dispatch, fallback, sync, and owner-surface census.
+- Map every physical generation path to InferenceRunner or name the bypass.
+- Classify legacy workflow fallback labels that are not inference fallback.
+- Publish migration ownership for every pointer family in assets/repository-census.md.
+
+### Out
+
+- No runtime behavior or schema change.
+- No inferred capability compatibility.
+
+## Acceptance criteria
+
+- [ ] Every production inference call site has one proposed capability ID and source owner.
+- [ ] Every mutable route pointer and resolver is listed with its migration story.
+- [ ] ProfileService transport-neutral authority bypass and profile sync path exposure are recorded.
+- [ ] One-path census proves current physical leaves and names every exception.
+- [ ] Counsel and owner audits are incorporated into the phase contracts.
+
+## Test plan
+
+- `rg`-based generated inventories checked into a focused unit fixture.
+- `uv run pytest -q tests/unit/test_one_path_census.py`.
+- `dw check holdspeak` and `git diff --check`.
+
+## Implementation notes
+
+- Follow [architecture-contract.md](./assets/architecture-contract.md), [owner-experience.md](./assets/owner-experience.md), and [repository-census.md](./assets/repository-census.md).
+- Product code, schema, inventories, migrations, tests, and evidence land in this story; status changes only after the evidence ledger exists.
+- Preserve unrelated dirty-worktree changes and do not create a second inference gateway, execution revision registry, or owner authority.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-02-canonical-capability-registry.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-02-canonical-capability-registry.md
@@ -1,0 +1,51 @@
+# HSEGHS001HS104-143-02 - Canonical Capability Registry
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-01
+- **Unblocks:** 143-04, 143-05, 143-07 through 143-10, 143-13
+- **Owner:** unassigned
+
+## Problem
+
+Capability strings are scattered across speech, meetings, Ask, Workbench, agents, recipes, Rails, and delivery. The browser cannot lawfully invent requirements or compatibility.
+
+## Scope
+
+### In
+
+- Implement InferenceCapabilityDefinition@1 and a deterministic composition-time registry.
+- Register every censused production capability with operation/result schema, modality, context, boundary, tool, and fallback requirements.
+- Implement immutable `InferenceRetryPolicyDefinition@1` registry; each
+  capability freezes its permitted policy IDs/default and startup validates all
+  references before assignment/plan code exists.
+- Expose safe owner labels/groups and exact compatibility facts.
+- Fail startup on unknown, duplicate, confusable, or schema-drifted definitions.
+
+### Out
+
+- No assignment persistence.
+- No browser-authored registry or plugin string passthrough.
+
+## Acceptance criteria
+
+- [ ] Registry canonical bytes and schema hashes are stable across restart and registration order.
+- [ ] Every production inference call site references one registered definition revision.
+- [ ] Plugin capabilities require a bounded plugin definition revision.
+- [ ] Unknown capability requests refuse before profile/runner access.
+- [ ] Owner projection contains labels and requirements but no secrets or implementation paths.
+- [ ] Retry-policy definitions are canonical/hash-bound and every capability
+  default/allowed reference resolves without cycles or unknown IDs.
+
+## Test plan
+
+- Unit fixtures for every definition and duplicate/confusable/schema drift.
+- Generated call-site-to-capability census equality.
+- Startup, restart, plugin, and HTTP/MCP projection tests.
+
+## Implementation notes
+
+- Follow [architecture-contract.md](./assets/architecture-contract.md), [owner-experience.md](./assets/owner-experience.md), and [repository-census.md](./assets/repository-census.md).
+- Product code, schema, inventories, migrations, tests, and evidence land in this story; status changes only after the evidence ledger exists.
+- Preserve unrelated dirty-worktree changes and do not create a second inference gateway, execution revision registry, or owner authority.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-03-reusable-model-profile-authority.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-03-reusable-model-profile-authority.md
@@ -1,0 +1,53 @@
+# HSEGHS001HS104-143-03 - Reusable Model Profile Authority
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-01, Phase 142
+- **Unblocks:** 143-04, 143-05, 143-12
+- **Owner:** unassigned
+
+## Problem
+
+ProfileRecord and InferenceTarget conflate friendly model identity, mutable endpoint/path/secret configuration, readiness, and execution identity. MCP can also reach ProfileService without service-level OWNER enforcement.
+
+## Scope
+
+### In
+
+- Add immutable ModelProfileRevision@2 and hub-local ProfileBinding authority.
+- Bind profiles only to existing deployment heads and immutable DeploymentRevision execution truth.
+- Adapt historical v1 profiles without rewriting their bytes.
+- Enforce OWNER in the application/service layer for list/get/create/update/delete/probe/bind.
+- Stop new profile bindings and active policies from syncing local paths, endpoints, or secrets.
+- Split legacy `download-and-use`, `use-existing`, and hosted
+  connect-and-route effects so model availability is separately receipted and
+  cannot mutate a legacy/new assignment as a side effect.
+
+### Out
+
+- No second deployment revision registry.
+- No automatic assignment when a model is added or connected.
+
+## Acceptance criteria
+
+- [ ] Profiles contain no secret, locator, live readiness, or mutable endpoint discovery.
+- [ ] Bindings are hub-local, revisioned, CAS-protected, and resolve one exact DeploymentRevision.
+- [ ] AGENT/MODEL_TURN cannot discover or mutate profiles via HTTP, MCP, or direct service call.
+- [ ] Legacy v1 executes byte-identically through one adapter binding.
+- [ ] Deleting a referenced profile refuses with exact dependent assignments.
+- [ ] V2 profile revisions and bindings are hub-local; hostile sync cannot
+  create either, and v1 historical bytes remain the only compatibility case.
+- [ ] Add/download/connect/use-existing changes zero assignment revisions.
+
+## Test plan
+
+- Authority matrix across service/HTTP/MCP principals.
+- V1 migration, path privacy, sync inertness, secret replacement, readiness drift, and restart.
+- Hash forgery and binding/deployment-head race tests.
+
+## Implementation notes
+
+- Follow [architecture-contract.md](./assets/architecture-contract.md), [owner-experience.md](./assets/owner-experience.md), and [repository-census.md](./assets/repository-census.md).
+- Product code, schema, inventories, migrations, tests, and evidence land in this story; status changes only after the evidence ledger exists.
+- Preserve unrelated dirty-worktree changes and do not create a second inference gateway, execution revision registry, or owner authority.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-04-assignment-store-resolver.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-04-assignment-store-resolver.md
@@ -1,0 +1,62 @@
+# HSEGHS001HS104-143-04 - Assignment Store and Resolver
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-02, 143-03
+- **Unblocks:** 143-05, 143-07 through 143-10, 143-11, 143-13
+- **Owner:** unassigned
+
+## Problem
+
+There is no canonical ordered profile-chain authority. Existing Config, subject, recipe, and Workbench pointers would become competing truth if fallbacks were added in place.
+
+## Scope
+
+### In
+
+- Implement the one canonical hub-local `InferenceAssignment@1` persistence;
+  `CapabilityRoutePolicy` is not a second table or service.
+- Implement precedence: invocation, subject, capability, group, global; first defined chain wins whole.
+- Add atomic ordered-chain set/clear commands with idempotency and narrow CAS.
+- Project effective named chains, inheritance source, readiness, compatibility, and boundary warnings.
+- Build one-way adapters/migration markers for legacy pointer families.
+- Retire/split setup command effects that previously combined making a model
+  available with changing the Thoughts target before enabling this authority.
+
+### Out
+
+- No fallback execution yet.
+- No partial per-slot autosave or chain concatenation.
+
+## Acceptance criteria
+
+- [ ] Chains are nonempty, unique, bounded to four, cycle-free, compatible, and recursively closed.
+- [ ] Use default deletes only the sparse override and names the effective chain.
+- [ ] Unrelated assignment edits do not conflict; same assignment races have one winner.
+- [ ] Adding/downloading/connecting a profile leaves all assignments byte-identical.
+- [ ] No consumer dual-reads Config after its migration marker commits.
+- [ ] Fresh no-model and dangling upgrade states project one named repair and
+  never auto-assign a newly added model.
+- [ ] An explicit starter bundle preview/apply is the only multi-group setup.
+- [ ] Group/global chains use each capability's default retry policy unless one
+  override is server-proven permitted by every member; differing policy sets,
+  registry growth, and incompatible inherited entries become named issues.
+- [ ] Use-default preview shows the exact capability-specific result before clear.
+- [ ] Saving during local runtime lease saturation succeeds when structural
+  compatibility holds; later execution observes capacity at preflight.
+
+## Test plan
+
+- All precedence layers, clear-to-inherit preview, duplicate/cycle/incompatible/dangling entries.
+- Group/global compatibility intersections, differing policy sets, and registry growth.
+- Heterogeneous global chain inherited by Speech recognition produces the exact
+  chain or `no_compatible_assignment`; it never filters/substitutes entries.
+- Replay/lost response/changed payload/concurrent same and unrelated assignment CAS.
+- Fresh and upgraded DB migrations for each legacy pointer family.
+
+## Implementation notes
+
+- Follow [architecture-contract.md](./assets/architecture-contract.md), [owner-experience.md](./assets/owner-experience.md), and [repository-census.md](./assets/repository-census.md).
+- Product code, schema, inventories, migrations, tests, and evidence land in this story; status changes only after the evidence ledger exists.
+- Preserve unrelated dirty-worktree changes and do not create a second inference gateway, execution revision registry, or owner authority.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-05-frozen-route-plans.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-05-frozen-route-plans.md
@@ -1,0 +1,53 @@
+# HSEGHS001HS104-143-05 - Frozen Route Plans
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-02, 143-03, 143-04
+- **Unblocks:** 143-06 through 143-10
+- **Owner:** unassigned
+
+## Problem
+
+A mutable assignment cannot authorize execution. Every parent must freeze exact capability, profile, binding, deployment, boundary, budget, and per-leg context truth before first egress.
+
+## Scope
+
+### In
+
+- Implement the one canonical `InferenceRoutePlan@1` and pure server resolver;
+  `ResolvedCapabilityRoutePlan` is not a second table or DTO.
+- Freeze content-free route chains separately from private per-operation
+  admitted-request plans; one-shot work creates both atomically, while each
+  later meeting/tool child plans from its own immutable material snapshot.
+- Adapt legacy one-target callers to one-leg plans without behavior change.
+- Persist content-free plan evidence and reconstruct it after restart.
+- Keep route-leg ordinal distinct from physical-attempt ordinal.
+
+### Out
+
+- No controller advance between legs.
+- No prompt, Note, transcript, key, endpoint credential, or local path in plan rows/projections.
+
+## Acceptance criteria
+
+- [ ] Profile/assignment/capability/route changes after freeze affect only the next parent.
+- [ ] Different tokenizer/template legs never reread, truncate, summarize, or mutate material.
+- [ ] Legacy target overrides become explicit one-leg plans before admission.
+- [ ] Route resolution performs no network, scan, probe, model load, or write and meets 10 ms p95 target.
+- [ ] Every physical child binds plan hash, leg ordinal, attempt ordinal, and exact DeploymentRevision.
+- [ ] Operation plans retain every leg's frozen eligibility; only executable
+  legs carry admitted-request/context/serialized-request hashes.
+
+## Test plan
+
+- Mutation-after-freeze, later meeting/tool material, restart, tamper,
+  lower/larger-context legs, Unicode/template drift.
+- Dialect retry plus later route leg produces unique child identities.
+- Zero-write/network/load census and route-resolution performance fixture.
+
+## Implementation notes
+
+- Follow [architecture-contract.md](./assets/architecture-contract.md), [owner-experience.md](./assets/owner-experience.md), and [repository-census.md](./assets/repository-census.md).
+- Product code, schema, inventories, migrations, tests, and evidence land in this story; status changes only after the evidence ledger exists.
+- Preserve unrelated dirty-worktree changes and do not create a second inference gateway, execution revision registry, or owner authority.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-06-fallback-controller-failure-law.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-06-fallback-controller-failure-law.md
@@ -1,0 +1,62 @@
+# HSEGHS001HS104-143-06 - Fallback Controller and Failure Law
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-05
+- **Unblocks:** 143-07 through 143-10, 143-14
+- **Owner:** unassigned
+
+## Problem
+
+Fallback must be a durable server decision, not a provider retry, browser loop, or hopeful Config list. Unknown physical outcomes and effects make blind advancement unsafe.
+
+## Scope
+
+### In
+
+- Implement RouteAttemptController above InferenceRunner with durable plan/attempt ledgers.
+- Centralize closed disposition classification and bounded retry/fallback policy.
+- Consume the immutable retry-policy registry from Story 02 and implement its
+  runtime classification, reservation, budget, and terminal behavior.
+- Reserve each leg/attempt transactionally with Stop, deadline, and budget fencing.
+- Adopt existing receipts after crash; never reconstruct from current settings.
+- Retire or rename fake workflow fallbackOnDevice/retryThenQueue semantics.
+
+### Out
+
+- No engine/provider hidden retry.
+- No fallback after refusal, authority failure, cancellation, deadline,
+  integrity, unclassified/unsafe context failure, or indeterminate completion.
+  Planning-time `context_overflow` may advance only to an already exact-planned
+  larger leg under explicit policy.
+
+## Acceptance criteria
+
+- [ ] Every provider-reaching try is a separately admitted inference.invoke@1 child.
+- [ ] Known eligible failure advances exactly once; all forbidden dispositions create zero later egress.
+- [ ] Local-to-cloud advance requires frozen saved disclosure and appears in receipt.
+- [ ] Crash after failed receipt resumes once; unknown completion becomes indeterminate.
+- [ ] RouteExecutionReceipt explains considered/attempted legs, dispositions, actual model/boundary, and terminal truth.
+- [ ] Runner obtains a controller-backed durable reservation before any primary,
+  retry, or dialect-compatibility physical child; Stop/deadline/budget fences it.
+- [ ] Post-send timeout/disconnect is unknown and creates zero retry/fallback.
+- [ ] “All N models failed” renders only when all N physically attempted and
+  failed; skipped/unavailable entries use distinct receipt-driven copy.
+
+## Test plan
+
+- Disposition/policy table at budget -1/equality/+1, including primary overflow
+  to larger planned leg and post-admission context drift refusal.
+- Pre-send failure, explicit 429, post-send timeout/disconnect, missing key, and
+  unavailable-leg fixtures.
+- Local lease saturation at preflight, capacity return, and exact
+  `local_capacity_unavailable` disposition.
+- Stop/result, deadline/result, concurrent controller, lost response, every crash boundary.
+- One-path monkeypatch census and exact 0/1/N child cardinality.
+
+## Implementation notes
+
+- Follow [architecture-contract.md](./assets/architecture-contract.md), [owner-experience.md](./assets/owner-experience.md), and [repository-census.md](./assets/repository-census.md).
+- Product code, schema, inventories, migrations, tests, and evidence land in this story; status changes only after the evidence ledger exists.
+- Preserve unrelated dirty-worktree changes and do not create a second inference gateway, execution revision registry, or owner authority.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-07-thoughts-ask-writing-adoption.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-07-thoughts-ask-writing-adoption.md
@@ -1,0 +1,41 @@
+# HSEGHS001HS104-143-07 - Thoughts, Ask, and Writing Adoption
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-04, 143-05, 143-06
+- **Unblocks:** 143-10, 143-13, 143-14
+- **Owner:** unassigned
+
+## Problem
+
+Thought interview, synthesis, Ask, intent, rewrite, and punctuation still depend
+on separate mutable Config targets. They are the smallest coherent adoption
+that proves profiles, assignments, frozen plans, and fallback end to end.
+
+## Scope
+
+- **In:** Migrate `thought.interview`, `thought.synthesis`, `ask.answer`,
+  `speech.intent_classify`, `speech.rewrite`, and `speech.punctuate`; freeze the
+  server-projected chain with Ask/composite reservation; expose application
+  summary/override seams for Story 13; one-way Config migration markers.
+- **Out:** Meeting/transcription migration and executable tool turns.
+
+## Acceptance criteria
+
+- [ ] Ask uses the visible next-run chain exactly once and receipts actual model, fallback, and boundary.
+- [ ] Assignment edits never retarget an in-flight turn.
+- [ ] Every leg preserves the same typed operation/result and exact-context law.
+- [ ] No-model, incompatible, and overflow states nominate one lawful repair.
+- [ ] Upgraded owners keep the same effective primary until they edit an assignment.
+
+## Test plan
+
+- **Unit:** assignment freeze, typed schema, and Config migration fixtures.
+- **Integration:** Workbench composite/restart/admission races with primary failure and fallback success.
+- **Manual / device:** API-level next-run and runtime receipt walk; shared
+  1440/393 chooser glass belongs to Story 13.
+
+## Notes / open questions
+
+Preserve all Phase 141 Workbench cursor, editor, placement, append-effect, and focus laws.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-08-meetings-speech-background-adoption.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-08-meetings-speech-background-adoption.md
@@ -1,0 +1,39 @@
+# HSEGHS001HS104-143-08 - Meetings, Speech, and Background Adoption
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-04, 143-05, 143-06, 143-07
+- **Unblocks:** 143-10, 143-14
+- **Owner:** unassigned
+
+## Problem
+
+MeetingIntelPlan and SpeechPlan are the proven ordered-revision pattern but
+remain parallel authorities. Background services add further route pointers.
+
+## Scope
+
+- **In:** Adapt speech and meeting plans; migrate live/bookmark/title/deferred/plugin,
+  Rails, cadence, decision, and delivery capabilities; fix leg/attempt ordinals;
+  remove duplicate controls and legacy reads after migration markers.
+- **Out:** Arbitrary plugin strings and provider-hidden retries.
+
+## Acceptance criteria
+
+- [ ] Existing histories remain readable and restarts never duplicate egress.
+- [ ] Dialect retry then fallback creates three unique children and exact receipts.
+- [ ] Speech preload remains lifecycle work, not an owner-facing LLM assignment.
+- [ ] Service principals cannot inherit OWNER-only routes implicitly.
+- [ ] All migrated call sites leave the legacy-pointer census.
+
+## Test plan
+
+- **Unit:** plugin definitions, ordinals, migrations, and authority.
+- **Integration:** meeting/speech restart, offline, Stop, retry, and fallback.
+- **Manual / device:** backend/application assignment summaries and receipts;
+  shared editable owner glass belongs to Story 13.
+
+## Notes / open questions
+
+The canonical plan replaces the old plan authority without rewriting v1 histories.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-09-tool-turn-routing-safe-fallback.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-09-tool-turn-routing-safe-fallback.md
@@ -1,0 +1,41 @@
+# HSEGHS001HS104-143-09 - Tool Capability Foundation and Safe Routing
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-06, 143-07
+- **Unblocks:** 143-13, 143-14
+- **Owner:** unassigned
+
+## Problem
+
+The ruled Tool Capability Foundation is design-only. This story makes its
+controller, durable private lease, ledgers, and child laws executable before
+adding tool-capable model fallback.
+
+## Scope
+
+- **In:** Implement the bounded server-owned ToolTurn controller, canonical
+  private capability-lease ledger, model/tool/effect child ledgers and budgets;
+  then route each model step through a frozen assignment with tool-qualified
+  correction/fallback, receipt adoption, and separate owner truth.
+- **Out:** Owner MCP tokens/catalogs and route-controller ownership of tool calls.
+
+## Acceptance criteria
+
+- [ ] Fallback cannot expand palette, scope, budgets, policy, or egress.
+- [ ] Receipted effects are adopted; unknown effect completion never falls back.
+- [ ] Tool service outage is a typed result, not automatically a model failure.
+- [ ] Required tools refuse before dispatch when no qualified profile exists.
+- [ ] Every model step and tool call is separately admitted and receipted.
+
+## Test plan
+
+- **Unit:** confusable calls, schema drift, lease expiry/revocation, palette escalation.
+- **Integration:** crash at model/tool/effect boundaries, Stop races, receipt adoption.
+- **Manual / device:** exact tools-used, proposed/executed effect, and model-fallback disclosures.
+
+## Notes / open questions
+
+Part A is the concrete Tool Capability Foundation gate; Part B cannot advertise
+or execute tool use until Part A's service/controller/ledger tests pass.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-10-agents-workbenches-recipes-adoption.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-10-agents-workbenches-recipes-adoption.md
@@ -1,0 +1,39 @@
+# HSEGHS001HS104-143-10 - Agents, Workbenches, Recipes, and Workflows Adoption
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-06, 143-07
+- **Unblocks:** 143-14
+- **Owner:** unassigned
+
+## Problem
+
+Workbench→Recipe→global SQL resolution, agent overrides, sequences/workflows,
+and reference-resolution code currently reconstruct placement independently.
+
+## Scope
+
+- **In:** Migrate non-tool Agent, Workbench, Recipe, sequence/workflow, and
+  reference-resolution callers; retire mutable `inference.run` late routing and
+  fake workflow fallback labels. Tool-bearing steps are owned by Story 09.
+- **Out:** Feature-owned route editors and unrelated workflow branching changes.
+
+## Acceptance criteria
+
+- [ ] Every caller uses the canonical resolver/controller and InferenceRunner waist.
+- [ ] Workbench/Recipe/Agent precedence preserves its old effective primary until owner edit.
+- [ ] Subject changes affect next run only and never mutate group/global policy.
+- [ ] `inference.run` cannot physically dispatch through mutable late resolution.
+- [ ] Generated census finds no remaining placement-resolution fork.
+
+## Test plan
+
+- **Unit:** precedence, deletion, dangling subject, concurrent override.
+- **Integration:** recipe/workflow restart and receipt reconstruction.
+- **Manual / device:** application-level subject summary/override walk; shared
+  editable UI and cross-surface reuse belong to Story 13.
+
+## Notes / open questions
+
+The shared UI must replace, not sit beside, private target selectors.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-11-http-mcp-sync-compatibility.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-11-http-mcp-sync-compatibility.md
@@ -1,0 +1,39 @@
+# HSEGHS001HS104-143-11 - HTTP, MCP, Sync, and Compatibility
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-03, 143-04, 143-05, 143-06
+- **Unblocks:** 143-12 through 143-14
+- **Owner:** unassigned
+
+## Problem
+
+The new authority needs exact transport parity and a safe compatibility
+boundary. Current profile MCP access and sync can bypass OWNER or expose local
+binding material.
+
+## Scope
+
+- **In:** Closed HTTP/MCP twins for library, profiles/bindings, registry,
+  assignments, previews, and route receipts; shared OWNER service methods;
+  idempotency, narrow CAS, safe DTOs, hub-local sync classification.
+- **Out:** Model-facing owner resources and events as authority.
+
+## Acceptance criteria
+
+- [ ] Reciprocal golden fixtures match inside transport envelopes.
+- [ ] Nested unknown fields refuse; replay succeeds; changed payload refuses.
+- [ ] None/AGENT/MODEL_TURN fail before DB/config discovery.
+- [ ] Hostile sync cannot bind, assign, download, probe, resume, or invoke.
+- [ ] No secret, path, prompt, owner material, or private endpoint leaks.
+
+## Test plan
+
+- **Unit:** auth matrix, recursive schemas, mapping, request receipts.
+- **Integration:** restart, lost response, sync forgery/inertness, v1 exception.
+- **Manual / device:** regenerate HTTP/MCP inventories and inspect safe Details.
+
+## Notes / open questions
+
+GET reconstructs authority; advisory events can always be lost.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-12-model-library-providers.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-12-model-library-providers.md
@@ -1,0 +1,41 @@
+# HSEGHS001HS104-143-12 - Model Library and Providers
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-03, 143-11, Phase 142
+- **Unblocks:** 143-13, 143-14
+- **Owner:** unassigned
+
+## Problem
+
+Models currently mixes setup, provider connection, and immediate Thoughts
+assignment. Owners need one compact library while assignments remain unchanged.
+
+## Scope
+
+- **In:** Unified downloadable/detected/installed/connected rows; focused
+  Providers for OpenRouter, Anthropic, custom, private, paired, and future
+  backends; one Add model flow with Download from catalog, Connect hosted,
+  Define endpoint, and Use model file; lawful commands; server truth.
+- **Out:** Silent `Download & use`/`Connect & use` and browser recommendations.
+
+## Acceptance criteria
+
+- [ ] Adding a model changes zero assignment revisions and says so explicitly.
+- [ ] Huge detected inventories use compact wrapped rows, not cards.
+- [ ] Secrets clear only after confirmed save and never enter DOM/projection/log.
+- [ ] Broken configured entries remain visible with one repair.
+- [ ] Exact selected states are Download, Add to library, Connect, Add model,
+  Ready, Checking, Try again, or one typed repair; none implies assignment.
+- [ ] 1440 shows six rows/details/action; 393 shows three rows/one action.
+
+## Test plan
+
+- **Unit:** local GGUF/MLX, hosted/custom, storage/license/runtime/key states.
+- **Integration:** provider CAS, delayed save, conflict/rebase, restart, secret sentinel.
+- **Manual / device:** 1440/393/200% zoom/a11y/no-overflow real-path glass.
+
+## Notes / open questions
+
+Technical provenance and locators stay in explicit owner-only Details.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-13-capability-assignments-experience.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-13-capability-assignments-experience.md
@@ -1,0 +1,43 @@
+# HSEGHS001HS104-143-13 - Capability Assignments Experience
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-02, 143-04, 143-07, 143-11, 143-12
+- **Unblocks:** 143-14
+- **Owner:** unassigned
+
+## Problem
+
+Granular routing must not become a capability×model matrix or verbose wizard.
+Owners need bounded group summaries and one focused ordered-chain editor.
+
+## Scope
+
+- **In:** Bounded Assignments overview; searchable overrides/issues; shared
+  AssignmentSummary/Editor/model chooser; atomic reorder save; exact inheritance,
+  boundary, issue, and runtime receipt copy.
+- **Out:** Select-per-row UI, raw IDs, and duplicate feature-owned selectors.
+
+## Acceptance criteria
+
+- [ ] The twentieth capability does not increase default page height.
+- [ ] One-primary editor atomically saves order and supports keyboard reorder.
+- [ ] Default/Automatic always names the effective chain.
+- [ ] Broken saved entries remain visible; issues sort first with one Fix.
+- [ ] 393 has 44 px targets, sticky in-sheet Save, wrapped names, no overflow.
+- [ ] Only migrated consumer families are editable; Thoughts ships first, and
+  Stories 08–10 activate their groups/leaves without creating new UI.
+- [ ] Group/global editors render server-projected compatibility/policy issues;
+  leaf Use-default previews its exact effective chain before clearing.
+
+## Test plan
+
+- **Unit:** inheritance, group/global differing-policy compatibility, registry
+  growth issues, Use-default preview, reorder, conflict, focus, keyboard, screen reader.
+- **Integration:** library→assignment→Thought next-run and fallback receipt.
+- **Manual / device:** 1440/393 one-primary/no-matrix real-path glass.
+
+## Notes / open questions
+
+Follow the exact composition and rejection criteria in `assets/owner-experience.md`.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-14-chaos-glass-closeout.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-14-chaos-glass-closeout.md
@@ -1,0 +1,39 @@
+# HSEGHS001HS104-143-14 - Chaos, Glass, and Closeout
+
+- **Project:** holdspeak
+- **Phase:** 143
+- **Status:** backlog
+- **Depends on:** 143-07 through 143-13
+- **Unblocks:** phase close
+- **Owner:** unassigned
+
+## Problem
+
+This phase changes authority across almost every AI workload. It closes only
+with broad restart, concurrency, privacy, compatibility, performance, and owner
+experience proof.
+
+## Scope
+
+- **In:** Full adversarial matrix; every legacy migration/capability family;
+  crash/concurrency/sync/privacy proof; 1440/393/200% glass; inventories and
+  zero-bypass censuses.
+- **Out:** Waived kill criteria and mocked browser rows as authority evidence.
+
+## Acceptance criteria
+
+- [ ] All phase kill criteria are demonstrably false on production paths.
+- [ ] Every physical generation is an InferenceRunner child.
+- [ ] Restart reconstructs plans/attempts/receipts without duplicate unknown work.
+- [ ] No Config/assignment dual authority or obsolete feature selector remains.
+- [ ] Owner walks prove compact library, bounded assignments, exact fallback truth, accessibility, and budgets.
+
+## Test plan
+
+- **Unit:** full backend/web suites, schema/API/MCP/census guards, production build.
+- **Integration:** isolated HOME/database/artifact/provider chaos harness.
+- **Manual / device:** two-width and 200%-zoom glass with evidence ledger.
+
+## Notes / open questions
+
+No story or phase status flips without the required evidence file and PMO checks.


### PR DESCRIPTION
## What changed

- charters Phase 143 as one capability registry, reusable model-profile/binding authority, ordered Assignments, frozen route plans, and durable failure-driven fallback
- adds 14 recipe-like implementation stories with exact dependencies, acceptance gates, migrations, transport/sync laws, and chaos proof
- separates the owner experience into Model Library and Assignments, with compact 1440/393 laws and no silent assignment during setup
- records the horizontal repository census and preserves DeploymentRevision + InferenceRunner as the sole execution truth and physical waist

## Why

HoldSpeak currently has capable but fragmented inference pointers and frozen-plan implementations. This charter generalizes the proven meeting/speech pattern without adding fallback arrays to mutable Config/ProfileRecord or creating a second inference architecture.

## Validation

- `uv run pytest -q tests/unit/test_one_path_census.py tests/unit/test_api_surface.py` — 9 passed
- `git diff --check`
- owner/product review — RATIFY
- architecture/counsel review — RATIFY
- `dw check holdspeak` reaches one inherited Phase 101 evidence/story-status inconsistency; Phase 143 introduces no new PMO error

## Scope

This is the atomic HSEGHS001HS104-143-01 phase-charter and repository-census planning chunk. No product code, story completion, or evidence-status claim is included.