### PR TITLE
docs: complete repository-wide accuracy sweep

### DIFF
--- a/.guru_meditation.md
+++ b/.guru_meditation.md
@@ -1,5 +1,11 @@
 # Guru Meditation: HoldSpeak
 
+> Historical architecture review captured on 2026-06-07. Counts, roadmap
+> status, frontend technology, and recommendations below describe that moment;
+> they are not current operating guidance. Start with
+> [`README.md`](README.md), [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), and
+> [`docs/internal/DOC_AUDIT_2026-08.md`](docs/internal/DOC_AUDIT_2026-08.md).
+
 Date: 2026-06-07
 
 ## Interrupt Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,32 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
 
 > **0.x, early but real.** HoldSpeak is published on PyPI (`pip install
 > holdspeak`). APIs, config, and defaults can still change while it is pre-1.0;
-> upgrades are safe by default (your database is backed up first).
+> database shape is reconciled additively, with a timestamped backup before an
+> existing database needs a real shape change.
 
 ## [Unreleased]
 
 ### Added
+- **One Model Library and one Assignments editor.** Models are registered once,
+  secrets stay in owner-only custody, and each capability receives an ordered
+  model list without adding or editing a model silently changing placement.
+  The inference router freezes route/operation plans, records every physical
+  attempt, and applies the same admission rules across Web, CLI, MCP, and jobs.
+- **The Door is the front page.** The React Desk opens on a working board with
+  upcoming calendar events, scheduled recordings, meetings, and honest action
+  verbs. Multiple ICS sources are independently bounded and reported; a
+  calendar screenshot can be reviewed into a local ICS source; **Record this**
+  arms an event through the normal scheduled-recording conductor.
+- **Thought Workbench.** Notes can be developed through an explicit interview,
+  with preserved originals, user-selected context, frozen context revisions,
+  placement/egress receipts, and no background model call on open or edit.
+- **Encrypted People records.** Relationship material lives in a dedicated
+  AES-256-GCM sidecar whose data key is held by the native credential store.
+  It fails closed when key custody is unavailable and is excluded from normal
+  search, sync, exports, Cadence, backups, and generic MCP projections.
+- **Delivery and operation authority.** Consequential operations now use one
+  typed policy, scoped grants, payload/destination binding, and durable receipts
+  across actuator, dictation, coder-steering, and sync/cadence families.
 - **The mesh knows its models.** A new synced `model` manifest ("this node has
   this model, with these capabilities") joins the sync wire as its eleventh
   kind: devices advertise their installed models on push, the hub stores them
@@ -23,6 +44,21 @@ and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.
   cards on the desk, speak or type an instruction, keep the printed answer —
   now persists as an artifact whose provenance names every card it read and
   the exact prompt, on the synced wire the web and hub already read.
+
+### Changed
+- The default control posture is YOLO. Registered fixed-destination operations
+  may execute from captured posture authority, while Secure and Normal retain
+  explicit decisions and bounded grants. Identity, secret custody,
+  destination/payload binding, audit receipts, and schema safety cannot be
+  weakened by control mode.
+- Meeting actuator and webhook allow-lists default to wildcard enabled. The
+  connector manifest, configured-destination checks, payload parity, and audit
+  path still apply, and operators can narrow the lists.
+- Database startup uses declarative additive reconciliation instead of a
+  hand-maintained version ladder. `schema_version` is informational; a newer
+  stamp alone is not a refusal condition.
+- The browser product is one React 19/Vite application served by FastAPI. The
+  earlier Astro designer handoff is retained only as an archived snapshot.
 
 ### Fixed
 - The iPad's printed run card and routing theater stated where the run went

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,8 @@ regressions. If you touch anything under `web/`, rebuild the static bundle
 (`cd web && npm run build`; Node ≥ 22.12) since some tests read the built JS.
 Before changing web pages or their scripts, read
 [`docs/internal/ARCHITECTURE_WEB_FRONTEND.md`](docs/internal/ARCHITECTURE_WEB_FRONTEND.md)
-— it records the page decomposition pattern (section partials + behavior
-modules), the Astro scoped-CSS-on-JS-rendered-DOM trap, and the density
-budgets a guard test enforces. Before changing `web_runtime.py` or
+— it records the React/Vite source boundaries, Desk surface-core pattern,
+runtime bus, design-token contract, and the architectural guards. Before changing `web_runtime.py` or
 `meeting_session/`, read
 [`docs/internal/ARCHITECTURE_BACKEND_RUNTIME.md`](docs/internal/ARCHITECTURE_BACKEND_RUNTIME.md)
 — the backend twin: the mixin pattern, where patch targets live, and the

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Read [Models](docs/MODELS.md) for setup or the internal
 [Intelligence Router architecture](docs/internal/ARCHITECTURE_INTELLIGENCE_ROUTER.md)
 for the technical mechanics.
 
-> **Status: 0.x, early but real.** HoldSpeak is on PyPI (`pip install holdspeak`).
-> The features are mature; APIs, config, and defaults can still change while it is
-> pre-1.0. Upgrades are safe by default (your data is backed up first). Feedback
-> and contributions welcome.
+> **Status: 0.x, early but real.** The latest published release is
+> `holdspeak==0.4.0` on PyPI. This README tracks `main`, which includes
+> unreleased work after `0.4.0`; install from a checkout when you need exact
+> documentation parity. APIs, config, and defaults can still change before
+> 1.0. Shape-changing database upgrades create a backup first.
 
 ## The two modes
 
@@ -186,9 +187,9 @@ of reach by design.
   [meeting intelligence](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md).
 - **Honest by construction.** `holdspeak doctor` reports what is actually
   broken. The import panel says which timestamps are approximate. The learning
-  digest never inflates a count. Upgrades back your database up before
-  touching it and refuse to open data written by a newer build. The docs hold
-  themselves to the same bar.
+  digest never inflates a count. A database shape change creates a backup
+  before the additive reconcile runs, and a newer informational schema stamp
+  is not mistaken for corruption. The docs hold themselves to the same bar.
 
 ## See it learn
 
@@ -254,8 +255,8 @@ they do; pick the one that fits.
 | Tool | What it does better | What HoldSpeak does better |
 |---|---|---|
 | **OS dictation** (Apple Dictation, Windows Voice Typing) | Zero setup, free, always available | Your own models, LLM rewriting with project context, the learning loop, meetings |
-| **Local Whisper apps** (superwhisper, MacWhisper, VoiceInk) | Simpler setup, polished single-purpose UX | The LLM stays local too (their AI modes often call cloud APIs), a visible learning loop, meeting intelligence, Linux support |
-| **AI dictation services** (Wispr Flow, Aqua Voice) | Out-of-box accuracy and editing polish, no model management | Your voice never leaves your machine, open source, no subscription, meetings |
+| **Local Whisper apps** (superwhisper, MacWhisper, VoiceInk) | Simpler setup, polished single-purpose UX | Owner-chosen model endpoints, a visible learning loop, meeting intelligence, Linux support |
+| **AI dictation services** (Wispr Flow, Aqua Voice) | Out-of-box accuracy and editing polish, no model management | Local transcription, explicit destination boundaries, open source, no subscription, meetings |
 | **Talon** | The deepest hands-free coding and computer control there is | Prose-first dictation with LLM rewriting, lower learning curve, meeting intelligence |
 | **Raw Whisper tooling** (whisper.cpp scripts) | Total control, minimal surface | A product: typing integration, routing, the journal, meetings, a web UI |
 
@@ -265,7 +266,7 @@ Windows build today, and Wayland limits global hotkeys to best effort.
 
 ## Quickstart
 
-Install from PyPI and launch the web runtime:
+For the latest published release:
 
 ```bash
 pip install holdspeak
@@ -274,17 +275,26 @@ holdspeak          # launch the web runtime (the browser opens on the Desk)
 
 Prefer [`uv`](https://docs.astral.sh/uv/)? `uv pip install holdspeak`.
 
-Or use the install script (creates an isolated venv and a `holdspeak` launcher),
-or work from a clone:
+The documentation on `main` includes features added after the `0.4.0` release.
+For exact parity with these docs, install from a current checkout:
+
+```bash
+git clone https://github.com/karolswdev/HoldSpeak.git
+cd HoldSpeak
+uv pip install -e .
+holdspeak
+```
+
+The install script creates an isolated venv and a `holdspeak` launcher. It pins
+the latest release by default; set `HOLDSPEAK_REF=main` only when you
+deliberately want the unreleased source state:
 
 ```bash
 # one-line install
 curl -fsSL https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/scripts/install.sh | bash
 
-# or from a clone (for development)
-git clone https://github.com/karolswdev/HoldSpeak.git && cd HoldSpeak
-uv pip install -e .
-holdspeak
+# unreleased main in the same isolated layout
+curl -fsSL https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/scripts/install.sh | HOLDSPEAK_REF=main bash
 ```
 
 ### Your first sentence
@@ -333,10 +343,11 @@ pip install 'holdspeak[dictation-openai]' # the dictation pipeline via an OpenAI
 
 Your whole HoldSpeak database is a single SQLite file. Before a version jump you
 can snapshot it with `holdspeak backup`, and put one back with `holdspeak
-restore`. Upgrades are safe by default: HoldSpeak backs up an older database
-before it touches it, and refuses to open a database written by a newer build
-rather than risk your data. `holdspeak doctor` reports the schema and config
-state it found. The full policy is in
+restore`. On open, HoldSpeak reconciles missing tables and columns additively.
+It backs up an existing database before a real shape change and never drops an
+unknown table, column, or row. The schema stamp is informational, so a database
+stamped by a newer build opens without a version-gate refusal. `holdspeak
+doctor` reports the schema and config state it found. The full policy is in
 [`docs/RELEASING.md`](https://github.com/karolswdev/HoldSpeak/blob/main/docs/RELEASING.md).
 
 ## Platform support
@@ -398,8 +409,8 @@ dictionary on that dictation path, reads a meeting back with its artifacts,
 confidence, and sources, closes the meeting's loop from the aftercare digest
 (an accepted action item becomes a GitHub issue proposal, typed against a
 repo you name inline), reviews every pending proposal for a meeting wherever
-it was created (the human gate stays its own step, and approving a Slack
-send carries the cloud mark because that approval executes), searches and
+it was created (Secure and Normal keep the human authorization step; default
+YOLO can execute an eligible configured destination immediately), searches and
 filters the archive with the same facets the web has (narrowed on the hub,
 never a stale page filtered locally), imports a recording or transcript file
 into the hub's full intelligence pipeline (the new meeting appears

--- a/aipi-lite/IMPORT.md
+++ b/aipi-lite/IMPORT.md
@@ -1,5 +1,9 @@
 # AIPI-Lite Import Note
 
+> Historical provenance record for the original repository import. Paths,
+> branch names, commit IDs, and the listed dirty files are intentionally
+> point-in-time facts, not current setup instructions.
+
 This directory makes the AIPI-Lite firmware and bridge a first-class part of
 the HoldSpeak checkout.
 

--- a/aipi-lite/README.md
+++ b/aipi-lite/README.md
@@ -113,20 +113,20 @@ For the full operations guide (daemonising, PSK rotation,
 multi-device meetings, the troubleshooting table) see
 [`docs/HOLDSPEAK_BRIDGE.md`](docs/HOLDSPEAK_BRIDGE.md).
 
-## Project status
+## Software status
 
-- **Phase 1 — Provisioning:** implementation-complete on disk;
-  hardware verification + close-out is the open item. Multi-SSID +
-  captive portal + BLE + serial + factory-reset gestures are all
-  wired in `aipi.yaml`.
-- **Phase 2 — Bridge protocol translator:** in-progress; pairs
-  with HoldSpeak HS-14. The thin-forwarder rewrite is on `main`;
-  hardware end-to-end smoke + close-out remaining.
-- **Phase 3 — Cross-network transport:** scaffolding open. TLS
-  (`wss://`), tunnel/VPN choice, PSK lifecycle. Pairs with HoldSpeak
-  HS-15.
+- `aipi.yaml` implements multi-SSID provisioning, captive portal, BLE Improv,
+  serial recovery, and factory-reset gestures. Hardware-specific behavior still
+  needs validation on the exact board and peripherals you flash.
+- The Python bridge is the implemented thin protocol translator and has unit
+  coverage for configuration, protocol shapes, audio helpers, and reconnect
+  behavior. Use `--check` before an end-to-end hardware run.
+- The bridge currently constructs plaintext `ws://` and `http://` HoldSpeak
+  URLs. Its safe default is a co-located bridge talking to HoldSpeak on
+  `127.0.0.1`; it does not provide TLS termination for a cross-network link.
 
-Roadmap detail: [`pm/roadmap/aipi-lite/`](pm/roadmap/aipi-lite/).
+Historical roadmap and hardware evidence:
+[`pm/roadmap/aipi-lite/`](pm/roadmap/aipi-lite/).
 
 ## A note to the community
 

--- a/aipi-lite/docs/HOLDSPEAK_BRIDGE.md
+++ b/aipi-lite/docs/HOLDSPEAK_BRIDGE.md
@@ -30,7 +30,7 @@ the typing/transcription pipeline. The bridge only translates events:
   firmware's `update_screen` API service.
 
 Wire contract: see HoldSpeak's
-`~/dev/HoldSpeak/docs/DEVICE_PROTOCOL.md`. Don't duplicate it
+[`../../docs/DEVICE_PROTOCOL.md`](../../docs/DEVICE_PROTOCOL.md). Don't duplicate it
 here — that doc is canonical.
 
 ---
@@ -38,7 +38,7 @@ here — that doc is canonical.
 ## 2. Prerequisites
 
 - **HoldSpeak** running on the host where you want voice typing
-  to land. See `~/dev/HoldSpeak/README.md` for install. Minimum:
+  to land. See [`../../README.md`](../../README.md) for install. Minimum:
   the `holdspeak` web runtime up (`holdspeak web`).
 - **AIPI-Lite** flashed with the production firmware. See
   [`PROVISIONING.md`](./PROVISIONING.md) for first-time flash and
@@ -77,9 +77,9 @@ here — that doc is canonical.
    ```
 
    The port is in HoldSpeak's startup log
-   (`Uvicorn running on http://127.0.0.1:<port>`). For phase 14
-   the runtime binds to `127.0.0.1` only — run the bridge on the
-   same machine.
+   (`Uvicorn running on http://127.0.0.1:<port>`). The default runtime binds to
+   `127.0.0.1`, so run the bridge on the same machine unless you have deliberately
+   configured and secured an off-loopback deployment.
 
 3. **Configure the bridge:**
 
@@ -174,15 +174,15 @@ include its `device_id` in the meeting-start payload.
      ```
 
 3. **Speak naturally.** Audio streams continuously into HoldSpeak
-   regardless of button state — meetings own the recorder. Per
-   HS-14-06, button presses during an active meeting are
+   regardless of button state — meetings own the recorder. Button presses during an active meeting are
    server-side no-ops (HoldSpeak ignores attached-device
    `start`/`stop` frames while the meeting is recording).
 4. **End the meeting** from the HoldSpeak dashboard. HoldSpeak
    transcribes per-segment and runs its meeting-intelligence
    pipeline (topics, action items, summary) either inline or via
-   the deferred queue — see `~/dev/HoldSpeak/holdspeak/intel.py`
-   for which path your install uses.
+   the deferred queue — see
+   [`../../holdspeak/intel_queue.py`](../../holdspeak/intel_queue.py) for the
+   queue implementation.
 5. **The transcript** shows segments tagged with the device's
    label (`DEVICE_LABEL` from `bridge.env`, defaults to
    `DEVICE_ID`). Multi-device meetings tag each segment with the
@@ -402,8 +402,9 @@ state-publish loses to an immediate connection close (observed live
 - Provisioning: [`PROVISIONING.md`](./PROVISIONING.md)
 - Roadmap: [`pm/roadmap/aipi-lite/`](../pm/roadmap/aipi-lite/) —
   full phase + story breakdowns, decisions, risks
-- HoldSpeak protocol (canonical): `~/dev/HoldSpeak/docs/DEVICE_PROTOCOL.md`
+- HoldSpeak protocol (canonical):
+  [`../../docs/DEVICE_PROTOCOL.md`](../../docs/DEVICE_PROTOCOL.md)
 - HoldSpeak device-side implementation:
-  `~/dev/HoldSpeak/holdspeak/device_audio.py`,
-  `~/dev/HoldSpeak/holdspeak/device_audio_ws.py`,
-  `~/dev/HoldSpeak/holdspeak/voice_typing.py`
+  [`../../holdspeak/device_audio.py`](../../holdspeak/device_audio.py),
+  [`../../holdspeak/device_audio_ws.py`](../../holdspeak/device_audio_ws.py),
+  [`../../holdspeak/voice_typing.py`](../../holdspeak/voice_typing.py)

--- a/apple/ARCHITECTURE.md
+++ b/apple/ARCHITECTURE.md
@@ -42,7 +42,7 @@ domain (`Contracts`/`RuntimeCore`) never links it. The package manifest
 | 2 | `RuntimeCore` | Meeting-intelligence engine, MIR routing, the sync engine. No UI, no engine. | Contracts, Providers |
 | 3 | `Providers` | The port protocols (`I*`) + their Foundation adapters (audio core, transcription registry, SQLite storage, model store/downloader, HTTP sync + queue, the endpoint LLM provider). | Contracts |
 | 3 | `InferenceLlama` | `LlamaProvider` — the on-device (Mode A) `ILLMProvider` on **llama.cpp via LLM.swift**. Kept a separate product so the engine never links into the domain. | Providers, Contracts, LLM.swift |
-| 4 | `Hosts` | The SwiftUI iPad/iPhone apps (Phases 8–9). | RuntimeCore, Providers, Contracts |
+| 4 | `Hosts` + `App/` | Shared host code and the native SwiftUI iPad/iPhone app. | RuntimeCore, Providers, Contracts |
 
 ## The provider seams (Layer 3)
 

--- a/apple/README.md
+++ b/apple/README.md
@@ -1,78 +1,84 @@
-# HoldSpeak Mobile (Apple)
+# HoldSpeak for Apple platforms
 
-The Apple runtime of the HoldSpeak ecosystem (iPhone/iPad). Roadmap + canon live
-at [`../pm/roadmap/holdspeak-mobile/`](../pm/roadmap/holdspeak-mobile/); this is
-the Swift codebase that roadmap builds.
+This directory contains the Swift runtime, native iPhone/iPad application
+sources, and device-build tooling for HoldSpeak. The architectural map is
+[`ARCHITECTURE.md`](./ARCHITECTURE.md); historical roadmap and contract rationale
+live under [`../pm/roadmap/holdspeak-mobile/`](../pm/roadmap/holdspeak-mobile/).
 
-**New here? Read [`ARCHITECTURE.md`](./ARCHITECTURE.md)** — the map of the four
-layers, the provider seams, the two inference modes, the meeting-intelligence + MIR
-path, and sync.
+## Layout
 
-## Layout (charter four-layer architecture)
-
-```
+```text
 Sources/
-  Contracts/    # Layer 1 — language-neutral schema as Swift Codable types (Foundation only)
-  RuntimeCore/  # Layer 2 — meeting/artifact/MIR engines, persistence, sync (no UI)
-  Providers/    # Layer 3 — ITranscriber / ILLMProvider / IAudioCapture / IStorage / ISyncProvider
-  Hosts/        # Layer 4 — iPad/iPhone SwiftUI apps (the only UI layer)
-Tests/
-  ContractsTests/  # round-trips the Phase-0 golden fixtures
+  Contracts/       language-neutral Codable contracts
+  RuntimeCore/     meeting, artifact, routing, persistence, and sync logic
+  Providers/       audio, transcription, storage, endpoint, and sync adapters
+  InferenceLlama/  llama.cpp-backed on-device inference adapter
+  Hosts/           shared host-facing Swift code
+App/               native SwiftUI app and harness entry points
+Tests/             package tests for all runtime layers
+scripts/           generated-Xcode-project and physical-device workflows
 ```
 
-**Layer rule (enforced):** `Contracts`, `RuntimeCore`, and `Providers` import no
-SwiftUI/UIKit/WebKit — business logic does not depend on UI (charter Architecture
-§Principle).
+Only host/application code imports SwiftUI or UIKit. `Contracts`, `RuntimeCore`,
+and `Providers` remain UI-independent; the package and layer-guard tests enforce
+that boundary.
 
-## Build & test
+The supported deployment floors declared by `Package.swift` are macOS 14 and
+iOS 17. Swift tools version 6.0 is required.
+
+## Build and test the runtime
 
 ```bash
 cd apple
-swift build      # compiles all four layers (macOS host)
-swift test       # round-trips the Phase-0 fixtures through Swift Codable
+swift build
+swift test
 ```
 
-The `Contracts` types are written against
-[`../pm/roadmap/holdspeak-mobile/contracts/`](../pm/roadmap/holdspeak-mobile/contracts/)
-(the schemas + serialization contract + golden fixtures). The tests read those
-same fixtures, so the Swift and Python runtimes are validated against one source.
+The contract tests read the golden wire fixtures under the mobile roadmap, so
+Swift and Python are checked against the same serialized shapes. Tests needing
+a real model, endpoint, or device are opt-in; see
+[`ARCHITECTURE.md`](./ARCHITECTURE.md#testing).
 
-### Launch the shell on a device
+## Run the native app
+
+The primary physical-device workflow generates a signed Xcode project under the
+gitignored `apple/build/` directory, builds it, installs it, and launches it:
 
 ```bash
-# Simulator (Gate 1, no signing): iPhone + iPad simulators, screenshots each.
-scripts/gate1-launch.sh
-
-# Physical device (Gate 1 on real metal): build → sign → install → launch via
-# devicectl. Auto-selects a connected iPad. One-time prereqs (all persist):
-#   Xcode > Settings > Accounts signed in · latest Apple Developer PLA accepted ·
-#   Developer Mode on the device · the device registered in the account.
-scripts/gate1-device.sh [device-udid]
+cd apple
+scripts/meeting-capture-device.sh [device-udid]
 ```
 
-`gate1-device.sh` calls `gen-device-project.rb` to generate a signed iOS app
-project under `build/` (gitignored). Override the signing team with `HS_TEAM=…`.
+One-time prerequisites are an Xcode account with an accepted developer
+agreement, a trusted/registered device with Developer Mode enabled, and valid
+automatic signing. The script prefers a connected iPad, then an iPhone. Review
+the script before running it: as part of signing recovery it clears cached local
+provisioning profiles so Xcode can regenerate them for the selected device.
 
-## Serve the mesh
+Other scripts are purpose-built harnesses rather than alternate production app
+roots:
 
-The device can host runs for the whole mesh: Settings → "Serve my models to
-the mesh" (off by default). While the toggle is on and the app is in the
-foreground, a worker (`MeshServeWorker`, Providers layer) claims relayed runs
-from the paired hub and executes them on this device's own active profile —
-its model, its Keychain key; neither ever leaves the device. Hub-side, a
-profile with the Mesh node kind naming `iPad`/`iPhone` routes any run here,
-badged `Mesh · <node>`. Closing the app reads offline within seconds and
-further runs refuse fast, naming the node. Serving requires an on-device
-model or an endpoint profile — a profile that itself runs elsewhere refuses
-to serve, by name.
+- `gate1-launch.sh` and `gate1-device.sh`: minimal shell smoke tests.
+- `harness-device.sh`: endpoint/inference harness.
+- `local-harness-device.sh`: on-device inference harness.
+- `speak-harness-device.sh`: speech/dictation harness.
+- `push-model-device.sh`: copy a GGUF into an installed app container.
 
-## Status
+Each device script prints its exact prerequisites and accepted arguments.
 
-Phase 1 (Mobile Foundation): the SPM package + `Contracts` types are in
-(HSM-1-01/02). CI (HSM-1-03) and the on-device launch closeout (HSM-1-04) are the
-remaining Phase-1 stories. The SwiftUI app target / Xcode project arrives with the
-iPad (Phase 8) and iPhone (Phase 9) experience phases; `Hosts` is a placeholder
-until then so the package builds + tests on the macOS host.
+## Mesh serving
 
-Provisional iOS floor: 17 — revisit at Phase 5 (if Core ML wins, `MLState` moves
-it to 18; PROGRAM-RISKS P6).
+The native app can serve its active model to the paired HoldSpeak mesh. Enable
+**Serve my models to the mesh** in Settings. Serving is off by default and
+foreground-only: while enabled, `MeshServeWorker` claims signed work from the
+hub and executes it with the device's own model and Keychain-held endpoint key.
+The model and key stay on the device. Closing the app makes the node offline and
+later runs refuse with the node named.
+
+## Current status
+
+The Swift package and native app are both implemented. `App/MeetingCapture/`
+contains the flagship desk, recording/review, models, sync, companion, and mesh
+surfaces; the remaining app entry points are focused test and compatibility
+harnesses. Treat `pm/` as historical planning/evidence, not as the current
+product-status reference.

--- a/designer-handoff/README.md
+++ b/designer-handoff/README.md
@@ -1,9 +1,13 @@
-# HoldSpeak Designer Handoff
+# Archived HoldSpeak Designer Handoff
 
-This directory packages the current HoldSpeak UI/UX layer for a graphic
-designer and product designer. It describes what exists, what each screen
-does, where the interaction boundaries are, and which screenshots represent
-the current implementation.
+> Historical snapshot captured on 2026-04-29 from the retired Astro frontend.
+> It is preserved for design archaeology and is not a current product map.
+> See [`../docs/WEB_DESK.md`](../docs/WEB_DESK.md),
+> [`../docs/internal/DESIGN_SYSTEM.md`](../docs/internal/DESIGN_SYSTEM.md), and
+> [`../web/README.md`](../web/README.md) for the React/Vite implementation.
+
+This directory packages that snapshot for a graphic or product designer. It
+describes the screens and visual language that existed at capture time.
 
 ## Product Frame
 
@@ -24,7 +28,7 @@ The design direction should stay quiet, dense, and trustworthy:
 
 - [functional-handoff.md](./functional-handoff.md) - screen-by-screen behavior,
   workflows, and interaction states.
-- [style-handoff.md](./style-handoff.md) - current visual language, constraints,
+- [style-handoff.md](./style-handoff.md) - captured visual language, constraints,
   and open style questions.
 - [ux-inventory.md](./ux-inventory.md) - routes, components, controls, data
   states, and designer review checklist.
@@ -32,9 +36,9 @@ The design direction should stay quiet, dense, and trustworthy:
   each one is meant to evaluate.
 - [capture-screenshots.py](./capture-screenshots.py) - repeatable Playwright
   capture script.
-- [screenshots/](./screenshots/) - Playwright screenshots of the current app.
+- [screenshots/](./screenshots/) - Playwright screenshots of the archived app.
 
-## Current Capture Target
+## Archived Capture Target
 
 Screenshots were captured from the local web runtime:
 

--- a/designer-handoff/functional-handoff.md
+++ b/designer-handoff/functional-handoff.md
@@ -1,5 +1,8 @@
 # Functional Handoff
 
+> Archived 2026-04-29 Astro-era snapshot. It does not describe the current
+> React/Vite Desk; start with [`../docs/WEB_DESK.md`](../docs/WEB_DESK.md).
+
 ## Global Navigation Model
 
 HoldSpeak currently exposes several local web routes:

--- a/designer-handoff/screenshot-index.md
+++ b/designer-handoff/screenshot-index.md
@@ -1,5 +1,8 @@
 # Screenshot Index
 
+> Archived 2026-04-29 Astro-era capture set. These images are not current UI
+> reference material; see [`../docs/WEB_DESK.md`](../docs/WEB_DESK.md).
+
 Screenshots are captured from the local running app and stored in
 [`screenshots/`](./screenshots/).
 

--- a/designer-handoff/style-handoff.md
+++ b/designer-handoff/style-handoff.md
@@ -1,6 +1,10 @@
 # Style Handoff
 
-## Current Visual Language
+> Archived 2026-04-29 Astro-era snapshot. Current design tokens and components
+> are documented in
+> [`../docs/internal/DESIGN_SYSTEM.md`](../docs/internal/DESIGN_SYSTEM.md).
+
+## Captured Visual Language
 
 Phase 12 replatformed the values layer onto a **Workbench-evoking
 voice** — symbolic of Amiga Workbench, not a literal pixel

--- a/designer-handoff/ux-inventory.md
+++ b/designer-handoff/ux-inventory.md
@@ -1,5 +1,9 @@
 # UX Inventory
 
+> Archived 2026-04-29 Astro-era inventory. Routes and components below are
+> historical; see [`../docs/WEB_DESK.md`](../docs/WEB_DESK.md) for the current
+> Desk.
+
 ## Routes
 
 | Route | Purpose | Main User |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,18 +19,19 @@ hardware-facing pieces and a local FastAPI server (`MeetingWebServer`) that
 serves the web UI and the API. Two modes run on top of the same building
 blocks:
 
-- **Dictation** turns held-key or wake-word speech into typed text, with an
-  optional pipeline that routes and rewrites it before it lands.
+- **Dictation** turns held-key or wake-word speech into typed text. Its
+  always-on pipeline routes it through local stages and uses a model only for
+  configured model-backed stages.
 - **Meetings** turn captured or imported audio into a transcript, typed
-  artifacts, and an aftercare digest, with approval-gated actions out.
+  artifacts, and an aftercare digest, with control-mode-authorized actions out.
 
-Transcription is local (`Transcriber`, MLX or faster-whisper). The LLM runs
-wherever you pointed it: since HS-112-01 the `profiles` table is the single
-source of truth for endpoint and model identity (an `InferenceTarget`), each
-feature holds one pointer into it, and `resolve_inference_target` is the one
-resolver. State lives in one SQLite database behind
-a set of repositories. Nothing takes an outbound action without an explicit
-approval, and the network crossings are enumerated in the
+Transcription is local (`Transcriber`, MLX or faster-whisper). Model Library is
+the authority for available model profiles, Assignments owns the ordered
+compatible choices for each registered capability, and the Intelligence Router
+freezes the selected route before a physical attempt. State lives in one SQLite
+database behind a set of repositories. Outbound actions require audited
+authority from the captured control posture, a scoped grant, or a per-action
+decision, and the network crossings are enumerated in the
 [trust boundary](#the-trust-boundary) below and in
 [`SECURITY.md`](SECURITY.md).
 
@@ -138,7 +139,7 @@ flowchart TB
     TY["Keyboard inject<br/>(typer.py)"]
     DESK["The Desk, the operating surface<br/>(web/src/desk/: WebGL stage + windows,<br/>every product surface a window at /)"]
     UI["The rooms + presence<br/>(web/src/pages/, desktop_presence.py)"]
-    BUS["Runtime bus, the one /ws per page<br/>(web/src/scripts/runtime-bus.js)"]
+    BUS["Runtime bus, the one /ws per page<br/>(web/src/runtime/RuntimeBus.tsx)"]
     CN["Gated connectors<br/>(plugins/gated_connector.py)"]
   end
 
@@ -359,13 +360,13 @@ flowchart TD
   IR --> LLM(["LLM backend"])
   HOST --> ART["Typed artifacts:<br/>decisions, action items, ADRs, risk registers, and more"]
   RUNB["An Agent / chain / workflow run<br/>(web/routes/primitives/)"] -- "run-born artifact,<br/>lineage names the capability" --> ART
-  GRAPH["A Workbench graph, authored on the iPad canvas<br/>or the web desk, synced as graph_json"] -- "linear subset runs;<br/>control flow refused with a warning<br/>(web/routes/workflow_graph.py)" --> RUNB
+  GRAPH["A Workbench graph, authored on the iPad canvas<br/>or the web desk, synced as graph_json"] -- "linear subset runs;<br/>control flow refused with a warning<br/>(services/sequence_workflow_service.py)" --> RUNB
   ART --> AFT["Aftercare digest:<br/>open, decided, changed since last time<br/>(meeting_aftercare.py)"]
   AFT --> ISSUE["An accepted action becomes<br/>a GitHub issue proposal"]
   AFT --> SLACK["The digest or draft becomes<br/>a Send to Slack proposal (slack_export.py)"]
-  ISSUE --> APV{"Propose, approve, execute<br/>(plugins/actuator_executor.py)"}
+  ISSUE --> APV{"Propose, authorize, execute<br/>(plugins/actuator_executor.py)"}
   SLACK --> APV
-  APV -. "approved only" .-> EXT(["GitHub, Slack"])
+  APV -. "authorized only" .-> EXT(["GitHub, Slack"])
 ```
 
 ### The scheduled recording conductor

--- a/docs/CADENCE.md
+++ b/docs/CADENCE.md
@@ -70,9 +70,11 @@ is off. The switch only governs the autonomous in-runtime tick.
 This is a *pressure system*, not an autonomous agent. The guarantees, enforced by tests
 rather than good intentions:
 
-1. **No external side effect without your approval.** Any outbound action (a GitHub
-   issue, a Slack post) goes through HoldSpeak's existing propose, approve, execute
-   path. Cadence never calls a connector directly.
+1. **No external side effect without audited authority.** Any outbound action (a
+   GitHub issue, a Slack post) goes through HoldSpeak's proposal, authority, and
+   guarded-execution path. Eligible fixed destinations can execute under the
+   captured YOLO posture; Normal/Secure require a decision or bounded grant.
+   Cadence never calls a connector directly.
 2. **The cadence core is pure.** It performs no network, terminal, subprocess, or
    connector execution. A test fails the build if that ever changes. Every surface that
    does reach out (the Telegram bot, the agent-reply delivery, the LLM provider) lives

--- a/docs/DICTATION_COPILOT.md
+++ b/docs/DICTATION_COPILOT.md
@@ -129,7 +129,7 @@ so the task still landed in the right block.
 | # | Feature | What happened above | Configure with |
 |---|---------|---------------------|-----------------|
 | ① | **Multi-pass rewriting** | Drafted, then critiqued + tightened in a second pass (latency-budget-gated). | `rewrite_passes: 2` |
-| ② | **Correction memory** | A correction you made last session (`this kind of utterance → agent_task_buildout`) nudged routing. The LLM classifier actually *failed* on this turn; the correction **rescued** it. **Persists across restarts** (DB-backed); curate it in `/dictation → Memory`. | Always on (pinned since HS-139-02). |
+| ② | **Correction memory** | A correction you made last session (`this kind of utterance → agent_task_buildout`) nudged routing. The LLM classifier actually *failed* on this turn; the correction **rescued** it. **Persists across restarts** (DB-backed); curate it in `/dictation → Memory`. | Always on. |
 | ③ | **Model-assisted target** | No window signal was available (the Wayland/terminal reality). The heuristic gave `unknown@0.00`; below the threshold, the LLM **inferred** `claude_code` from your words. A manual override always wins. | `target_detect_llm_enabled: true` |
 | ④ | **KB injection** | The matched block injected the project's stack / invariants / definition-of-done before the rewrite. | add a block with an `inject` template |
 
@@ -143,7 +143,7 @@ text un-typeable.
 the cockpit to configure its runtime and depth:
 
 ```
-/dictation -> Runtime         # pick a runtime and model destination
+/dictation -> Runtime         # choose a runtime and assigned model
 /dictation -> Runtime -> Copilot depth   # rewrite passes and model-assist
 /dictation -> Memory          # see + curate what the copilot has learned
 ```
@@ -182,10 +182,10 @@ at any local or LAN [OpenAI-compatible / GGUF / MLX endpoint](./MODELS.md)):
 }
 ```
 
-The endpoint and model are not config fields any more (HS-112-01). Author the
-endpoint once as a destination under **Settings, Models** and pick it as the
-dictation **Runs on**; assigning it also selects the `openai_compatible`
-backend. Set or replace its key inline in **Settings, Models**; the environment
+The endpoint and model are not dictation config fields. Add the endpoint once
+in **Settings > Models > Model Library** and select it for **Writing &
+dictation** in **Assignments**; assigning it also selects the
+`openai_compatible` backend. Set or replace its key in Model Library; the environment
 variable `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless fallback.
 
 </details>

--- a/docs/DICTATION_PIPELINE_GUIDE.md
+++ b/docs/DICTATION_PIPELINE_GUIDE.md
@@ -104,7 +104,7 @@ In `/dictation -> Runtime`, set:
 | Backend | `openai_compatible` |
 | Base URL | `http://127.0.0.1:8000/v1` |
 | Model | `qwen2.5-7b-instruct` |
-| API key | Set inline in **Settings, Models**; optional headless fallback `HOLDSPEAK_PROFILE_<ID>_KEY` |
+| API key | Set on the model profile in **Model Library**; optional headless fallback `HOLDSPEAK_PROFILE_<ID>_KEY` |
 | Timeout seconds | `8` |
 
 Config file shape:
@@ -125,12 +125,13 @@ Config file shape:
 }
 ```
 
-The endpoint and model are not config fields (HS-112-01). Author the endpoint
-once as a destination under **Settings, Models** and pick it as the dictation
-**Runs on**; assigning it also selects the `openai_compatible` backend. See
+The endpoint and model are not dictation config fields. Add the endpoint once
+in **Settings > Models > Model Library** and select it for **Writing &
+dictation** in **Assignments**; assigning it also selects the
+`openai_compatible` backend. See
 [MODELS.md](./MODELS.md).
 
-Set the destination key inline in **Settings, Models**. For a headless hub,
+Set the model profile's key in Model Library. For a headless hub,
 `HOLDSPEAK_PROFILE_<ID>_KEY` remains the fallback. Do not put API keys in
 `.hs/` files.
 
@@ -423,7 +424,7 @@ confidence threshold.](assets/cockpit/copilot-depth.png)
 | Control (Runtime → Copilot depth) | Knob (`dictation.pipeline`) | Default | What it does |
 | --- | --- | --- | --- |
 | **Rewrite passes** (segmented 1-5) | `rewrite_passes` | `1` | Project-rewriter passes (draft → critique → refine). `1` is single-pass. Extra passes are skipped if they would breach `max_total_latency_ms`. |
-| **Learn from my corrections** | `corrections_enabled` | `true` | Always on (pinned since HS-139-02). Consult the **correction memory** when routing: a correction you made earlier nudges a similar later utterance. |
+| **Learn from my corrections** | `corrections_enabled` | `true` | Always on. Consult the **correction memory** when routing: a correction you made earlier nudges a similar later utterance. |
 | **Infer the target when unsure** (toggle) | `target_detect_llm_enabled` | `false` | When window/app detection is unsure, ask the LLM to infer the **output target** from your words. A manual override always wins. |
 | **Ask the model below confidence** (slider) | `target_detect_llm_below` | `0.8` | The heuristic-confidence threshold below which the LLM fallback fires. |
 
@@ -453,8 +454,7 @@ timings.](assets/cockpit/memory-panel.png)
 
 The **What the copilot has learned** panel lists every persistent correction
 (kind · gist · → corrected value · when) with a remove (`×`) on each, an **add**
-form and a **Forget all** button. Correction memory is always on (pinned
-since HS-139-02).
+form and a **Forget all** button. Correction memory is always on.
 
 **Model-assisted target detection.** On Wayland/terminal setups where the active
 window can't be read, the heuristic returns low confidence; with the fallback on,
@@ -729,11 +729,11 @@ wipe*, not from being off:
   are checked with the same secret-shape filter the correction memory uses; a
   field that looks like it carries a key/token is redacted, so a secret never
   lands in the journal.
-- **Retention-capped.** The journal keeps the most recent 500 entries
-  (pinned since HS-139-02) and prunes older ones on every write.
+- **Retention-capped.** The journal keeps the most recent 500 entries and
+  prunes older ones on every write.
 - **Curatable.** Delete any single entry, or **Clear journal** to wipe it all,
   from the tab.
-- **Always on.** The journal is always enabled (pinned since HS-139-02);
+- **Always on.** The journal is always enabled;
   journaling is a pure side-channel that never changes what gets typed or
   how fast.
 
@@ -830,8 +830,8 @@ The learning is real, local, and bounded. Be clear-eyed about what it is:
   threshold. The "learned from N similar" count everywhere in the UI is that same
   measure, run over your journal. There is no hidden training and no embedding
   model, which is also why the count is honest and easy to reason about.
-- **Always on for routing.** Correction memory is always enabled (pinned
-  since HS-139-02). A correction nudges routing from the moment you make it.
+- **Always on for routing.** Correction memory is always enabled. A correction
+  nudges routing from the moment you make it.
 - **It is local.** Corrections and the journal live on your machine, gist-only
   and secret-filtered, like everything else in this loop. A secret-shaped
   correction teaches nothing, and the confirmation says so.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -10,7 +10,16 @@ Desk automatically. No extra setup is required before that first value.
 
 ## 1. Install
 
-From a checkout:
+The latest published release is `0.4.0`:
+
+```bash
+python -m pip install holdspeak
+```
+
+This guide tracks `main`, which includes unreleased work after `0.4.0`. For
+exact parity with the screens and features described below, install from a
+checkout. Building the bundled Web app requires npm and a Vite-compatible
+Node.js release (20.19+ or 22.12+):
 
 ```bash
 uv pip install -e .
@@ -279,12 +288,12 @@ preserving edits, filing, attachments, and deletions. To deliberately restore
 the furnished defaults, use the destructive, confirmed **Settings, Desk →
 Reset to seed** action.
 
-For model-backed work or headless deployment, open **Settings, Models → Choose
-your AI**. Pick an OpenRouter Qwen preset, point **This device** at a GGUF chat
-model, or define any compatible provider and choose it for the relevant job. A
+For model-backed work or headless deployment, open **Settings > Models > Model
+Library**. Add a local GGUF, preset, or compatible endpoint, then choose the
+ordered model list for each relevant job in **Assignments**. A
 `HOLDSPEAK_PROFILE_<ID>_KEY` environment variable remains the headless key
-fallback. See [Models (bring your own)](MODELS.md) and [Inference
-destinations](INFERENCE_TARGETS.md) for those optional contracts.
+fallback. See [Models (bring your own)](MODELS.md) and [Models and
+assignments](INFERENCE_TARGETS.md) for those optional contracts.
 
 ## 11. Configure model-backed rewriting later
 
@@ -329,6 +338,6 @@ Once hold-to-talk feels natural, the rest is one setting away each:
   works, turn on the project-aware copilot.
 - [Meeting Mode Guide](MEETING_MODE_GUIDE.md): meeting-specific setup and capture.
 - [Models (bring your own)](MODELS.md): pick and point at an LLM.
-- [Inference destinations](INFERENCE_TARGETS.md): the destination contract behind
-  Settings, Models.
+- [Models and assignments](INFERENCE_TARGETS.md): availability, job selection,
+  frozen plans, and secret custody.
 - [Security & Privacy](SECURITY.md): what's stored and what can leave your machine.

--- a/docs/MEETING_MODE_GUIDE.md
+++ b/docs/MEETING_MODE_GUIDE.md
@@ -4,7 +4,7 @@ A meeting should end with decisions, owners, and follow-ups, not a recording
 you never reopen. Meeting Mode captures your microphone plus remote
 participants' audio, transcribes in real time, and runs meeting intelligence
 over the transcript: typed artifacts, action items, aftercare, and
-approval-gated follow-through. It runs local-first, with optional endpoint
+audited follow-through. It runs local-first, with optional endpoint
 inference when configured.
 
 ## Table of Contents
@@ -36,7 +36,7 @@ holdspeak meeting --setup
 # 3. Start HoldSpeak web runtime (default command)
 holdspeak
 
-# 4. Start a meeting from the dashboard ("Start meeting") or POST /api/meeting/start
+# 4. Open Meetings > Record and choose "Start meeting"
 ```
 
 ---
@@ -56,19 +56,18 @@ holdspeak
   Bring your own; any GGUF chat model works (see [MODELS.md](./MODELS.md)). A
   current small/mid instruct model (e.g. a Qwen3.5 build) is a good default;
   larger models give better intel at the cost of speed.
-- Optional endpoint mode: `intel_provider: "cloud"` (or `auto` fallback) points
-  at **any OpenAI-compatible endpoint**: a self-hosted LAN server, Ollama, vLLM,
-  llama.cpp-server, or a hosted API. Author the endpoint once as a destination
-  under **Settings, Models** and pick it as the meetings **Runs on**; the API
-  key is optional for keyless self-hosted endpoints. The `intel_cloud_*`
-  config fields are dead (HS-112-01): an upgrade converts a configured legacy
-  endpoint into a `legacy-intel` destination, once.
+- Optional endpoint mode: add an OpenAI-compatible endpoint to **Settings >
+  Models > Model Library**, then select it for **Meetings** in **Assignments**.
+  This supports self-hosted LAN servers, Ollama, vLLM, llama.cpp-server, and
+  hosted APIs. A key is optional for a keyless self-hosted endpoint. Legacy
+  `intel_cloud_model`, `intel_cloud_api_key_env`, and `intel_cloud_base_url`
+  values are migration inputs only; an upgrade converts them to a model profile
+  once.
 
 ### For Web Interfaces
-- **FastAPI + Uvicorn** - Web server dependencies
-```bash
-uv pip install fastapi uvicorn
-```
+
+FastAPI and Uvicorn are core HoldSpeak dependencies; no separate web install is
+needed. Building the browser app from source requires Node.js 20.19+ or 22.12+.
 
 ---
 
@@ -129,7 +128,7 @@ runs inside it.
 
 ### Starting a Meeting
 
-From the web runtime, use the dashboard controls (the **Start meeting** button)
+From the web runtime, open **Meetings > Record** and use **Start meeting**
 or the API directly:
 - `POST /api/meeting/start` to begin a meeting
 - `POST /api/meeting/stop` to stop and persist meeting output
@@ -175,17 +174,12 @@ Use this during or after meetings for cross-session management:
 - Manage deferred-intel queue (list jobs, process now, retry meeting jobs)
 - Manage deferred MIR plugin queue (list jobs, process due jobs, force retry scheduled jobs, retry/cancel individual jobs)
 - Run MIR CLI dry-run and manual reroute flows for saved meetings
-- Edit app settings from browser, including cloud options:
-  - `intel_provider` (`local`, `cloud`, `auto`)
-  - the endpoint itself is not a settings field: it is the destination picked
-    as the meetings **Runs on** under Settings, Models. The settings write path
-    strips `intel_cloud_model`, `intel_cloud_api_key_env`, and
-    `intel_cloud_base_url` from the wire (HS-112-01).
-  - `intel_cloud_store` (**dead, HS-112-01**): when `true`, HoldSpeak sends OpenAI's `store` flag with
-    each request. **Advisory:** this only takes effect if your endpoint honors
-    the `store` parameter (OpenAI does; many OpenAI-compatible servers ignore
-    unknown fields). HoldSpeak forwards the flag but cannot guarantee the remote
-    acts on it; verify with your provider if retention matters.
+- Edit app settings in the browser. Add runnable models in **Model Library** and
+  choose the ordered model list for **Meetings** in **Assignments**. The
+  low-level `intel_provider` (`local`, `cloud`, or `auto`) and provider tuning
+  remain available in the Meetings raw settings. When `intel_cloud_store` is
+  true, HoldSpeak forwards the OpenAI `store` flag; compatible endpoints may
+  ignore it, so verify retention behavior with the endpoint operator.
 
 ### Multiple Clients
 
@@ -204,7 +198,7 @@ a copy-as-Markdown card at `/history`:
 
 HoldSpeak supports three intelligence modes:
 - `local`: requires a local GGUF model
-- `cloud`: uses your configured OpenAI-compatible endpoint and destination key
+- `cloud`: uses your assigned OpenAI-compatible endpoint and model-profile key
 - `auto`: local-first, then cloud fallback
 
 ### Where your transcripts go (egress posture)
@@ -234,9 +228,10 @@ MIR classifies each meeting segment against multiple intent categories simultane
 
 **Enabling MIR**
 
-MIR is always on (pinned to `true` since HS-139-02; no longer a user
-toggle). The `mir_enabled` field remains in the config dataclass but is
-not exposed on the Settings surface.
+MIR controls are available in the shipped runtime. Automatic intent-window
+routing is opt-in: enable **Intent router** in the Meetings settings or set
+`meeting.intent_router_enabled` to `true`. The low-level `mir_enabled` field is
+pinned on and is not an ordinary Settings toggle.
 
 **Intent Routing Presets**
 
@@ -253,7 +248,7 @@ The active preset sets which intents are weighted most heavily and which plugin 
 Change the preset from the web dashboard (Intent routing preset in the live meeting view) or in config:
 
 ```json
-{ "meeting": { "mir_profile": "architect" } }
+{ "meeting": { "routing_profile": "architect" } }
 ```
 
 **During a Meeting**
@@ -288,13 +283,14 @@ Notes:
 For local-first capture plus remote intel on your LAN:
 
 1. Run an OpenAI-compatible endpoint on homelab (for example vLLM/Ollama-compatible API).
-2. Author it as a destination under **Settings, Models** (with the endpoint's
-   `http://host:port/v1` URL) and pick it as the meetings **Runs on**. There
-   is no hand-edited alternative; `intel_cloud_base_url` is dead.
-3. Deferred intel is always on (`intel_deferred_enabled` pinned to `true`
-   since HS-139-02), so meetings continue when the homelab is temporarily
+2. Add it in **Settings > Models > Model Library** with the endpoint's
+   `http://host:port/v1` URL.
+3. Select that model for **Meetings** in **Assignments**. Deferred intelligence
+   remains enabled, so meetings continue when the homelab is temporarily
    unavailable.
-4. Set the destination key inline in **Settings, Models** and run `holdspeak doctor` to preflight reachability and model availability. `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless fallback; the Runs on line names the destination each pipeline resolves to.
+4. Set the model profile's key in Model Library and run `holdspeak doctor` to
+   preflight reachability and availability. `HOLDSPEAK_PROFILE_<ID>_KEY`
+   remains a headless fallback.
 
 ### What It Extracts
 
@@ -386,23 +382,27 @@ a real timestamp resolves to a real segment, so there is no misleading jump to
 
 When you have reviewed and accepted an action item, a "File as issue" button
 appears on it in the panel. It opens a small form for a target repo (`owner/name`)
-and creates a GitHub-issue **proposal**. This reuses the existing actuator system
-(propose, then approve, then execute), so filing here records a proposal only.
-Nothing leaves your machine at this step.
+and creates a GitHub-issue **proposal**. Proposal construction never performs the
+connector call itself. The captured control posture then decides whether the
+proposal waits for authorization or can proceed immediately.
 
 ![The "File as issue" proposal in the Proposed actions section: a create_issue -> github proposal awaiting approval, showing the full payload preview (repo, title, body) with Approve and Reject controls.](assets/aftercare/file-as-issue.png)
 
-*The filed proposal lands in the existing Proposed actions section, awaiting your approval. Execution is a separate, audited step.*
+*In Secure or Normal mode, the filed proposal lands in Proposed actions and
+waits for your decision. Execution remains a separate, audited lifecycle axis.*
 
-The execution posture depends on your control mode (HS-139-08):
+The execution posture depends on your control mode:
 
 - **On by default (YOLO posture).** `allow_actuators` defaults to `true` with a
-  wildcard allow-list. Under YOLO, proposals to a registered destination
-  auto-execute at creation and produce a receipt. You can switch to neutral or
-  safe posture in Settings > System to restore manual approval.
-- **Human-approved under neutral/safe.** Under neutral or safe posture, you
+  wildcard allow-list. Under YOLO, an eligible proposal to a registered fixed
+  destination can be authorized by the captured posture and execute at creation,
+  producing a receipt. Switch to Normal or Secure in **Settings > System** to
+  require a decision or bounded grant.
+- **Reviewed under Normal/Secure.** Under Normal or Secure, you
   approve or reject each proposal yourself in the Proposed actions section.
-  Approval only records the decision; execution is a separate step.
+  For registered Slack, webhook, and GitHub targets, approval also invokes the
+  guarded executor in the same request; review and execution state remain
+  separate in the record.
 - **Audited, and what executes is what you saw.** Every state change is recorded,
   and a payload-parity check aborts execution if the stored payload no longer
   matches what was approved.
@@ -431,19 +431,21 @@ a "Send to Slack" button on the digest and another on the follow-up draft.
 With no URL configured, the buttons do not exist and nothing about Slack
 appears anywhere.
 
-![The aftercare panel with Send to Slack configured: a green Send to Slack pill in the panel header, the follow-up draft open with Copy draft and Send to Slack side by side, and the one-line note that sending creates a proposal you approve.](assets/aftercare/send-to-slack.png)
+![The aftercare panel with Send to Slack configured: a green Send to Slack pill in the panel header, the follow-up draft open with Copy draft and Send to Slack side by side, and the one-line authority note.](assets/aftercare/send-to-slack.png)
 
-*The one outbound door: the green buttons appear only after you configure a webhook URL, and they create proposals, not sends.*
+*The one outbound door: the green buttons appear only after you configure a
+webhook URL. In Normal or Secure they create a proposal awaiting authority; in
+YOLO an eligible fixed-destination proposal can execute immediately.*
 
 How a send actually works:
 
 1. Clicking the button creates a **proposal** in the Proposed actions
    section. The proposal's preview is the exact message Slack will receive,
    so what you read is what posts, byte for byte.
-2. **Approving the proposal is the moment it posts.** Unlike the
-   GitHub-issue flow above, you initiated this send yourself and the
-   approval is your confirmation, so HoldSpeak posts immediately on
-   approval. Rejecting it ends there; nothing is sent.
+2. The captured control posture resolves authority. In YOLO, an eligible send
+   to the configured fixed destination posts immediately and records a receipt.
+   In Normal or Secure, **approving the proposal is the moment it posts**;
+   rejecting it ends there.
 3. The message can only ever go to the host of the URL you configured. The
    connector refuses any other destination before a single byte leaves, and
    a failed post is recorded honestly on the proposal.
@@ -553,11 +555,10 @@ Configuration file: `~/.config/holdspeak/config.json`
 
 ### Meeting Settings
 
-User-configurable keys the `meeting` config block still holds, with
-defaults. Keys pinned by HS-139-02 (always-on values removed from the
-Settings surface) and killed by HS-139-01 (no runtime consumer) are
-omitted; the `intel_cloud_*` keys are listed because they persist on
-disk but are dead (HS-112-01) and the reference table says so per row.
+The browser Settings surfaces are the preferred editor. This representative
+`meeting` block shows the supported low-level controls most often needed for
+capture, intelligence, routing, and connectors. Model placement itself belongs
+in Model Library and Assignments, not in hand-authored endpoint fields.
 
 ```json
 {
@@ -573,15 +574,17 @@ disk but are dead (HS-112-01) and the reference table says so per row.
     "intel_retry_failure_webhook_url": null,
     "intel_retry_failure_webhook_header_name": null,
     "intel_retry_failure_webhook_header_value": null,
-    "intel_cloud_model": "gpt-5-mini",
-    "intel_cloud_api_key_env": "OPENAI_API_KEY",
-    "intel_cloud_base_url": null,
     "intel_cloud_reasoning_effort": null,
     "intel_cloud_store": false,
     "intel_summary_model": null,
+    "routing_profile": "balanced",
+    "intent_router_enabled": false,
     "allow_actuators": true,
     "allowed_actuators": ["*"],
     "webhook_allowed_hosts": ["*"],
+    "slack_webhook_url": "",
+    "companion_webhook_url": "",
+    "companion_github_repo": "",
     "diarization_enabled": false,
     "diarize_mic": false,
     "similarity_threshold": 0.75
@@ -589,15 +592,9 @@ disk but are dead (HS-112-01) and the reference table says so per row.
 }
 ```
 
-> **Pinned defaults (HS-139-02):** The following fields still exist in the config
-> dataclass but are pinned to their values and no longer appear on the Settings
-> surface: `intel_enabled` (true), `intel_deferred_enabled` (true),
-> `mir_enabled` (true), `mic_label` ("Me"), `remote_label` ("Remote"),
-> `cross_meeting_recognition` (true), `web_auto_open` (true).
->
-> **Killed (HS-139-01):** `intel_queue_poll_seconds`,
-> `intel_retry_failure_alert_percent`, `intel_retry_failure_hysteresis_minutes`
-> had no runtime consumer and were removed entirely.
+`intel_cloud_model`, `intel_cloud_api_key_env`, and `intel_cloud_base_url` are
+accepted only for one-time migration from older installations. Do not use them
+for new configuration. Model Library and Assignments are authoritative.
 
 ### Option Details
 
@@ -614,28 +611,25 @@ disk but are dead (HS-112-01) and the reference table says so per row.
 | `intel_retry_failure_webhook_url` | string | null | Optional HTTP(S) webhook for sustained failure alerts |
 | `intel_retry_failure_webhook_header_name` | string | null | Optional custom header name added to failure-alert webhooks |
 | `intel_retry_failure_webhook_header_value` | string | null | Optional custom header value (set together with header name) |
-| `intel_cloud_model` | string | "gpt-5-mini" | **Dead (HS-112-01).** Read once by the legacy migration, then ignored. The model comes from the meetings Runs on destination. |
-| `intel_cloud_api_key_env` | string | "OPENAI_API_KEY" | **Dead (HS-112-01).** Set the destination key inline in **Settings, Models**; `HOLDSPEAK_PROFILE_<ID>_KEY` remains the per-destination headless fallback. |
-| `intel_cloud_base_url` | string | null | **Dead (HS-112-01).** Read once by the legacy migration, then ignored. The URL comes from the meetings Runs on destination. |
-| `intel_cloud_reasoning_effort` | string | null | **Dead (HS-112-01).** Read only by the one-time legacy migration. |
-| `intel_cloud_store` | bool | false | **Dead (HS-112-01).** Read only by the one-time legacy migration. |
+| `intel_cloud_reasoning_effort` | string | null | Optional reasoning effort forwarded to compatible endpoint models. |
+| `intel_cloud_store` | bool | false | Forward the OpenAI `store` flag; endpoint support and retention behavior vary. |
 | `intel_summary_model` | string | null | Path to larger model for end-of-meeting summary. Falls back to realtime model if null. |
-| `allow_actuators` | bool | true | Master switch for actuator execution (HS-139-08: on by default). |
+| `routing_profile` | string | `balanced` | MIR weighting preset: `balanced`, `architect`, `delivery`, `product`, or `incident`. |
+| `intent_router_enabled` | bool | false | Enable automatic intent-window routing at meeting finalization. |
+| `allow_actuators` | bool | true | Master switch for actuator execution. Control mode still determines authority. |
 | `allowed_actuators` | list | `["*"]` | Per-actuator allow-list. `["*"]` = all actuators may execute. |
 | `webhook_allowed_hosts` | list | `["*"]` | Webhook host allow-list. `["*"]` = any host may be POSTed to. |
+| `slack_webhook_url` | string | `""` | Fixed Slack incoming-webhook credential. Empty keeps Slack aftercare offline. |
+| `companion_webhook_url` | string | `""` | Fixed generic webhook credential for the companion desk. |
+| `companion_github_repo` | string | `""` | Default `owner/name` repo for companion GitHub issue creation. |
 | `diarization_enabled` | bool | false | Enable speaker diarization for system audio |
 | `diarize_mic` | bool | false | Enable diarization for microphone stream |
 | `similarity_threshold` | float | 0.75 | Matching threshold for speaker recognition (`0.0` to `1.0`) |
 
-> **Pinned defaults removed from this table (HS-139-02):** `mic_label` ("Me"),
-> `remote_label` ("Remote"), `intel_enabled` (true), `intel_deferred_enabled`
-> (true), `web_auto_open` (true), `cross_meeting_recognition` (true),
-> `mir_enabled` (true). These fields still exist in the config dataclass but
-> are no longer user-configurable from the Settings surface.
->
-> **Killed fields removed (HS-139-01):** `intel_queue_poll_seconds`,
-> `intel_retry_failure_alert_percent`, `intel_retry_failure_hysteresis_minutes`
-> had no runtime consumer.
+The config model also retains defaults such as `mic_label`, `remote_label`,
+`intel_enabled`, `intel_deferred_enabled`, `cross_meeting_recognition`, and
+`mir_enabled`. They are intentionally absent from the ordinary Settings
+surface. Removed no-op fields are not part of this reference.
 
 ---
 
@@ -688,7 +682,7 @@ Health check endpoint.
 - `GET /api/meetings/{meeting_id}/aftercare` - read-only aftercare digest (open items by owner, decisions, the since-last-meeting diff)
 - `GET /api/meetings/{meeting_id}/followup-draft` - locally-assembled follow-up draft (preview + copy; nothing sent)
 - `POST /api/meetings/{meeting_id}/aftercare/file-issue` - file an accepted action as a GitHub-issue actuator proposal (under default YOLO, an eligible configured action executes with a receipt; Secure and Normal retain approval; audited)
-- `POST /api/meetings/{meeting_id}/export/slack` - propose sending the digest or follow-up draft to the configured Slack webhook (`what`: `digest` or `followup`; records a proposal whose preview is the exact message; refuses when no URL is configured)
+- `POST /api/meetings/{meeting_id}/export/slack` - propose sending the digest or follow-up draft to the configured Slack webhook (`what`: `digest` or `followup`; the preview is the exact message; captured YOLO may execute it immediately, while Normal/Secure wait for authority; refuses when no URL is configured)
 - `GET /api/all-action-items`
 - `PATCH /api/all-action-items/{item_id}` - update persisted action item status
 - `PATCH /api/all-action-items/{item_id}/review` - update persisted action item review state
@@ -771,7 +765,7 @@ Send `"ping"` text message, receive `"pong"` response.
 
 ### Web dashboard not loading
 
-1. Check FastAPI is installed: `uv pip install fastapi uvicorn`
+1. Verify the HoldSpeak installation: `holdspeak doctor`
 2. Verify the runtime URL printed at startup is accessible
 3. Check firewall isn't blocking localhost
 4. Try `/history` directly on the same port to confirm server health
@@ -780,12 +774,11 @@ Send `"ping"` text message, receive `"pong"` response.
 
 1. Run `holdspeak doctor` and check the `Cloud intel preflight` line.
 2. If it reports DNS/connection failures, verify the homelab hostname/IP, LAN routing, and firewall.
-3. If it reports auth failures (HTTP 401/403), check the destination key in
-   **Settings, Models**. For a headless hub, check the
-   `HOLDSPEAK_PROFILE_<ID>_KEY` fallback for the destination the meetings Runs
-   on picker names.
-4. If it reports model mismatch, set that destination's model to one of the model IDs exposed by `/models`.
-5. Verify that destination's base URL starts with `http://` or `https://` and includes the right API prefix (commonly `/v1`). PROBE in Settings, Models tests reachability.
+3. If it reports auth failures (HTTP 401/403), check the model profile's key in
+   **Settings > Models > Model Library**. For a headless hub, check its
+   `HOLDSPEAK_PROFILE_<ID>_KEY` fallback.
+4. If it reports model mismatch, set that profile's model to one of the model IDs exposed by `/models`.
+5. Verify that profile's base URL starts with `http://` or `https://` and includes the right API prefix (commonly `/v1`). **Probe** in Model Library tests reachability.
 
 ### Transcription quality is poor
 
@@ -797,8 +790,8 @@ Send `"ping"` text message, receive `"pong"` response.
 
 1. Use smaller quantization (Q4 instead of Q6)
 2. Close other applications
-3. Intel is always on (pinned since HS-139-02); to reduce memory, use a
-   smaller quantization or assign a lighter model as your Runs on destination.
+3. Meeting intelligence is enabled in the shipped configuration. To reduce
+   memory, use a smaller quantization or assign a lighter model to Meetings.
 
 ---
 

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -111,13 +111,15 @@ is a hint for rendering. The built-ins use these values:
 | `artifact_generator` | A diagram or formatted document | `mermaid_architecture`, `adr_drafter`, `stakeholder_update_drafter` |
 | `validator` | Flags gaps or issues | `action_owner_enforcer`, `scope_guard` |
 | `signals` | Extracted signals/intelligence | `customer_signal_extractor` |
-| `actuator` | Proposes an external side effect (approval-gated) | `followup_ticket_actuator` |
+| `actuator` | Proposes an external side effect (authority-gated) | `followup_ticket_actuator` |
 
 **Actuators propose; they never act on their own.** A plugin whose
 `kind` is `actuator` returns an `ActuatorProposal` from `run()`, a
 *description* of a side effect, which the host records (status
-`proposed`); the effect only happens after an explicit human **approval**
-and the governance gate, performed by a separate guarded executor. This
+`proposed`). A separate authority policy and guarded executor decide whether an
+eligible fixed-destination proposal may execute immediately under YOLO, is
+authorized by a scoped grant, or waits for an explicit decision under
+Normal/Secure. This
 is its own topic; see [Actuators](#actuators) below before authoring one.
 
 ### Execution mode
@@ -382,7 +384,7 @@ def create_plugin():            # zero-arg factory → a HostPlugin instance
 `invalid_execution_mode`, `unknown_profile`, `unknown_intent`), so you fix
 all issues in one pass. `actuator` **is** a valid `kind` (see
 [Actuators](#actuators)); a manifest may declare one, but executing its
-proposals is approval- and gate-controlled.
+proposals is authority- and gate-controlled.
 
 **Discovery.** Drop the file into `~/.holdspeak/plugin_packs/`
 (override with `HOLDSPEAK_USER_PLUGIN_PACKS_DIR`). At startup the loader
@@ -499,17 +501,16 @@ proposes an **external side effect** — file a ticket, post a message,
 open a PR comment. Because that *leaves the machine*, actuators are built
 around one invariant:
 
-> **No external side effect occurs without an explicit, audited,
-> per-action human approval — and what executes is exactly what was
-> previewed.**
+> **No external side effect occurs without captured, audited authority, and
+> what executes is exactly what was previewed.**
 
 The contract enforces that invariant by splitting "decide what to do"
 from "do it":
 
 ```
- actuator.run()        human          guarded executor
- ─────────────►  proposal  ──────►  approve  ──────►  execute  ──► audit
-   (proposes)    (persisted)      (HS approval UI)   (connector)
+ actuator.run()       authority policy        guarded executor
+ ─────────────► proposal ───────────────► authorized ───────► execute ──► audit
+   (proposes)   (persisted)       (posture / grant / review)  (connector)
 ```
 
 ### What an actuator returns: `ActuatorProposal`
@@ -546,14 +547,16 @@ Three independent gates stand between a proposal and a side effect:
 1. **Capability (`actuator`)** — to even *propose*, the host must have
    `actuator` in `enabled_capabilities`. It's off by default, so a
    registered actuator is `blocked` until an operator opts in.
-2. **Human approval** — execution acts only on an `approved` proposal.
-   Approve/reject happens in the meeting UI (or
-   `POST /api/meetings/{id}/proposals/{pid}/decision`); approving records
-   `decided_by` + an audit entry and performs **no** side effect.
-3. **Governance (`MeetingConfig`)** — `allow_actuators` is the master
-   switch (default `False`); `allowed_actuators` is a per-project
-   allow-list of actuator ids. **Default-safe:** off + empty ⇒ no
-   external side effect ever runs, even for an approved proposal.
+2. **Authority policy** — an executor receives only an `approved` proposal.
+   YOLO may authorize an eligible operation to a registered fixed destination
+   from the captured control posture. Normal and Secure require an explicit
+   review decision or an exact, bounded grant. For registered product
+   connectors, an approval request may invoke the executor immediately; review
+   and execution are still recorded as separate state axes.
+3. **Governance (`MeetingConfig`)** — `allow_actuators` is the master switch
+   and `allowed_actuators` is the per-actuator allow-list. Shipped configuration
+   defaults to `true` and `["*"]`; an individual host/executor constructor
+   remains closed unless explicitly enabled. Projects can narrow either value.
 
 ### The guarded executor
 
@@ -585,7 +588,7 @@ class FollowupTicketActuator:
     id = "followup_ticket_actuator"
     version = "0.1.0"
     kind = "actuator"
-    required_capabilities = ["actuator"]   # off by default → opt-in
+    required_capabilities = ["actuator"]   # the host must admit proposal creation
 
     def run(self, context):
         unowned = _first_unowned(context.get("action_items") or [])
@@ -615,7 +618,7 @@ register_followup_actuator(host)                       # opt-in, NOT in register
 result = host.execute("followup_ticket_actuator", context=ctx, ...)   # → status "proposed"
 record_actuator_proposal(db, run_from(result))         # persist
 
-# ... a human approves in the UI ...
+# Normal/Secure example: a human approves in the UI.
 db.actuators.transition_proposal(pid, to_status="approved", actor="karol")
 
 executor = ActuatorExecutor(
@@ -634,7 +637,7 @@ GitHub issue, POST to a webhook — the connector must still be unable to do
 anything it didn't declare. That's what
 [`build_gated_connector`](../holdspeak/plugins/gated_connector.py) gives you: a
 *write* connector behind a per-connector **permission manifest**, layered
-**under** the approval + policy + parity gates (it only ever *narrows* what can
+**under** the authority + policy + parity gates (it only ever *narrows* what can
 reach the wire — it never replaces a gate above it).
 
 A [`WriteConnectorManifest`](../holdspeak/plugins/gated_connector.py) declares
@@ -679,16 +682,17 @@ no tokens.) Tests inject a fake runner — no real `gh`:
 **Reference 2 — webhook POST (`network:outbound`).**
 [`webhook_post_actuator.py`](../holdspeak/plugins/builtin/webhook_post_actuator.py)
 proposes an HTTP POST (payload `{url, body}`); `build_webhook_connector` POSTs
-**only to an allow-listed host** — `MeetingConfig.webhook_allowed_hosts` (default
-empty ⇒ nothing posts). An off-list host is refused before egress; a non-2xx /
+**only to an allow-listed host** — `MeetingConfig.webhook_allowed_hosts`
+(`["*"]` in the shipped config, which can be narrowed to exact hosts). An
+off-list host is refused before egress; a non-2xx /
 transport error → `failed` + audit; the status is the result. A Slack/Teams
 incoming webhook is simply a URL whose host you add to the allow-list — not a
 bespoke API integration. Tests inject a fake client — no real HTTP:
 [`test_webhook_post_actuator.py`](../tests/unit/test_webhook_post_actuator.py).
 
 Both reference connectors are **host-side** (the executor injects them; they are
-not discovered packs) and **off by default** — reached only after approval + the
-policy/parity gates + the manifest. jira/linear/etc. are the same pattern (a CLI
+not discovered packs) and require explicit registration — reached only after
+authority resolution, the policy/parity gates, and the manifest. jira/linear/etc. are the same pattern (a CLI
 or webhook connector + a manifest), not separate machinery.
 
 ### Live proposals
@@ -699,10 +703,10 @@ When the pipeline produces a proposal, the `MeetingSession` emits a **read-only*
 / `reversible` only; the machine `payload` is **never** put on the wire — and the
 live dashboard shows it in a **"Pending actions"** panel with Approve / Reject.
 Live approval reuses the *same* gated decision endpoint
-(`POST /api/meetings/{id}/proposals/{pid}/decision`): it records a decision (+
-audit) and performs **no** side effect — it's a surface, not a new way to act.
-Default off; nothing broadcasts unless an actuator is registered + the capability
-enabled. See
+(`POST /api/meetings/{id}/proposals/{pid}/decision`). It records the decision
+and audit; for a registered connector target, that request can also invoke the
+guarded executor. Nothing broadcasts unless an actuator is registered and its
+capability is enabled. See
 [`test_live_proposals.py`](../tests/unit/test_live_proposals.py).
 
 ### Registering + testing
@@ -712,7 +716,7 @@ Register actuators **explicitly and opt-in** — `register_followup_actuator` /
 of `register_builtin_plugins`, so the default plugin set and routing chains stay
 unchanged. Test the loop end-to-end against a stub or injected connector (no real
 egress — inject the runner / HTTP client): assert the proposal is faithful, that
-executing **before** approval / with the gate off / when not allow-listed / for an
+executing **without authority** / with the gate off / when not allow-listed / for an
 operation the manifest doesn't admit performs **no** side effect, and that
 approve → execute writes the audited terminal state. See
 [`test_actuator_reference.py`](../tests/unit/test_actuator_reference.py).

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ Studio, and Settings are focused workrooms.
   word (hands-free entry, previewed before it types), the spoken language
   setting (any of Whisper's 99 languages), and the spoken-symbol dictionary.
 - **[Dictation Pipeline Setup](./DICTATION_PIPELINE_GUIDE.md)**: the project-aware
-  pipeline. Intent routing, project facts, Runs on destinations, and LLM rewriting.
+  pipeline. Intent routing, project facts, model assignments, and LLM rewriting.
 - **[Project knowledge: facts + context](./DICTATION_PIPELINE_GUIDE.md#5-set-up-project-knowledge)**:
   teach the copilot about a repo. Facts (the `project.yaml` KB, stamped in verbatim)
   and context (the `.hs/` files an optional rewrite reads) are two different things;
@@ -80,9 +80,10 @@ Studio, and Settings are focused workrooms.
   together, get a live transcript with speaker labels, review AI-extracted topics,
   actions, and artifacts at `/history`, then close the loop with aftercare: see
   what is still open, decided, or changed since last time, jump to the transcript
-  moment that justifies a result, file an accepted action as a human-approved
+  moment that justifies a result, file an accepted action as an authorized
   issue, draft the follow-up, or send the digest to your team with Send to
-  Slack (every send is a proposal you approve). Import recordings and transcripts you
+  Slack. Under the default YOLO control mode, an eligible configured destination
+  executes with a Receipt; Secure and Normal keep per-action approval. Import recordings and transcripts you
   already have (web upload or `holdspeak import`; vtt and srt keep their real
   timestamps and speaker names) and filter the archive by date, speaker, tag,
   and open actions.
@@ -90,7 +91,8 @@ Studio, and Settings are focused workrooms.
 ## Extend: build on it
 
 - **[MCP sidecar](./MCP_SIDECAR.md)**: the desk's programmable surface over
-  stdio. 127 tools and 32 resources, wired automatically
+  stdio. 135 tools across 30 domain families, with 29 resources in default
+  non-owner discovery and 32 for the owner, wired automatically
   in Claude Code via the repo's `.mcp.json`. The reference for families,
   model-invoking tools, trust model, resources, and the explicit opt-in,
   shared-intent-only People boundary.
@@ -99,11 +101,11 @@ Studio, and Settings are focused workrooms.
   items in Zones and inspect their results and Receipts.
 - **[Plugin Authoring](./PLUGIN_AUTHORING.md)**: write a meeting-intel plugin. The
   `HostPlugin` contract, prompt to LLM to structured output, rendering, sequences, and
-  the actuator propose/approve/execute flow.
+  the actuator proposal, authority, and execution flow.
 - **[Connector Development](./CONNECTOR_DEVELOPMENT.md)**: build a local activity
   connector (the `cli_enrichment` / `pipeline` / other kinds).
 - **[Claude/Codex automation hooks](./AGENT_HOOK_INSTALL.md)**: wire Claude/Codex automation hooks
-  into the intelligent-typing layer.
+  into the dictation pipeline.
 - **[Firefox Extension Guide](./FIREFOX_EXTENSION_GUIDE.md)**: the browser activity
   connector.
 - **[AIPI-Lite Developer Workflow](./AIPI_LITE_DEV_WORKFLOW.md)** and **[Device
@@ -125,8 +127,10 @@ Design RFCs, phase specs, and cross-platform/port planning live in
 context, not as user-facing guides, and some describe work in progress or already
 shipped. Also there: the docs working notes,
 **[`internal/DOCS_STYLE.md`](./internal/DOCS_STYLE.md)** (voice and page skeleton)
-and **[`internal/DOC_AUDIT_2026-06.md`](./internal/DOC_AUDIT_2026-06.md)** (the
-accuracy audit and canonical facts). A few highlights:
+and **[`internal/DOC_AUDIT_2026-08.md`](./internal/DOC_AUDIT_2026-08.md)** (the
+current accuracy audit and canonical facts). The
+**[June audit](./internal/DOC_AUDIT_2026-06.md)** remains a historical snapshot.
+A few highlights:
 
 - `internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md`: the parent plugin-system RFC.
 - `internal/PLAN_PHASE_DICTATION_INTENT_ROUTING.md`: the DIR-01 dictation pipeline spec.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,9 +1,9 @@
 # Releasing, upgrading, and your data
 
 This is the contract for how HoldSpeak versions itself, what happens to your
-data when you upgrade, and how to be safe about it. It is forward-looking: it
-describes how upgrades behave from this release on. There is no historical
-migration ladder, because no older versions were ever published.
+data when you upgrade, and how to be safe about it. HoldSpeak no longer carries
+an ordered historical migration ladder. Every supported database is reconciled
+against the canonical shape instead.
 
 If you are installing for the first time, start with
 [`GETTING_STARTED.md`](GETTING_STARTED.md) instead.
@@ -77,10 +77,9 @@ were in is still saved.
 
 `holdspeak doctor` reports the state it actually found, so you are never guessing:
 
-- **Database.** The stamped schema version reads as a pass. A database whose
-  shape differs from the build reads as a warning (the reconcile will bring it
-  forward on the next start and back it up first). A file that is not a
-  readable HoldSpeak database reads as a warning.
+- **Database.** The check reports the path, informational schema stamp, and
+  table count. A missing database is a clean first-run state. A file that is
+  not readable SQLite, or has no HoldSpeak tables, reads as a warning.
 - **Config.** A config newer than this build reads as a warning that some settings
   may be ignored. Otherwise it passes and shows the config version.
 
@@ -96,7 +95,8 @@ For whoever cuts a release:
    prints the new number. The drift test (`tests/unit/test_version_ssot.py`)
    enforces this, so step 4 also covers it.
 3. If the on-disk database or config shape changed, bump `SCHEMA_VERSION`
-   (`holdspeak/db/schema.py`) or `CONFIG_VERSION` (`holdspeak/config.py`). The
+   (`holdspeak/db/schema.py`) or `CONFIG_VERSION`
+   (`holdspeak/config/core.py`). The
    schema reconcile handles forward changes automatically (additive-only); the
    version bump is an informational stamp. Most releases change neither.
 4. Run the suite and read the output:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,8 +1,8 @@
 # HoldSpeak Security & Privacy Posture
 
 **Status:** living document.
-**Last updated:** 2026-08-18 (HS-139-08 open throttle: YOLO default posture,
-actuators on, People MCP default write; hard boundary unchanged).
+**Last updated:** 2026-08-29 (YOLO default posture, actuators on, People MCP
+default write; hard boundary unchanged).
 
 This document is the threat model for HoldSpeak: what data it holds, where that
 data lives, what can leave the machine, and the decisions behind its at-rest
@@ -128,16 +128,17 @@ HoldSpeak is **local-first**. The design goal is that nothing leaves your
 machine unless you explicitly choose a feature that sends it. The sections below
 make that promise auditable rather than aspirational.
 
-### Control posture (HS-139-08)
+### Control posture
 
 The control posture (`control_mode` in config) governs how actuator proposals
-are handled. Three modes exist: **YOLO**, **neutral**, and **safe**.
+are handled. Three product modes exist: **YOLO**, **Normal**, and **Secure**;
+their persisted wire values are `yolo`, `neutral`, and `safe`.
 
-**YOLO is the default** (owner ruling: ledger-not-gate). Under YOLO:
+**YOLO is the default.** Under YOLO:
 - Actuator proposals to a registered, configured destination auto-execute at
   propose time. Every execution writes an immutable receipt.
-- The propose-approve lifecycle is still intact as a code path and activates
-  under neutral or safe postures.
+- The propose-authorize-execute lifecycle remains intact and requires a
+  decision or exact bounded grant under Normal or Secure.
 - Actuators are on by default (`allow_actuators: true`) with a wildcard
   allowlist.
 
@@ -209,7 +210,7 @@ If that credential store is absent, locked, or mismatched, People fails closed.
 People content is excluded from the normal database, its safety backups, global
 FTS/Search/Ask/Memory, sync, exports/connectors, Cadence, generic MCP surfaces, and
 content-bearing logs. The People MCP adapter defaults to write capability for the local owner
-process (HS-139-08: ledger-not-gate). Leader-private content is always excluded
+process. Leader-private content is always excluded
 from MCP projections. The owner can set `HOLDSPEAK_MCP_PEOPLE_ACCESS=off` or
 `=read` to restrict; the hard boundary (encryption at rest, key custody,
 policy refusal matrix) does not loosen regardless of the access mode.
@@ -356,10 +357,10 @@ adds implementation detail but is not a second product inventory.
 | **Calendar snapshot extraction** (`services/calendar_snapshot_service.py`) | Owner imports a calendar screenshot via **IMPORT SCREENSHOT** or a Desk glass drop. | The screenshot image is sent to the vision model assigned to `calendar.snapshot_extract`. Where that assignment routes determines the egress: a local model means nothing leaves; a cloud endpoint means the image reaches that host, stated by the extraction result's egress badge. The generated `.ics` is a local file source and causes zero network egress. | Assignment-gated: no vision assignment means a named refusal, not a silent skip. The generated `.ics` passes through the same bounded parser as every ICS source (5 MiB, 14-day horizon, 128 occurrences per master event). |
 | **Deferred-intel failure webhook** (`intel_queue.py`, the `urlopen` send) | User configures `intel_retry_failure_webhook_url` | Queue statistics only (counts, rates), **no transcript** | Opt-in (URL must be set). |
 | **Wake-model download** (`wake_word.py`, first enable) | `wake_word.enabled` flipped on with models absent | Nothing leaves: an inbound fetch of the detection models (~7 MB) from the openWakeWord GitHub releases, once, cached locally | Opt-in (the feature is off by default); stated in the settings copy. Detection itself runs locally and no audio ever egresses. |
-| **Send to Slack** (`slack_export.py` → the gated webhook connector) | User configures `meeting.slack_webhook_url`; under YOLO posture (the default) the send auto-executes at propose time; under neutral/safe posture, per-action approval is required | The meeting digest or follow-up draft, exactly as previewed on the proposal (plain text; no transcript, no audio) | The URL must be set (consent for exactly its host; the connector refuses any other host before egress). Under YOLO, execution is immediate with a receipt; under neutral/safe, every send is a separate approval. The webhook URL is treated as a credential: never in proposals, broadcasts, or API responses. |
-| **Desk Slack relay** (`web/routes/desk_actuators.py` → the same gated webhook connector) | A desk or companion card proposes a Slack send; under YOLO the registered destination auto-executes; under neutral/safe, per-action approval | The proposed text, exactly as previewed (plain text) | Same gate as Send to Slack: `meeting.slack_webhook_url` must be set; the URL never rides a payload. |
-| **Desk webhook connector** (`web/routes/desk_actuators.py` → `actuator_shared.execute_webhook_proposal`) | `meeting.companion_webhook_url` is configured; under YOLO the registered destination auto-executes; under neutral/safe, per-action approval | The proposed text, exactly as previewed, to that one configured endpoint (Discord, Zapier, n8n, or any URL you set) | The URL must be set (consent for exactly its host). Every execution writes a receipt. The URL is a credential: never in proposals, broadcasts, or API responses. |
-| **Desk GitHub issue** (`web/routes/desk_actuators.py` → `gh issue create`) | The GitHub connector is enabled; under YOLO a registered repo auto-executes; under neutral/safe, per-action approval | The issue title and body, exactly as previewed, through your own `gh` CLI | Runs your authenticated `gh`, never a stored token of ours. Unregistered repos are refused even under YOLO. Distinct from the read-only enrichment row below. |
+| **Send to Slack** (`slack_export.py` → the gated webhook connector) | User configures `meeting.slack_webhook_url`; under YOLO posture (the default) the send auto-executes at propose time; under Normal/Secure, per-action authorization or an exact bounded grant is required | The meeting digest or follow-up draft, exactly as previewed on the proposal (plain text; no transcript, no audio) | The URL must be set (consent for exactly its host; the connector refuses any other host before egress). Under YOLO, execution is immediate with a receipt; under Normal/Secure, every send requires authority. The webhook URL is treated as a credential: never in proposals, broadcasts, or API responses. |
+| **Desk Slack relay** (`web/routes/desk_actuators.py` → the same gated webhook connector) | A desk or companion card proposes a Slack send; under YOLO the registered destination auto-executes; under Normal/Secure, per-action authorization or a grant is required | The proposed text, exactly as previewed (plain text) | Same gate as Send to Slack: `meeting.slack_webhook_url` must be set; the URL never rides a payload. |
+| **Desk webhook connector** (`web/routes/desk_actuators.py` → `actuator_shared.execute_webhook_proposal`) | `meeting.companion_webhook_url` is configured; under YOLO the registered destination auto-executes; under Normal/Secure, per-action authorization or a grant is required | The proposed text, exactly as previewed, to that one configured endpoint (Discord, Zapier, n8n, or any URL you set) | The URL must be set (consent for exactly its host). Every execution writes a receipt. The URL is a credential: never in proposals, broadcasts, or API responses. |
+| **Desk GitHub issue** (`web/routes/desk_actuators.py` → `gh issue create`) | The GitHub connector is enabled; under YOLO a registered repo auto-executes; under Normal/Secure, per-action authorization or a grant is required | The issue title and body, exactly as previewed, through your own `gh` CLI | Runs your authenticated `gh`, never a stored token of ours. Unregistered repos are refused even under YOLO. Distinct from the read-only enrichment row below. |
 | **Connector CLI enrichment** (`gh`, `jira` via subprocess) | User enables the connector pack | Entity IDs (PR/issue/ticket numbers) to the user's own CLI tools, which call their services | Opt-in + manifest permissions (`shell:exec`, `network:outbound`). |
 | **Mission-control receipts** (`missioncontrol_bridge.py` → `gh pr list`) | A rails repo is named in your project map (`~/.holdspeak/delivery_workbench.json`) and the desk conveyor is open | Nothing composed: a read of that repo's open pull requests through your own authenticated `gh` CLI (GitHub learns which repo asked) | The map is yours to author; the belt's routes are GET-only end to end (fitness-tested); `gh` missing or failing renders as a typed absence, never a retry loop. |
 | **PR receipts** (`delivery/pr_receipts.py` → `gh pr list`) | You click **Refresh** on the Pull requests section, or you set `pr_refresh_seconds` on a source's registry entry yourself | Nothing composed: one batched read of that registered repo's pull requests through your own authenticated `gh` (GitHub learns which repo asked). The optional **fetch** offered when a diff's commits are absent locally is a separate, explicit `git fetch` | Manual verb by default, never ambient; the cadence is per-source and hand-set. `gh` is grep-censused to this one module; a failing refresh degrades to a named stale row, keeping last-known-good. |
@@ -377,13 +378,14 @@ machine except via the connector CLIs above (entity IDs only).
 
 ## 5. Secrets handling
 
-- **Cloud API key**: Set, replace, or remove it inline in **Settings, Models**.
+- **Cloud API key**: Set, replace, or remove it on the model profile in
+  **Settings > Models > Model Library**.
   The value travels only through an owner-only secret write/delete subresource,
   never a general model-management resource, sync, DTOs, the database, read
   responses, logs, or receipts. The hub stores it locally in owner-only `0600` custody; reads report
   presence only. `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless fallback. A UI
-  deletion writes a tombstone that suppresses that fallback for the destination.
-  A destination never borrows another one's key.
+  deletion writes a tombstone that suppresses that fallback for the profile.
+  A profile never borrows another one's key.
 - **Device PSK**: generated lazily, stored in `config.json`
   (`device_audio.ensure_device_psk`); constant-time comparison; empty PSK fails
   closed.
@@ -394,7 +396,7 @@ machine except via the connector CLIs above (entity IDs only).
   a credential everywhere else: shown only in the Settings window, never on a
   proposal record, a broadcast, or any other API response (the connector
   joins it to the POST in memory at execution time).
-- **Runs on destination keys**: a destination stores only its definition:
+- **Model-profile keys**: a profile stores only its non-secret definition:
   name, kind, endpoint, model, and context window. Its key is local to the hub,
   never part of a general model-management resource or sync, and joined only at run time. The Settings
   read surface reports only whether a key is set; it never returns the value.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -57,7 +57,7 @@ Choose **Finish Thought** to finish immediately, with no confirmation step.
 Opening or editing the Workbench never starts AI by itself.
 If no runnable model is configured, Interview places **Set up AI** directly
 beneath the explanation and opens Settings in **Models**. On a phone, the fixed
-footer first takes you to that Interview action. After a model destination is
+footer first takes you to that Interview action. After a runnable model is
 saved, the open Workbench rechecks readiness and restores **Ask AI**
 automatically.
 
@@ -324,21 +324,21 @@ Use `openai_compatible` when the model is served somewhere else:
 - LiteLLM
 - OpenAI or another hosted compatible API
 
-The one path: add the endpoint once under **Settings, Models → AI connections**,
-then choose it for **Writing & dictation** under **Choose AI for each job**.
-Assigning a connection is itself the "run it there" instruction, so the
+The one path: add the endpoint once under **Settings > Models > Model Library**,
+then choose it for **Writing & dictation** under **Assignments**.
+Assigning a model is itself the "run it there" instruction, so the
 dictation backend follows. Set
-or replace its key inline in **Settings, Models**; the environment variable
+or replace its key on the model profile in Model Library; the environment variable
 `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless fallback.
 
 The old `dictation.runtime.openai_compatible_*` fields no longer configure
-anything (HS-112-01). An upgrade reads a configured legacy endpoint once,
-converts it into a destination named `legacy-dictation`, and points dictation
-at it; the legacy key env deliberately does not carry over.
+anything. An upgrade reads a configured legacy endpoint once,
+converts it into a model profile named `legacy-dictation`, and points dictation
+at it; the legacy key environment value deliberately does not carry over.
 `dictation.runtime.openai_compatible_timeout_seconds` is not part of the
-destination and still applies.
+model profile and still applies.
 
-Known-good endpoint families include llama.cpp server, LM Studio, Ollama's OpenAI bridge, vLLM, LiteLLM, and hosted OpenAI-compatible APIs. HoldSpeak uses the key you set inline for that destination, or its `HOLDSPEAK_PROFILE_<ID>_KEY` headless fallback. It does not put the key in the destination definition, config, or project context files. If the endpoint is unavailable, times out, or returns malformed output, HoldSpeak preserves the original transcript and surfaces the failure in dry-run/readiness output.
+Known-good endpoint families include llama.cpp server, LM Studio, Ollama's OpenAI bridge, vLLM, LiteLLM, and hosted OpenAI-compatible APIs. HoldSpeak uses the key you set on that model profile, or its `HOLDSPEAK_PROFILE_<ID>_KEY` headless fallback. It does not put the key in the profile definition, config, or project context files. If the endpoint is unavailable, times out, or returns malformed output, HoldSpeak preserves the original transcript and surfaces the failure in dry-run/readiness output.
 
 ## Project Context
 
@@ -691,14 +691,14 @@ Local-first behavior:
 
 Cloud or homelab behavior:
 
-- If you set `meeting.intel_provider` to `cloud` (or `auto`, which can fall back to it), meeting text may be sent to the destination you picked for analysis.
-- The one path: add the endpoint once under **Settings, Models → AI connections**,
-  then choose it for **Meetings** under **Choose AI for each job**. The
-  `intel_cloud_*` fields are dead (HS-112-01).
-- Use `holdspeak doctor` from the same shell environment to verify endpoint, model, TLS, DNS, and authentication; its Runs on line names the destination each pipeline resolves to.
+- If you set `meeting.intel_provider` to `cloud` (or `auto`, which can fall back to it), meeting text may be sent to the model endpoint you picked for analysis.
+- The one path: add the endpoint once under **Settings > Models > Model Library**,
+  then choose it for **Meetings** under **Assignments**. The
+  `intel_cloud_*` fields are legacy migration inputs and do not configure runs.
+- Use `holdspeak doctor` from the same shell environment to verify endpoint, model, TLS, DNS, and authentication; its placement line names the model each pipeline resolves to.
 
 The provider switch itself still lives in config (deferred intel is
-always on, pinned since HS-139-02):
+always on and no longer user-configurable):
 
 ```json
 {
@@ -798,8 +798,8 @@ and the iPad shows it:
 
 The iPad's own storage is schema safe the way the desktop is: it backs an older
 database up before migrating it, and refuses to open one written by a newer
-build rather than risk your data. The on-device screens for these are still
-coming together; the client layer they ride on is shipped and tested.
+build rather than risk your data. Its Settings readiness section reports that
+store health alongside the paired desktop's status.
 
 ### AIPI-Lite
 
@@ -1118,7 +1118,7 @@ Sensitive files:
 
 - Do not place secrets in `.hs/`.
 - Use `.hs/ignore` to document paths and topics that should not be injected.
-- Set destination keys inline in **Settings, Models**; use environment variables
+- Set model-profile keys in **Model Library**; use environment variables
   when provisioning a headless hub.
 
 ## Troubleshooting

--- a/docs/internal/DOCS_STYLE.md
+++ b/docs/internal/DOCS_STYLE.md
@@ -1,12 +1,13 @@
 # HoldSpeak docs style guide
 
-The 13 guides were written across many phases and drifted in tone and shape.
+HoldSpeak's live guides were written across many releases and can drift in tone
+and shape.
 This is the **floor** they should all clear — a shared voice and a standard page
 skeleton — so the set reads as one product, not an anthology. It is a floor, not
 a cage: reference docs keep their depth; a doc may add sections, just not skip the
 spine.
 
-Companion to [`DOC_AUDIT_2026-06.md`](./DOC_AUDIT_2026-06.md) (accuracy) — this
+Companion to [`DOC_AUDIT_2026-08.md`](./DOC_AUDIT_2026-08.md) (accuracy) — this
 one is **voice + structure + navigation**.
 
 ## Voice
@@ -125,8 +126,9 @@ link, not re-derive.
 
 ## Cross-links & anchors (what the link-check enforces)
 
-- **Relative links only** between docs (`./FILE.md`, `../README.md`) — never an
-  absolute repo path or a bare filename. The dangling-link guard
+- **Relative links only** between docs (`FILE.md`, `./FILE.md`,
+  `../README.md`) — never an absolute repository path. A sibling bare filename
+  and its `./` form are both valid. The dangling-link guard
   (`tests/unit/test_doc_drift_guard.py`) fails the build on a path that doesn't
   resolve.
 - **Anchors** follow GitHub's slugger: lowercase, punctuation `().,&` stripped,
@@ -158,7 +160,7 @@ table — same journeys, same names.
 
 ## See also
 
-- [`DOC_AUDIT_2026-06.md`](./DOC_AUDIT_2026-06.md) — the accuracy audit + canonical
+- [`DOC_AUDIT_2026-08.md`](./DOC_AUDIT_2026-08.md) — the current accuracy audit + canonical
   facts the guides are measured against.
 - [`../README.md`](../README.md) — the public entry; the index map mirrors its
   "Where to go next" table.

--- a/docs/internal/DOC_AUDIT_2026-06.md
+++ b/docs/internal/DOC_AUDIT_2026-06.md
@@ -1,5 +1,10 @@
 # Documentation truth audit — 2026-06
 
+> **Historical snapshot.** This audit records the June 2026 documentation
+> state. It is not the current product ledger. Use
+> [`DOC_AUDIT_2026-08.md`](./DOC_AUDIT_2026-08.md) for the current sweep and
+> canonical facts.
+
 **Story:** HS-46-01 (Phase 46 — Documentation Excellence & the 10-Second Hook).
 **Date:** 2026-06-06. **Method:** every claim checked against live code at
 `HEAD` of `phase-46-documentation-lift`. Paths below are repo-root relative.

--- a/docs/internal/DOC_AUDIT_2026-08.md
+++ b/docs/internal/DOC_AUDIT_2026-08.md
@@ -1,0 +1,109 @@
+# Documentation truth audit — 2026-08
+
+**Audit date:** 2026-08-29. **Code baseline:** `origin/main` at `16477660b`.
+**Method:** inventory every Markdown file, separate maintained guidance from
+historical evidence, check live claims against code/configuration/tests, run the
+generated-contract and link guards, and verify publication facts against the
+project's [PyPI page](https://pypi.org/project/holdspeak/0.4.0/) and
+[GitHub releases](https://github.com/karolswdev/HoldSpeak/releases).
+
+This is the current accuracy ledger. The
+[June audit](./DOC_AUDIT_2026-06.md) is retained as a historical snapshot.
+
+## Scope: all 3,294 tracked Markdown files at audit start accounted for
+
+The inventory uses `git ls-files '*.md'`, so hidden fixture and diagnostic files
+are included. The audit does not rewrite evidence as if it were current
+guidance. That would destroy provenance. The corpus is divided by contract:
+
+| Corpus | Files at audit start | Treatment |
+|---|---:|---|
+| `pm/**/*.md` | 3,038 | Historical planning and evidence. Preserve verbatim. |
+| `aipi-lite/pm/**/*.md` | 63 | Historical device planning and evidence. Preserve verbatim. |
+| `docs/evidence/**/*.md` | 41 | Generated proof snapshots. Preserve verbatim. |
+| `dogfood/results/*.md` | 1 | Recorded run result. Preserve verbatim. |
+| `dogfood/repos/**/*.md` | 38 | Deliberate fixture-repository content, including hidden `.hs/` context. Validate as fixtures; do not rewrite to match HoldSpeak. |
+| `tests/fixtures/**/*.md` | 4 | Deliberate dictation fixture content. Preserve the test input. |
+| Everything else | 109 | Maintained guides, contributor references, archived diagnostics, design records, UAT/device runbooks, prompt skills, and indexes. Audit for current purpose, links, commands, and truth. |
+
+The maintained 109 comprise five root documents; 28 top-level user/operator
+guides; 37 internal design records; one asset README; six active AIPI-Lite
+documents; three Apple documents; five designer-handoff documents; three
+dogfood harness documents; ten packaged skill documents; seven UAT documents;
+and four Web documents.
+
+Internal plans remain design records, not install instructions. A plan may
+describe a superseded decision in past tense. Current operational advice in an
+internal document is still subject to the global drift guards.
+
+## Canonical facts at the baseline
+
+| Surface | Current truth | Source of truth |
+|---|---|---|
+| Source package version | `0.4.0`; Python `>=3.10` | `pyproject.toml` |
+| Published release | PyPI and GitHub latest are `0.4.0` (2026-07-04) | PyPI and GitHub Releases |
+| Documentation version | The repository docs describe `main`, which contains unreleased work after `v0.4.0`; use a source install for exact parity | Git history from `v0.4.0..main` |
+| Primary CLI commands | 19: `web`, `meeting`, `history`, `actions`, `intel`, `dictation`, `agent-hook`, `gate`, `cadence`, `control-mode`, `device-psk`, `memory`, `doctor`, `import`, `mesh`, `node`, `backup`, `restore`, `seed` | `holdspeak/main.py` |
+| Browser shell routes | 19 canonical or compatibility routes, all served by one React shell | `holdspeak/web/routes/pages.py` |
+| HTTP/WebSocket routes | 540; iOS consumes 89 and Web consumes 418 at this baseline | generated `docs/api-surface.json` |
+| MCP surface | 135 tools across 30 domain families; 29 default non-owner resources, 32 owner resources | `holdspeak/mcp/tools.py`, `holdspeak/mcp/resources.py`, `docs/MCP_SIDECAR.md` |
+| Meeting-intel plugins | 14 built-ins and zero deterministic fallbacks in the registry | `holdspeak/plugins/builtin/__init__.py` plus plugin tests |
+| Dictation defaults | Pipeline on; correction memory on; journal on with last-500 retention | `holdspeak/config/dictation.py` |
+| Authority defaults | YOLO; actuator execution on; wildcard actuator/host allow-lists. Hard identity, destination, payload, secret, audit, and schema invariants remain | `holdspeak/config/core.py`, `holdspeak/config/meeting.py`, `holdspeak/operation_policy.py` |
+| Ambient defaults | Desktop presence, Qlippy, wake word, Cadence, and Telegram cadence are off | `holdspeak/config/device.py`, `holdspeak/config/integrations.py` |
+| Database upgrades | Declarative, additive reconcile. Back up before a real shape change; no database-version refusal gate | `holdspeak/db/reconcile.py`, `tests/unit/test_db_schema_policy.py` |
+| Apple floor | macOS 14 and iOS 17 in SwiftPM; native app sources exist under `apple/App/` | `apple/Package.swift`, `apple/App/` |
+| Web build | Vite + React 19, Node.js 20.19+ or 22.12+ for build/test, FastAPI for the shipped runtime | `web/package.json`, `web/README.md` |
+
+## Findings and dispositions
+
+| ID | Finding | Disposition |
+|---|---|---|
+| A1 | The June audit still claimed `0.2.1`, nine CLI commands, old defaults, and no PyPI release. | Kept as a clearly labelled historical snapshot; this ledger replaces it as current canon. |
+| A2 | PyPI `0.4.0` predates a large unreleased body of work documented on `main`. A bare PyPI quickstart implied feature parity. | Install docs now distinguish the published release from a source install matching `main`. |
+| A3 | Root docs said the desktop refused a newer-stamped database. The current reconciler explicitly has no version gate. | README and release guidance now describe additive reconcile and shape-change backups. Apple keeps its separate version-gated store statement. |
+| A4 | The roadmap-vocabulary guard recognized only one- and two-digit story numbers, so `HS-112` and `HS-139` leaked into user docs. | Guard widened to three digits; affected guides rewritten in product tense. |
+| A5 | Plugin authoring still taught mandatory per-action human approval and default-off execution, while the default YOLO posture can authorize a fixed configured destination. | Actuator docs now distinguish proposal review, authorization, and execution and describe all three control modes. |
+| A6 | The docs index reported 127 MCP tools and overstated approval requirements. | Counts and authority language aligned with the MCP registry and control policy. |
+| A7 | The API generator opened the contributor's ambient database, so doc generation could fail on unrelated local state. | Generator now assembles routes against a disposable isolated database. |
+| A8 | Source paths moved during module splits (`config.py`, `intel.py`, the runtime bus, workflow service), but several guides retained old paths. | Maintained references now point at the live modules. |
+| A9 | Apple README still described the native host as a future placeholder. | README now describes the existing SwiftPM layers, app sources, device scripts, and current iOS floor. |
+| A10 | The April Astro designer handoff called itself current after the React hard cut. | The handoff is explicitly archived; current design and implementation references are linked. |
+| A11 | UAT census numbers and a few path examples drifted as campaigns grew. | Volatile hard-coded census prose was replaced with current generated inventory guidance; paths corrected. |
+| A12 | The changelog's Unreleased section covered only two mobile changes despite extensive post-`0.4.0` work. | Added a grouped, user-visible summary and kept release-specific history unchanged. |
+
+## Validation contract
+
+Run these before merging documentation changes:
+
+```bash
+uv run pytest -q tests/unit/test_doc_drift_guard.py tests/unit/test_api_surface.py
+uv run pytest -q tests/unit/test_reconcile.py tests/unit/test_db_schema_policy.py
+uv run pytest -q tests/uat/test_decks.py tests/uat/test_scenarios.py tests/uat/test_smoke_pack.py
+npm --prefix web run check
+cd apple && swift test
+```
+
+`scripts/gen_api_surface.py` now uses a temporary database. Regenerating the
+API contract does not read or reconcile `~/.local/share/holdspeak/holdspeak.db`.
+
+## Standing rules for the next sweep
+
+1. Treat code, schemas, generated contracts, and tests as authority. Treat
+   screenshots and prose as claims to verify.
+2. Keep release docs and `main` docs distinct while `main` is ahead of the
+   latest published tag.
+3. Preserve roadmap/evidence records verbatim. Add a current pointer instead
+   of rewriting history.
+4. Prefer generated counts. If a count is worth publishing, pin it to its
+   registry with a test.
+5. Never run documentation generators against ambient user data.
+6. Update this ledger when an externally visible default, command, route,
+   platform floor, or release channel changes.
+
+## See also
+
+- [`DOCS_STYLE.md`](./DOCS_STYLE.md): voice, structure, and navigation rules.
+- [`../ARCHITECTURE.md`](../ARCHITECTURE.md): current runtime map.
+- [`../RELEASING.md`](../RELEASING.md): package and data-upgrade contract.
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md): contributor workflow and checks.

--- a/dogfood/PROTOCOL.md
+++ b/dogfood/PROTOCOL.md
@@ -223,21 +223,21 @@ pass bar; if reality disagrees, that's a `FAIL` and a finding.
 ### 2.4 Aftercare
 
 - [ ] **T2-12 · Aftercare digest + jump + draft.** On a finished meeting: `/api/meetings/<id>/aftercare`, `/followup-draft`; in the UI use the transcript-moment jump.
-  - Expect: an open/decided/changed digest; jumping lands on the right transcript moment; a local follow-up email draft reads sensibly. Read-only — nothing executes without approval.
+  - Expect: an open/decided/changed digest; jumping lands on the right transcript moment; a local follow-up email draft reads sensibly. These read/draft actions do not call a connector.
   - Result: ___  · Note:
 
-### 2.5 Actuators — propose → approve → execute
+### 2.5 Actuators — propose → authorize → execute
 
-- [ ] **T2-13 · Approval is the gate.** With `allow_actuators=false`, open a meeting's aftercare.
-  - Expect: the dashboard/UI offers no un-gated execute affordance; nothing runs without an explicit approval. (Per the ratified aftercare design, approving a proposal IS the execution gate on that route — approval executing is correct, not a failure.)
+- [ ] **T2-13 · Secure refusal is the gate.** Set `control_mode="safe"` and `allow_actuators=false`, then open a meeting's aftercare.
+  - Expect: the dashboard/UI offers no ungated execute affordance; a proposal waits for authority and a disabled executor refuses. For registered product connectors, an approval request may execute in the same request; review and execution still have separate recorded states.
   - Result: ___  · Note:
 
-- [ ] **T2-14 · GitHub issue actuator.** Set `allow_actuators=true`, `allowed_actuators=["github_issue_actuator"]`. From an accepted action item, propose → approve → `/aftercare/file-issue`.
-  - Expect: a proposal with target + preview; approval gates execution; the result carries an **egress badge** (cloud + target). (Use a throwaway repo or a dry path.)
+- [ ] **T2-14 · GitHub issue actuator.** Keep Secure mode, set `allow_actuators=true`, `allowed_actuators=["github_issue_actuator"]`. From an accepted action item, propose → authorize → `/aftercare/file-issue`.
+  - Expect: a proposal with target + preview; authorization admits execution; the result carries an **egress badge** (cloud + target). (Use a throwaway repo or a dry path.)
   - Result: ___  · Note:
 
-- [ ] **T2-15 · Slack send.** Set `slack_webhook_url` (a real incoming webhook, or observe the refusal when empty). `POST /api/meetings/<id>/export/slack`.
-  - Expect: with a URL set, the digest/draft posts to Slack via propose→approve→execute; the egress badge shows `cloud` + the Slack target; the URL never appears in any stored payload.
+- [ ] **T2-15 · Slack send.** Set `slack_webhook_url` (a real incoming webhook, or observe the refusal when empty). `POST /api/meetings/<id>/export/slack`. Exercise Secure for a reviewed send, then YOLO for a captured-posture send.
+  - Expect: Secure waits for authorization; YOLO can execute immediately to the configured fixed destination. Both paths write a receipt and show the Slack egress badge; the URL never appears in any stored payload.
   - Result: ___  · Note:
 
 - [ ] **T2-16 · Webhook host allowlist.** Enable `webhook_post_actuator`, set `webhook_allowed_hosts=["example.com"]`, try a proposal targeting a non-listed host.

--- a/dogfood/README.md
+++ b/dogfood/README.md
@@ -1,7 +1,8 @@
 # dogfood/ — the HoldSpeak dogfooding harness
 
-A self-contained rig for exercising **all** of HoldSpeak against believable
-data, on real metal, and recording what works. Built in Phase 67.
+A self-contained rig for exercising HoldSpeak against believable data, on real
+metal, and recording what works. It complements the broader UAT conductor with
+a compact pair of deterministic and live-model tiers.
 
 What's here:
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,7 +1,7 @@
 """Hatch build hooks for HoldSpeak.
 
 The default ``holdspeak`` command serves the web runtime, so wheels built from
-source must contain the Astro output under ``holdspeak/static/_built``.
+source must contain the Vite/React output under ``holdspeak/static/_built``.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
 class CustomBuildHook(BuildHookInterface):
-    """Build the Astro frontend before packaging the Python wheel."""
+    """Build the Vite/React frontend before packaging the Python wheel."""
 
     def initialize(self, version: str, build_data: dict) -> None:
         _ = version

--- a/holdspeak/config/meeting.py
+++ b/holdspeak/config/meeting.py
@@ -101,8 +101,9 @@ class MeetingConfig:
     # PROPOSE by default; *executing* an approved proposal needs BOTH the master
     # switch on AND the actuator id on the per-project allow-list.
     # HS-139-08: permissive defaults (owner ruling: ledger-not-gate).
-    # allow_actuators=True with a wildcard allow-list so actuators run by
-    # default. Approval is always additionally required (the proposal lifecycle).
+    # allow_actuators=True with a wildcard allow-list so eligible actuators can
+    # run by default. Authority still comes from the captured control posture,
+    # an exact scoped grant, or a per-action decision.
     allow_actuators: bool = True
     allowed_actuators: list[str] = field(default_factory=lambda: ["*"])
     # HS-38-03: the webhook write connector's host allow-list (the resolved
@@ -208,8 +209,8 @@ class MeetingConfig:
         self.allowed_actuators = normalized_act
 
         # HS-38-03: the webhook host allow-list -- normalized like the others, but
-        # lowercased (DNS hostnames are case-insensitive). Default-empty refuses
-        # every host, so a misconfigured webhook actuator posts nowhere.
+        # lowercased (DNS hostnames are case-insensitive). The shipped wildcard
+        # default admits any host; operators can narrow it to exact hosts.
         if not isinstance(self.webhook_allowed_hosts, list) or not all(
             isinstance(h, str) for h in self.webhook_allowed_hosts
         ):
@@ -339,7 +340,7 @@ def validate_spoken_symbols(raw: object) -> list[dict]:
 
 @dataclass
 class DictationPipelineConfig:
-    """DIR-01 dictation pipeline config (spec $9.4). OFF by default."""
+    """DIR-01 dictation pipeline config (spec $9.4), enabled by default."""
 
     # HS-139-02: pinned to True (was False). The pipeline is core
     # functionality; toggling it off breaks dictation. Removed from the
@@ -431,5 +432,3 @@ class DictationConfig:
 
     def __post_init__(self) -> None:
         self.spoken_symbols = validate_spoken_symbols(self.spoken_symbols)
-
-

--- a/holdspeak/meeting_plugins.py
+++ b/holdspeak/meeting_plugins.py
@@ -17,7 +17,7 @@ Design (the phase's load-bearing call):
   meeting/window/plugin/transcript-hash, so re-running an unchanged meeting
   dedups instead of duplicating; artifact synthesis upserts by artifact id.
 - **Actuators stay proposal-only** (`allow_actuators=False` on the standalone
-  host — proposing is always allowed, executing is the approval flow's job).
+  host — proposing is always allowed, executing is the authority flow's job).
 - **Heavy plugins run inline** (``defer_heavy=False``): callers are background
   contexts (the queue, the CLI), not a latency-budgeted UI thread.
 """

--- a/holdspeak/plugin_sdk.py
+++ b/holdspeak/plugin_sdk.py
@@ -30,8 +30,9 @@ from typing import Any, Mapping, Optional
 # built-ins declare (see `plugins/builtin/__init__.py`). `actuator` is the
 # third kind, unblocked in Phase 37 (HS-37-01): an actuator proposes an
 # external side effect rather than emitting a read-only artifact. It is
-# *proposable* here; *executing* a proposal is gated behind explicit human
-# approval + the host `allow_actuators` flag (see `plugins/actuators.py`).
+# *proposable* here; *executing* a proposal requires captured posture authority,
+# a scoped grant, or an explicit decision plus the host `allow_actuators` flag
+# (see `plugins/actuators.py`).
 KNOWN_PLUGIN_KINDS: frozenset[str] = frozenset(
     {
         "synthesizer",        # structured intermediate data (decisions, requirements, …)
@@ -39,7 +40,7 @@ KNOWN_PLUGIN_KINDS: frozenset[str] = frozenset(
         "artifact_generator", # a diagram or formatted document
         "signals",            # extracted customer/intelligence signals
         "detector",           # identifies associated projects/entities
-        "actuator",           # proposes an external side effect (Phase 37; approval-gated)
+        "actuator",           # proposes an external side effect (authority-gated)
     }
 )
 

--- a/holdspeak/plugins/builtin/__init__.py
+++ b/holdspeak/plugins/builtin/__init__.py
@@ -1,11 +1,8 @@
 """Built-in MIR plugins shipped with the runtime host.
 
-The package keeps the deterministic-stub `DeterministicPlugin` and the
-generic `register_builtin_plugins` registrar that existed when this was
-a single module, alongside real plugin implementations (one per
-submodule). Phase 16 ships `mermaid_architecture` as the first real
-LLM-backed synthesizer; the remaining plugin IDs continue to register
-as `DeterministicPlugin` stubs until their own stories land.
+The package keeps `DeterministicPlugin` as a compatibility and test helper,
+alongside the generic registrar and one real implementation module for every
+currently declared built-in plugin ID.
 """
 
 from __future__ import annotations
@@ -71,7 +68,8 @@ from .stakeholder_update_drafter import (
     _extract_update,
 )
 
-# Real plugin classes keyed by ID; every other ID falls back to the stub.
+# Real plugin classes keyed by ID. Every current built-in definition appears
+# here; the registrar's fallback remains defensive for compatibility.
 _REAL_PLUGINS = {
     "mermaid_architecture": MermaidArchitecturePlugin,
     "action_owner_enforcer": ActionOwnerEnforcerPlugin,
@@ -145,9 +143,9 @@ _BUILTIN_PLUGIN_DEFS: tuple[tuple[str, str], ...] = (
 def register_builtin_plugins(host: PluginHost) -> list[str]:
     """Register built-in plugins onto the provided host.
 
-    Plugin IDs in `_REAL_PLUGINS` register as their real class; every other
-    entry registers as a `DeterministicPlugin` stub until its dedicated phase
-    ships.
+    Every currently declared built-in ID registers its real class. The
+    deterministic fallback is retained for compatibility if a definition is
+    introduced before its implementation mapping.
     """
     registered: list[str] = []
     for plugin_id, kind in _BUILTIN_PLUGIN_DEFS:

--- a/holdspeak/plugins/builtin/webhook_post_actuator.py
+++ b/holdspeak/plugins/builtin/webhook_post_actuator.py
@@ -21,15 +21,15 @@ Two halves, the same safety split as the GitHub connector (HS-38-02):
 
 Decision (resolved here, deferred from HS-38-01): **host allow-listing granularity**
 is a *config allow-list of hosts* — `MeetingConfig.webhook_allowed_hosts`. A
-proposal's target host must be a member; the list is **default-empty**, so a
-misconfigured webhook actuator posts nowhere. Slack/Teams are simply incoming-webhook
-URLs whose host is on the allow-list — not bespoke API integrations (no OAuth, no
-rich blocks; a plain incoming-webhook POST only).
+proposal's target host must be a member. The shipped config defaults to `["*"]`;
+operators can narrow it to exact hosts. Slack/Teams are simply incoming-webhook
+URLs whose host is on the allow-list — not bespoke API integrations (no OAuth,
+no rich blocks; a plain incoming-webhook POST only).
 
 Like the other connectors this is a **host-side gated connector** the executor
 injects (not a discovered pack), opt-in (`register_webhook_post_actuator`, NOT in
-`register_builtin_plugins`) and off by default — reached only after approval + the
-policy/parity gates + `network:outbound`.
+`register_builtin_plugins`) — reached only after authority resolution, the
+policy/parity gates, and `network:outbound`.
 """
 from __future__ import annotations
 

--- a/scripts/gen_api_surface.py
+++ b/scripts/gen_api_surface.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import re
+import tempfile
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -45,16 +46,27 @@ _BRACE_PARAM = re.compile(r"\{[^}]*\}")
 
 def build_app_routes() -> list[dict[str, Any]]:
     """Enumerate the real app's HTTP routes (path, methods, defining module)."""
+    from holdspeak.db import get_database, reset_database
     from holdspeak.web_server import MeetingWebServer, WebRuntimeCallbacks
 
-    server = MeetingWebServer(
-        WebRuntimeCallbacks(
-            on_bookmark=lambda *_a, **_k: None,
-            on_stop=lambda *_a, **_k: None,
-            get_state=lambda: None,
-        ),
-        host="127.0.0.1",
-    )
+    # Route generation must never open or reconcile a contributor's live Desk.
+    # MeetingWebServer reaches the process-wide database singleton while it
+    # assembles a few service-backed routers, so point that singleton at an
+    # isolated, disposable database for the duration of this read-only census.
+    reset_database()
+    with tempfile.TemporaryDirectory(prefix="holdspeak-api-surface-") as tmp:
+        get_database(Path(tmp) / "api-surface.db")
+        try:
+            server = MeetingWebServer(
+                WebRuntimeCallbacks(
+                    on_bookmark=lambda *_a, **_k: None,
+                    on_stop=lambda *_a, **_k: None,
+                    get_state=lambda: None,
+                ),
+                host="127.0.0.1",
+            )
+        finally:
+            reset_database()
     routes: list[dict[str, Any]] = []
     for route in server.app.routes:
         path = getattr(route, "path", "")

--- a/tests/unit/test_doc_drift_guard.py
+++ b/tests/unit/test_doc_drift_guard.py
@@ -31,6 +31,47 @@ def _live_docs() -> list[Path]:
     ]
 
 
+def _maintained_docs() -> list[Path]:
+    """Current guidance outside frozen roadmap, evidence, and fixture corpora."""
+    paths = [
+        *(_REPO / name for name in (
+            ".guru_meditation.md",
+            "CHANGELOG.md",
+            "CLAUDE.md",
+            "CONTRIBUTING.md",
+            "README.md",
+        )),
+        *_live_docs(),
+    ]
+    for relative in (
+        "aipi-lite",
+        "apple",
+        "designer-handoff",
+        "dogfood",
+        "holdspeak/skills_library",
+        "uat",
+        "web",
+    ):
+        root = _REPO / relative
+        for path in root.rglob("*.md"):
+            posix = path.as_posix()
+            if any(
+                excluded in posix
+                for excluded in (
+                    "/pm/",
+                    "/results/",
+                    "/repos/",
+                    "/_runs/",
+                    "/.build/",
+                    "/build/",
+                    "/node_modules/",
+                )
+            ):
+                continue
+            paths.append(path)
+    return sorted(set(paths))
+
+
 def test_no_live_doc_claims_a_deterministicplugin_stub() -> None:
     offenders: list[str] = []
     for path in _live_docs():
@@ -200,15 +241,15 @@ def test_retired_calendar_singular_vocab_guard_patterns_are_nonvacuous() -> None
         assert not _RETIRED_CALENDAR_SINGULAR.search(current), current
 
 
-# HS-33-03: a lightweight link-check so the `docs/` reorg (and future moves)
-# can't silently leave a dangling relative link. Scope is the same live-docs
-# set; the PMO corpus + evidence snapshots are frozen history and excluded.
+# HS-33-03: a lightweight link-check so reorgs cannot silently leave dangling
+# relative links. The PMO/evidence/fixture corpora are frozen and excluded; all
+# maintained root, product, device, UAT, and contributor docs are included.
 _MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 
 
 def test_no_live_doc_has_a_dangling_relative_link() -> None:
     offenders: list[str] = []
-    for path in _live_docs():
+    for path in _maintained_docs():
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             for target in _MD_LINK.findall(line):
                 target = target.strip()
@@ -226,9 +267,25 @@ def test_no_live_doc_has_a_dangling_relative_link() -> None:
                     )
 
     assert not offenders, (
-        "A live doc links a path that does not exist (dangling relative link). "
+        "A maintained doc links a path that does not exist (dangling relative link). "
         "Fix the path or the move:\n  " + "\n  ".join(offenders)
     )
+
+
+def test_mcp_tool_count_claims_match_registry() -> None:
+    """Published MCP counts stay pinned to the actual aggregate registry."""
+    from holdspeak.mcp.tools import TOOLS
+
+    claim = re.compile(
+        r"(\d+)\s+(?:MCP\s+)?tools\s+(?:across|are organized)", re.IGNORECASE
+    )
+    for relative in (Path("docs/README.md"), Path("docs/MCP_SIDECAR.md")):
+        text = (_REPO / relative).read_text(encoding="utf-8")
+        counts = [int(value) for value in claim.findall(text)]
+        assert counts, f"{relative} must state its MCP tool count"
+        assert set(counts) == {len(TOOLS)}, (
+            f"{relative} states MCP tool counts {counts}, registry has {len(TOOLS)}"
+        )
 
 
 # HS-107-06: the current effect census is stated at both security/architecture
@@ -367,7 +424,7 @@ def test_all_embedded_image_refs_resolve() -> None:
 # real (see Phase 51 HS-51-02), and the patterns stay narrow enough that the kept
 # architecture spec names MIR-01 / DIR-01 / WFS-01 never match.
 _ROADMAP_VOCAB = re.compile(
-    r"\bHS-\d{1,2}(?:-\d+)?\b"    # story ids: HS-25, HS-17-05, HS-9-03
+    r"\bHS-\d{1,3}(?:-\d+)?\b"    # story ids: HS-139, HS-17-05, HS-9-03
     r"|\bphase[ -]\d+\b"          # phase tags: Phase 15, phase-37, phase 9
     r"|\bPMO\b"
     r"|the current roadmap",
@@ -419,7 +476,7 @@ def test_roadmap_vocab_guard_scans_real_user_facing_docs() -> None:
 def test_roadmap_vocab_pattern_is_narrow_enough_to_keep_spec_names() -> None:
     """The pattern flags phase/story tags but never the kept architecture spec names
     (MIR-01 / DIR-01 / WFS-01) or bare 'phase' with no number."""
-    for leak in ("Phase 15", "phase-37", "phase 9", "HS-25-03", "HS-17-05",
+    for leak in ("Phase 15", "phase-137", "phase 9", "HS-139-02", "HS-17-05",
                  "HS-9-03",  # single-digit phase — leaked past the old pattern (found live)
                  "the current roadmap", "PMO", "from HS-19 closeout"):
         assert _ROADMAP_VOCAB.search(leak), f"guard should flag {leak!r}"

--- a/uat/DEVICE-RUNBOOK.md
+++ b/uat/DEVICE-RUNBOOK.md
@@ -8,7 +8,7 @@ same iPad are different execution slots.
 ## Start and pair
 
 ```bash
-cd /Users/karol/dev/tools/HoldSpeak
+cd /path/to/HoldSpeak
 UAT_HOST=0.0.0.0 uv run python -m uat.conductor
 ```
 

--- a/uat/FUNCTIONAL-PASS.md
+++ b/uat/FUNCTIONAL-PASS.md
@@ -28,14 +28,14 @@ Responsive desktop emulation is never native evidence.
 Desktop-only campaigns:
 
 ```bash
-cd /Users/karol/dev/tools/HoldSpeak
+cd /path/to/HoldSpeak
 uv run python -m uat.conductor
 ```
 
 Native or cross-device campaigns:
 
 ```bash
-cd /Users/karol/dev/tools/HoldSpeak
+cd /path/to/HoldSpeak
 UAT_HOST=0.0.0.0 uv run python -m uat.conductor
 ```
 

--- a/uat/README.md
+++ b/uat/README.md
@@ -28,20 +28,18 @@ separate campaign legs, and parity is joined only after both legs were run.
 ## The owner's functional runbook
 
 ```bash
-cd /Users/karol/dev/tools/HoldSpeak
+cd /path/to/HoldSpeak
 git pull                                 # the merged framework
 uv run python -m uat.conductor           # opens the UAT site; note the URL it prints
 ```
 
 Then, in the browser (it prints `http://localhost:8799`):
 
-1. Start **1 · React Web Desk foundation — desktop**. The twelve numbered owner
+1. Start **1 · React Web Desk foundation — desktop**. The thirteen numbered owner
    campaigns are the execution protocol; ordinary packs remain below them as
-   reference/diagnostic material. Campaigns 10–12 are the Phase 93/94
-   physical-proof legs (BACKLOG candidate Y): 10 is production-Web owner
-   evidence, 11 is the flagship pass on physical devices (TestFlight build 12+),
-   12 is the Delivery Runtime on real metal (second machine, iPad, tailnet
-   HTTPS).
+   reference/diagnostic material. Campaigns 10–12 are the production-Web,
+   physical flagship, and Delivery Runtime proof legs; campaign 13 covers the
+   Desk OS on React and flagship Swift.
 2. Walk the beats: each says *do this*, *expect this*. Use **Open the product**
    to jump to the right screen. Cast a verdict only for the displayed
    **target/form-factor slot**. Campaign 1 is React desktop; Campaign 5 is the
@@ -59,14 +57,13 @@ Then, in the browser (it prints `http://localhost:8799`):
 If anything is broken or pending, it is named honestly under **Known state**
 below.
 
-Campaigns 1–9 contain 90 scenarios and 327 direct observations: 54 are fully
-automatic, 27 are recipe-staged plus a real-world preflight, and 9 begin at a
-genuinely hands-on boundary. Exact meeting/action/proposal fixtures remove
-model wording and manual setup from UI-mechanics tests; live inference stays
-in the scenarios that judge intelligence itself. Campaigns 10–12 add 20
-scenarios that are deliberately hands-on: they exist to capture the owner and
-physical-device evidence the Phase 93/94 closes parked, so most beats start at
-a human boundary (real microphones, real devices, a second machine).
+The conductor computes scenario, verdict-slot, and bootstrap counts directly
+from the current campaign YAML; the guided site's campaign cards are the
+authoritative totals. Exact meeting/action/proposal fixtures remove model
+wording and manual setup from UI-mechanics tests, while live inference remains
+in scenarios that judge intelligence itself. Later proof campaigns deliberately
+start at human boundaries such as real microphones, physical devices, and a
+second machine.
 
 ---
 

--- a/web/README.md
+++ b/web/README.md
@@ -6,8 +6,8 @@ builds into `../holdspeak/static/_built/`; FastAPI serves the hashed assets at
 
 ## Requirements and commands
 
-Node.js 20 or newer is needed only to build and test. The shipped runtime stays
-Python/FastAPI.
+Node.js 20.19+ or 22.12+ is needed only to build and test, matching Vite 7's
+runtime requirement. The shipped runtime stays Python/FastAPI.
 
 ```bash
 npm install
@@ -52,15 +52,16 @@ The machine-readable URL/verb/state inventory is
   `../holdspeak/static/_built/`.
 - Browser routes and API payloads remain stable; React Router does not redefine
   backend contracts.
-- API keys never enter browser storage or response bodies. Runtime profiles
-  carry only shape and `requires_key`; the key remains an environment variable
-  on the hub.
+- API keys never enter browser storage or ordinary response bodies. Model
+  profiles carry only shape and secret-state metadata; key values remain in
+  owner-only hub secret custody, with per-profile environment variables as a
+  headless fallback.
 - `localStorage` is only for explicitly device-local preferences such as Desk
   positions, Workbench layout, chat threads, and project-root history.
 - New browser network calls go through the typed API client. New live consumers
   subscribe to `RuntimeBus`; they do not open another `/ws`.
 
-## Adding a surface (the Desk OS pattern, HS-95-04)
+## Adding a surface (the Desk OS pattern)
 
 Features do not own surfaces; the OS owns surfaces and features plug into
 them (docs/internal/CONSTITUTION.md, Articles I–II). To add or re-home a
@@ -74,7 +75,7 @@ surface:
    (`tests/unit/test_page_cores_guard.py` enforces this mechanically).
    The core owns its verbs and hands them to the optional `hero` slot so
    each host chooses the chrome.
-2. **Demote the route** (HS-95-08): there are no flat wrappers anymore.
+2. **Demote the route:** there are no flat wrappers anymore.
    Add one `DEMOTED_ROUTES` row in `src/routes.tsx` mapping the legacy
    path to the surface key (plus a `subjectKind` when deep links carry a
    scope); the path then lands on the Desk with the window open.
@@ -84,7 +85,7 @@ surface:
    menu and the tool shelf dispatch through `desk/shell.ts`; the no-exit
    lock (`tests/unit/test_desk_no_exit_guard.py`) forbids desk navigation
    outright.
-4. **Compose the surface kit** (HS-98): a core builds its interior
+4. **Compose the surface kit:** a core builds its interior
    from `src/desk/surface/` — `SurfaceVerbs` (one sticky verb bar),
    `SurfaceSection` (hairline + quiet label, never a nested card),
    `SurfaceRows`/`SurfaceRow` (dense honest rows, revealed verbs),
@@ -105,7 +106,7 @@ surface:
    entries; the focus and pressed state grammars are inherited — never
    hand-roll them; the window material is ONE `:where()` rule — no
    per-window recipes.
-6. **The chrome ladder** (HS-99; the chrome ladder chapter in
+6. **The chrome ladder** (see the chrome ladder chapter in
    `DESIGN_SYSTEM.md` is the contract): interiors layer by TONE
    (head/rail/well around the body fill), never by borders. Popovers
    render through `DeskMenuList`/`DeskMenuItem` (`src/desk/components/
@@ -114,7 +115,7 @@ surface:
    control foundation mechanically; never opt a control out of it.
    Scrollbars are the drawn pill — verify HEADED (the headless shell
    suppresses them).
-7. **Window grammar** (HS-97; the physics floors chapter in
+7. **Window grammar** (see the physics floors chapter in
    `DESIGN_SYSTEM.md` is the contract): windows are placed by the OS —
    never hand-position a surface window; its CSS default is only the
    placement seed. A fixed shelf verb registers through


### PR DESCRIPTION
## Summary

- audit all 3,294 tracked Markdown files present at the start of the sweep and classify maintained documentation, frozen evidence/history, fixtures, and generated/reference surfaces
- reconcile the maintained root, product, security, architecture, release, plugin, Apple, AIPI, UAT, dogfood, designer-handoff, and web documentation with the current implementation
- distinguish the published 0.4.0 release from the substantially newer `main` branch behavior
- add an August 2026 audit ledger and stronger drift guards for maintained-doc links, roadmap leakage, API/MCP counts, and generated API isolation
- correct adjacent source comments that were themselves being used as documentation authority

The audit ledger is `docs/internal/DOC_AUDIT_2026-08.md`. Historical roadmap, captured evidence, dogfood snapshots, and fixture Markdown remain immutable by design and are recorded as such in the ledger.

## Key corrections

- current YOLO / Normal / Secure authority semantics and actuator defaults
- Model Library, Assignments, and current routing configuration
- additive database reconciliation and backup behavior
- 19 CLI commands, 19 SPA routes, 540 generated HTTP routes, and 135 MCP tools across 30 families
- native Apple package/app layout and macOS 14 / iOS 17 deployment floors
- React 19 + Vite web workflow and supported Node versions
- current device, bridge, UAT, and designer-snapshot status

## Validation

- `uv run ruff check ...` — pass
- focused Python documentation/API/authority/schema/UAT suite — **142 passed**
- `uv run python scripts/gen_api_surface.py` followed by a generated-file diff — pass; **540 routes**, no drift
- `swift test --package-path apple` — **566 tests completed, 9 skipped, 0 failures**
- `npm --prefix web run build` — pass
- `git diff --check` — pass

`npm --prefix web run check` is not green on the current web baseline. Its CSS-token audit, architecture guards, TypeScript check, and Vitest suite report failures in unchanged implementation/test files; Vitest reports 1,332 passing and 6 failing tests. This PR changes `web/README.md` only under `web/` and does not alter or suppress those failures.

## Release references

- Published package baseline: https://pypi.org/project/holdspeak/0.4.0/
- Published release history: https://github.com/karolswdev/HoldSpeak/releases
- Vite Node support: https://vite.dev/guide/
