### PR TITLE
HS-143-01: freeze the capability and route census

### DIFF
--- a/pm/roadmap/holdspeak/README.md
+++ b/pm/roadmap/holdspeak/README.md
@@ -8,7 +8,8 @@
 > from evidence, Terra waves with serialized shipping, walks, honest ledgers —
 > is canon at [`docs/internal/ORCHESTRATION.md`](../../../docs/internal/ORCHESTRATION.md).
 
-**Newest update (2026-08-21): Phase 143 — The Intelligence Router — PLANNING.**
+**Newest update (2026-08-21): Phase 143 — The Intelligence Router — ACTIVE
+(1/14).**
 The full execution charter is ready: one server-owned capability registry,
 reusable immutable model profiles with hub-local bindings, sparse ordered
 Assignments, frozen per-run route plans, and durable disposition-driven
@@ -18,7 +19,10 @@ agents, Workbenches, Recipes, and future tool turns. Owner settings separate
 **Model Library** (what is available) from **Assignments** (which models do
 which jobs), so adding a model never silently changes a job. The default UI
 stays bounded as capabilities grow; ordered fallbacks are edited in one atomic
-sheet and local-to-cloud expansion is explicit. Fourteen recipe-like stories,
+sheet and local-to-cloud expansion is explicit. Story 01 is done: three exact
+generated ledgers now fail closed on new Python or Swift execution doors,
+semantic AI callers, mutable routing authorities, browser selectors, and
+retry/fallback branches. Fourteen recipe-like stories,
 the repository census, architecture contract, owner experience, migration law,
 kill criteria, and chaos/glass matrix are in the
 [Phase 143 record](./phase-143-intelligence-router/current-phase-status.md).
@@ -916,7 +920,7 @@ canon, canon wins.
 | 140 | The First Sentence: one obvious first-value act on the Chair, a useful editable result, in-place recovery, then a furnished six-drawer reveal with explicitly attachable Everyday context. | in-progress (5/6) | [phase-140-the-first-sentence](./phase-140-the-first-sentence/) |
 | 141 | From Thought to Work: preserve rough speech, develop it through one owner-triggered grounded question at a time, then freeze typed local or GitHub-backed outcomes on the existing authority and receipt spine. | in-progress (6/9) | [phase-141-from-thought-to-work](./phase-141-from-thought-to-work/) |
 | 142 | Make AI capability, runtime, artifact, route, and readiness truth server-owned before adding acquisition or new execution paths. | active | [phase-142-inference-instrument](./phase-142-inference-instrument/) |
-| 143 | Route every AI workload through one server-owned capability assignment to reusable model profiles, with ordered qualified fallbacks, frozen execution truth, and the Model Library + Assignments owner system. | planning | [phase-143-intelligence-router](./phase-143-intelligence-router/) |
+| 143 | Route every AI workload through one server-owned capability assignment to reusable model profiles, with ordered qualified fallbacks, frozen execution truth, and the Model Library + Assignments owner system. | in-progress (0/14) | [phase-143-intelligence-router](./phase-143-intelligence-router/) |
 
 (Status values: `planning`, `in-progress`, `done`, `paused`, `cancelled`.)
 

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/architecture-contract.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/architecture-contract.md
@@ -78,7 +78,7 @@ exact definition revision and schema hash.
 
 | Group | Capability IDs | Existing seam |
 |---|---|---|
-| Thoughts & notes | `thought.interview`, `thought.synthesis`, `ask.answer` | refinement coordinator, Ask service |
+| Thoughts & notes | `thought.interview` (question-or-synthesis result union), `ask.answer` | refinement coordinator, Ask service; an independently assignable synthesis requires a future distinct admitted operation |
 | Writing & dictation | `speech.intent_classify`, `speech.rewrite`, `speech.punctuate` | `speech_session.plan` |
 | Speech recognition | `speech.transcribe`; internal `speech.preload` | Whisper session plans; `speech.preload` is lifecycle work with `owner_visibility=internal`, never an assignable row |
 | Meetings | `meeting.live_analysis`, `meeting.bookmark_label`, `meeting.auto_title`, `meeting.deferred_analysis`, `meeting.plugin.<id>` | `MeetingIntelPlan` |

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/generated-inference-capability-census.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/generated-inference-capability-census.md
@@ -1,0 +1,177 @@
+# Generated inference/capability census
+
+**Story:** HSEGHS001HS104-143-01
+
+**Captured:** 2026-08-21
+
+This is the checked-in baseline for the Phase 143 route migration. Its
+machine-readable fixture is
+[`tests/unit/test_phase143_inference_capability_census.py`](../../../../../tests/unit/test_phase143_inference_capability_census.py).
+It consumes the Phase 131 AST census rather than a broad text search. The
+fixture has one literal `path:line / scope / target / kind` entry for each
+site; moving a site or adding a second execution-shaped expression in an
+already admitted scope fails the focused test until it receives an explicit
+capability and source-owner classification.
+
+## Current result
+
+99 Python production model-shaped sites are registered. There are 14 direct
+Python provider/model leaves and **zero Python legacy bypasses**. The Phase 131
+findings ledger is empty. `InferenceRunner` remains the Python physical
+admission waist; all Python direct leaves are context-gated adapters or
+dispatch closures reached from an admitted child. Apple has seven separately
+inventoried legacy physical leaves below; it does not yet use the Python runner.
+
+| Proposed capability | Sites | Current source owner |
+|---|---:|---|
+| `agent.tool_turn` | 1 | `plugins.intelligence` |
+| `internal.inference.dispatch` | 37 | runner, target factories, MeetingIntel provider adapters |
+| `internal.speech.runtime_assembly` | 15 | speech-session/dictation runtime assembly |
+| `meeting.auto_title` | 2 | `meeting_session` |
+| `meeting.bookmark_label` | 2 | `meeting_session` |
+| `meeting.deferred_analysis` | 2 | `meeting_session.deferred_admission` |
+| `meeting.live_analysis` | 1 | `meeting_session` |
+| `project_doc.suggest_update` | 3 | `project_doc_suggestions` |
+| `speech.intent_classify` | 6 | `speech_session` |
+| `speech.preload` | 1 | `speech_session.transcription` |
+| `speech.punctuate` | 1 | `speech_session` |
+| `speech.rewrite` | 10 | `speech_session` |
+| `speech.target_classify` | 3 | `target_profile` |
+| `speech.transcribe` | 15 | `speech_session.transcription` |
+
+`internal.inference.dispatch` and `internal.speech.runtime_assembly` are
+non-assignable proposed implementation IDs. They mark shared gateway/factory
+work, not a generic owner-facing model task. A parent caller supplies the
+eventual typed capability at admission; Story 02 replaces these proposal IDs
+with registry definitions where a persisted capability is required.
+
+## Direct physical leaves
+
+Every row below is admitted by `InferenceRunner`; there is no bypass/legacy
+adapter exception to carry into the migration.
+
+| Source location | Physical operation | Proposed capability |
+|---|---|---|
+| `intel/engine.py:273` | local `create_chat_completion` | `internal.inference.dispatch` |
+| `intel/engine.py:311` | OpenAI-compatible `chat.completions.create` callback | `internal.inference.dispatch` |
+| `intel/engine.py:349` | streaming local `create_chat_completion` | `internal.inference.dispatch` |
+| `intel/engine.py:387` | streaming OpenAI-compatible callback | `internal.inference.dispatch` |
+| `intel/mesh_relay.py:252` | relay `run_prompt` | `internal.inference.dispatch` |
+| `plugins/dictation/runtime_llama_cpp.py:134` | constrained `create_completion` | `speech.intent_classify` |
+| `plugins/dictation/runtime_llama_cpp.py:162` | rewrite `create_completion` | `speech.rewrite` |
+| `plugins/dictation/runtime_mesh_relay.py:106` | relay `run_prompt` | `internal.speech.runtime_assembly` |
+| `plugins/dictation/runtime_openai_compatible.py:141` | classify `chat.completions.create` | `speech.intent_classify` |
+| `plugins/dictation/runtime_openai_compatible.py:188` | rewrite `chat.completions.create` | `speech.rewrite` |
+| `transcribe.py:241` | MLX model preload `get_model` | `speech.preload` |
+| `transcribe.py:251` | silent-audio MLX warmup `transcribe` | `speech.transcribe` |
+| `transcribe.py:296` | MLX Whisper `transcribe` | `speech.transcribe` |
+| `transcribe.py:378` | faster-whisper `transcribe` | `speech.transcribe` |
+
+The first four rows are reached through a runner-built `MeetingIntel` and its
+canonical adapter. Dictation rows are reached through the admitted dictation
+runtime; the two Whisper preload/warmup rows and both transcription backends
+run under `TranscriptionAdmission`, which admits an `inference.invoke@1` child
+before their callback can execute. The fixture asserts each physical leaf is a
+Phase 131 `allowlist` site and that its recorded admission is `InferenceRunner`.
+
+## Product entrances into the runner
+
+The physical-site inventory above is not enough on its own: these are the 12
+production callers of `InferenceRunner.invoke`, including first-class bound
+method references passed to `asyncio.to_thread`. The checked-in fixture fails
+on any new `.invoke` expression, so a new service cannot inherit an existing
+source owner's review by merely using the runner.
+
+| Source location | Proposed capability provenance | Source owner |
+|---|---|---|
+| `kernel/mesh_local_runner.py:232` | dynamic: frozen mesh dispatch-offer capability | `kernel.mesh_local_runner` |
+| `meeting_session/intel_child.py:193` | dynamic: frozen `MeetingIntelPlan` capability | `meeting_session.intel_child` |
+| `rails_observer.py:268` | `background.rails_summary` | `rails_observer` |
+| `services/ask_service.py:63` | `internal.semantic_dispatch`; exact capability supplied by the semantic caller | `services.ask_service` |
+| `services/cadence_service.py:284` | `background.cadence_draft` | `services.cadence_service` |
+| `services/decision_lifecycle_service.py:81` | `decision.promotion_draft` | `services.decision_lifecycle_service` |
+| `services/recipe_service.py:52` | `internal.semantic_dispatch`; exact capability supplied by the semantic caller | `services.recipe_service` |
+| `services/sequence_workflow_service.py:44` | `internal.semantic_dispatch`; exact capability supplied by the semantic caller | `services.sequence_workflow_service` |
+| `services/workbench_runner.py:41` | `workbench.item` | `services.workbench_runner` |
+| `services/workbench_service.py:414` | `voice.reference_resolve` | `services.workbench_service` |
+| `speech_session/child.py:181` | dynamic: frozen `SpeechSessionPlan` capability | `speech_session.child` |
+| `web/routes/delivery_prs.py:252` | `delivery.pr_review_draft` | `web.routes.delivery_prs` |
+
+The three dynamic rows are deliberately provenance descriptors, not fake
+registry IDs: their current plan or signed offer chooses a typed capability at
+admission. Story 02 must carry that exact capability into its registry/route
+plan rather than collapsing the family into one broad assignment.
+
+## Shared semantic callers
+
+`AskService._invoke`, `RecipeService._invoke`, and
+`SequenceWorkflowService._invoke` are shared helpers, not capabilities. The
+semantic caller census is therefore separate from the 12 runner entrances and
+walks every production Python module (including direct constructors, service
+factories, local aliases, and Refinement's injected Ask factory) before Story 02
+routes it. A synthetic new Ask/Recipe caller is a fail-closed test mutation.
+
+| Source location | Capability | Source owner |
+|---|---|---|
+| `mcp/families/ask.py:146`, `web/routes/primitives/ask.py:49` | `ask.answer` | Ask transports |
+| `services/refinement_coordinator.py:328` | `thought.interview` (question-or-synthesis result branch) | refinement coordinator |
+| `mcp/tools.py:533`, `web/routes/primitives/recipes.py:100` | `recipe.run` | Recipe transports |
+| `mcp/tools.py:537`, `web/routes/primitives/recipes.py:115` | `recipe.chat` | Recipe transports |
+| `services/sequence_workflow_service.py:133` | `sequence.step` | Sequence service |
+| `services/sequence_workflow_service.py:186` | `workflow.node` | Workflow service |
+
+Refinement is one `thought.interview` capability. Its sealed result contract can
+be the next interview question or a terminal synthesis; `thought.synthesis` is
+not separately routable today. It must not be reduced to `ask.answer` merely
+because it invokes `AskService`.
+
+## Apple Swift scope
+
+Apple source is in scope for the physical-leaf baseline but is not covered by
+the Python `InferenceRunner`. Seven Swift leaves are named **legacy bypasses**
+with their migration owner; they must converge on the Phase 143 route/fallback
+law before an Apple capability can claim parity.
+
+| Swift leaf | Proposed capability | Exact migration story |
+|---|---|---|
+| `InferenceLlama/LlamaProvider.swift:124` | `apple.local_completion` | Story 143-10 — Agents/workbenches/recipes adoption |
+| `Providers/Inference/OpenAIEndpointProvider.swift:48` | `apple.endpoint_completion` | Story 143-10 — Agents/workbenches/recipes adoption |
+| `Providers/Inference/StructuredOutput.swift:64` | `apple.structured_output` | Story 143-10 — Agents/workbenches/recipes adoption |
+| `Providers/Desktop/MeshServeWorker.swift:99` | `apple.mesh_serve` | Story 143-10 — Agents/workbenches/recipes adoption |
+| `RuntimeCore/Companion/CoderAnswer.swift:109` | `apple.coder_answer` | Story 143-10 — Agents/workbenches/recipes adoption |
+| `RuntimeCore/Workbench/BlueprintInterpreter.swift:343` | `apple.workbench.blueprint` | Story 143-06 — fallback-controller migration |
+| `RuntimeCore/Workbench/WorkflowRunner.swift:366` | `apple.workbench.workflow` | Story 143-06 — fallback-controller migration |
+
+`WorkflowRunner` and `BlueprintInterpreter` currently retry and may use an
+injected fallback provider; those are legacy application-level physical calls,
+not evidence of a canonical route-plan controller. Their Story 143-06 migration
+must replace that law before Story 143-10 adopts the resulting route.
+The scanner catches every Swift `.complete(` receiver (including `fallback`)
+and every `URLSession.data(for:)` open under `Providers/Inference`; both have
+synthetic mutation proofs.
+
+## Migration implications
+
+* Meeting child closures already distinguish live analysis, deferred analysis,
+  bookmark label, and title; route-plan adoption can migrate those without
+  collapsing their current admission boundaries.
+* Speech has stable typed work (`transcribe`, `preload`, `intent_classify`,
+  `rewrite`, `punctuate`); its runtime construction sites stay infrastructure,
+  not assignment choices.
+* Generic MeetingIntel/provider construction is shared implementation work.
+  It must read only a frozen route/deployment provided by the resolver after
+  its family crosses; it must never turn into an alternate capability resolver.
+* The existing plugin intelligence handle maps to `agent.tool_turn`; its future
+  executable route remains gated on Story 09's Tool Capability Foundation.
+
+## Regeneration/check
+
+```bash
+uv run pytest -q tests/unit/test_one_path_census.py \
+  tests/unit/test_phase143_inference_capability_census.py --tb=short
+```
+
+The 143 test is intentionally fail-closed: update the literal fixture, its
+classification, semantic caller rows, Swift leaf rows, and this generated
+summary in the same reviewed change. A passing test is evidence of current
+coverage, not permission to add an unreviewed model call.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/generated-routing-authority-census.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/generated-routing-authority-census.md
@@ -1,0 +1,127 @@
+# Phase 143 generated routing-authority census
+
+**Generated baseline:** 2026-08-21 from production `holdspeak/**` anchors on
+merged `main`. This is the checked-in review fixture for HSEGHS001HS104-143-01;
+it records today's authority, not the intended Phase 143 design. Test coverage:
+`tests/unit/test_phase143_routing_authority_census.py`.
+
+## Classification vocabulary
+
+| Classification | Meaning |
+| --- | --- |
+| mutable assignment pointer | A persisted or request-time selection that can choose a target after it is changed. It must have one migration owner. |
+| immutable evidence | A frozen revision, receipt, or plan reference. It is execution proof, never a new routing selector. |
+| display | A projection, diagnostic, or serialized explanation of an already-resolved choice. |
+| credential/provider identity | Secret-slot, provider, endpoint, runtime, or readiness identity. It cannot become assignment authority. |
+| unrelated | A different domain's use of “profile”, including target-application and agent-launch profiles. |
+| legacy-delete | A compatibility writer or old fallback whose assignment effect must disappear, rather than be adapted as new authority. |
+
+## Production site inventory
+
+| Family | Production anchors | Classification | Migration story |
+| --- | --- | --- | --- |
+| ProfileRecord mutable destination fields | `holdspeak/services/profile_service.py:ProfileService`; `holdspeak/inference_targets.py:target_from_profile` | mutable assignment pointer | 143-03 |
+| Deployment head selected by a future profile binding | `holdspeak/services/inference_acquisition_service.py:_activate`; `holdspeak/deployment_revisions.py:_artifact_revision_for_identity` | mutable assignment pointer | 143-03 |
+| Thoughts and Ask default/request pointer | `holdspeak/config/integrations.py:ThoughtsConfig.inference_target_id`; `holdspeak/inference_targets.py:resolve_thought_placement`; `holdspeak/services/refinement_coordinator.py:_admission_claim`; `holdspeak/services/refinement_application_service.py:get_workbench`; `holdspeak/services/refinement_thought_service.py:_validate_current_admission_under_write_fence`; `holdspeak/services/ask_service.py:AskService.ask` | mutable assignment pointer | 143-07 |
+| Writing and dictation runtime pointer | `holdspeak/config/model.py:LLMRuntimeConfig.profile_id`; `holdspeak/intel/providers.py:effective_dictation_llm`; `holdspeak/speech_session/plan.py:DictationSessionPlanResolver` | mutable assignment pointer | 143-07 |
+| Meeting intelligence pointer and provider placement | `holdspeak/config/meeting.py:MeetingConfig.intel_profile_id`; `holdspeak/intel/providers.py:effective_intel_cloud`; `holdspeak/intel/providers.py:resolve_meeting_placement`; `holdspeak/meeting_session/intel_plan.py:freeze_meeting_intel_plan` | mutable assignment pointer | 143-08 |
+| Recipe and agent default pointer | `holdspeak/db/models/__init__.py:RecipeRecord.profile_id`; `holdspeak/services/recipe_service.py:RecipeService._target`; `holdspeak/services/schedule_delegation.py:_terms`; `holdspeak/inference_targets.py:resolve_placement` | mutable assignment pointer | 143-10 |
+| Workbench execution pointer | `holdspeak/db/models/workbench.py:WorkbenchRecord.profile_id`; `holdspeak/services/workbench_runner.py:WorkbenchRunner`; `holdspeak/services/workbench_service.py`; `holdspeak/deployment_revisions.py:resolve_workbench_deployment_revision` (raw SQLite snapshot) | mutable assignment pointer | 143-10 |
+| Workbench voice-resolver pointer | `holdspeak/db/models/workbench.py:WorkbenchRecord.resolver_profile_id`; `holdspeak/services/workbench_service.py:resolve_voice_references` | mutable assignment pointer | 143-10 |
+| Recipe, Sequence, and Workflow request placement override | `holdspeak/services/recipe_service.py:RecipeService.run`; `holdspeak/services/sequence_workflow_service.py:SequenceWorkflowService._target`; MCP Sequence adapters | mutable assignment pointer | 143-10 |
+| Kernel `inference.run` requested target selector | `holdspeak/kernel/inference.py:InferenceInvokeCodec.decode/authorize`; `requested_target_id` is decoded at line 86 and resolved at line 103 | mutable assignment pointer | 143-10 |
+| Decision and delivery request placement override | `holdspeak/services/decision_lifecycle_service.py:draft_promoted_with_model`; `holdspeak/web/routes/delivery_prs.py:api_delivery_pr_draft_review` | mutable assignment pointer | 143-08 |
+| Rails observer background pointer | `holdspeak/config/integrations.py:RailsObserverConfig.profile_id`; `holdspeak/rails_observer.py:build_profile_summarizer`; `holdspeak/web_server.py` | mutable assignment pointer | 143-08 |
+| Cadence background global resolver | `holdspeak/services/cadence_service.py:_drafted_next_action`; `holdspeak/inference_targets.py:resolve_placement` | mutable assignment pointer | 143-08 |
+| Legacy setup download-and-use assignment side effect | `holdspeak/services/inference_acquisition_service.py:_activate`; `holdspeak/services/inference_setup_service.py` | mutable assignment pointer | 143-03 |
+| Legacy seed profile adoption assignment side effect | `holdspeak/db/seed.py:_adopt_profiles` | mutable assignment pointer | 143-04 |
+| V1 profile and workbench sync payload | `holdspeak/services/sync_service.py:SYNC_REGISTRY`; `holdspeak/services/sync_service.py:_MERGEABLE`; `holdspeak/services/sync_service.py:pull` | mutable assignment pointer | 143-11 |
+| Settings Thoughts and writing legacy pointer writers | `holdspeak/services/settings_service.py:SettingsService.update_settings`; dictation/thoughts pointer normalization | mutable assignment pointer | 143-07 |
+| Settings meeting and background legacy pointer writers | `holdspeak/services/settings_service.py:SettingsService.update_settings`; meeting/rails pointer normalization | mutable assignment pointer | 143-08 |
+| DeploymentRevision ID in runner, lease, and receipts | `holdspeak/deployment_revisions.py:resolve_deployment_revision`; `holdspeak/kernel/inference_runner.py`; `holdspeak/kernel/local_runtime_lease.py` | immutable evidence | — |
+| Frozen meeting and speech plan entries | `holdspeak/meeting_session/intel_plan.py:MeetingIntelPlan`; `holdspeak/speech_session/plan.py` | immutable evidence | — |
+| InferenceTarget and placement response DTOs | `holdspeak/inference_targets.py:InferenceTarget.to_dict`; `holdspeak/services/ask_service.py:_ask_projection`; `holdspeak/services/recipe_service.py:_chat_projection` | display | — |
+| Doctor, desk, and MCP destination views | `holdspeak/commands/doctor.py`; `holdspeak/services/desk_service.py`; `holdspeak/mcp/resources.py` | display | — |
+| Endpoint/profile key slot and key custody | `holdspeak/intel/providers.py:profile_key_env`; `holdspeak/services/profile_key_service.py:ProfileKeyService`; `holdspeak/profile_key_store.py` | credential/provider identity | 143-03 |
+| Provider/runtime/readiness facts | `holdspeak/inference_targets.py:DeploymentIdentity`; `holdspeak/intel/providers.py:resolve_intel_provider`; `holdspeak/services/profile_service.py:probe_inference_target` | credential/provider identity | 143-03 |
+| Target-application profiles for dictation | `holdspeak/target_profile.py`; `holdspeak/config/meeting.py:target_profile_override`; `holdspeak/desktop_typing.py` | unrelated | — |
+| MIR plugin-routing profile | `holdspeak/config/meeting.py:routing_profile`; `holdspeak/plugins/router.py`; `holdspeak/intel_queue.py` | unrelated | — |
+| Delivery agent launch profile | `holdspeak/delivery/factory_launch.py`; `holdspeak/kernel/process_spawn.py` | unrelated | — |
+| Legacy config endpoint migration | `holdspeak/config/core.py:migrate_legacy_endpoints`; legacy `intel_cloud_*` and `openai_compatible_*` fields | legacy-delete | 143-03 |
+| Old dictation auto-placement fallback labels | `holdspeak/plugins/dictation/assembly.py` | legacy-delete | 143-07 |
+| Old meeting auto-placement fallback labels | `holdspeak/intel/providers.py:resolve_meeting_placement`; `holdspeak/meeting_session/intel_plan.py` | legacy-delete | 143-08 |
+
+The migration-story column is deliberately singular for every mutable family.
+Story 143-04 owns the common assignment store/resolver and seed migration.
+Stories 143-07, 143-08, and 143-10 own removal of their product families'
+legacy selectors; none may create a second authority while doing so.
+
+## Machine-checked source equality
+
+`test_phase143_routing_authority_census.py` parses every production Python AST
+and requires exact equality with this ledger's source baseline. It deliberately
+includes imports as well as calls: an imported resolver is a route authority
+edge even if the physical call is conditional. The guard covers the execution
+waist (`kernel/inference_invoke.py`, `kernel/inference_runner.py`) and its
+projection revalidation (`kernel/projection_stager.py`) as immutable revision
+evidence, never as a mutable selector.
+
+| Source family | Exact observed production sites | Classification |
+| --- | --- | --- |
+| Public routing resolver definitions | `deployment_revisions.py:202,224`; `inference_targets.py:497,551,591`; `intel/providers.py:666` | resolver authority |
+| Placement / deployment resolver imports and uses | `deployment_revisions.py:205,214`; `inference_targets.py:585,602`; `intel/__init__.py:60`; `intel/providers.py:193,235,337,864`; `kernel/inference.py:9,103`; `kernel/inference_invoke.py:10,92`; `kernel/inference_runner.py:7,317`; `kernel/projection_stager.py:133,134`; `meeting_session/intel_plan.py:185,186,192,194`; `rails_observer.py:249,255`; `services/ask_service.py:146,147`; `services/cadence_service.py:222,226`; `services/decision_lifecycle_service.py:67,71`; `services/inference_setup_service.py:23,184`; `services/profile_service.py:115,116`; `services/recipe_service.py:130,131,173,174`; `services/schedule_delegation.py:9,18`; `services/sequence_workflow_service.py:31,33`; `services/settings_service.py:68,76`; `services/workbench_runner.py:30,31`; `services/workbench_service.py:167,171,378,379`; `speech_session/plan.py:452,461,611,620`; `web/routes/delivery_prs.py:234,241` | resolver authority |
+| Thought direct resolver callers | `services/refinement_application_service.py:63,64,70,71`; `services/refinement_coordinator.py:222,223`; `services/refinement_thought_service.py:609,615` | mutable Thoughts pointer, 143-07 |
+| Config/record mutable pointer attributes | `config/core.py:135,158`; `config/integrations.py:22,23`; `config/meeting.py:143,144`; `db/models/__init__.py:1095`; `db/models/workbench.py:139`; `db/seed.py:270,271`; `services/inference_acquisition_service.py:54,832`; `services/inference_setup_service.py:181,603,604,608`; `services/settings_service.py:567,816`; `services/workbench_service.py:376,379,401,422,471` | mutable assignment pointer |
+| Every `profile_id` attribute read | Exact AST baseline: 41 sites classified as 25 mutable assignment pointers, 11 display/evidence reads, and 5 credential/provider identity reads; no unclassified `profile_id` read is permitted. Routing reads include Config runtime, Recipe/Workbench/sequence, sync, plan, and Rails; DTO/doctor/receipt reads remain display; provider readiness remains identity. | semantic classification, fail-closed |
+| Kernel `inference.run` target handoff | `kernel/inference.py:86,103,147` (`requested_target_id` decode, `resolve_inference_target`, receipt) | mutable request selector until Story 143-10 removes late routing; the receipt is immutable evidence afterward |
+
+The guard's mutation fixture adds a new `resolve_late_inference_target` public
+helper, the exact `requested_target_id` late read used by the current kernel,
+and a public `profile_id` read beneath `kernel/inference.py`; all are rejected
+until the source baseline and this ledger receive explicit review. This
+prevents a late selector from being introduced under a neutral name after the
+Phase 143 routing waist is adopted.
+
+## Resolver and precedence ledger
+
+| Resolver / writer | Current precedence or effect | Phase 143 treatment |
+| --- | --- | --- |
+| `resolve_placement` | invocation → workbench → recipe/agent → `this_machine` | 143-04 supplies canonical infrastructure only; 143-07/08/10 remove each consumer's selector and 143-05 freezes its result. |
+| `resolve_thought_placement` | `Config.thoughts.inference_target_id` becomes the workbench tier | 143-07 migrates today's single `thought.interview` operation, whose result is a question-or-synthesis union; any independently assignable synthesis operation requires a distinct admitted call. |
+| `effective_intel_cloud` / `resolve_meeting_placement` | `intel_profile_id` competes with local/auto/cloud fields | 143-08 migrates the meeting family; 143-05 consumes a frozen ordered plan. |
+| `effective_dictation_llm` / speech plan resolver | one runtime profile controls classify/rewrite/punctuate | 143-07 migrates typed writing/dictation capability assignments. |
+| `RecipeService._target` | request override → Workbench → Recipe profile → global | 143-10 replaces the subject selector for agents/workbenches/recipes. |
+| `resolve_workbench_deployment_revision` | re-reads workbench and recipe profile fields from one SQLite snapshot | 143-10 retires dual subject reads; 143-05 freezes the chosen deployment revision. |
+| `WorkbenchService.resolve_voice_references` | `resolver_profile_id` directly chooses an invocation target | 143-10 migrates to `voice.reference_resolve`. |
+| `schedule_delegation._terms` | resolves stored Workbench/Recipe pointers before scheduler delegation | 143-10 removes subject selector reads before delegated execution. |
+| `SequenceWorkflowService._target` | accepts an `inference_target_id`/`requested_placement` body field | 143-10 adopts the canonical invocation override layer. |
+| `DecisionLifecycleService.draft_promoted_with_model` and `api_delivery_pr_draft_review` | accept/request a target directly for background drafting | 143-08 migrates these request selectors with their background capabilities. |
+| `build_profile_summarizer` | Rails profile or hard-coded `this_machine` | 143-08 migrates to `background.rails_summary`. |
+| `CadenceService._drafted_next_action` | re-resolves the global target for bounded service inference | 143-08 migrates to `background.cadence_draft`. |
+| `_adopt_profiles` | seed fills blank dictation/meeting pointers | 143-04 removes this legacy assignment write while installing the canonical migration machinery. |
+| `InferenceAcquisitionApplicationService._activate` | download/use-existing changes local model and clears Thoughts pointer | 143-03 separates availability receipt from assignment. |
+
+## Profile authority and sync blockers
+
+These are **BLOCKER findings**, not permitted behavior or exceptions.
+
+| ID | Observed production seam | Why it blocks Phase 143 | Owning story |
+| --- | --- | --- | --- |
+| `PROFILE_SERVICE_OWNER_ENFORCEMENT_GAP` | `holdspeak/services/profile_service.py:ProfileService` accepts `principal` for list/get/create/update/delete/probe yet performs no `PrincipalKind.OWNER` check; HTTP and MCP resources call it directly. | AGENT, MODEL_TURN, or a direct service caller can discover or mutate model-profile precursor state. The replacement service boundary must enforce OWNER. | 143-03 |
+| `PROFILE_SYNC_PATH_BEARING_SEAM` | `holdspeak/services/sync_service.py:SYNC_REGISTRY` syncs `profile`; `_MERGEABLE["profiles"]` includes `model_file` and `base_url`; pull serializes profile rows. | Local model paths and endpoint locators cross the v1 sync seam. V2 profile revisions/bindings must be hub-local, and import must not create authority. | 143-11 |
+
+## Legacy assignment ownership
+
+Story 143-04 owns only the canonical assignment persistence, precedence, and
+one-way migration infrastructure. It does **not** own product-family removals.
+Story 143-03 separates profile/setup availability from assignment; 143-07 owns
+Thoughts/Ask/writing; 143-08 owns meetings, speech, background, decision, and
+delivery; and 143-10 owns Agents, Workbenches, Recipes, sequence/workflow, and
+voice resolution. Sync migration (143-11) removes routing and path-bearing v2
+state from the wire; it does not invent a remote assignment.
+
+`SettingsService.update_settings` is the shared transport seam through which
+the present Settings UI writes several product-family pointers. Story 143-13
+replaces those controls with Assignment glass; Stories 143-07 and 143-08 remove
+the corresponding Thoughts/writing and meeting/background pointer mutations
+from the service contract. The UI never becomes a second assignment service.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/generated-surface-fallback-census.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/generated-surface-fallback-census.md
@@ -1,0 +1,97 @@
+# Phase 143 generated surface and fallback census
+
+**Captured:** 2026-08-21.  This is the executable companion to
+`repository-census.md`: `tests/unit/test_phase143_surface_fallback_census.py`
+fails when a new private selector, recovery helper, or browser routing-pointer
+surface lacks a reviewed classification.
+
+## Classification rule
+
+Each surface/family below has **exactly one Phase 143 story** as its migration
+owner.  “Fallback” is reserved for an advance to a different frozen model-route
+leg.  It does not mean an owner pressing a button, queue rescheduling, lexical
+output preservation, a provider dialect change, or a workflow label that carries
+input forward.
+
+## Owner routing controls
+
+| Surface/family | Current controls and source anchors | Current authority | One migration story |
+|---|---|---|---|
+| Profile library and credential identity | `holdspeak/services/profile_service.py`, `holdspeak/services/profile_key_service.py`, `holdspeak/intel/providers.py`, `holdspeak/inference_targets.py` | `ProfileRecord`, key slot, legacy profile factory | 143-03 |
+| Setup/library acquisition previews | `holdspeak/services/inference_acquisition_service.py`, `holdspeak/services/inference_setup_service.py`, `web/src/pages/cores/InferenceCapabilityPanel.tsx` | setup catalog and selected artifact preview; not a saved assignment | 143-12 |
+| Thoughts and Ask destination | `holdspeak/config/integrations.py`, `holdspeak/services/ask_service.py`, `holdspeak/services/inference_setup_service.py`, `web/src/desk/ask.ts`, `web/src/desk/chat.ts`, `web/src/desk/store/dataSlice.ts` | `Config.thoughts.inference_target_id` and request override | 143-07 |
+| Dictation/rewrite/punctuation destination | `holdspeak/config/model.py`, `holdspeak/speech_session/plan.py`, `holdspeak/plugins/dictation/assembly.py`, `holdspeak/target_profile.py`, `web/src/pages/cores/dictation/useSpeakDeck.ts` | `dictation.runtime.profile_id` and typed runtime policy | 143-07 |
+| Meetings destination and frozen plan | `holdspeak/config/meeting.py`, `holdspeak/meeting_session/intel_plan.py`, `holdspeak/intel/engine.py` | `intel_profile_id` plus legacy local/auto/cloud placement; `MeetingIntelPlan` freezes legs | 143-08 |
+| Deferred meeting/background jobs | `holdspeak/intel_queue.py`, `holdspeak/services/meeting_intel_service.py`, `holdspeak/services/settings_service.py` | queue schedule/recovery controls | 143-08 |
+| Workbench, Recipe, Agent and workflow placement | `holdspeak/deployment_revisions.py`, `holdspeak/services/{recipe_service,sequence_workflow_service,support,workbench_runner,workbench_service}.py`, `web/src/desk/components/{WorkbenchWindow,WorkbenchTemplatePicker,workbenchTarget}.tsx`, `web/src/desk/pullouts/editors/RecipeEditor.tsx`, `web/src/desk/infoContract.ts`, `web/src/pages/cores/WorkbenchesHomeCore.tsx` | workbench → recipe → default precedence and per-run request fields | 143-10 |
+| HTTP/MCP/browser pointer transport and types | `holdspeak/mcp/`, `holdspeak/web/routes/`, `web/src/desk/{api,detail-types,store/types}.ts`, `web/src/pages/cores/core-types.ts` | transport/projection only; must not resolve a route | 143-11 |
+| Assignment editor shell | `web/src/pages/cores/{SettingsCore,settingsModels}.tsx` | duplicated owner-facing Settings controls pending one editor | 143-13 |
+| Generic route/failure law and physical attempts | `holdspeak/kernel/{inference_runner,projection_stager}.py`, `holdspeak/intel/engine.py` | runner physical attempt and provider compatibility seam | 143-06 |
+| Baseline false positives/non-inference selectors | `holdspeak/desktop_presence.py`, `holdspeak/speaker_intel.py`, `holdspeak/plugins/dictation/builtin/project_rewriter.py` | renderer, speaker, and input selection—not model routing | 143-01 |
+
+## Recovery mechanism census
+
+| Mechanism | Anchors | Classification and truth | One migration story |
+|---|---|---|---|
+| Ordered `MeetingIntelPlan` legs | `holdspeak/meeting_session/intel_plan.py:_placement_legs` | **true model-route fallback**: a frozen local→cloud (or other) second deployment revision. It is not dynamically resolved after admission. | 143-08 |
+| Generic same-leg/next-leg control | `holdspeak/kernel/inference_runner.py:_cancelled_before_retry`, `holdspeak/kernel/projection_stager.py:_retry_stage` | Controller-owned physical-attempt and receipt semantics. The future controller decides bounded retry versus a later frozen leg; no provider/engine loop may do so. | 143-06 |
+| `max_tokens` dialect learning | `holdspeak/intel/engine.py:_compatibility_retry`, `holdspeak/kernel/provider_signals.py` | **provider dialect attempt**: a typed compatibility signal creates a distinct admitted child. It is neither a second model nor model-route fallback. | 143-06 |
+| Dictation `response_format` dialect learning | `holdspeak/speech_session/provider.py`, `holdspeak/plugins/dictation/runtime_openai_compatible.py` | **provider dialect attempt**: retrying without `response_format` is a separately admitted classify child. It is not a model change. | 143-07 |
+| Deferred meeting job backoff | `holdspeak/intel_queue.py:_compute_retry_delay_seconds`, `holdspeak/intel_queue.py:_retry_or_fail_job` | **scheduling retry**: a later queued job/parent, not another same-turn provider attempt or a model-route fallback. | 143-08 |
+| Meeting recovery button | `holdspeak/services/meeting_intel_service.py:_retry`, `web/src/meetings/MeetingIntelRecovery.tsx` | **explicit owner retry**: an owner asks to recover retained meeting work. It cannot silently advance a model chain. | 143-08 |
+| Thoughts/Ask “Try again” | `holdspeak/services/refinement_coordinator.py`, `holdspeak/services/ask_service.py`, `web/src/desk/thought-workspace/ThoughtWorkspaceWindow.tsx` | **explicit owner retry**: a new visible invocation/turn; preserve the old terminal receipt. | 143-07 |
+| Dictation lexical recovery | `holdspeak/dictation_telemetry.py:_fallback_category`, `holdspeak/plugins/dictation/`, `holdspeak/web/routes/dictation/` | **lexical degradation**: deterministic retained words/rules when classifier or runtime fails. Never call it a profile/model fallback. | 143-07 |
+| Dictation runner publication backstop | `holdspeak/dictation_runner.py` | **lexical degradation**: the original words are published through the admitted session fence after pipeline failure. This protects words; it does not try another model. | 143-07 |
+| Runtime `auto` backend choice | `holdspeak/plugins/dictation/runtime.py`, `holdspeak/speech_session/plan.py` | Preflight runtime selection (for example, `auto` chooses `llama_cpp` when MLX is unavailable), not retry and not a route-leg fallback. The frozen plan records the resulting target. | 143-07 |
+| Whisper preload / silent-audio load | `holdspeak/transcribe.py`, `holdspeak/meeting_session/transcribe_admission.py`, `holdspeak/speech_session/transcription.py` | Separate admitted transcription/load child. The silent-audio dispatch warms a fixed Whisper artifact; it never selects another model or retries an unknown provider send. | 143-08 |
+| Persisting a completed speech callback | `holdspeak/speech_session/fence.py` | Storage-delivery retry of the exact completed callback, not inference execution or route fallback. | 143-08 |
+| Endpoint-health refusal | `holdspeak/intel/endpoint_health.py`, `holdspeak/meeting_session/live_readiness.py` | Readiness/circuit-breaker refusal before egress. It can expose an already frozen meeting leg, but cannot synthesize a model fallback. | 143-08 |
+| Python workflow `fallbackOnDevice` / `retryThenQueue` | `holdspeak/services/support.py`, `holdspeak/services/sequence_workflow_service.py` | **Python fake workflow label**: the active hub treats `fallbackOnDevice` as pure carry-through and `retryThenQueue` as an ordinary surfaced error. Neither selects another model nor queues work. Story 10 removes/renames these legacy workflow labels while migrating workflow execution to the canonical route/controller. | 143-10 |
+| Swift WorkflowRunner `fallbackOnDevice` / `retryThenQueue` | `apple/Sources/RuntimeCore/Workbench/WorkflowRunner.swift` | **Swift dormant/client fallback**: this separate client runner retries an injected provider, can invoke an injected on-device fallback provider, and can return a parked queue result. It is a real legacy alternate-execution path, not evidence that the Python hub did so. Story 06 must retire or controller-align it under the server failure law. | 143-06 |
+| Swift BlueprintInterpreter `fallbackOnDevice` / `retryThenQueue` | `apple/Sources/RuntimeCore/Workbench/BlueprintInterpreter.swift` | **Swift dormant/client fallback with different queue truth**: it has its own bounded provider retries and real injected on-device fallback, but `retryThenQueue` is only a surfaced hard failure—nothing is parked. Story 06 retires or controller-aligns the physical retry/fallback and removes the false queue label. | 143-06 |
+
+## Guarded private decisions
+
+The test AST-walks all backend private functions whose names indicate fallback or
+retry, plus route/profile/target/placement selectors with route evidence.  Every
+current match is deliberately classified here; sources are grouped by the one
+story that owns their migration.
+
+| Story | Guarded backend anchors |
+|---|---|
+| 143-01 | `holdspeak/desktop_presence.py`, `holdspeak/plugins/dictation/builtin/project_rewriter.py`, `holdspeak/speaker_intel.py` |
+| 143-03 | `holdspeak/commands/doctor.py`, `holdspeak/inference_targets.py`, `holdspeak/intel/engine.py`, `holdspeak/intel/providers.py`, `holdspeak/services/profile_key_service.py`, `holdspeak/services/profile_service.py` |
+| 143-04 | `holdspeak/db/seed.py` (`_adopt_profiles` mutates legacy Config assignments; it is not ProfileRecord authority) |
+| 143-06 | `holdspeak/intel/engine.py`, `holdspeak/kernel/inference_runner.py`, `holdspeak/kernel/projection_stager.py` |
+| 143-07 | `holdspeak/dictation_telemetry.py`, `holdspeak/plugins/dictation/assembly.py`, `holdspeak/plugins/dictation/builtin/project_rewriter.py`, `holdspeak/plugins/dictation/runtime_mlx.py`, `holdspeak/services/inference_setup_service.py`, `holdspeak/target_profile.py` |
+| 143-08 | `holdspeak/intel_queue.py`, `holdspeak/meeting_session/intel_plan.py`, `holdspeak/services/meeting_intel_service.py` |
+| 143-10 | `holdspeak/delivery/factory_launch.py`, `holdspeak/services/recipe_service.py`, `holdspeak/services/sequence_workflow_service.py`, `holdspeak/services/support.py`, `holdspeak/services/workbench_runner.py` |
+| 143-12 | `holdspeak/services/inference_acquisition_service.py`, `holdspeak/services/inference_setup_service.py` |
+
+## Guarded web routing consumers
+
+`tests/unit/test_phase143_surface_fallback_census.py` inventories every
+production `web/src` TypeScript module containing a snake-case pointer,
+camel-case selector (`inferenceTargetId`, `intelProfileId`, `profileId`, or
+`resolverProfileId`), or an import/definition of `RunsOnPicker`.  A surface is
+classified as `inference-route`, `display-transport`, or `unrelated`; only the
+first category may participate in a future assignment migration.
+
+| Classification | Surfaces | One migration story |
+|---|---|---|
+| inference-route | `web/src/desk/ask.ts`, `web/src/desk/chat.ts`, `web/src/desk/components/AskPanel.tsx`, `web/src/desk/components/EditorAIBar.tsx`, `web/src/desk/store/dataSlice.ts`, `web/src/pages/cores/ProjectMemoryCore.tsx`, `web/src/pages/cores/dictation/UtteranceWell.tsx`, `web/src/pages/cores/dictation/useSpeakDeck.ts` | 143-07 |
+| inference-route | `web/src/desk/components/PersonaChat.tsx`, `web/src/desk/components/WorkbenchTemplatePicker.tsx`, `web/src/desk/components/WorkbenchWindow.tsx`, `web/src/desk/pullouts/editors/RecipeEditor.tsx`, `web/src/desk/pullouts/shared/CapabilitySection.tsx` | 143-10 |
+| inference-route | `web/src/desk/components/RunsOnPicker.tsx`, `web/src/pages/cores/SettingsCore.tsx`, `web/src/pages/cores/settingsModels.tsx` | 143-13 |
+| display-transport | `web/src/desk/api.ts`, `web/src/desk/components/Pullout.tsx`, `web/src/desk/detail-types.ts`, `web/src/desk/store/types.ts`, `web/src/lib/primitives.ts`, `web/src/pages/cores/core-types.ts` | 143-11 |
+| display-transport | `web/src/desk/components/workbenchTarget.ts`, `web/src/desk/infoContract.ts`, `web/src/pages/cores/WorkbenchesHomeCore.tsx` | 143-10 |
+| unrelated | `web/src/desk/components/DeliveryBoard.tsx`, `web/src/desk/deliveryFactory.ts` | 143-01 |
+
+Adding another production routing consumer—or a private selector/recovery
+helper—fails the focused test until it is classified above and assigned exactly
+one story. The guard does not grant runtime authority; it preserves the census
+boundary until the target story implements its one-way migration.
+
+The same test scans every Swift `case .fallbackOnDevice`,
+`case .retryThenQueue`, and `policy.maxRetries` execution site. The six current
+sites are classified above; a synthetic new runner proves another policy branch
+or retry loop fails closed rather than hiding behind a known file.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/repository-census.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/assets/repository-census.md
@@ -1,7 +1,21 @@
 # Phase 143 repository census — routing before consolidation
 
 **Captured:** 2026-08-21 from merged `main` after Phase 142 Story 06.
-**Purpose:** charter evidence; implementation stories must refresh anchors.
+**Purpose:** orientation and index; the generated fixtures below are the
+build-breaking authority.
+
+## Executable baselines
+
+| Ledger | Generated artifact | Build guard |
+|---|---|---|
+| Physical/model-shaped and direct Runner entrances → proposed capability/source owner | [generated-inference-capability-census.md](./generated-inference-capability-census.md) | `tests/unit/test_phase143_inference_capability_census.py` |
+| Mutable pointers, resolvers, profile/sync authority, and migration owner | [generated-routing-authority-census.md](./generated-routing-authority-census.md) | `tests/unit/test_phase143_routing_authority_census.py` |
+| Owner routing surfaces and retry/fallback semantic families | [generated-surface-fallback-census.md](./generated-surface-fallback-census.md) | `tests/unit/test_phase143_surface_fallback_census.py` |
+
+Each fixture is exact and fail-closed. A new site must receive one capability,
+classification, source owner, and migration story in the same reviewed change.
+These ledgers name unsafe existing seams as blockers; appearing in a census is
+not permission or an allowlist.
 
 ## Existing authorities and proved patterns
 
@@ -10,7 +24,7 @@
 | Mutable destination | `ProfileRecord` plus built-in `this_machine`; `InferenceTarget` resolves readiness/placement | `holdspeak/inference_targets.py` | preserve profile identity; remove post-freeze mutable reads |
 | Immutable execution | content-addressed `DeploymentRevision` v1/v2 consumed by `InferenceRunner` | `holdspeak/deployment_revisions.py`, `holdspeak/kernel/inference_runner.py` | sole executable revision registry remains |
 | Local artifacts/deployments | Phase 142 artifact ledger and mutable `inference_deployments` heads | `holdspeak/services/inference_acquisition_service.py`, `holdspeak/services/inference_setup_service.py` | profiles point to deployment heads; do not duplicate artifact/runtime truth |
-| Thoughts pointer | `Config.thoughts.inference_target_id` | `holdspeak/config/integrations.py`, `holdspeak/inference_targets.py` | migrate to `thought.interview`/`thought.synthesis` assignments |
+| Thoughts pointer | `Config.thoughts.inference_target_id` | `holdspeak/config/integrations.py`, `holdspeak/inference_targets.py` | migrate today's single `thought.interview` operation; its result is a question-or-synthesis union |
 | Dictation pointer | `Config.dictation.runtime.profile_id` plus runtime knobs | `holdspeak/config/model.py`, `holdspeak/intel/providers.py` | split intent/rewrite/punctuation capabilities; keep runtime policy typed |
 | Meeting pointer | `Config.meeting.intel_profile_id` plus local/auto/cloud legacy placement | `holdspeak/config/meeting.py`, `holdspeak/intel/providers.py` | migrate meeting capability family, not one blunt pointer |
 | Background pointer | `Config.rails_observer.profile_id`; Cadence uses bounded service inference | `holdspeak/config/integrations.py`, `holdspeak/services/cadence_service.py`, `holdspeak/web_server.py` | explicit background capability assignments |
@@ -19,7 +33,7 @@
 | Speech capabilities | transcribe/preload/intent/rewrite/punctuate are already stable constants | `holdspeak/speech_session/plan.py` | seed canonical registry; keep speech vs text requirements distinct |
 | Meeting capabilities | live analysis, bookmark, title, deferred analysis, plugins, Whisper | `holdspeak/meeting_session/intel_plan.py` | seed canonical registry and adapters |
 | Tool authority | future `ToolTurnController`/private lease ruled; owner MCP sidecar forbidden | `proposals/inference-catalog-and-context-policy.md` | required prerequisite for executable tool-aware fallback |
-| Admission waist | every physical model call is `inference.invoke@1` through `InferenceRunner` | Phase 131 census and `tests/unit/test_one_path_census.py` | expand census; controller remains above runner |
+| Admission waist | every Python/backend physical model call is `inference.invoke@1` through `InferenceRunner`; seven Apple/Swift leaves remain named legacy bypasses | Phase 131 census and `tests/unit/test_one_path_census.py`; generated Phase 143 Swift leaf census | migrate the Apple exceptions in Stories 06/10; controller remains above runner |
 
 ## Fragmentation visible today
 
@@ -53,17 +67,20 @@ fallback controls independently.
 
 ## Initial owner-facing capability groups
 
-Default Assignments glass is intentionally stable at five summary rows:
+Default Assignments glass is intentionally stable at seven assignment rows:
 
 * Default for AI work
 * Thoughts & notes
 * Writing & dictation
+* Speech recognition
 * Meetings
 * Agents & tools
+* Background
 
-Background tasks and every leaf capability exist in the searchable override
-disclosure. Issues and explicit overrides rise into default glass. Capability
-count may grow without permanent-screen growth.
+Every owner-visible leaf capability exists in the searchable override
+disclosure; internal lifecycle work such as speech preload does not. Issues and
+explicit overrides rise inside that disclosure. Capability count may grow
+without permanent-screen growth.
 
 ## Audit commands for Story 01
 

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/current-phase-status.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/current-phase-status.md
@@ -44,7 +44,7 @@ Assignments.
 
 | ID | Story | Status | Story file | Evidence |
 |---|---|---|---|---|
-| HSEGHS001HS104-143-01 | Capability and Route Census | ready | [story-01-capability-route-census](./story-01-capability-route-census.md) | - |
+| HSEGHS001HS104-143-01 | Capability and Route Census | done | [story-01-capability-route-census](./story-01-capability-route-census.md) | [evidence](./evidence-story-01.md) |
 | HSEGHS001HS104-143-02 | Canonical Capability Registry | backlog | [story-02-canonical-capability-registry](./story-02-canonical-capability-registry.md) | - |
 | HSEGHS001HS104-143-03 | Reusable Model Profile Authority | backlog | [story-03-reusable-model-profile-authority](./story-03-reusable-model-profile-authority.md) | - |
 | HSEGHS001HS104-143-04 | Assignment Store and Resolver | backlog | [story-04-assignment-store-resolver](./story-04-assignment-store-resolver.md) | - |
@@ -69,11 +69,16 @@ transport-neutral profile authority, scattered Config/subject pointers,
 late-routing `inference.run`, raw-SQL Workbench resolution, fake workflow
 fallback labels, and path-bearing profile sync.
 
-Story 01 is ready to turn the audit into generated census gates. Stories 02–06
-then establish the registry, profile/binding authority, assignments, frozen
-plans, and controller before any product family migrates. Stories 07–10 migrate
-all callers in bounded waves. Stories 11–13 ship parity and the two owner jobs:
-Model Library and Assignments. Story 14 is the cross-product chaos/glass gate.
+Story 01 is done. Three generated, mutation-tested ledgers now fail closed on a
+new execution door, semantic helper caller, mutable resolver/pointer, browser
+selector, or Swift physical/fallback path. The baseline records 99 Python
+model-shaped sites, 14 Python physical leaves with zero bypasses, and seven
+named Apple legacy leaves owned by Stories 06/10. Stories 02 and 03 can now
+establish the canonical capability/retry registry and reusable profile/binding
+authority in parallel. Stories 04–06 then add assignments, frozen plans, and
+the durable controller before product families migrate in Stories 07–10.
+Stories 11–13 ship parity and the two owner jobs: Model Library and Assignments.
+Story 14 is the cross-product chaos/glass gate.
 
 Normative assets: [architecture contract](./assets/architecture-contract.md),
 [owner experience](./assets/owner-experience.md), [repository census](./assets/repository-census.md),

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/evidence-story-01.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/evidence-story-01.md
@@ -1,0 +1,106 @@
+# Evidence - HSEGHS001HS104-143-01
+
+- **Story:** HSEGHS001HS104-143-01 - Capability and Route Census
+- **Status:** done
+- **Date:** 2026-08-21
+
+## Outcome
+
+Story 01 establishes a checked-in, fail-closed baseline for every current
+inference execution door, semantic capability caller, mutable routing
+authority, owner routing surface, and retry/fallback policy. It changes no
+product runtime behavior.
+
+The three generated ledgers are:
+
+- `assets/generated-inference-capability-census.md`
+- `assets/generated-routing-authority-census.md`
+- `assets/generated-surface-fallback-census.md`
+
+## Census truth
+
+- 99 exact Python model-shaped AST sites with explicit capability/source-owner
+  classification; no heuristic or catch-all classification remains.
+- 12 direct `InferenceRunner.invoke` entrances and 14 Python physical leaves;
+  zero Python bypasses.
+- 9 semantic Ask/Recipe/Sequence/Workflow callers, including one current
+  `thought.interview` operation with a question-or-synthesis result union.
+- 7 Apple/Swift physical leaves named as legacy bypasses with exact Story 06 or
+  Story 10 migration ownership.
+- 18 mutable routing families with one migration owner, 6 public resolver
+  definitions, 63 resolver references, and 41 semantically classified
+  `profile_id` reads.
+- 33 backend selector/recovery helpers, 27 browser routing surfaces, and 6
+  Swift retry/fallback policy sites classified exactly.
+- Named blockers remain visible for Story 03/11:
+  `PROFILE_SERVICE_OWNER_ENFORCEMENT_GAP` and
+  `PROFILE_SYNC_PATH_BEARING_SEAM`.
+
+Mutation fixtures prove that a new model-shaped site, public/late resolver,
+mutable pointer read, Ask/Recipe semantic caller, browser selector, Swift
+provider open, Swift `.complete` leaf, or Swift retry/fallback branch fails the
+gate until it receives an explicit reviewed classification.
+
+## Verification
+
+### Focused census and mutation suite
+
+```text
+uv run pytest -q \
+  tests/unit/test_phase143_inference_capability_census.py \
+  tests/unit/test_phase143_routing_authority_census.py \
+  tests/unit/test_phase143_surface_fallback_census.py --tb=short
+
+...................                                                      [100%]
+19 passed in 15.34s
+```
+
+### Integrated census, one-path, and API surface gate
+
+- **Index-tree:** `3fbbc57774eabe2024dc2eaded64f62481ece382`
+
+```text
+uv run pytest -q \
+  tests/unit/test_phase143_inference_capability_census.py \
+  tests/unit/test_phase143_routing_authority_census.py \
+  tests/unit/test_phase143_surface_fallback_census.py \
+  tests/unit/test_one_path_census.py \
+  tests/unit/test_api_surface.py --tb=short
+
+56 passed in 63.47s
+```
+
+The JUnit record reported `errors=0`, `failures=0`, and `skipped=0`.
+
+### Static hygiene
+
+```text
+uv run ruff check \
+  tests/unit/test_phase143_inference_capability_census.py \
+  tests/unit/test_phase143_routing_authority_census.py \
+  tests/unit/test_phase143_surface_fallback_census.py
+All checks passed!
+
+git diff --check
+# clean
+```
+
+### DW status
+
+`dw check holdspeak` reaches one inherited, out-of-scope Phase 101 mismatch:
+
+```text
+ERROR pm/roadmap/holdspeak/phase-101-the-native-innards/evidence-story-04.md:
+evidence exists but matching story is not done
+```
+
+Story 01 introduces no Phase 101 change. The inherited mismatch is recorded
+here rather than silently repaired or omitted.
+
+## Review result
+
+Independent owner and architecture/counsel reviews both returned **RATIFY**
+after the final mutation counterexamples were closed. The review specifically
+confirmed current Thought taxonomy, RunsOnPicker/camel-case browser coverage,
+kernel late-routing coverage, repository-wide helper discovery, Swift physical
+and policy coverage, and singular migration ownership.

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-01-capability-route-census.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-01-capability-route-census.md
@@ -2,7 +2,7 @@
 
 - **Project:** holdspeak
 - **Phase:** 143
-- **Status:** ready
+- **Status:** done
 - **Depends on:** none
 - **Unblocks:** 143-02 through 143-14
 - **Owner:** unassigned
@@ -27,16 +27,17 @@ HoldSpeak currently resolves intelligence through Config pointers, ProfileRecord
 
 ## Acceptance criteria
 
-- [ ] Every production inference call site has one proposed capability ID and source owner.
-- [ ] Every mutable route pointer and resolver is listed with its migration story.
-- [ ] ProfileService transport-neutral authority bypass and profile sync path exposure are recorded.
-- [ ] One-path census proves current physical leaves and names every exception.
-- [ ] Counsel and owner audits are incorporated into the phase contracts.
+- [x] Every production inference call site has one proposed capability ID and source owner.
+- [x] Every mutable route pointer and resolver is listed with its migration story.
+- [x] ProfileService transport-neutral authority bypass and profile sync path exposure are recorded.
+- [x] One-path census proves current physical leaves and names every exception.
+- [x] Counsel and owner audits are incorporated into the phase contracts.
 
 ## Test plan
 
-- `rg`-based generated inventories checked into a focused unit fixture.
-- `uv run pytest -q tests/unit/test_one_path_census.py`.
+- Exact AST/static inventories checked into three focused unit fixtures with
+  synthetic fail-closed mutation cases.
+- `uv run pytest -q tests/unit/test_phase143_*_census.py tests/unit/test_one_path_census.py tests/unit/test_api_surface.py`.
 - `dw check holdspeak` and `git diff --check`.
 
 ## Implementation notes

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-06-fallback-controller-failure-law.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-06-fallback-controller-failure-law.md
@@ -22,6 +22,9 @@ Fallback must be a durable server decision, not a provider retry, browser loop, 
 - Reserve each leg/attempt transactionally with Stop, deadline, and budget fencing.
 - Adopt existing receipts after crash; never reconstruct from current settings.
 - Retire or rename fake workflow fallbackOnDevice/retryThenQueue semantics.
+- Retire the Swift `WorkflowRunner`/`BlueprintInterpreter` client-owned
+  retry/fallback loops or route every one of their physical attempts through
+  the same durable server controller and `InferenceRunner` child law.
 
 ### Out
 

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-07-thoughts-ask-writing-adoption.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-07-thoughts-ask-writing-adoption.md
@@ -9,17 +9,20 @@
 
 ## Problem
 
-Thought interview, synthesis, Ask, intent, rewrite, and punctuation still depend
+Thought interview, Ask, intent, rewrite, and punctuation still depend
 on separate mutable Config targets. They are the smallest coherent adoption
 that proves profiles, assignments, frozen plans, and fallback end to end.
 
 ## Scope
 
-- **In:** Migrate `thought.interview`, `thought.synthesis`, `ask.answer`,
+- **In:** Migrate `thought.interview` (including its question-or-synthesis
+  result union), `ask.answer`,
   `speech.intent_classify`, `speech.rewrite`, and `speech.punctuate`; freeze the
   server-projected chain with Ask/composite reservation; expose application
   summary/override seams for Story 13; one-way Config migration markers.
-- **Out:** Meeting/transcription migration and executable tool turns.
+- **Out:** Meeting/transcription migration, executable tool turns, and any
+  independently assignable `thought.synthesis` until a genuinely distinct
+  admitted operation and result contract exist.
 
 ## Acceptance criteria
 

--- a/pm/roadmap/holdspeak/phase-143-intelligence-router/story-10-agents-workbenches-recipes-adoption.md
+++ b/pm/roadmap/holdspeak/phase-143-intelligence-router/story-10-agents-workbenches-recipes-adoption.md
@@ -16,7 +16,9 @@ and reference-resolution code currently reconstruct placement independently.
 
 - **In:** Migrate non-tool Agent, Workbench, Recipe, sequence/workflow, and
   reference-resolution callers; retire mutable `inference.run` late routing and
-  fake workflow fallback labels. Tool-bearing steps are owned by Story 09.
+  fake workflow fallback labels; bring the remaining censused Apple provider,
+  companion, and mesh physical leaves behind the server route-plan and
+  `InferenceRunner` waist. Tool-bearing steps are owned by Story 09.
 - **Out:** Feature-owned route editors and unrelated workflow branching changes.
 
 ## Acceptance criteria
@@ -26,6 +28,9 @@ and reference-resolution code currently reconstruct placement independently.
 - [ ] Subject changes affect next run only and never mutate group/global policy.
 - [ ] `inference.run` cannot physically dispatch through mutable late resolution.
 - [ ] Generated census finds no remaining placement-resolution fork.
+- [ ] The Apple physical-leaf census has no remaining unadmitted provider leaf;
+  Swift workflow retry/fallback law is first retired or controller-aligned by
+  Story 06.
 
 ## Test plan
 

--- a/tests/unit/test_phase143_inference_capability_census.py
+++ b/tests/unit/test_phase143_inference_capability_census.py
@@ -1,0 +1,660 @@
+"""HSEGHS001HS104-143-01 — checked-in capability/physical-path baseline.
+
+Phase 131's ``test_one_path_census`` is the fail-closed AST authority for
+model-shaped production code.  This companion fixture deliberately pins its
+*individual source positions* to a proposed Phase 143 capability and source
+owner.  A second call in an existing allowlisted function therefore cannot hide
+behind that function's Phase 131 entry: it has no row here and fails this test.
+
+``internal.*`` rows are non-assignable implementation capabilities.  They are
+not a proposal for a generic owner-facing model picker; they identify shared
+gateway/factory work whose eventual caller capability is frozen above the
+adapter.  Story 02 replaces the proposed IDs with registry definitions.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+from tests.unit import test_one_path_census as one_path
+
+
+@dataclass(frozen=True)
+class ProposedRoute:
+    capability_id: str
+    source_owner: str
+    admission: str
+
+
+def _key(site: one_path.Site) -> str:
+    return f"{site.path}:{site.line}|{site.scope}|{site.target}|{site.kind}"
+
+
+def _runner_entrances() -> list[str]:
+    """Every production reference to the runner's public ``invoke`` verb.
+
+    Looking for the bound method as a value is intentional: cadence, decision,
+    and delivery hand it to ``asyncio.to_thread`` rather than spelling a direct
+    call.  There are no other production ``.invoke`` expressions today, so an
+    unexpected one fails closed instead of relying on a receiver-name heuristic.
+    """
+    entries: list[str] = []
+    for path in sorted(one_path.PRODUCTION.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        scopes = one_path._scope_index(tree)
+        called = {id(node.func) for node in ast.walk(tree) if isinstance(node, ast.Call)}
+        relative = path.relative_to(one_path.REPO).as_posix()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "invoke":
+                kind = "call" if id(node) in called else "ref"
+                entries.append(f"{relative}:{node.lineno}|{scopes.get(id(node), '<module>')}|{kind}")
+    return sorted(entries)
+
+
+# Generated from `one_path.census()` on 2026-08-21.  Keep one literal row per
+# AST site, rather than a scope allowlist: line movement and a second invocation
+# both require an intentional capability/owner review.
+EXPECTED_CALL_SITES = frozenset("""
+holdspeak/commands/dictation.py:165|_cmd_dry_run|build_pipeline|call
+holdspeak/dictation_runner.py:342|run_pipeline_corrections_only|build_pipeline|call
+holdspeak/dictation_runner.py:534|run_dictation_pipeline|build_pipeline|call
+holdspeak/inference_targets.py:656|local_pinned_meeting_intel|_local_pinned_engine|call
+holdspeak/inference_targets.py:679|_local_pinned_engine|MeetingIntel|call
+holdspeak/inference_targets.py:701|build_intel_for_revision|_engine_for_revision|call
+holdspeak/inference_targets.py:728|_engine_for_revision|MeetingIntel|call
+holdspeak/inference_targets.py:735|_engine_for_revision|local_pinned_meeting_intel|call
+holdspeak/inference_targets.py:755|_engine_for_revision|build_meeting_intel_for_profile|call
+holdspeak/intel/engine.py:177|MeetingIntel._ensure_openai_client_loaded|OpenAI|call
+holdspeak/intel/engine.py:209|MeetingIntel._ensure_local_model_loaded|Llama|call
+holdspeak/intel/engine.py:228|MeetingIntel._ensure_runtime_loaded|_ensure_local_model_loaded|call
+holdspeak/intel/engine.py:233|MeetingIntel._ensure_runtime_loaded|_ensure_openai_client_loaded|call
+holdspeak/intel/engine.py:238|MeetingIntel._ensure_model_loaded|_ensure_runtime_loaded|call
+holdspeak/intel/engine.py:273|MeetingIntel._chat_completion_text|create_chat_completion|call
+holdspeak/intel/engine.py:311|MeetingIntel._chat_completion_text|_remote_completion|call
+holdspeak/intel/engine.py:311|MeetingIntel._chat_completion_text|chat.completions.create|ref
+holdspeak/intel/engine.py:349|MeetingIntel._chat_completion_stream|create_chat_completion|call
+holdspeak/intel/engine.py:387|MeetingIntel._chat_completion_stream|_remote_completion|call
+holdspeak/intel/engine.py:387|MeetingIntel._chat_completion_stream|chat.completions.create|ref
+holdspeak/intel/engine.py:436|MeetingIntel.run_prompt|_chat_completion_text|call
+holdspeak/intel/engine.py:452|MeetingIntel._analyze_once|_chat_completion_text|call
+holdspeak/intel/engine.py:528|MeetingIntel._analyze_stream|_chat_completion_stream|call
+holdspeak/intel/engine.py:597|MeetingIntel.generate_title|_chat_completion_text|call
+holdspeak/intel/engine.py:672|MeetingIntel.generate_bookmark_label_with_context|_chat_completion_text|call
+holdspeak/intel/mesh_relay.py:252|MeshRelayIntel._chat_completion_text|run_prompt|call
+holdspeak/intel/providers.py:239|_configured_engine|MeshRelayIntel|call
+holdspeak/intel/providers.py:251|_configured_engine|MeetingIntel|call
+holdspeak/intel/providers.py:276|configured_meeting_intel|_configured_engine|call
+holdspeak/intel/providers.py:783|build_meeting_intel_for_profile|_profile_engine|call
+holdspeak/intel/providers.py:809|_profile_engine|MeshRelayIntel|call
+holdspeak/intel/providers.py:819|_profile_engine|configured_meeting_intel|call
+holdspeak/intel/providers.py:823|_profile_engine|MeetingIntel|call
+holdspeak/intel/providers.py:842|_profile_engine|MeetingIntel|call
+holdspeak/intel/providers.py:843|_profile_engine|configured_meeting_intel|call
+holdspeak/intel_queue.py:234|process_next_intel_job|analyze|call
+holdspeak/kernel/executor.py:14|<module>|_install_claim_issuer|call
+holdspeak/kernel/executor.py:79|ExecutorPlane.claim|_issue_claim_witness|call
+holdspeak/kernel/inference_runner.py:50|InferenceRunner.__init__|build_intel_for_revision|ref
+holdspeak/kernel/inference_runner.py:188|InferenceRunner._attempt|_issue_dispatch_context|call
+holdspeak/kernel/prompt_adapter.py:14|CanonicalPromptAdapter.dispatch|run_prompt|call
+holdspeak/main.py:765|_run_meeting_mode|transcribe|call
+holdspeak/main.py:774|_run_meeting_mode|transcribe|call
+holdspeak/meeting_import.py:313|_transcribe_import_windows|transcribe|call
+holdspeak/meeting_session/deferred_admission.py:229|DeferredIntelJob.analyze.call|analyze|call
+holdspeak/meeting_session/deferred_admission.py:268|DeferredIntelJob.bookmark_label.call|generate_bookmark_label_with_context|call
+holdspeak/meeting_session/deferred_admission.py:308|DeferredIntelJob.auto_title.call|generate_title|call
+holdspeak/meeting_session/intel_admission.py:448|IntelAdmissionMixin._admitted_live_window.call|analyze|call
+holdspeak/meeting_session/intel_admission.py:495|IntelAdmissionMixin._admitted_bookmark_label.call|generate_bookmark_label_with_context|call
+holdspeak/meeting_session/intel_admission.py:525|IntelAdmissionMixin._admitted_auto_title.call|generate_title|call
+holdspeak/meeting_session/transcribe_loop.py:80|TranscribeLoopMixin._transcribe_audio|transcribe|call
+holdspeak/plugins/dictation/assembly.py:327|_try_build_runtime|MeshRelayRuntime|call
+holdspeak/plugins/dictation/builtin/intent_router.py:171|IntentRouter.run|classify|call
+holdspeak/plugins/dictation/builtin/project_rewriter.py:203|ProjectRewriter.run|rewrite|ref
+holdspeak/plugins/dictation/builtin/project_rewriter.py:204|ProjectRewriter.run|rewrite|ref
+holdspeak/plugins/dictation/builtin/project_rewriter.py:241|ProjectRewriter.run|rewrite|call
+holdspeak/plugins/dictation/runtime.py:215|_default_factories._llama_factory|LlamaCppRuntime|call
+holdspeak/plugins/dictation/runtime.py:222|_default_factories._openai_factory|OpenAICompatibleRuntime|call
+holdspeak/plugins/dictation/runtime_counters.py:227|CountingRuntime.classify|classify|call
+holdspeak/plugins/dictation/runtime_counters.py:271|CountingRuntime.rewrite|rewrite|ref
+holdspeak/plugins/dictation/runtime_counters.py:272|CountingRuntime.rewrite|rewrite|ref
+holdspeak/plugins/dictation/runtime_counters.py:277|CountingRuntime.rewrite|rewrite|call
+holdspeak/plugins/dictation/runtime_llama_cpp.py:74|LlamaCppRuntime._resolve_factories|Llama|ref
+holdspeak/plugins/dictation/runtime_llama_cpp.py:134|LlamaCppRuntime.classify|create_completion|call
+holdspeak/plugins/dictation/runtime_llama_cpp.py:162|LlamaCppRuntime.rewrite|create_completion|call
+holdspeak/plugins/dictation/runtime_mesh_relay.py:52|MeshRelayRuntime.load|MeshRelayIntel|call
+holdspeak/plugins/dictation/runtime_mesh_relay.py:106|MeshRelayRuntime._run|run_prompt|call
+holdspeak/plugins/dictation/runtime_openai_compatible.py:67|OpenAICompatibleRuntime.load|OpenAI|ref
+holdspeak/plugins/dictation/runtime_openai_compatible.py:141|OpenAICompatibleRuntime.classify|chat.completions.create|call
+holdspeak/plugins/dictation/runtime_openai_compatible.py:188|OpenAICompatibleRuntime.rewrite|chat.completions.create|call
+holdspeak/plugins/intelligence.py:362|PluginDispatch.chat|_chat_completion_text|call
+holdspeak/project_doc_suggestions.py:72|suggest_project_doc_update|rewrite|ref
+holdspeak/project_doc_suggestions.py:73|suggest_project_doc_update|rewrite|ref
+holdspeak/project_doc_suggestions.py:84|suggest_project_doc_update|rewrite|call
+holdspeak/runtime/dictation_capture.py:103|DictationCaptureMixin._transcribe_and_type|transcribe|call
+holdspeak/runtime/dictation_capture.py:390|DictationCaptureMixin.transcribe_audio_admitted|transcribe|call
+holdspeak/runtime/dictation_capture.py:401|DictationCaptureMixin.transcribe_audio_admitted|transcribe|call
+holdspeak/runtime/wake_glue.py:366|WakeWordGlueMixin._transcribe_wake_admitted|transcribe|call
+holdspeak/speech_session/provider.py:180|ProviderAdmission.target|bound_target|call
+holdspeak/speech_session/provider.py:306|ProviderAdmission.rewrite.call|rewrite|call
+holdspeak/speech_session/provider.py:347|ProviderAdmission.punctuate.call|rewrite|call
+holdspeak/speech_session/provider.py:402|_ClassifyLeg.run.call|classify|call
+holdspeak/speech_session/provider.py:466|_mesh_bound|MeshRelayRuntime|call
+holdspeak/speech_session/provider.py:515|AdmittedDictationRuntime.classify|classify|call
+holdspeak/speech_session/provider.py:522|AdmittedDictationRuntime.rewrite|rewrite|call
+holdspeak/speech_session/revision_target.py:143|rebind|OpenAICompatibleRuntime|call
+holdspeak/speech_session/revision_target.py:165|bound_target|rebind|call
+holdspeak/target_profile.py:191|apply_model_assisted_target|rewrite|ref
+holdspeak/target_profile.py:192|apply_model_assisted_target|rewrite|ref
+holdspeak/target_profile.py:195|apply_model_assisted_target|rewrite|call
+holdspeak/transcribe.py:241|_MlxTranscriber._model_holder_get._run|get_model|call
+holdspeak/transcribe.py:251|_MlxTranscriber._silent_audio_load._run|transcribe|call
+holdspeak/transcribe.py:296|_MlxTranscriber.transcribe._run|transcribe|call
+holdspeak/transcribe.py:378|_FasterWhisperTranscriber.transcribe|transcribe|call
+holdspeak/transcribe.py:511|Transcriber._timed_transcribe|transcribe|call
+holdspeak/transcribe.py:521|Transcriber._timed_transcribe._run|transcribe|call
+holdspeak/web/routes/dictation/_helpers.py:786|_run_dictation_dry_run_text|build_pipeline|call
+holdspeak/web/routes/system/voice.py:193|build_voice_router.api_transcribe|transcribe|call
+holdspeak/web/routes/system/voice_stream.py:245|build_voice_stream_router.ws_dictation_stream|transcribe|call
+""".strip().splitlines())
+
+
+# This is deliberately a second census.  The model-shaped AST vocabulary above
+# proves physical leaves; this list proves every product/service entrance into
+# the one public admission waist has a proposed Phase-143 source owner too.
+# ``dynamic:...`` means the current family already carries the exact typed
+# capability in its frozen plan/offer and Story 02 must preserve that provenance
+# rather than replace it with a made-up generic slug.
+PRODUCT_RUNNER_ENTRANCES: dict[str, ProposedRoute] = {
+    "holdspeak/kernel/mesh_local_runner.py:232|MeshLocalRunner.execute|call": ProposedRoute(
+        "dynamic:mesh dispatch offer capability", "kernel.mesh_local_runner", "InferenceRunner worker-local admission",
+    ),
+    "holdspeak/meeting_session/intel_child.py:193|run_admitted_child|call": ProposedRoute(
+        "dynamic:MeetingIntelPlan capability", "meeting_session.intel_child", "InferenceRunner admitted child",
+    ),
+    "holdspeak/rails_observer.py:268|build_profile_summarizer.summarize|call": ProposedRoute(
+        "background.rails_summary", "rails_observer", "InferenceRunner service child",
+    ),
+    "holdspeak/services/ask_service.py:63|AskService._invoke|call": ProposedRoute(
+        "internal.semantic_dispatch", "services.ask_service", "InferenceRunner service child; capability supplied by semantic caller",
+    ),
+    "holdspeak/services/cadence_service.py:284|CadenceService._draft_child|ref": ProposedRoute(
+        "background.cadence_draft", "services.cadence_service", "InferenceRunner service child",
+    ),
+    "holdspeak/services/decision_lifecycle_service.py:81|DecisionLifecycleService.draft_promoted_with_model|ref": ProposedRoute(
+        "decision.promotion_draft", "services.decision_lifecycle_service", "InferenceRunner service child",
+    ),
+    "holdspeak/services/recipe_service.py:52|RecipeService._invoke|call": ProposedRoute(
+        "internal.semantic_dispatch", "services.recipe_service", "InferenceRunner service child; capability supplied by semantic caller",
+    ),
+    "holdspeak/services/sequence_workflow_service.py:44|SequenceWorkflowService._invoke|call": ProposedRoute(
+        "internal.semantic_dispatch", "services.sequence_workflow_service", "InferenceRunner service child; capability supplied by semantic caller",
+    ),
+    "holdspeak/services/workbench_runner.py:41|WorkbenchRunner._invoke|call": ProposedRoute(
+        "workbench.item", "services.workbench_runner", "InferenceRunner service child",
+    ),
+    "holdspeak/services/workbench_service.py:414|WorkbenchService.resolve_voice.run_prompt_fn|call": ProposedRoute(
+        "voice.reference_resolve", "services.workbench_service", "InferenceRunner service child",
+    ),
+    "holdspeak/speech_session/child.py:181|run_admitted_speech_child|call": ProposedRoute(
+        "dynamic:SpeechSessionPlan capability", "speech_session.child", "InferenceRunner admitted child",
+    ),
+    "holdspeak/web/routes/delivery_prs.py:252|build_delivery_prs_router.api_delivery_pr_draft_review|ref": ProposedRoute(
+        "delivery.pr_review_draft", "web.routes.delivery_prs", "InferenceRunner service child",
+    ),
+}
+
+
+# AskService._invoke, RecipeService._invoke, and SequenceWorkflowService._invoke
+# are deliberately shared internal helpers, so their runner entrances cannot
+# truthfully name one capability. This second census records semantic callers.
+# Refinement is one
+# ``thought.interview`` capability whose result contract branches to either a
+# next-question or terminal synthesis; synthesis is not separately routable.
+def _semantic_helper_calls(sources: dict[str, str] | None = None) -> list[str]:
+    """Repository-wide Ask/Recipe semantic caller discovery.
+
+    The service can arrive as a direct constructor, a local service variable, a
+    factory returning the service, or RefinementCoordinator's injected
+    ``_ask_factory``. Restricting this to today's transport files would make a
+    new caller invisible precisely when it needs a capability decision.
+    """
+    sources = sources or {
+        path.relative_to(one_path.REPO).as_posix(): path.read_text(encoding="utf-8")
+        for path in one_path.PRODUCTION.rglob("*.py")
+    }
+    entries: list[str] = []
+    for relative, source in sorted(sources.items()):
+        tree = ast.parse(source)
+        scopes = one_path._scope_index(tree)
+        ask_factories: set[str] = set()
+        recipe_factories: set[str] = set()
+        ask_aliases: set[str] = set()
+        recipe_aliases: set[str] = set()
+        ask_attributes: set[str] = set()
+        recipe_attributes: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                returned = {
+                    value.value.func.id for value in ast.walk(node)
+                    if isinstance(value, ast.Return) and isinstance(value.value, ast.Call)
+                    and isinstance(value.value.func, ast.Name)
+                }
+                if "AskService" in returned:
+                    ask_factories.add(node.name)
+                if "RecipeService" in returned:
+                    recipe_factories.add(node.name)
+            if isinstance(node, (ast.Assign, ast.AnnAssign)) and isinstance(getattr(node, "value", None), ast.Call):
+                value = node.value
+                if isinstance(value.func, ast.Name) and value.func.id in {"AskService", "RecipeService"} | ask_factories | recipe_factories:
+                    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                    names = {target.id for target in targets if isinstance(target, ast.Name)}
+                    attributes = {target.attr for target in targets if isinstance(target, ast.Attribute)}
+                    if value.func.id in {"AskService"} | ask_factories:
+                        ask_aliases.update(names)
+                        ask_attributes.update(attributes)
+                    else:
+                        recipe_aliases.update(names)
+                        recipe_attributes.update(attributes)
+        for node in ast.walk(tree):
+            if (
+                relative.endswith("sequence_workflow_service.py")
+                and isinstance(node, ast.Attribute)
+                and node.attr == "_invoke"
+            ):
+                entries.append(f"{relative}:{node.lineno}|{scopes.get(id(node), '<module>')}|_invoke")
+                continue
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            verb = node.func.attr
+            receiver = node.func.value
+            receiver_name = receiver.id if isinstance(receiver, ast.Name) else (
+                receiver.func.id if isinstance(receiver, ast.Call) and isinstance(receiver.func, ast.Name) else ""
+            )
+            direct_constructor = isinstance(receiver, ast.Call) and isinstance(receiver.func, ast.Name)
+            receiver_attribute = receiver.attr if isinstance(receiver, ast.Attribute) else ""
+            is_ask = verb == "ask" and (
+                receiver_name in ask_factories | ask_aliases | {"AskService"}
+                or receiver_attribute in ask_attributes
+                or isinstance(receiver, ast.Call) and isinstance(receiver.func, ast.Attribute)
+                and receiver.func.attr == "_ask_factory"
+            )
+            is_recipe = verb in {"run", "chat"} and (
+                receiver_name in recipe_factories | recipe_aliases | {"RecipeService"}
+                or receiver_attribute in recipe_attributes
+                or direct_constructor and receiver_name == "RecipeService"
+            )
+            if is_ask or is_recipe:
+                entries.append(f"{relative}:{node.lineno}|{scopes.get(id(node), '<module>')}|{verb}")
+    return sorted(entries)
+
+
+SEMANTIC_HELPER_CALLERS: dict[str, ProposedRoute] = {
+    "holdspeak/mcp/families/ask.py:146|dispatch|ask": ProposedRoute(
+        "ask.answer", "mcp.families.ask", "AskService semantic caller",
+    ),
+    "holdspeak/services/refinement_coordinator.py:328|RefinementCoordinator._coordinate|ask": ProposedRoute(
+        "thought.interview", "services.refinement_coordinator", "AskService semantic caller; question-or-synthesis result branch",
+    ),
+    "holdspeak/web/routes/primitives/ask.py:49|build_ask_router.api_ask|ask": ProposedRoute(
+        "ask.answer", "web.routes.primitives.ask", "AskService semantic caller",
+    ),
+    "holdspeak/mcp/tools.py:533|dispatch|run": ProposedRoute(
+        "recipe.run", "mcp.tools", "RecipeService semantic caller",
+    ),
+    "holdspeak/mcp/tools.py:537|dispatch|chat": ProposedRoute(
+        "recipe.chat", "mcp.tools", "RecipeService semantic caller",
+    ),
+    "holdspeak/web/routes/primitives/recipes.py:100|build_recipes_router.api_run_recipe|run": ProposedRoute(
+        "recipe.run", "web.routes.primitives.recipes", "RecipeService semantic caller",
+    ),
+    "holdspeak/web/routes/primitives/recipes.py:115|build_recipes_router.api_chat_recipe|chat": ProposedRoute(
+        "recipe.chat", "web.routes.primitives.recipes", "RecipeService semantic caller",
+    ),
+    "holdspeak/services/sequence_workflow_service.py:133|SequenceWorkflowService.run_sequence|_invoke": ProposedRoute(
+        "sequence.step", "services.sequence_workflow_service", "Sequence semantic caller",
+    ),
+    "holdspeak/services/sequence_workflow_service.py:186|SequenceWorkflowService.run_workflow|_invoke": ProposedRoute(
+        "workflow.node", "services.sequence_workflow_service", "Workflow semantic caller",
+    ),
+}
+
+
+# Apple is a separate executable product, so its providers cannot truthfully be
+# called "behind InferenceRunner" today. This narrow source census is intentional:
+# it inventories every Swift `ILLMProvider.complete`/llama completion expression
+# plus the OpenAI-compatible wire open, and makes each current bypass explicit.
+SWIFT_SOURCES = one_path.REPO / "apple" / "Sources"
+
+
+def _swift_physical_leaves(sources: dict[str, str] | None = None) -> list[str]:
+    """Repository-wide Swift provider/open inventory, including fallback values."""
+    sources = sources or {
+        path.relative_to(one_path.REPO).as_posix(): path.read_text(encoding="utf-8")
+        for path in SWIFT_SOURCES.rglob("*.swift")
+    }
+    entries: list[str] = []
+    for relative, source in sorted(sources.items()):
+        for line_no, line in enumerate(source.splitlines(), start=1):
+            marker = ""
+            if ".complete(" in line:
+                marker = "Swift.complete"
+            elif "llm.getCompletion(" in line:
+                marker = "LLM.getCompletion"
+            elif relative.startswith("apple/Sources/Providers/Inference/") and ".data(for:" in line:
+                marker = "InferenceProvider.URLSession.data"
+            if marker:
+                entries.append(f"{relative}:{line_no}|{marker}")
+    return sorted(entries)
+
+
+SWIFT_PHYSICAL_LEAVES: dict[str, ProposedRoute] = {
+    "apple/Sources/InferenceLlama/LlamaProvider.swift:124|LLM.getCompletion": ProposedRoute(
+        "apple.local_completion", "apple.inference_llama", "LEGACY BYPASS: Story 143-10 Apple inference runtime",
+    ),
+    "apple/Sources/Providers/Inference/OpenAIEndpointProvider.swift:48|InferenceProvider.URLSession.data": ProposedRoute(
+        "apple.endpoint_completion", "apple.providers.inference", "LEGACY BYPASS: Story 143-10 Apple inference runtime",
+    ),
+    "apple/Sources/Providers/Inference/StructuredOutput.swift:64|Swift.complete": ProposedRoute(
+        "apple.structured_output", "apple.providers.inference", "LEGACY BYPASS: Story 143-10 Apple inference runtime",
+    ),
+    "apple/Sources/Providers/Desktop/MeshServeWorker.swift:99|Swift.complete": ProposedRoute(
+        "apple.mesh_serve", "apple.providers.desktop", "LEGACY BYPASS: Story 143-10 Apple/mesh adoption",
+    ),
+    "apple/Sources/RuntimeCore/Companion/CoderAnswer.swift:109|Swift.complete": ProposedRoute(
+        "apple.coder_answer", "apple.runtimecore.companion", "LEGACY BYPASS: Story 143-10 Apple/agent adoption",
+    ),
+    "apple/Sources/RuntimeCore/Workbench/BlueprintInterpreter.swift:343|Swift.complete": ProposedRoute(
+        "apple.workbench.blueprint", "apple.runtimecore.workbench", "LEGACY BYPASS: Story 143-06 fallback-controller migration",
+    ),
+    "apple/Sources/RuntimeCore/Workbench/WorkflowRunner.swift:366|Swift.complete": ProposedRoute(
+        "apple.workbench.workflow", "apple.runtimecore.workbench", "LEGACY BYPASS: Story 143-06 fallback-controller migration",
+    ),
+}
+
+
+def _group(route: ProposedRoute, keys: str) -> tuple[ProposedRoute, tuple[str, ...]]:
+    return route, tuple(keys.strip().splitlines())
+
+
+# Deliberately no path/target heuristic and no default: every Phase-131 AST site
+# occurs in exactly one literal group. The set-equality test below makes an
+# unreviewed site (including one in a familiar module) a failure.
+EXPLICIT_ROUTE_GROUPS = (
+    _group(ProposedRoute("internal.speech.runtime_assembly", "speech_session", "InferenceRunner context-gated adapter"), """
+holdspeak/commands/dictation.py:165|_cmd_dry_run|build_pipeline|call
+holdspeak/dictation_runner.py:342|run_pipeline_corrections_only|build_pipeline|call
+holdspeak/dictation_runner.py:534|run_dictation_pipeline|build_pipeline|call
+holdspeak/plugins/dictation/assembly.py:327|_try_build_runtime|MeshRelayRuntime|call
+holdspeak/plugins/dictation/runtime.py:215|_default_factories._llama_factory|LlamaCppRuntime|call
+holdspeak/plugins/dictation/runtime.py:222|_default_factories._openai_factory|OpenAICompatibleRuntime|call
+holdspeak/plugins/dictation/runtime_llama_cpp.py:74|LlamaCppRuntime._resolve_factories|Llama|ref
+holdspeak/plugins/dictation/runtime_mesh_relay.py:52|MeshRelayRuntime.load|MeshRelayIntel|call
+holdspeak/plugins/dictation/runtime_mesh_relay.py:106|MeshRelayRuntime._run|run_prompt|call
+holdspeak/plugins/dictation/runtime_openai_compatible.py:67|OpenAICompatibleRuntime.load|OpenAI|ref
+holdspeak/speech_session/provider.py:180|ProviderAdmission.target|bound_target|call
+holdspeak/speech_session/provider.py:466|_mesh_bound|MeshRelayRuntime|call
+holdspeak/speech_session/revision_target.py:143|rebind|OpenAICompatibleRuntime|call
+holdspeak/speech_session/revision_target.py:165|bound_target|rebind|call
+holdspeak/web/routes/dictation/_helpers.py:786|_run_dictation_dry_run_text|build_pipeline|call
+"""),
+    _group(ProposedRoute("internal.inference.dispatch", "inference_targets", "InferenceRunner gateway/context-gated adapter"), """
+holdspeak/inference_targets.py:656|local_pinned_meeting_intel|_local_pinned_engine|call
+holdspeak/inference_targets.py:679|_local_pinned_engine|MeetingIntel|call
+holdspeak/inference_targets.py:701|build_intel_for_revision|_engine_for_revision|call
+holdspeak/inference_targets.py:728|_engine_for_revision|MeetingIntel|call
+holdspeak/inference_targets.py:735|_engine_for_revision|local_pinned_meeting_intel|call
+holdspeak/inference_targets.py:755|_engine_for_revision|build_meeting_intel_for_profile|call
+"""),
+    _group(ProposedRoute("internal.inference.dispatch", "intel.engine", "InferenceRunner gateway/context-gated adapter"), """
+holdspeak/intel/engine.py:177|MeetingIntel._ensure_openai_client_loaded|OpenAI|call
+holdspeak/intel/engine.py:209|MeetingIntel._ensure_local_model_loaded|Llama|call
+holdspeak/intel/engine.py:228|MeetingIntel._ensure_runtime_loaded|_ensure_local_model_loaded|call
+holdspeak/intel/engine.py:233|MeetingIntel._ensure_runtime_loaded|_ensure_openai_client_loaded|call
+holdspeak/intel/engine.py:238|MeetingIntel._ensure_model_loaded|_ensure_runtime_loaded|call
+holdspeak/intel/engine.py:273|MeetingIntel._chat_completion_text|create_chat_completion|call
+holdspeak/intel/engine.py:311|MeetingIntel._chat_completion_text|_remote_completion|call
+holdspeak/intel/engine.py:311|MeetingIntel._chat_completion_text|chat.completions.create|ref
+holdspeak/intel/engine.py:349|MeetingIntel._chat_completion_stream|create_chat_completion|call
+holdspeak/intel/engine.py:387|MeetingIntel._chat_completion_stream|_remote_completion|call
+holdspeak/intel/engine.py:387|MeetingIntel._chat_completion_stream|chat.completions.create|ref
+holdspeak/intel/engine.py:436|MeetingIntel.run_prompt|_chat_completion_text|call
+holdspeak/intel/engine.py:452|MeetingIntel._analyze_once|_chat_completion_text|call
+holdspeak/intel/engine.py:528|MeetingIntel._analyze_stream|_chat_completion_stream|call
+holdspeak/intel/engine.py:597|MeetingIntel.generate_title|_chat_completion_text|call
+holdspeak/intel/engine.py:672|MeetingIntel.generate_bookmark_label_with_context|_chat_completion_text|call
+"""),
+    _group(ProposedRoute("internal.inference.dispatch", "intel.providers", "InferenceRunner gateway/context-gated adapter"), """
+holdspeak/intel/providers.py:239|_configured_engine|MeshRelayIntel|call
+holdspeak/intel/providers.py:251|_configured_engine|MeetingIntel|call
+holdspeak/intel/providers.py:276|configured_meeting_intel|_configured_engine|call
+holdspeak/intel/providers.py:783|build_meeting_intel_for_profile|_profile_engine|call
+holdspeak/intel/providers.py:809|_profile_engine|MeshRelayIntel|call
+holdspeak/intel/providers.py:819|_profile_engine|configured_meeting_intel|call
+holdspeak/intel/providers.py:823|_profile_engine|MeetingIntel|call
+holdspeak/intel/providers.py:842|_profile_engine|MeetingIntel|call
+holdspeak/intel/providers.py:843|_profile_engine|configured_meeting_intel|call
+"""),
+    _group(ProposedRoute("speech.transcribe", "speech_session.transcription", "InferenceRunner via TranscriptionAdmission"), """
+holdspeak/main.py:765|_run_meeting_mode|transcribe|call
+holdspeak/main.py:774|_run_meeting_mode|transcribe|call
+holdspeak/meeting_import.py:313|_transcribe_import_windows|transcribe|call
+holdspeak/meeting_session/transcribe_loop.py:80|TranscribeLoopMixin._transcribe_audio|transcribe|call
+holdspeak/runtime/dictation_capture.py:103|DictationCaptureMixin._transcribe_and_type|transcribe|call
+holdspeak/runtime/dictation_capture.py:390|DictationCaptureMixin.transcribe_audio_admitted|transcribe|call
+holdspeak/runtime/dictation_capture.py:401|DictationCaptureMixin.transcribe_audio_admitted|transcribe|call
+holdspeak/runtime/wake_glue.py:366|WakeWordGlueMixin._transcribe_wake_admitted|transcribe|call
+holdspeak/transcribe.py:251|_MlxTranscriber._silent_audio_load._run|transcribe|call
+holdspeak/transcribe.py:296|_MlxTranscriber.transcribe._run|transcribe|call
+holdspeak/transcribe.py:378|_FasterWhisperTranscriber.transcribe|transcribe|call
+holdspeak/transcribe.py:511|Transcriber._timed_transcribe|transcribe|call
+holdspeak/transcribe.py:521|Transcriber._timed_transcribe._run|transcribe|call
+holdspeak/web/routes/system/voice.py:193|build_voice_router.api_transcribe|transcribe|call
+holdspeak/web/routes/system/voice_stream.py:245|build_voice_stream_router.ws_dictation_stream|transcribe|call
+"""),
+    _group(ProposedRoute("speech.intent_classify", "speech_session", "InferenceRunner admitted child"), """
+holdspeak/plugins/dictation/builtin/intent_router.py:171|IntentRouter.run|classify|call
+holdspeak/plugins/dictation/runtime_counters.py:227|CountingRuntime.classify|classify|call
+holdspeak/plugins/dictation/runtime_llama_cpp.py:134|LlamaCppRuntime.classify|create_completion|call
+holdspeak/plugins/dictation/runtime_openai_compatible.py:141|OpenAICompatibleRuntime.classify|chat.completions.create|call
+holdspeak/speech_session/provider.py:402|_ClassifyLeg.run.call|classify|call
+holdspeak/speech_session/provider.py:515|AdmittedDictationRuntime.classify|classify|call
+"""),
+    _group(ProposedRoute("speech.rewrite", "speech_session", "InferenceRunner admitted child"), """
+holdspeak/plugins/dictation/builtin/project_rewriter.py:203|ProjectRewriter.run|rewrite|ref
+holdspeak/plugins/dictation/builtin/project_rewriter.py:204|ProjectRewriter.run|rewrite|ref
+holdspeak/plugins/dictation/builtin/project_rewriter.py:241|ProjectRewriter.run|rewrite|call
+holdspeak/plugins/dictation/runtime_counters.py:271|CountingRuntime.rewrite|rewrite|ref
+holdspeak/plugins/dictation/runtime_counters.py:272|CountingRuntime.rewrite|rewrite|ref
+holdspeak/plugins/dictation/runtime_counters.py:277|CountingRuntime.rewrite|rewrite|call
+holdspeak/plugins/dictation/runtime_llama_cpp.py:162|LlamaCppRuntime.rewrite|create_completion|call
+holdspeak/plugins/dictation/runtime_openai_compatible.py:188|OpenAICompatibleRuntime.rewrite|chat.completions.create|call
+holdspeak/speech_session/provider.py:306|ProviderAdmission.rewrite.call|rewrite|call
+holdspeak/speech_session/provider.py:522|AdmittedDictationRuntime.rewrite|rewrite|call
+"""),
+    _group(ProposedRoute("meeting.deferred_analysis", "meeting_session", "InferenceRunner admitted child"), """
+holdspeak/intel_queue.py:234|process_next_intel_job|analyze|call
+holdspeak/meeting_session/deferred_admission.py:229|DeferredIntelJob.analyze.call|analyze|call
+"""),
+    _group(ProposedRoute("meeting.bookmark_label", "meeting_session", "InferenceRunner admitted child"), """
+holdspeak/meeting_session/deferred_admission.py:268|DeferredIntelJob.bookmark_label.call|generate_bookmark_label_with_context|call
+holdspeak/meeting_session/intel_admission.py:495|IntelAdmissionMixin._admitted_bookmark_label.call|generate_bookmark_label_with_context|call
+"""),
+    _group(ProposedRoute("meeting.auto_title", "meeting_session", "InferenceRunner admitted child"), """
+holdspeak/meeting_session/deferred_admission.py:308|DeferredIntelJob.auto_title.call|generate_title|call
+holdspeak/meeting_session/intel_admission.py:525|IntelAdmissionMixin._admitted_auto_title.call|generate_title|call
+"""),
+    _group(ProposedRoute("meeting.live_analysis", "meeting_session", "InferenceRunner admitted child"), """
+holdspeak/meeting_session/intel_admission.py:448|IntelAdmissionMixin._admitted_live_window.call|analyze|call
+"""),
+    _group(ProposedRoute("project_doc.suggest_update", "project_doc_suggestions", "InferenceRunner admitted child"), """
+holdspeak/project_doc_suggestions.py:72|suggest_project_doc_update|rewrite|ref
+holdspeak/project_doc_suggestions.py:73|suggest_project_doc_update|rewrite|ref
+holdspeak/project_doc_suggestions.py:84|suggest_project_doc_update|rewrite|call
+"""),
+    _group(ProposedRoute("speech.target_classify", "target_profile", "InferenceRunner admitted child"), """
+holdspeak/target_profile.py:191|apply_model_assisted_target|rewrite|ref
+holdspeak/target_profile.py:192|apply_model_assisted_target|rewrite|ref
+holdspeak/target_profile.py:195|apply_model_assisted_target|rewrite|call
+"""),
+    _group(ProposedRoute("speech.preload", "speech_session.transcription", "InferenceRunner via TranscriptionAdmission"), """
+holdspeak/transcribe.py:241|_MlxTranscriber._model_holder_get._run|get_model|call
+"""),
+    _group(ProposedRoute("speech.punctuate", "speech_session", "InferenceRunner admitted child"), """
+holdspeak/speech_session/provider.py:347|ProviderAdmission.punctuate.call|rewrite|call
+"""),
+    _group(ProposedRoute("agent.tool_turn", "plugins.intelligence", "InferenceRunner admitted child"), """
+holdspeak/plugins/intelligence.py:362|PluginDispatch.chat|_chat_completion_text|call
+"""),
+    _group(ProposedRoute("internal.inference.dispatch", "intel.mesh_relay", "InferenceRunner gateway/context-gated adapter"), """
+holdspeak/intel/mesh_relay.py:252|MeshRelayIntel._chat_completion_text|run_prompt|call
+"""),
+    _group(ProposedRoute("internal.inference.dispatch", "kernel.executor", "InferenceRunner gateway/context-gated adapter"), """
+holdspeak/kernel/executor.py:14|<module>|_install_claim_issuer|call
+holdspeak/kernel/executor.py:79|ExecutorPlane.claim|_issue_claim_witness|call
+"""),
+    _group(ProposedRoute("internal.inference.dispatch", "kernel.inference_runner", "InferenceRunner gateway/context-gated adapter"), """
+holdspeak/kernel/inference_runner.py:50|InferenceRunner.__init__|build_intel_for_revision|ref
+holdspeak/kernel/inference_runner.py:188|InferenceRunner._attempt|_issue_dispatch_context|call
+"""),
+    _group(ProposedRoute("internal.inference.dispatch", "kernel.prompt_adapter", "InferenceRunner gateway/context-gated adapter"), """
+holdspeak/kernel/prompt_adapter.py:14|CanonicalPromptAdapter.dispatch|run_prompt|call
+"""),
+)
+
+PROPOSED_ROUTES = {
+    key: route for route, keys in EXPLICIT_ROUTE_GROUPS for key in keys
+}
+
+
+# Direct provider/Whisper model work, including the first-class SDK callback
+# references that perform the eventual request.  The route string is deliberately
+# literal: the baseline found zero legacy bypasses.
+PHYSICAL_LEAF_KEYS = frozenset({
+    key for key in EXPECTED_CALL_SITES
+    if any(token in key for token in (
+        "|create_chat_completion|", "|chat.completions.create|", "|create_completion|",
+        "|MeshRelayIntel._chat_completion_text|run_prompt|", "|MeshRelayRuntime._run|run_prompt|",
+        "|get_model|", "_silent_audio_load._run|transcribe|",
+        "|_MlxTranscriber.transcribe._run|transcribe|", "|_FasterWhisperTranscriber.transcribe|transcribe|",
+    ))
+})
+
+
+def test_phase143_call_site_fixture_is_complete_and_fail_closed() -> None:
+    live = {_key(site) for site in one_path.census()}
+    assert live == EXPECTED_CALL_SITES, (
+        "Phase 143 inference/capability census changed; register every new site "
+        "with exactly one proposed capability and source owner.\n"
+        f"unregistered={sorted(live - EXPECTED_CALL_SITES)}\n"
+        f"stale={sorted(EXPECTED_CALL_SITES - live)}"
+    )
+    assert len(live) == 99
+
+
+def test_phase143_every_product_runner_entrance_has_one_owner() -> None:
+    live = set(_runner_entrances())
+    expected = set(PRODUCT_RUNNER_ENTRANCES)
+    assert live == expected, (
+        "Phase 143 runner-entrance census changed; register the new public "
+        "InferenceRunner.invoke caller with capability provenance and source owner.\n"
+        f"unregistered={sorted(live - expected)}\n"
+        f"stale={sorted(expected - live)}"
+    )
+    for proposed in PRODUCT_RUNNER_ENTRANCES.values():
+        assert proposed.capability_id
+        assert proposed.source_owner
+        assert proposed.admission == "InferenceRunner admitted child" or "InferenceRunner" in proposed.admission
+
+
+def test_phase143_shared_helpers_have_semantic_callers() -> None:
+    live = set(_semantic_helper_calls())
+    assert live == set(SEMANTIC_HELPER_CALLERS), (
+        "shared Ask/Recipe helper callers changed; classify the public semantic "
+        "operation rather than assigning the helper one false capability.\n"
+        f"unregistered={sorted(live - set(SEMANTIC_HELPER_CALLERS))}\n"
+        f"stale={sorted(set(SEMANTIC_HELPER_CALLERS) - live)}"
+    )
+    assert SEMANTIC_HELPER_CALLERS[
+        "holdspeak/services/refinement_coordinator.py:328|RefinementCoordinator._coordinate|ask"
+    ].capability_id == "thought.interview"
+
+    architecture = (one_path.REPO / (
+        "pm/roadmap/holdspeak/phase-143-intelligence-router/assets/architecture-contract.md"
+    )).read_text(encoding="utf-8")
+    repository = (one_path.REPO / (
+        "pm/roadmap/holdspeak/phase-143-intelligence-router/assets/repository-census.md"
+    )).read_text(encoding="utf-8")
+    bootstrap_row = next(line for line in architecture.splitlines() if line.startswith("| Thoughts & notes |"))
+    pointer_row = next(line for line in repository.splitlines() if line.startswith("| Thoughts pointer |"))
+    assert "`thought.synthesis`" not in bootstrap_row
+    assert "`thought.synthesis`" not in pointer_row
+
+
+def test_phase143_semantic_census_rejects_new_ask_or_recipe_caller() -> None:
+    mutated = _semantic_helper_calls({"holdspeak/rogue_semantic.py": """
+from holdspeak.services.ask_service import AskService
+from holdspeak.services.recipe_service import RecipeService
+class Rogue:
+    def __init__(self):
+        self.ask_service = AskService(db)
+        self.recipe_service = RecipeService(db)
+    def go(self):
+        self.ask_service.ask(principal, "unregistered")
+        self.recipe_service.chat(principal, "recipe", question="unregistered")
+"""})
+    assert set(mutated) == {
+        "holdspeak/rogue_semantic.py:9|Rogue.go|ask",
+        "holdspeak/rogue_semantic.py:10|Rogue.go|chat",
+    }
+    assert not set(mutated) <= set(SEMANTIC_HELPER_CALLERS)
+
+
+def test_phase143_swift_physical_leaves_are_explicit_legacy_bypasses() -> None:
+    live = set(_swift_physical_leaves())
+    assert live == set(SWIFT_PHYSICAL_LEAVES), (
+        "Apple physical inference inventory changed; name its capability, source "
+        "owner, and migration owner/bypass status.\n"
+        f"unregistered={sorted(live - set(SWIFT_PHYSICAL_LEAVES))}\n"
+        f"stale={sorted(set(SWIFT_PHYSICAL_LEAVES) - live)}"
+    )
+    assert all("LEGACY BYPASS: Story 143-" in route.admission for route in SWIFT_PHYSICAL_LEAVES.values())
+    workflow = SWIFT_PHYSICAL_LEAVES[
+        "apple/Sources/RuntimeCore/Workbench/WorkflowRunner.swift:366|Swift.complete"
+    ]
+    assert workflow.source_owner == "apple.runtimecore.workbench"
+
+
+def test_phase143_swift_census_rejects_fallback_or_new_provider_open() -> None:
+    mutated = _swift_physical_leaves({
+        "apple/Sources/Providers/Inference/RogueProvider.swift": """
+let output = try await fallback.complete(prompt: prompt)
+let data = try await URLSession.shared.data(for: request)
+""",
+    })
+    assert set(mutated) == {
+        "apple/Sources/Providers/Inference/RogueProvider.swift:2|Swift.complete",
+        "apple/Sources/Providers/Inference/RogueProvider.swift:3|InferenceProvider.URLSession.data",
+    }
+    assert not set(mutated) <= set(SWIFT_PHYSICAL_LEAVES)
+
+
+def test_phase143_every_censused_site_has_one_capability_and_source_owner() -> None:
+    live = {_key(site) for site in one_path.census()}
+    declared_keys = [key for _, keys in EXPLICIT_ROUTE_GROUPS for key in keys]
+    assert set(PROPOSED_ROUTES) == live == EXPECTED_CALL_SITES
+    assert len(declared_keys) == len(set(declared_keys)), "a call site has two proposed routes"
+    for proposed in PROPOSED_ROUTES.values():
+        assert proposed.capability_id
+        assert proposed.source_owner
+        assert proposed.admission
+        # Phase 143's canonical registry owns stable ASCII IDs; internal rows are
+        # intentionally non-assignable implementation capabilities.
+        assert proposed.capability_id.replace(".", "").replace("_", "").isalnum()
+
+
+def test_phase143_physical_leaves_have_no_legacy_bypass() -> None:
+    sites = {_key(site): site for site in one_path.census()}
+    assert PHYSICAL_LEAF_KEYS <= set(sites)
+    assert all(one_path._bucket(sites[key]) == "allowlist" for key in PHYSICAL_LEAF_KEYS)
+    assert all("InferenceRunner" in PROPOSED_ROUTES[key].admission for key in PHYSICAL_LEAF_KEYS)
+    assert one_path.NAMED_FINDINGS == {}
+    assert one_path.BLOCKING_FAMILIES == frozenset()

--- a/tests/unit/test_phase143_routing_authority_census.py
+++ b/tests/unit/test_phase143_routing_authority_census.py
@@ -1,0 +1,360 @@
+"""HS-104-143-01 — fence the routing-authority census to observed production.
+
+This is intentionally a static inventory test.  It does not bless the two
+known unsafe seams: they are named blockers until their owning stories replace
+them.  Updating a source anchor therefore requires an explicit census review.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+CENSUS = REPO / (
+    "pm/roadmap/holdspeak/phase-143-intelligence-router/assets/"
+    "generated-routing-authority-census.md"
+)
+
+CLASSES = frozenset({
+    "mutable assignment pointer",
+    "immutable evidence",
+    "display",
+    "credential/provider identity",
+    "unrelated",
+    "legacy-delete",
+})
+
+# One owner per mutable family.  The value is deliberately a story, not a
+# module: implementation work may move files without creating rival authority.
+MUTABLE_FAMILY_OWNERS = {
+    "ProfileRecord mutable destination fields": "143-03",
+    "Deployment head selected by a future profile binding": "143-03",
+    "Thoughts and Ask default/request pointer": "143-07",
+    "Writing and dictation runtime pointer": "143-07",
+    "Meeting intelligence pointer and provider placement": "143-08",
+    "Recipe and agent default pointer": "143-10",
+    "Workbench execution pointer": "143-10",
+    "Workbench voice-resolver pointer": "143-10",
+    "Recipe, Sequence, and Workflow request placement override": "143-10",
+    "Kernel `inference.run` requested target selector": "143-10",
+    "Decision and delivery request placement override": "143-08",
+    "Rails observer background pointer": "143-08",
+    "Cadence background global resolver": "143-08",
+    "Legacy setup download-and-use assignment side effect": "143-03",
+    "Legacy seed profile adoption assignment side effect": "143-04",
+    "V1 profile and workbench sync payload": "143-11",
+    "Settings Thoughts and writing legacy pointer writers": "143-07",
+    "Settings meeting and background legacy pointer writers": "143-08",
+}
+
+ROUTING_RESOLVER_NAMES = frozenset({
+    "resolve_inference_target",
+    "resolve_placement",
+    "resolve_thought_placement",
+    "resolve_meeting_placement",
+    "resolve_workbench_deployment_revision",
+    "resolve_deployment_revision",
+})
+
+# This is deliberately exact: definitions, imports, and use-sites are all
+# authority.  A new resolver or a late read cannot silently evade Story 01 by
+# looking like a harmless helper in a new module.
+ROUTING_RESOLVER_DEFINITIONS = {
+    "holdspeak/deployment_revisions.py:202:resolve_workbench_deployment_revision",
+    "holdspeak/deployment_revisions.py:224:resolve_deployment_revision",
+    "holdspeak/inference_targets.py:551:resolve_placement",
+    "holdspeak/inference_targets.py:497:resolve_inference_target",
+    "holdspeak/inference_targets.py:591:resolve_thought_placement",
+    "holdspeak/intel/providers.py:666:resolve_meeting_placement",
+}
+
+ROUTING_RESOLVER_REFERENCES = {
+    "holdspeak/deployment_revisions.py:205:import:resolve_inference_target",
+    "holdspeak/deployment_revisions.py:214:ref:resolve_inference_target",
+    "holdspeak/inference_targets.py:602:ref:resolve_placement",
+    "holdspeak/inference_targets.py:585:ref:resolve_inference_target",
+    "holdspeak/kernel/inference.py:9:import:resolve_inference_target",
+    "holdspeak/kernel/inference.py:103:ref:resolve_inference_target",
+    "holdspeak/services/inference_setup_service.py:23:import:resolve_inference_target",
+    "holdspeak/services/inference_setup_service.py:184:ref:resolve_inference_target",
+    "holdspeak/services/profile_service.py:115:import:resolve_inference_target",
+    "holdspeak/services/profile_service.py:116:ref:resolve_inference_target",
+    "holdspeak/intel/__init__.py:60:import:resolve_meeting_placement",
+    "holdspeak/intel/providers.py:193:ref:resolve_meeting_placement",
+    "holdspeak/intel/providers.py:235:ref:resolve_meeting_placement",
+    "holdspeak/intel/providers.py:337:ref:resolve_meeting_placement",
+    "holdspeak/intel/providers.py:864:ref:resolve_meeting_placement",
+    "holdspeak/kernel/inference_invoke.py:10:import:resolve_deployment_revision",
+    "holdspeak/kernel/inference_invoke.py:92:ref:resolve_deployment_revision",
+    "holdspeak/kernel/inference_runner.py:7:import:resolve_deployment_revision",
+    "holdspeak/kernel/inference_runner.py:317:ref:resolve_deployment_revision",
+    "holdspeak/kernel/projection_stager.py:133:import:resolve_workbench_deployment_revision",
+    "holdspeak/kernel/projection_stager.py:134:ref:resolve_workbench_deployment_revision",
+    "holdspeak/meeting_session/intel_plan.py:185:import:resolve_placement",
+    "holdspeak/meeting_session/intel_plan.py:186:import:resolve_meeting_placement",
+    "holdspeak/meeting_session/intel_plan.py:192:ref:resolve_meeting_placement",
+    "holdspeak/meeting_session/intel_plan.py:194:ref:resolve_placement",
+    "holdspeak/rails_observer.py:249:import:resolve_placement",
+    "holdspeak/rails_observer.py:255:ref:resolve_placement",
+    "holdspeak/services/ask_service.py:146:import:resolve_placement",
+    "holdspeak/services/ask_service.py:147:ref:resolve_placement",
+    "holdspeak/services/cadence_service.py:222:import:resolve_placement",
+    "holdspeak/services/cadence_service.py:226:ref:resolve_placement",
+    "holdspeak/services/decision_lifecycle_service.py:67:import:resolve_placement",
+    "holdspeak/services/decision_lifecycle_service.py:71:ref:resolve_placement",
+    "holdspeak/services/recipe_service.py:130:import:resolve_placement",
+    "holdspeak/services/recipe_service.py:131:ref:resolve_placement",
+    "holdspeak/services/recipe_service.py:173:import:resolve_placement",
+    "holdspeak/services/recipe_service.py:174:ref:resolve_placement",
+    "holdspeak/services/refinement_application_service.py:63:import:resolve_placement",
+    "holdspeak/services/refinement_application_service.py:64:ref:resolve_placement",
+    "holdspeak/services/refinement_application_service.py:70:import:resolve_thought_placement",
+    "holdspeak/services/refinement_application_service.py:71:ref:resolve_thought_placement",
+    "holdspeak/services/refinement_coordinator.py:222:import:resolve_thought_placement",
+    "holdspeak/services/refinement_coordinator.py:223:ref:resolve_thought_placement",
+    "holdspeak/services/refinement_thought_service.py:609:import:resolve_thought_placement",
+    "holdspeak/services/refinement_thought_service.py:615:ref:resolve_thought_placement",
+    "holdspeak/services/schedule_delegation.py:9:import:resolve_placement",
+    "holdspeak/services/schedule_delegation.py:18:ref:resolve_placement",
+    "holdspeak/services/sequence_workflow_service.py:31:import:resolve_placement",
+    "holdspeak/services/sequence_workflow_service.py:33:ref:resolve_placement",
+    "holdspeak/services/settings_service.py:68:import:resolve_meeting_placement",
+    "holdspeak/services/settings_service.py:76:ref:resolve_meeting_placement",
+    "holdspeak/services/workbench_runner.py:30:import:resolve_placement",
+    "holdspeak/services/workbench_runner.py:31:ref:resolve_placement",
+    "holdspeak/services/workbench_service.py:167:import:resolve_placement",
+    "holdspeak/services/workbench_service.py:171:ref:resolve_placement",
+    "holdspeak/services/workbench_service.py:378:import:resolve_placement",
+    "holdspeak/services/workbench_service.py:379:ref:resolve_placement",
+    "holdspeak/speech_session/plan.py:452:import:resolve_placement",
+    "holdspeak/speech_session/plan.py:461:ref:resolve_placement",
+    "holdspeak/speech_session/plan.py:611:import:resolve_placement",
+    "holdspeak/speech_session/plan.py:620:ref:resolve_placement",
+    "holdspeak/web/routes/delivery_prs.py:234:import:resolve_placement",
+    "holdspeak/web/routes/delivery_prs.py:241:ref:resolve_placement",
+}
+
+ROUTING_POINTER_ATTRIBUTES = {
+    "holdspeak/config/core.py:135:intel_profile_id",
+    "holdspeak/config/core.py:158:intel_profile_id",
+    "holdspeak/config/integrations.py:22:inference_target_id",
+    "holdspeak/config/integrations.py:23:inference_target_id",
+    "holdspeak/config/meeting.py:143:intel_profile_id",
+    "holdspeak/config/meeting.py:144:intel_profile_id",
+    "holdspeak/db/models/__init__.py:1095:resolver_profile_id",
+    "holdspeak/db/models/workbench.py:139:resolver_profile_id",
+    "holdspeak/db/seed.py:270:intel_profile_id",
+    "holdspeak/db/seed.py:271:intel_profile_id",
+    "holdspeak/services/inference_acquisition_service.py:54:inference_target_id",
+    "holdspeak/services/inference_acquisition_service.py:832:inference_target_id",
+    "holdspeak/services/inference_setup_service.py:603:inference_target_id",
+    "holdspeak/services/inference_setup_service.py:604:inference_target_id",
+    "holdspeak/services/inference_setup_service.py:608:intel_profile_id",
+    "holdspeak/services/inference_setup_service.py:181:inference_target_id",
+    "holdspeak/services/settings_service.py:567:intel_profile_id",
+    "holdspeak/services/settings_service.py:816:inference_target_id",
+    "holdspeak/services/workbench_service.py:376:resolver_profile_id",
+    "holdspeak/services/workbench_service.py:379:resolver_profile_id",
+    "holdspeak/services/workbench_service.py:401:resolver_profile_id",
+    "holdspeak/services/workbench_service.py:422:resolver_profile_id",
+    "holdspeak/services/workbench_service.py:471:resolver_profile_id",
+    "holdspeak/kernel/inference.py:103:requested_target_id",
+    "holdspeak/kernel/inference.py:147:requested_target_id",
+}
+
+# `profile_id` is deliberately not treated as a synonym for routing.  This
+# exhaustive classification makes every production read visible while keeping
+# receipts, DTOs, readiness, and unrelated records out of the assignment lane.
+PROFILE_ID_CLASSIFICATIONS = {
+    **{site: "mutable assignment pointer" for site in {
+        "holdspeak/config/core.py:138:profile_id", "holdspeak/config/core.py:169:profile_id",
+        "holdspeak/config/integrations.py:101:profile_id", "holdspeak/config/model.py:80:profile_id",
+        "holdspeak/db/models/__init__.py:1094:profile_id", "holdspeak/db/models/workbench.py:138:profile_id",
+        "holdspeak/db/seed.py:267:profile_id", "holdspeak/db/seed.py:268:profile_id",
+        "holdspeak/meeting_session/intel_plan.py:193:profile_id", "holdspeak/plugins/dictation/assembly.py:318:profile_id",
+        "holdspeak/services/recipe_service.py:131:profile_id", "holdspeak/services/recipe_service.py:141:profile_id",
+        "holdspeak/services/recipe_service.py:146:profile_id", "holdspeak/services/recipe_service.py:174:profile_id",
+        "holdspeak/services/recipe_service.py:178:profile_id", "holdspeak/services/schedule_delegation.py:18:profile_id",
+        "holdspeak/services/sequence_workflow_service.py:129:profile_id", "holdspeak/services/settings_service.py:717:profile_id",
+        "holdspeak/services/settings_service.py:789:profile_id", "holdspeak/services/workbench_runner.py:31:profile_id",
+        "holdspeak/services/workbench_service.py:172:profile_id", "holdspeak/services/workbench_service.py:470:profile_id",
+        "holdspeak/web_server.py:1128:profile_id", "holdspeak/services/sync_service.py:610:profile_id",
+        "holdspeak/services/sync_service.py:625:profile_id",
+    }},
+    **{site: "display" for site in {
+        "holdspeak/commands/doctor.py:488:profile_id", "holdspeak/commands/doctor.py:787:profile_id",
+        "holdspeak/commands/doctor.py:795:profile_id", "holdspeak/commands/doctor.py:809:profile_id",
+        "holdspeak/commands/doctor.py:934:profile_id",
+        "holdspeak/db/models/__init__.py:656:profile_id", "holdspeak/inference_targets.py:162:profile_id",
+        "holdspeak/services/ask_service.py:157:profile_id",
+        "holdspeak/services/inference_setup_service.py:607:profile_id", "holdspeak/services/settings_service.py:99:profile_id",
+        "holdspeak/setup_status.py:151:profile_id",
+    }},
+    **{site: "credential/provider identity" for site in {
+        "holdspeak/intel/providers.py:687:profile_id", "holdspeak/intel/providers.py:694:profile_id",
+        "holdspeak/intel/providers.py:703:profile_id", "holdspeak/setup_runtime.py:198:profile_id",
+        "holdspeak/trust_destinations.py:59:profile_id",
+    }},
+}
+
+
+def _text(path: str | Path) -> str:
+    return (REPO / path).read_text(encoding="utf-8") if isinstance(path, str) else path.read_text(encoding="utf-8")
+
+
+def _routing_ast_inventory(root: Path) -> tuple[set[str], set[str], set[str], set[str]]:
+    """Return every public routing resolver, reference, and mutable pointer.
+
+    The source root is an argument so the mutation test below proves that this
+    guard catches both a new public resolver and a late mutable-pointer read.
+    """
+    definitions: set[str] = set()
+    references: set[str] = set()
+    pointers: set[str] = set()
+    profile_ids: set[str] = set()
+    for path in sorted((root / "holdspeak").rglob("*.py")):
+        relative = path.relative_to(root).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name.startswith("resolve_") and (
+                    "placement" in node.name
+                    or "deployment_revision" in node.name
+                    or "inference_target" in node.name
+                ):
+                    definitions.add(f"{relative}:{node.lineno}:{node.name}")
+            elif isinstance(node, ast.Name) and node.id in ROUTING_RESOLVER_NAMES:
+                references.add(f"{relative}:{node.lineno}:ref:{node.id}")
+            elif isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.name in ROUTING_RESOLVER_NAMES:
+                        references.add(f"{relative}:{node.lineno}:import:{alias.name}")
+            elif isinstance(node, ast.Attribute) and node.attr in {
+                "inference_target_id", "intel_profile_id", "resolver_profile_id",
+                "requested_target_id",
+            }:
+                pointers.add(f"{relative}:{node.lineno}:{node.attr}")
+            elif isinstance(node, ast.Attribute) and node.attr == "profile_id":
+                profile_ids.add(f"{relative}:{node.lineno}:profile_id")
+    return definitions, references, pointers, profile_ids
+
+
+def _inventory_rows(census: str) -> dict[str, tuple[str, str]]:
+    section = census.split("## Production site inventory", 1)[1].split("## ", 1)[0]
+    rows: dict[str, tuple[str, str]] = {}
+    for line in section.splitlines():
+        if not line.startswith("|") or "Family" in line or "---" in line:
+            continue
+        parts = [part.strip() for part in line.strip().strip("|").split("|")]
+        assert len(parts) == 4, f"malformed census row: {line}"
+        family, _anchors, classification, owner = parts
+        assert classification in CLASSES, f"unknown classification for {family}: {classification}"
+        assert family not in rows, f"duplicate census family: {family}"
+        rows[family] = (classification, owner)
+    return rows
+
+
+def test_census_inventory_has_one_owner_for_each_mutable_family() -> None:
+    rows = _inventory_rows(_text(CENSUS))
+    observed = {
+        family: owner for family, (classification, owner) in rows.items()
+        if classification == "mutable assignment pointer"
+    }
+    assert observed == MUTABLE_FAMILY_OWNERS
+    assert all(re.fullmatch(r"143-\d{2}", owner) for owner in observed.values())
+
+
+def test_census_anchors_current_routing_resolvers_and_legacy_assignment_writers() -> None:
+    census = _text(CENSUS)
+    required_anchors = {
+        "holdspeak/inference_targets.py:resolve_placement": "holdspeak/inference_targets.py",
+        "holdspeak/inference_targets.py:resolve_thought_placement": "holdspeak/inference_targets.py",
+        "holdspeak/intel/providers.py:effective_intel_cloud": "holdspeak/intel/providers.py",
+        "holdspeak/intel/providers.py:effective_dictation_llm": "holdspeak/intel/providers.py",
+        "holdspeak/meeting_session/intel_plan.py:freeze_meeting_intel_plan": "holdspeak/meeting_session/intel_plan.py",
+        "holdspeak/speech_session/plan.py:DictationSessionPlanResolver": "holdspeak/speech_session/plan.py",
+        "holdspeak/deployment_revisions.py:resolve_workbench_deployment_revision": "holdspeak/deployment_revisions.py",
+        "holdspeak/services/schedule_delegation.py:_terms": "holdspeak/services/schedule_delegation.py",
+        "holdspeak/services/sequence_workflow_service.py:SequenceWorkflowService._target": "holdspeak/services/sequence_workflow_service.py",
+        "holdspeak/services/decision_lifecycle_service.py:draft_promoted_with_model": "holdspeak/services/decision_lifecycle_service.py",
+        "holdspeak/web/routes/delivery_prs.py:api_delivery_pr_draft_review": "holdspeak/web/routes/delivery_prs.py",
+        "holdspeak/services/cadence_service.py:_drafted_next_action": "holdspeak/services/cadence_service.py",
+        "holdspeak/services/settings_service.py:SettingsService.update_settings": "holdspeak/services/settings_service.py",
+        "holdspeak/services/inference_acquisition_service.py:_activate": "holdspeak/services/inference_acquisition_service.py",
+        "holdspeak/db/seed.py:_adopt_profiles": "holdspeak/db/seed.py",
+    }
+    for anchor, path in required_anchors.items():
+        assert anchor in census
+        symbol = anchor.rsplit(":", 1)[1].rsplit(".", 1)[-1]
+        assert symbol in _text(path)
+
+
+def test_ast_census_is_exact_for_every_routing_resolver_reference_and_pointer() -> None:
+    definitions, references, pointers, profile_ids = _routing_ast_inventory(REPO)
+    assert definitions == ROUTING_RESOLVER_DEFINITIONS
+    assert references == ROUTING_RESOLVER_REFERENCES
+    assert pointers == ROUTING_POINTER_ATTRIBUTES
+    assert profile_ids == set(PROFILE_ID_CLASSIFICATIONS)
+    assert set(PROFILE_ID_CLASSIFICATIONS.values()) <= CLASSES
+    assert len(PROFILE_ID_CLASSIFICATIONS) == 41
+    assert sum(value == "mutable assignment pointer" for value in PROFILE_ID_CLASSIFICATIONS.values()) == 25
+    assert sum(value == "display" for value in PROFILE_ID_CLASSIFICATIONS.values()) == 11
+    assert sum(value == "credential/provider identity" for value in PROFILE_ID_CLASSIFICATIONS.values()) == 5
+
+
+def test_ast_census_rejects_a_new_public_resolver_or_late_pointer_read(tmp_path: Path) -> None:
+    """Mutation proof: a new authority cannot arrive without census review."""
+    root = tmp_path
+    source = root / "holdspeak" / "kernel"
+    source.mkdir(parents=True)
+    (source / "inference.py").write_text(
+        "def resolve_late_inference_target(admission):\n"
+        "    return admission.requested_target_id\n"
+        "def public_profile(config):\n"
+        "    return config.runtime.profile_id\n",
+        encoding="utf-8",
+    )
+    definitions, references, pointers, profile_ids = _routing_ast_inventory(root)
+    assert definitions == {"holdspeak/kernel/inference.py:1:resolve_late_inference_target"}
+    assert references == set()
+    assert pointers == {"holdspeak/kernel/inference.py:2:requested_target_id"}
+    assert profile_ids == {"holdspeak/kernel/inference.py:4:profile_id"}
+    assert definitions != ROUTING_RESOLVER_DEFINITIONS
+    assert pointers != ROUTING_POINTER_ATTRIBUTES
+
+
+def test_profile_service_owner_gap_is_a_named_blocker_not_an_exception() -> None:
+    census = _text(CENSUS)
+    source = _text("holdspeak/services/profile_service.py")
+    assert "PROFILE_SERVICE_OWNER_ENFORCEMENT_GAP" in census
+    assert "BLOCKER" in census
+    # Current ProfileService accepts a principal but never verifies OWNER.  This
+    # assertion is intentionally inverted when Story 143-03 supplies the gate:
+    # remove the blocker row in the same reviewed change rather than allowlist it.
+    assert "PrincipalKind" not in source
+    assert "owner_principal_required" not in source
+
+
+def test_path_bearing_profile_sync_seam_is_a_named_blocker_not_an_exception() -> None:
+    census = _text(CENSUS)
+    source = _text("holdspeak/services/sync_service.py")
+    assert "PROFILE_SYNC_PATH_BEARING_SEAM" in census
+    profile_merge = re.search(r'"profiles": \([^\n]+\)', source)
+    assert profile_merge, "profiles must remain visible to the census until Story 143-11 retires it"
+    assert "model_file" in profile_merge.group(0)
+    assert "base_url" in profile_merge.group(0)
+    assert 'SyncKindSpec("profile", "profiles", "profile.schema.json", True)' in source
+
+
+def test_legacy_assignment_writers_are_delete_work_not_normalized_authority() -> None:
+    census = _text(CENSUS)
+    rows = _inventory_rows(census)
+    assert rows["Legacy config endpoint migration"] == ("legacy-delete", "143-03")
+    assert rows["Old dictation auto-placement fallback labels"] == ("legacy-delete", "143-07")
+    assert rows["Old meeting auto-placement fallback labels"] == ("legacy-delete", "143-08")
+    assert "config.thoughts.inference_target_id = None" in _text(
+        "holdspeak/services/inference_acquisition_service.py"
+    )
+    assert "config.meeting.intel_profile_id = profile_id" in _text("holdspeak/db/seed.py")

--- a/tests/unit/test_phase143_surface_fallback_census.py
+++ b/tests/unit/test_phase143_surface_fallback_census.py
@@ -1,0 +1,249 @@
+"""HS-143-01 — executable census of owner route controls and recovery semantics.
+
+This is intentionally a *static* fence.  Phase 143 has not consolidated these
+authorities yet, so letting a new helper select a model, or letting a browser
+invent a fallback, would make the migration inventory stale before the new
+controller exists.  A new production selector/recovery helper therefore needs a
+literal classification here and a row in the reviewed census artifact.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+BACKEND = REPO / "holdspeak"
+WEB = REPO / "web" / "src"
+APPLE = REPO / "apple" / "Sources"
+ARTIFACT = REPO / "pm/roadmap/holdspeak/phase-143-intelligence-router/assets/generated-surface-fallback-census.md"
+
+# A key is deliberately file + private scope, rather than a family-wide glob:
+# each new private decision is a new authority until a reviewer says otherwise.
+# The value is (classification, one Phase 143 owner story).
+BACKEND_PRIVATE_DECISIONS: dict[tuple[str, str], tuple[str, str]] = {
+    ("holdspeak/commands/doctor.py", "_check_runtime_profiles"): ("readiness audit; no route selection", "143-03"),
+    ("holdspeak/db/seed.py", "_adopt_profiles"): ("legacy Config-pointer adoption migration", "143-04"),
+    ("holdspeak/delivery/factory_launch.py", "_valid_profile"): ("agent delivery validation", "143-10"),
+    ("holdspeak/desktop_presence.py", "_select_presence_renderer"): ("non-inference false positive", "143-01"),
+    ("holdspeak/dictation_telemetry.py", "_fallback_category"): ("lexical/degraded telemetry, never model fallback", "143-07"),
+    ("holdspeak/inference_targets.py", "_profile_key_present"): ("profile credential readiness", "143-03"),
+    ("holdspeak/intel/engine.py", "_compatibility_retry"): ("provider dialect attempt; separate admitted physical child", "143-06"),
+    ("holdspeak/intel/engine.py", "_resolved_model_path"): ("immutable local artifact read", "143-03"),
+    ("holdspeak/intel/providers.py", "_lookup_profile_record"): ("legacy profile lookup", "143-03"),
+    ("holdspeak/intel/providers.py", "_apply_runtime_profile"): ("legacy profile-shaped runtime construction", "143-03"),
+    ("holdspeak/intel/providers.py", "_profile_engine"): ("profile engine factory behind admitted context", "143-03"),
+    ("holdspeak/intel_queue.py", "_compute_retry_delay_seconds"): ("deferred scheduling backoff", "143-08"),
+    ("holdspeak/intel_queue.py", "_retry_or_fail_job"): ("deferred scheduling retry; new job, not route fallback", "143-08"),
+    ("holdspeak/kernel/inference_runner.py", "_cancelled_before_retry"): ("same-leg physical-attempt cancellation fence", "143-06"),
+    ("holdspeak/kernel/projection_stager.py", "_retry_stage"): ("projection adoption for dialect child", "143-06"),
+    ("holdspeak/meeting_session/intel_plan.py", "_placement_legs"): ("frozen real route legs", "143-08"),
+    ("holdspeak/plugins/dictation/assembly.py", "_frozen_local_target"): ("frozen dictation target", "143-07"),
+    ("holdspeak/plugins/dictation/builtin/project_rewriter.py", "_selected_activity_context"): ("non-route input selection", "143-01"),
+    ("holdspeak/plugins/dictation/builtin/project_rewriter.py", "_target_directive"): ("deterministic dictation directive", "143-07"),
+    ("holdspeak/plugins/dictation/runtime_mlx.py", "_resolve_generator_factory"): ("dictation runtime factory", "143-07"),
+    ("holdspeak/services/inference_acquisition_service.py", "_route_revision"): ("setup preview revision; not assignment authority", "143-12"),
+    ("holdspeak/services/inference_setup_service.py", "_thought_target"): ("legacy Thoughts selector", "143-07"),
+    ("holdspeak/services/inference_setup_service.py", "_safe_target"): ("setup readiness selector", "143-12"),
+    ("holdspeak/services/meeting_intel_service.py", "_retry"): ("explicit owner recovery request", "143-08"),
+    ("holdspeak/services/profile_key_service.py", "_profile"): ("credential owner lookup", "143-03"),
+    ("holdspeak/services/profile_service.py", "_target_fields"): ("profile transport-neutral mutation", "143-03"),
+    ("holdspeak/services/recipe_service.py", "_target"): ("recipe/workbench precedence", "143-10"),
+    ("holdspeak/services/sequence_workflow_service.py", "_target"): ("workflow legacy placement", "143-10"),
+    ("holdspeak/services/support.py", "_norm_run_target"): ("workflow placement normalization", "143-10"),
+    ("holdspeak/services/workbench_runner.py", "_target"): ("workbench/recipe precedence", "143-10"),
+    ("holdspeak/speaker_intel.py", "_get_fallback_speaker"): ("speaker identity fallback, not inference", "143-01"),
+    ("holdspeak/target_profile.py", "_build_model_target_prompt"): ("model-assisted target prompt", "143-07"),
+    ("holdspeak/target_profile.py", "_profile"): ("legacy target-profile lookup", "143-07"),
+}
+
+# Every production browser module which reads/writes a routing pointer is known.
+# Types and transport projections are included so a new UI cannot hide a selector
+# behind a wire helper or a "display-only" component.
+WEB_ROUTING_SURFACES: dict[str, tuple[str, str]] = {
+    "web/src/desk/api.ts": ("display-transport", "143-11"),
+    "web/src/desk/ask.ts": ("inference-route", "143-07"),
+    "web/src/desk/chat.ts": ("inference-route", "143-07"),
+    "web/src/desk/components/AskPanel.tsx": ("inference-route", "143-07"),
+    "web/src/desk/components/DeliveryBoard.tsx": ("unrelated", "143-01"),
+    "web/src/desk/components/EditorAIBar.tsx": ("inference-route", "143-07"),
+    "web/src/desk/components/PersonaChat.tsx": ("inference-route", "143-10"),
+    "web/src/desk/components/Pullout.tsx": ("display-transport", "143-11"),
+    "web/src/desk/components/RunsOnPicker.tsx": ("inference-route", "143-13"),
+    "web/src/desk/components/WorkbenchTemplatePicker.tsx": ("inference-route", "143-10"),
+    "web/src/desk/components/WorkbenchWindow.tsx": ("inference-route", "143-10"),
+    "web/src/desk/components/workbenchTarget.ts": ("display-transport", "143-10"),
+    "web/src/desk/deliveryFactory.ts": ("unrelated", "143-01"),
+    "web/src/desk/detail-types.ts": ("display-transport", "143-11"),
+    "web/src/desk/infoContract.ts": ("display-transport", "143-10"),
+    "web/src/desk/pullouts/editors/RecipeEditor.tsx": ("inference-route", "143-10"),
+    "web/src/desk/pullouts/shared/CapabilitySection.tsx": ("inference-route", "143-10"),
+    "web/src/desk/store/dataSlice.ts": ("inference-route", "143-07"),
+    "web/src/desk/store/types.ts": ("display-transport", "143-11"),
+    "web/src/lib/primitives.ts": ("display-transport", "143-11"),
+    "web/src/pages/cores/ProjectMemoryCore.tsx": ("inference-route", "143-07"),
+    "web/src/pages/cores/SettingsCore.tsx": ("inference-route", "143-13"),
+    "web/src/pages/cores/WorkbenchesHomeCore.tsx": ("display-transport", "143-10"),
+    "web/src/pages/cores/core-types.ts": ("display-transport", "143-11"),
+    "web/src/pages/cores/dictation/UtteranceWell.tsx": ("inference-route", "143-07"),
+    "web/src/pages/cores/dictation/useSpeakDeck.ts": ("inference-route", "143-07"),
+    "web/src/pages/cores/settingsModels.tsx": ("inference-route", "143-13"),
+}
+
+POINTER_TOKENS = ("inference_target_id", "intel_profile_id", "profile_id", "resolver_profile_id")
+CAMEL_POINTER_TOKENS = ("inferenceTargetId", "intelProfileId", "profileId", "resolverProfileId")
+RUNS_ON_PICKER_SURFACE = re.compile(
+    r"(?:import\s*\{\s*RunsOnPicker\s*\}|export\s+function\s+RunsOnPicker)"
+)
+STORY_RE = re.compile(r"^143-(?:0[1-9]|1[0-4])$")
+
+SWIFT_POLICY_SITES: dict[str, tuple[str, str]] = {
+    "apple/Sources/RuntimeCore/Workbench/BlueprintInterpreter.swift:321:fallbackOnDevice": (
+        "real injected-provider fallback", "143-06",
+    ),
+    "apple/Sources/RuntimeCore/Workbench/BlueprintInterpreter.swift:328:retryThenQueue": (
+        "fake queue label; surfaces hard failure", "143-06",
+    ),
+    "apple/Sources/RuntimeCore/Workbench/BlueprintInterpreter.swift:341:boundedRetry": (
+        "client-owned provider retry loop", "143-06",
+    ),
+    "apple/Sources/RuntimeCore/Workbench/WorkflowRunner.swift:236:fallbackOnDevice": (
+        "real injected-provider fallback", "143-06",
+    ),
+    "apple/Sources/RuntimeCore/Workbench/WorkflowRunner.swift:265:retryThenQueue": (
+        "real client-side parking result", "143-06",
+    ),
+    "apple/Sources/RuntimeCore/Workbench/WorkflowRunner.swift:374:boundedRetry": (
+        "client-owned provider retry loop", "143-06",
+    ),
+}
+
+
+def _private_decisions() -> set[tuple[str, str]]:
+    """Return every current private routing/recovery-shaped backend helper."""
+    found: set[tuple[str, str]] = set()
+    selector_words = ("resolve", "select", "route", "placement", "profile", "target")
+    route_evidence = (*POINTER_TOKENS, "deployment_revision", "resolve_placement", "InferenceRunner", "provider", "model")
+    for path in sorted(BACKEND.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or not node.name.startswith("_"):
+                continue
+            body = ast.get_source_segment(source, node) or ""
+            name = node.name.lower()
+            is_recovery = "fallback" in name or "retry" in name
+            is_selector = any(word in name for word in selector_words) and any(token in body for token in route_evidence)
+            if is_recovery or is_selector:
+                found.add((path.relative_to(REPO).as_posix(), node.name))
+    return found
+
+
+def _web_routing_surfaces() -> set[str]:
+    """Return exact route consumers, including picker imports and camel selectors."""
+    found: set[str] = set()
+    for path in sorted(WEB.rglob("*")):
+        if path.suffix not in {".ts", ".tsx"} or ".test." in path.name or "/__tests__/" in path.as_posix():
+            continue
+        source = path.read_text(encoding="utf-8")
+        if (
+            any(token in source for token in (*POINTER_TOKENS, *CAMEL_POINTER_TOKENS))
+            or RUNS_ON_PICKER_SURFACE.search(source)
+        ):
+            found.add(path.relative_to(REPO).as_posix())
+    return found
+
+
+def _swift_policy_sites(sources: dict[str, str] | None = None) -> set[str]:
+    """Return every current Swift retry/fallback policy branch and loop."""
+    sources = sources or {
+        path.relative_to(REPO).as_posix(): path.read_text(encoding="utf-8")
+        for path in APPLE.rglob("*.swift")
+    }
+    found: set[str] = set()
+    for relative, source in sorted(sources.items()):
+        for line_no, line in enumerate(source.splitlines(), start=1):
+            marker = ""
+            if "case .fallbackOnDevice:" in line:
+                marker = "fallbackOnDevice"
+            elif "case .retryThenQueue:" in line:
+                marker = "retryThenQueue"
+            elif "policy.maxRetries" in line:
+                marker = "boundedRetry"
+            if marker:
+                found.add(f"{relative}:{line_no}:{marker}")
+    return found
+
+
+def test_private_backend_route_and_recovery_decisions_are_classified() -> None:
+    """A new private selector/retry/fallback helper fails closed until reviewed."""
+    found = _private_decisions()
+    assert found == set(BACKEND_PRIVATE_DECISIONS), (
+        "Unclassified private route/recovery decision(s): "
+        f"{sorted(found - set(BACKEND_PRIVATE_DECISIONS))}; stale classifications: "
+        f"{sorted(set(BACKEND_PRIVATE_DECISIONS) - found)}"
+    )
+    assert all(STORY_RE.fullmatch(owner) for _, owner in BACKEND_PRIVATE_DECISIONS.values())
+
+
+def test_web_route_pointer_controls_are_classified_and_single_owned() -> None:
+    """A new browser routing consumer cannot appear outside the reviewed census."""
+    found = _web_routing_surfaces()
+    assert found == set(WEB_ROUTING_SURFACES), (
+        "Unclassified web route consumer(s): "
+        f"{sorted(found - set(WEB_ROUTING_SURFACES))}; stale classifications: "
+        f"{sorted(set(WEB_ROUTING_SURFACES) - found)}"
+    )
+    assert all(
+        classification in {"inference-route", "display-transport", "unrelated"}
+        and STORY_RE.fullmatch(owner)
+        for classification, owner in WEB_ROUTING_SURFACES.values()
+    )
+
+
+def test_census_artifact_covers_every_guarded_surface_and_recovery_kind() -> None:
+    text = ARTIFACT.read_text(encoding="utf-8")
+    for required in (
+        "true model-route fallback",
+        "scheduling retry",
+        "lexical degradation",
+        "explicit owner retry",
+        "provider dialect attempt",
+        "Python fake workflow label",
+        "Swift dormant/client fallback",
+        "response_format",
+        "silent-audio",
+        "Storage-delivery retry",
+        "fallbackOnDevice",
+        "retryThenQueue",
+        "exactly one Phase 143 story",
+    ):
+        assert required in text
+    for path, _scope in BACKEND_PRIVATE_DECISIONS:
+        assert path in text, f"census artifact omits guarded backend surface {path}"
+    for path in WEB_ROUTING_SURFACES:
+        assert path in text, f"census artifact omits guarded web surface {path}"
+
+
+def test_swift_retry_and_fallback_policy_sites_are_exact_and_fail_closed() -> None:
+    live = _swift_policy_sites()
+    assert live == set(SWIFT_POLICY_SITES), (
+        f"unclassified Swift policy sites={sorted(live - set(SWIFT_POLICY_SITES))}; "
+        f"stale={sorted(set(SWIFT_POLICY_SITES) - live)}"
+    )
+    assert all(STORY_RE.fullmatch(owner) for _, owner in SWIFT_POLICY_SITES.values())
+
+    mutated = _swift_policy_sites({
+        "apple/Sources/RuntimeCore/Workbench/RogueRunner.swift": """
+case .fallbackOnDevice:
+case .retryThenQueue:
+let tries = policy.maxRetries
+""",
+    })
+    assert mutated == {
+        "apple/Sources/RuntimeCore/Workbench/RogueRunner.swift:2:fallbackOnDevice",
+        "apple/Sources/RuntimeCore/Workbench/RogueRunner.swift:3:retryThenQueue",
+        "apple/Sources/RuntimeCore/Workbench/RogueRunner.swift:4:boundedRetry",
+    }
+    assert not mutated <= set(SWIFT_POLICY_SITES)


### PR DESCRIPTION
## What changed

- added three fail-closed Phase 143 ledgers for execution/capability sites, routing authority, and owner/fallback surfaces
- registered Python runner entrances and physical leaves, repository-wide semantic Ask/Recipe/Sequence/Workflow callers, and seven explicit Swift legacy bypasses
- classified every current mutable route family, public resolver, `profile_id` read, browser selector, and Swift retry/fallback policy site
- added mutation tests so new unregistered doors fail the build
- closed Story 143-01 with paired DW evidence and updated the downstream story contracts where the census exposed real ownership

## Why

Phase 143 replaces scattered model selection with one capability/profile/assignment/router system. That migration needs an executable baseline which fails when a new route or provider door appears; a hand-written architecture inventory was not sufficient.

## Impact

No product runtime behavior changes. Story 02 and Story 03 can now implement the canonical capability registry and reusable profile/binding authority against a ratified, build-breaking source of truth.

## Validation

- `56 passed` — Phase 143 censuses + Phase 131 one-path + API surface
- `19 passed` — focused census and synthetic mutation suite
- Ruff clean on all three new test modules
- `git diff --check` clean
- independent owner and counsel reviews: RATIFY
- `dw check holdspeak` reaches only the pre-existing Phase 101 evidence/status mismatch recorded in the Story 01 evidence
