### PR TITLE
Close the positional-INSERT vs reconcile-order bug class

### DIFF
--- a/holdspeak/kernel/journal.py
+++ b/holdspeak/kernel/journal.py
@@ -489,7 +489,7 @@ class JournalStore:
         }
         signature = hmac.new(secret.encode(), _json(material).encode(), hashlib.sha256).hexdigest()
         conn.execute(
-            "INSERT INTO kernel_inference_receipt_attestations VALUES(?,?,?,?,?)",
+            "INSERT INTO kernel_inference_receipt_attestations (receipt_id, operation_id, material_json, signature, created_at) VALUES(?,?,?,?,?)",
             (receipt["receipt_id"], operation["operation_id"], _json(material), signature, receipt["created_at"]),
         )
     def receipt(self, operation_id: str) -> dict[str, Any] | None:

--- a/holdspeak/services/inference_adoption_service.py
+++ b/holdspeak/services/inference_adoption_service.py
@@ -340,7 +340,7 @@ class ProductionRouteEvidence:
                 )
             return {**material, "material_snapshot_sha256": material_sha}
         conn.execute(
-            "INSERT INTO inference_adoption_material_snapshots VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO inference_adoption_material_snapshots (planning_reference, capability_id, operation_id, contract, contract_revision, payload_json, payload_sha256, material_snapshot_sha256, reserved_output_tokens, reserved_tool_calls, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
             (reference, capability_id, operation, contract, contract_revision,
              payload_json, payload_sha, material_sha, reserved_output_tokens,
              reserved_tool_calls, _now()),
@@ -487,7 +487,7 @@ class ProductionRouteEvidence:
                 )
         else:
             conn.execute(
-                "INSERT INTO inference_adoption_route_evidence VALUES (?,?,?,?,?,?,?,?)",
+                "INSERT INTO inference_adoption_route_evidence (evidence_ref, planning_reference, operation_id, capability_id, material_snapshot_sha256, evidence_json, evidence_sha256, created_at) VALUES (?,?,?,?,?,?,?,?)",
                 (
                     evidence_ref, planning_reference, operation_id, capability_id,
                     row["material_snapshot_sha256"], evidence_json, evidence_sha, _now(),
@@ -984,7 +984,7 @@ class RoutedInferenceCoordinator:
                 operation_plan_ids = [value["operation_request_plan"]["id"] for value in admitted]
                 result = {"schema": "InferenceAdoptionComposite@1", "id": composite_id, "operation_plan_ids": operation_plan_ids}
                 conn.execute(
-                    "INSERT INTO inference_adoption_composites VALUES (?,?,?,?,?,?)",
+                    "INSERT INTO inference_adoption_composites (composite_id, command_id, request_sha256, operation_plan_ids_json, result_sha256, created_at) VALUES (?,?,?,?,?,?)",
                     (
                         composite_id, command, request_sha,
                         _canonical(operation_plan_ids), _sha256(result), _now(),
@@ -1511,7 +1511,7 @@ class RoutedInferenceCoordinator:
                     ).fetchone()
                     if prior is None:
                         conn.execute(
-                            "INSERT INTO inference_adoption_attempt_results VALUES (?,?,?,?,?,?)",
+                            "INSERT INTO inference_adoption_attempt_results (attempt_id, child_invocation_id, producer_result_ref, result_json, result_sha256, created_at) VALUES (?,?,?,?,?,?)",
                             (
                                 str(reservation["attempt_id"]),
                                 str(reservation["child_invocation_id"]),
@@ -1714,7 +1714,7 @@ class RoutedInferenceCoordinator:
                     ).fetchone()
                     if prior is None:
                         conn.execute(
-                            "INSERT INTO inference_adoption_attempt_results VALUES (?,?,?,?,?,?)",
+                            "INSERT INTO inference_adoption_attempt_results (attempt_id, child_invocation_id, producer_result_ref, result_json, result_sha256, created_at) VALUES (?,?,?,?,?,?)",
                             (
                                 str(reservation["attempt_id"]),
                                 str(reservation["child_invocation_id"]),

--- a/holdspeak/services/inference_assignment_service.py
+++ b/holdspeak/services/inference_assignment_service.py
@@ -828,7 +828,7 @@ class InferenceAssignmentService:
                         ),
                     )
                     conn.execute(
-                        """INSERT INTO inference_assignment_heads VALUES (?,?,?,?,?)
+                        """INSERT INTO inference_assignment_heads (assignment_key, assignment_id, revision, cleared, updated_at) VALUES (?,?,?,?,?)
                            ON CONFLICT(assignment_key) DO UPDATE SET assignment_id=excluded.assignment_id,
                            revision=excluded.revision,cleared=0,updated_at=excluded.updated_at""",
                         (
@@ -841,7 +841,7 @@ class InferenceAssignmentService:
                     )
                     for entry in group["entries"]:
                         conn.execute(
-                            "INSERT INTO inference_assignments VALUES (?,?,?,?,?,?,?)",
+                            "INSERT INTO inference_assignments (id, assignment_id, assignment_revision, profile_id, profile_revision, profile_schema_version, ordinal) VALUES (?,?,?,?,?,?,?)",
                             (
                                 f"{assignment_id}:{revision}:{entry['ordinal']}",
                                 assignment_id,
@@ -1080,12 +1080,12 @@ class InferenceAssignmentService:
                             ),
                         )
                         conn.execute(
-                            "INSERT INTO inference_assignment_heads VALUES (?,?,?,?,?)",
+                            "INSERT INTO inference_assignment_heads (assignment_key, assignment_id, revision, cleared, updated_at) VALUES (?,?,?,?,?)",
                             (scope["assignment_key"], assignment_id, 1, 0, created_at),
                         )
                         for entry in entries:
                             conn.execute(
-                                "INSERT INTO inference_assignments VALUES (?,?,?,?,?,?,?)",
+                                "INSERT INTO inference_assignments (id, assignment_id, assignment_revision, profile_id, profile_revision, profile_schema_version, ordinal) VALUES (?,?,?,?,?,?,?)",
                                 (
                                     f"{assignment_id}:1:{entry['ordinal']}", assignment_id, 1,
                                     entry["profile_id"], entry["profile_revision"],
@@ -1115,7 +1115,7 @@ class InferenceAssignmentService:
                 }
                 committed_at = _now()
                 conn.execute(
-                    "INSERT INTO inference_assignment_migrations VALUES (?,?,?,?,?,?)",
+                    "INSERT INTO inference_assignment_migrations (family, marker_revision, source_sha256, result_json, result_sha256, committed_at) VALUES (?,?,?,?,?,?)",
                     (
                         clean_family, 1, source_sha256, _canonical(result),
                         _sha256(result), committed_at,
@@ -1199,9 +1199,9 @@ class InferenceAssignmentService:
                              scope["subject_kind"], "capability", capability.id, "", None,
                              _canonical(material), digest, created_at),
                         )
-                        conn.execute("INSERT INTO inference_assignment_heads VALUES (?,?,?,?,?)", (scope["assignment_key"], assignment_id, 1, 0, created_at))
+                        conn.execute("INSERT INTO inference_assignment_heads (assignment_key, assignment_id, revision, cleared, updated_at) VALUES (?,?,?,?,?)", (scope["assignment_key"], assignment_id, 1, 0, created_at))
                         for entry in entries:
-                            conn.execute("INSERT INTO inference_assignments VALUES (?,?,?,?,?,?,?)", (
+                            conn.execute("INSERT INTO inference_assignments (id, assignment_id, assignment_revision, profile_id, profile_revision, profile_schema_version, ordinal) VALUES (?,?,?,?,?,?,?)", (
                                 f"{assignment_id}:1:{entry['ordinal']}", assignment_id, 1,
                                 entry["profile_id"], entry["profile_revision"], entry["profile_schema_version"], entry["ordinal"],
                             ))
@@ -1221,7 +1221,7 @@ class InferenceAssignmentService:
                     "source_records": normalized_records,
                 }
                 committed_at = _now()
-                conn.execute("INSERT INTO inference_assignment_migrations VALUES (?,?,?,?,?,?)", (
+                conn.execute("INSERT INTO inference_assignment_migrations (family, marker_revision, source_sha256, result_json, result_sha256, committed_at) VALUES (?,?,?,?,?,?)", (
                     clean_family, 1, source_sha256, _canonical(result), _sha256(result), committed_at,
                 ))
                 conn.commit()
@@ -1367,7 +1367,7 @@ class InferenceAssignmentService:
                     )
                 committed_at = _now()
                 conn.execute(
-                    "INSERT INTO inference_assignment_migrations VALUES (?,?,?,?,?,?)",
+                    "INSERT INTO inference_assignment_migrations (family, marker_revision, source_sha256, result_json, result_sha256, committed_at) VALUES (?,?,?,?,?,?)",
                     (
                         family,
                         marker_revision,

--- a/holdspeak/services/inference_fallback_controller.py
+++ b/holdspeak/services/inference_fallback_controller.py
@@ -149,7 +149,7 @@ class InferenceFallbackController:
         )
         effect = {"execution_id": execution_id}
         conn.execute(
-            "INSERT INTO inference_route_execution_commands VALUES (?,?,?,?,?,?,?)",
+            "INSERT INTO inference_route_execution_commands (command_id, action, request_sha256, execution_id, effect_json, effect_sha256, created_at) VALUES (?,?,?,?,?,?,?)",
             (command, "start", request_hash, execution_id, _canonical(effect), _sha256(effect), created_at),
         )
         self._insert_transition(
@@ -281,7 +281,7 @@ class InferenceFallbackController:
                     )
                     if larger:
                         conn.execute(
-                            "INSERT INTO inference_route_execution_skips VALUES (?,?,?,?,?,?)",
+                            "INSERT INTO inference_route_execution_skips (id, execution_id, route_leg_ordinal, disposition, reason_code, created_at) VALUES (?,?,?,?,?,?)",
                             (f"{execution}:{leg_ordinal}", execution, leg_ordinal,
                              "context_overflow", str(planned["reason_code"]), now_text),
                         )
@@ -290,7 +290,7 @@ class InferenceFallbackController:
                 if planned["eligibility"] != "executable":
                     disposition = "context_overflow" if planned["eligibility"] == "known_context_overflow" else "preflight_unavailable"
                     conn.execute(
-                        "INSERT INTO inference_route_execution_skips VALUES (?,?,?,?,?,?)",
+                        "INSERT INTO inference_route_execution_skips (id, execution_id, route_leg_ordinal, disposition, reason_code, created_at) VALUES (?,?,?,?,?,?)",
                         (f"{execution}:{leg_ordinal}", execution, leg_ordinal, disposition, str(planned["reason_code"]), now_text),
                     )
                     # Current v1 policies do not authorize preflight-unavailable
@@ -1299,7 +1299,7 @@ class InferenceFallbackController:
     @staticmethod
     def _insert_command(conn: Any, command: str, action: str, request_hash: str, execution: str, effect: dict[str, Any], created_at: str) -> None:
         conn.execute(
-            "INSERT INTO inference_route_execution_commands VALUES (?,?,?,?,?,?,?)",
+            "INSERT INTO inference_route_execution_commands (command_id, action, request_sha256, execution_id, effect_json, effect_sha256, created_at) VALUES (?,?,?,?,?,?,?)",
             (command, action, request_hash, execution, _canonical(effect), _sha256(effect), created_at),
         )
 
@@ -1340,7 +1340,7 @@ class InferenceFallbackController:
         }
         digest = _sha256(material)
         conn.execute(
-            "INSERT INTO inference_route_execution_transitions VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO inference_route_execution_transitions (transition_id, execution_id, ordinal, action, command_id, prior_revision, post_revision, prior_state, post_state, effect_sha256, previous_sha256, sha256) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
             (
                 f"irt_{digest.removeprefix('sha256:')[:32]}", execution_id, ordinal,
                 action, command_id, prior_revision, post_revision, prior_state,

--- a/holdspeak/services/inference_parent_route_bundle_service.py
+++ b/holdspeak/services/inference_parent_route_bundle_service.py
@@ -540,7 +540,7 @@ class InferenceParentRouteBundleService:
             }
             digest = _sha256(material)
             conn.execute(
-                "INSERT INTO inference_parent_route_bundles VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                "INSERT INTO inference_parent_route_bundles (id, command_id, request_sha256, parent_operation_id, parent_deadline_at, parent_child_budget, lifecycle_child_budget, feature_principal_sha256, payload_json, sha256, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     bundle_id,
                     command,
@@ -557,7 +557,7 @@ class InferenceParentRouteBundleService:
             )
             for member in members:
                 conn.execute(
-                    "INSERT INTO inference_parent_route_bundle_members VALUES (?,?,?,?,?,?,?,?,?)",
+                    "INSERT INTO inference_parent_route_bundle_members (id, bundle_id, ordinal, route_key, capability_id, route_plan_id, route_plan_sha256, principal_policy_sha256, maximum_physical_attempts) VALUES (?,?,?,?,?,?,?,?,?)",
                     (
                         f"{bundle_id}:{member['ordinal']}",
                         bundle_id,
@@ -1163,7 +1163,7 @@ class InferenceParentRouteBundleService:
             }
             now = self._parents._clock()
             conn.execute(
-                "INSERT INTO inference_parent_stop_handoffs VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                "INSERT INTO inference_parent_stop_handoffs (command_id, request_sha256, bundle_id, parent_operation_id, evidence_provider_id, evidence_provider_revision, planning_reference, evidence_ref, evidence_sha256, state, effect_json, effect_sha256, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     command,
                     request_hash,
@@ -1182,7 +1182,7 @@ class InferenceParentRouteBundleService:
             )
             for ordinal, (execution_id, stop) in enumerate(zip(executions, effects), 1):
                 conn.execute(
-                    "INSERT INTO inference_parent_stop_handoff_executions VALUES (?,?,?,?,?)",
+                    "INSERT INTO inference_parent_stop_handoff_executions (command_id, ordinal, execution_id, stop_command_id, elected_state) VALUES (?,?,?,?,?)",
                     (
                         command,
                         ordinal,
@@ -1401,7 +1401,7 @@ class InferenceParentRouteBundleService:
         self._reconstruct_handoff_evidence(conn, row, expected_state="reserved")
         settled = {**dict(effect), "state": "committed"}
         conn.execute(
-            "INSERT INTO inference_parent_stop_handoff_settlements VALUES (?,?,?,?)",
+            "INSERT INTO inference_parent_stop_handoff_settlements (command_id, effect_json, effect_sha256, created_at) VALUES (?,?,?,?)",
             (
                 command_id,
                 _canonical(settled),

--- a/holdspeak/services/inference_route_plan_service.py
+++ b/holdspeak/services/inference_route_plan_service.py
@@ -610,7 +610,7 @@ class InferenceRoutePlanService:
             principal_policy_evidence=principal_policy,
         )
         conn.execute(
-            "INSERT INTO inference_route_plan_commands VALUES (?,?,?,?,?)",
+            "INSERT INTO inference_route_plan_commands (command_id, request_sha256, plan_id, plan_sha256, created_at) VALUES (?,?,?,?,?)",
             (command, request_hash, material["id"], digest, material["created_at"]),
         )
         return {**material, "sha256": digest}
@@ -675,7 +675,7 @@ class InferenceRoutePlanService:
             principal_policy_evidence=principal_policy,
         )
         conn.execute(
-            "INSERT INTO inference_route_plan_commands VALUES (?,?,?,?,?)",
+            "INSERT INTO inference_route_plan_commands (command_id, request_sha256, plan_id, plan_sha256, created_at) VALUES (?,?,?,?,?)",
             (command, request_hash, material["id"], resolved["sha256"], material["created_at"]),
         )
         return resolved
@@ -782,7 +782,7 @@ class InferenceRoutePlanService:
                 )
                 route_hash = _sha256(material)
                 self._insert_route(conn, material, route_hash, [deployment_revision], capability_definition=capability.canonical_dict(), retry_policy_definition=policy.canonical_dict(), frozen_preflight=({"route_leg_ordinal": 1, "eligibility": "executable", "reason_code": None},))
-                conn.execute("INSERT INTO inference_route_plan_commands VALUES (?,?,?,?,?)", (command, request_hash, material["id"], route_hash, material["created_at"]))
+                conn.execute("INSERT INTO inference_route_plan_commands (command_id, request_sha256, plan_id, plan_sha256, created_at) VALUES (?,?,?,?,?)", (command, request_hash, material["id"], route_hash, material["created_at"]))
                 conn.commit()
                 return {**material, "sha256": route_hash}
             except Exception:
@@ -967,7 +967,7 @@ class InferenceRoutePlanService:
                     material_snapshot_sha256,payload_json,sha256) VALUES (?,?,?,?,?,?,?)""",
                 (operation["id"], budget_material["provider_id"], budget_material["provider_revision"], operation["admission_evidence_ref"], operation["material_snapshot_sha256"], _canonical(budget_material), _sha256(budget_material)),
             )
-        conn.execute("INSERT INTO inference_operation_route_request_plan_commands VALUES (?,?,?,?,?,?,?)", (command, request_hash, route_material["id"], resolved["sha256"], operation["id"], operation_hash, operation["created_at"]))
+        conn.execute("INSERT INTO inference_operation_route_request_plan_commands (command_id, request_sha256, route_plan_id, route_plan_sha256, operation_plan_id, operation_plan_sha256, created_at) VALUES (?,?,?,?,?,?,?)", (command, request_hash, route_material["id"], resolved["sha256"], operation["id"], operation_hash, operation["created_at"]))
         return {"route_plan": resolved, "operation_request_plan": {**operation, "sha256": operation_hash}}
 
     def freeze_operation_for_route(
@@ -1089,7 +1089,7 @@ class InferenceRoutePlanService:
              _canonical(budget_material), _sha256(budget_material)),
         )
         conn.execute(
-            "INSERT INTO inference_operation_route_request_plan_commands VALUES (?,?,?,?,?,?,?)",
+            "INSERT INTO inference_operation_route_request_plan_commands (command_id, request_sha256, route_plan_id, route_plan_sha256, operation_plan_id, operation_plan_sha256, created_at) VALUES (?,?,?,?,?,?,?)",
             (command, request_hash, route["id"], route["sha256"], operation["id"], operation_hash, operation["created_at"]),
         )
         return {"route_plan": route, "operation_request_plan": {**operation, "sha256": operation_hash}}
@@ -1721,12 +1721,12 @@ class InferenceRoutePlanService:
                 (f"{material['id']}:{entry['ordinal']}", material["id"], entry["ordinal"], entry["profile_id"], entry["profile_revision"], entry["profile_schema_version"], entry["binding_id"], entry["binding_revision"], entry["deployment_head_id"], entry["deployment_configuration_revision"], entry["deployment_revision_id"], entry["capability_manifest_sha256"], entry["boundary"], _canonical(entry["context_support"])),
             )
         conn.execute(
-            "INSERT INTO inference_route_plan_authority_evidence VALUES (?,?,?,?,?)",
+            "INSERT INTO inference_route_plan_authority_evidence (plan_id, capability_definition_json, capability_definition_sha256, retry_policy_definition_json, retry_policy_definition_sha256) VALUES (?,?,?,?,?)",
             (material["id"], _canonical(capability_definition), capability_definition["schema_sha256"], _canonical(retry_policy_definition), retry_policy_definition["sha256"]),
         )
         if principal_policy_evidence is not None:
             conn.execute(
-                "INSERT INTO inference_route_plan_principal_evidence VALUES (?,?,?)",
+                "INSERT INTO inference_route_plan_principal_evidence (plan_id, payload_json, sha256) VALUES (?,?,?)",
                 (
                     material["id"],
                     _canonical(principal_policy_evidence),
@@ -1741,7 +1741,7 @@ class InferenceRoutePlanService:
             if int(item["route_leg_ordinal"]) != expected:
                 raise ConflictError("Route preflight order is invalid.", code="inference_route_plan_integrity_invalid")
             conn.execute(
-                "INSERT INTO inference_route_plan_preflight_evidence VALUES (?,?,?,?)",
+                "INSERT INTO inference_route_plan_preflight_evidence (plan_id, route_leg_ordinal, eligibility, reason_code) VALUES (?,?,?,?)",
                 (material["id"], expected, item["eligibility"], item.get("reason_code")),
             )
 

--- a/tests/unit/test_no_positional_inserts.py
+++ b/tests/unit/test_no_positional_inserts.py
@@ -1,0 +1,299 @@
+"""Fence: no positional INSERT INTO <table> VALUES in holdspeak/.
+
+Every INSERT must name its columns so that the reconcile engine's
+column-appending strategy (ADD COLUMN at end of table) cannot cause
+value/column misalignment on long-lived databases.
+
+See: the positional-inserts-vs-reconcile-order systemic defect.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+# Tables where positional INSERT is known-safe (e.g. test-only temp tables).
+# Add entries as ("filename_stem", "table_name") tuples.
+ALLOW_LIST: set[tuple[str, str]] = set()
+
+_POSITIONAL_RE = re.compile(
+    r"""(?ix)
+    INSERT \s+
+    (?:OR \s+ [A-Z]+ \s+)?
+    INTO \s+
+    ([a-zA-Z_][a-zA-Z0-9_]*) \s+
+    VALUES
+    """,
+)
+
+_NAMED_COL_RE = re.compile(
+    r"""(?ix)
+    INSERT \s+
+    (?:OR \s+ [A-Z]+ \s+)?
+    INTO \s+
+    [a-zA-Z_][a-zA-Z0-9_]* \s*
+    \(                          # opening paren of column list
+    """,
+)
+
+
+def _scan_holdspeak_source() -> list[str]:
+    """Return file:line entries for every positional INSERT in holdspeak/."""
+    root = Path(__file__).resolve().parents[2] / "holdspeak"
+    violations: list[str] = []
+    for py in sorted(root.rglob("*.py")):
+        rel = py.relative_to(root.parent)
+        for lineno, line in enumerate(py.read_text().splitlines(), 1):
+            stripped = line.strip()
+            # Skip comments and blank lines
+            if stripped.startswith("#") or not stripped:
+                continue
+            if _POSITIONAL_RE.search(stripped):
+                # It is positional -- no column list between table and VALUES.
+                # But check it's not actually a named-column INSERT by looking
+                # for a paren after the table name (before VALUES).
+                if _NAMED_COL_RE.search(stripped):
+                    continue  # has column list -- safe
+                table_match = _POSITIONAL_RE.search(stripped)
+                if table_match:
+                    table = table_match.group(1)
+                    stem = py.stem
+                    if (stem, table) in ALLOW_LIST:
+                        continue
+                    violations.append(f"{rel}:{lineno} -> {table}")
+    return violations
+
+
+def test_no_positional_inserts_in_holdspeak():
+    """Every INSERT in holdspeak/ must name its columns explicitly."""
+    violations = _scan_holdspeak_source()
+    if violations:
+        msg = (
+            "Positional INSERT statements found in holdspeak/ source.\n"
+            "These are unsafe when the reconcile engine appends columns,\n"
+            "causing column-order divergence on long-lived databases.\n\n"
+            "Fix each INSERT to name its columns explicitly:\n"
+            "  INSERT INTO table (col1, col2) VALUES (?, ?)\n\n"
+            "Violations:\n"
+        )
+        for v in violations:
+            msg += f"  {v}\n"
+        pytest.fail(msg)
+
+
+# ---------------------------------------------------------------------------
+# Regression: column-order divergence on inference_assignment_migrations
+# ---------------------------------------------------------------------------
+# The real defect: a long-lived DB created the table without result_sha256.
+# The reconcile added it at the END (after committed_at).  A positional
+# INSERT wrote the sha256 into committed_at and the timestamp into
+# result_sha256, breaking migration_marker integrity.  The fix: named
+# columns.  This test recreates the scenario and proves the fix holds.
+# ---------------------------------------------------------------------------
+
+
+def test_marker_integrity_survives_reconciled_column_order(tmp_path: Path) -> None:
+    """Marker INSERT works even when column order diverges from canonical."""
+    import hashlib
+    import json
+    import re as _re
+    import sqlite3
+
+    from holdspeak.db.schema import SCHEMA_SQL
+    from holdspeak.db.reconcile import reconcile_schema
+
+    # Step 1: Build an "old" DDL that lacks result_sha256.
+    # Replace the canonical definition with one missing result_sha256.
+    old_table = (
+        "CREATE TABLE IF NOT EXISTS inference_assignment_migrations (\n"
+        "    family TEXT PRIMARY KEY,\n"
+        "    marker_revision INTEGER NOT NULL,\n"
+        "    source_sha256 TEXT NOT NULL,\n"
+        "    result_json TEXT NOT NULL,\n"
+        "    committed_at TEXT NOT NULL\n"
+        ");"
+    )
+    old_schema = _re.sub(
+        r"CREATE TABLE IF NOT EXISTS inference_assignment_migrations\s*\(.*?\);",
+        old_table,
+        SCHEMA_SQL,
+        count=1,
+        flags=_re.DOTALL,
+    )
+    assert "result_sha256" not in old_schema.split("inference_assignment_migrations")[1].split(";")[0], \
+        "old_schema should not have result_sha256 in inference_assignment_migrations"
+
+    db_path = tmp_path / "old-marker.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.executescript(old_schema)
+        conn.commit()
+
+        # Verify the old column order: family, marker_revision, source_sha256, result_json, committed_at
+        cols_before = [
+            row[1] for row in conn.execute("PRAGMA table_info(inference_assignment_migrations)").fetchall()
+        ]
+        assert cols_before == [
+            "family", "marker_revision", "source_sha256", "result_json", "committed_at"
+        ]
+
+        # Step 2: Reconcile -- adds result_sha256 at the END
+        changed = reconcile_schema(conn, db_path=db_path)
+        assert changed is True
+
+        cols_after = [
+            row[1] for row in conn.execute("PRAGMA table_info(inference_assignment_migrations)").fetchall()
+        ]
+        # result_sha256 should now exist but be LAST (not in canonical position)
+        assert "result_sha256" in cols_after
+        assert cols_after[-1] == "result_sha256", (
+            f"reconcile should append result_sha256 at end, got: {cols_after}"
+        )
+        # Column order now diverges from canonical
+        assert cols_after != [
+            "family", "marker_revision", "source_sha256", "result_json", "result_sha256", "committed_at"
+        ]
+
+        # Step 3: Insert a marker row using the FIXED named-column INSERT
+        # (mirroring what the service does)
+        def _canonical(value):
+            return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False)
+
+        def _sha(value):
+            return "sha256:" + hashlib.sha256(_canonical(value).encode()).hexdigest()
+
+        result = {
+            "schema": "InferenceAssignmentMigrationMarker@1",
+            "family": "test-family",
+            "marker_revision": 1,
+            "source_sha256": "sha256:" + "a" * 64,
+            "assignments": [],
+        }
+        committed_at = "2026-08-30T12:00:00.000000Z"
+
+        conn.execute(
+            "INSERT INTO inference_assignment_migrations "
+            "(family, marker_revision, source_sha256, result_json, result_sha256, committed_at) "
+            "VALUES (?,?,?,?,?,?)",
+            ("test-family", 1, "sha256:" + "a" * 64, _canonical(result), _sha(result), committed_at),
+        )
+        conn.commit()
+
+        # Step 4: Read it back and verify integrity (like migration_marker does)
+        row = conn.execute(
+            "SELECT * FROM inference_assignment_migrations WHERE family=?",
+            ("test-family",),
+        ).fetchone()
+        assert row is not None
+
+        stored_result = json.loads(str(row["result_json"]))
+        stored_sha = str(row["result_sha256"])
+        stored_committed = str(row["committed_at"])
+
+        # The sha should match the result_json, NOT be a timestamp
+        assert stored_sha == _sha(stored_result), (
+            f"Integrity violation: result_sha256={stored_sha!r}, "
+            f"expected={_sha(stored_result)!r}, "
+            f"committed_at={stored_committed!r}"
+        )
+        # committed_at should be a timestamp, not a sha
+        assert stored_committed == committed_at, (
+            f"committed_at should be the timestamp, got: {stored_committed!r}"
+        )
+        assert stored_sha.startswith("sha256:"), (
+            f"result_sha256 should start with 'sha256:', got: {stored_sha!r}"
+        )
+    finally:
+        conn.close()
+
+
+def test_positional_insert_would_corrupt_on_divergent_order(tmp_path: Path) -> None:
+    """Prove that a POSITIONAL insert on a reconciled table writes wrong values.
+
+    This is the negative test: without named columns, the sha goes into
+    committed_at and the timestamp goes into result_sha256.
+    """
+    import hashlib
+    import json
+    import re as _re
+    import sqlite3
+
+    from holdspeak.db.schema import SCHEMA_SQL
+    from holdspeak.db.reconcile import reconcile_schema
+
+    old_table = (
+        "CREATE TABLE IF NOT EXISTS inference_assignment_migrations (\n"
+        "    family TEXT PRIMARY KEY,\n"
+        "    marker_revision INTEGER NOT NULL,\n"
+        "    source_sha256 TEXT NOT NULL,\n"
+        "    result_json TEXT NOT NULL,\n"
+        "    committed_at TEXT NOT NULL\n"
+        ");"
+    )
+    old_schema = _re.sub(
+        r"CREATE TABLE IF NOT EXISTS inference_assignment_migrations\s*\(.*?\);",
+        old_table,
+        SCHEMA_SQL,
+        count=1,
+        flags=_re.DOTALL,
+    )
+
+    db_path = tmp_path / "positional-corrupt.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.executescript(old_schema)
+        conn.commit()
+        reconcile_schema(conn, db_path=db_path)
+
+        def _canonical(value):
+            return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False)
+
+        def _sha(value):
+            return "sha256:" + hashlib.sha256(_canonical(value).encode()).hexdigest()
+
+        result = {
+            "schema": "InferenceAssignmentMigrationMarker@1",
+            "family": "corrupt-test",
+            "marker_revision": 1,
+            "source_sha256": "sha256:" + "b" * 64,
+            "assignments": [],
+        }
+        committed_at = "2026-08-30T12:00:00.000000Z"
+        result_sha = _sha(result)
+
+        # Positional INSERT (the broken way) -- values go in canonical order:
+        # family, marker_revision, source_sha256, result_json, result_sha256, committed_at
+        # But the table's column order after reconcile is:
+        # family, marker_revision, source_sha256, result_json, committed_at, result_sha256
+        # So position 5 (result_sha256) goes into committed_at, and position 6
+        # (committed_at) goes into result_sha256.
+        conn.execute(
+            "INSERT INTO inference_assignment_migrations VALUES (?,?,?,?,?,?)",
+            ("corrupt-test", 1, "sha256:" + "b" * 64, _canonical(result), result_sha, committed_at),
+        )
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT * FROM inference_assignment_migrations WHERE family=?",
+            ("corrupt-test",),
+        ).fetchone()
+
+        # The corruption: result_sha256 column has the timestamp, committed_at has the sha
+        assert str(row["result_sha256"]) == committed_at, (
+            "Without named columns, the timestamp leaks into result_sha256"
+        )
+        assert str(row["committed_at"]) == result_sha, (
+            "Without named columns, the sha leaks into committed_at"
+        )
+
+        # And integrity verification fails
+        stored_result = json.loads(str(row["result_json"]))
+        assert str(row["result_sha256"]) != _sha(stored_result), (
+            "Integrity check should fail on the corrupted row"
+        )
+    finally:
+        conn.close()


### PR DESCRIPTION
The generic reconcile appends new columns at the END of existing tables, so a long-lived DB's column order diverges from canonical (26 tables on the real hub). Any positional `INSERT INTO t VALUES(...)` then writes into the WRONG columns on the real DB while passing every fresh-DB test — proven live when the assignment-migration marker's sha landed in `committed_at` and web boot died on marker integrity.

- Names the columns in all 33 positional INSERTs across 6 files.
- Adds `tests/unit/test_no_positional_inserts.py`: a fence failing on any future positional INSERT, a regression proving marker integrity survives reconcile-appended order, and a negative proof of the corruption.
- 126 scoped tests green. The real DB's two damaged rows repaired live (backups kept); all other divergent tables had zero rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wvZJuEHkmosZR349Mv9J8