### PR TITLE
test(models): stabilize runtime proof glass

### DIFF
--- a/tests/e2e/test_hs141_models_setup_glass.py
+++ b/tests/e2e/test_hs141_models_setup_glass.py
@@ -62,6 +62,10 @@ def test_models_setup_is_projected_truth_with_one_action_seat(tmp_path: Path, mo
         if distribution == "llama-cpp-python"
         else original_package_revision(distribution, fallback),
     )
+    # The glass exercises the supported local-model picker independent of the
+    # CI image's optional llama.cpp wheel.  Version and importability are both
+    # parts of the server's runtime proof, so freeze both facts together.
+    monkeypatch.setattr(setup_module, "_package_available", lambda module: module == "llama_cpp")
     original_runtime_version = acquisition_module.importlib.metadata.version
     monkeypatch.setattr(
         acquisition_module.importlib.metadata,

--- a/tests/unit/test_inference_setup_capability_truth.py
+++ b/tests/unit/test_inference_setup_capability_truth.py
@@ -372,7 +372,18 @@ def test_local_preset_union_and_mlx_runtime_use_real_dependency(tmp_path: Path, 
 
 
 def test_http_and_mcp_share_exact_envelope_and_agent_cannot_discover(tmp_path: Path, monkeypatch):
+    import holdspeak.services.inference_setup_service as setup_service_module
+
     db, service = _service(tmp_path)
+    # HTTP and MCP are compared as transports, not as two hardware sampling
+    # instants.  Disk availability can change between the sequential reads, so
+    # hold the server observation fixed while proving exact DTO parity.
+    hardware = setup_service_module.inspect_hardware(home=tmp_path, now=NOW)
+    monkeypatch.setattr(
+        setup_service_module,
+        "inspect_hardware",
+        lambda *, home, now: hardware,
+    )
     app = FastAPI()
 
     @app.middleware("http")


### PR DESCRIPTION
## Summary
- freeze the complete llama.cpp runtime proof in the Models browser glass
- freeze hardware observation while comparing HTTP and MCP transport DTOs
- remove CI-host dependency and live-disk timing from the assertions

## Verification
- `PYTHONPATH=. .venv/bin/pytest -q tests/e2e/test_hs141_models_setup_glass.py tests/e2e/test_hs142_model_acquisition_glass.py tests/unit/test_inference_setup_capability_truth.py tests/unit/test_inference_model_acquisition.py` (31 passed)
- `git diff --check`
- `dw gate`