### PR TITLE
P0: cure the context_ceiling=0 poison — defined endpoints finally assignable

### DIFF
--- a/holdspeak/db/reconcile.py
+++ b/holdspeak/db/reconcile.py
@@ -919,6 +919,13 @@ def _apply_data_backfills(conn: sqlite3.Connection) -> None:
     # owner can independently assign a cheaper model.  Idempotent.
     _backfill_chat_practice_assignments(conn)
 
+    # ── deployment-revisions-context-ceiling (P0 fix) ──────────────────
+    # define-endpoint wrote context_ceiling=0 into deployment_revisions
+    # while inference_deployments carried 16384.  The compatibility
+    # checker reads deployment_revisions, so every defined endpoint was
+    # context_unsupported.  Heal existing poisoned rows.  Idempotent.
+    _backfill_deployment_revision_context_ceiling(conn)
+
 
 def _backfill_chat_route_assignments(conn: sqlite3.Connection) -> None:
     """Family ``chat-route-assignments`` (HS-151-02).
@@ -1107,4 +1114,38 @@ def _backfill_chat_practice_assignments(conn: sqlite3.Connection) -> None:
         log.info(
             "chat-practice-assignments backfill: copied chat.turn to %s (%d entries)",
             target_cap, len(entries),
+        )
+
+
+def _backfill_deployment_revision_context_ceiling(conn: sqlite3.Connection) -> None:
+    """Heal deployment_revisions.context_ceiling=0 from inference_deployments.
+
+    The define-endpoint path (model_library_service._ensure_provider_deployment)
+    wrote context_ceiling=0 via DeploymentRevision.from_identity() into
+    deployment_revisions while simultaneously writing 16384 into
+    inference_deployments.context_ceiling.  The compatibility checker reads
+    deployment_revisions, so every defined-endpoint profile was marked
+    context_unsupported.  This backfill copies the correct value from
+    inference_deployments for affected rows.  Idempotent: rows already !=0
+    are untouched.
+    """
+    healed = conn.execute(
+        """UPDATE deployment_revisions
+           SET context_ceiling = (
+               SELECT d.context_ceiling
+               FROM inference_deployments d
+               WHERE d.execution_revision_id = deployment_revisions.id
+                 AND d.context_ceiling > 0
+               LIMIT 1
+           )
+           WHERE deployment_revisions.context_ceiling = 0
+             AND EXISTS (
+                 SELECT 1 FROM inference_deployments d
+                 WHERE d.execution_revision_id = deployment_revisions.id
+                   AND d.context_ceiling > 0
+             )"""
+    ).rowcount
+    if healed:
+        log.info(
+            "deployment-revision-context-ceiling backfill: healed %d row(s)", healed,
         )

--- a/holdspeak/services/inference_adoption_service.py
+++ b/holdspeak/services/inference_adoption_service.py
@@ -853,8 +853,21 @@ class RoutedInferenceCoordinator:
                     reference=reference, route_request=route_request,
                 )
                 conn.commit()
-            except Exception:
+            except Exception as exc:
                 conn.rollback()
+                # Surface FK failures as a typed error instead of raw 500.
+                import sqlite3
+                if isinstance(exc, sqlite3.IntegrityError) and "FOREIGN KEY" in str(exc):
+                    raise ServiceError(
+                        "inference_admission_integrity_failure",
+                        "A required parent record is missing for this model assignment. "
+                        "The profile may need to be re-created or re-bound.",
+                        context={
+                            "capability_id": capability_id,
+                            "status": 409,
+                            "detail": str(exc),
+                        },
+                    ) from exc
                 raise
         return result
 

--- a/holdspeak/services/inference_route_plan_service.py
+++ b/holdspeak/services/inference_route_plan_service.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import re
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as _replace
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, Callable, Mapping, Sequence
@@ -765,10 +765,13 @@ class InferenceRoutePlanService:
                 source = SimpleNamespace(**dict(row))
                 adapted = adapt_v1_profile(source)
                 deployment_revision = self._legacy_deployment(source)
+                context_limit = int(row["context_limit"] or 0)
+                if context_limit > 0:
+                    deployment_revision = _replace(deployment_revision, context_ceiling=context_limit)
                 boundary = _BOUNDARIES.get(deployment_revision.boundary)
                 if boundary not in capability.allowed_boundaries:
                     raise ValidationError("Legacy target boundary is not permitted.", code="inference_route_boundary_unsupported")
-                context = self._context_support({"mode": "bounded", "maximum_tokens": int(row["context_limit"] or 0)})
+                context = self._context_support({"mode": "bounded", "maximum_tokens": context_limit})
                 self._validate_legacy_compatibility(capability, context, boundary)
                 created = self._clock()
                 if created.tzinfo is None:
@@ -1321,7 +1324,10 @@ class InferenceRoutePlanService:
                 profile = adapted["profile"]
                 binding = adapted["binding"]
                 deployment = self._legacy_deployment(source)
-                context = {"mode": profile["context_support"], "maximum_tokens": int(row["context_limit"] or 0)}
+                context_limit = int(row["context_limit"] or 0)
+                if context_limit > 0:
+                    deployment = _replace(deployment, context_ceiling=context_limit)
+                context = {"mode": profile["context_support"], "maximum_tokens": context_limit}
                 readiness = "unknown"
                 enabled = True
             else:

--- a/holdspeak/services/model_library_service.py
+++ b/holdspeak/services/model_library_service.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import re
 import uuid
+from dataclasses import replace as _replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -452,7 +453,10 @@ class ModelLibraryApplicationService:
         identity = target_from_profile(target, self._db).deployment
         if identity is None:
             raise ServiceError("model_library_provider_invalid", "Provider destination is unavailable.", context={"status": 409})
-        revision = DeploymentRevision.from_identity(identity)
+        revision = _replace(
+            DeploymentRevision.from_identity(identity),
+            context_ceiling=16_384,
+        )
         artifact_id = f"provider-material-{draft['profile_id']}-r{profile_revision}"
         material = {
             "schema": "ModelLibraryProviderMaterial@1",

--- a/holdspeak/services/model_profile_service.py
+++ b/holdspeak/services/model_profile_service.py
@@ -13,7 +13,7 @@ import json
 import platform
 import re
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as _replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping
@@ -1249,10 +1249,13 @@ class ModelProfileService:
                 "capability_sha256": str(row["capability_sha256"] or ""),
             }
             if schema_version == 1:
-                rebuilt = DeploymentRevision.from_identity(DeploymentIdentity(**{
-                    key: values[key]
-                    for key in ("destination_id", "kind", "engine", "model", "node", "boundary", "model_path", "endpoint", "secret_slot")
-                }))
+                rebuilt = _replace(
+                    DeploymentRevision.from_identity(DeploymentIdentity(**{
+                        key: values[key]
+                        for key in ("destination_id", "kind", "engine", "model", "node", "boundary", "model_path", "endpoint", "secret_slot")
+                    })),
+                    context_ceiling=values["context_ceiling"],
+                )
             elif schema_version == 2:
                 rebuilt = DeploymentRevision.from_artifact(
                     destination_id=values["destination_id"], engine=values["engine"],

--- a/tests/unit/test_model_wiring_p0.py
+++ b/tests/unit/test_model_wiring_p0.py
@@ -1,0 +1,346 @@
+"""P0 model-wiring regression tests.
+
+Bug A: define-endpoint wrote context_ceiling=0 into deployment_revisions while
+inference_deployments carried 16384.  The compatibility checker reads
+deployment_revisions, so every defined endpoint was context_unsupported.
+
+Bug B: legacy-profile freeze path must return a typed error on FK constraint
+violations instead of a raw HTTP 500.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import uuid
+from dataclasses import replace as _replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from holdspeak.db.core import Database
+from holdspeak.deployment_revisions import DeploymentRevision
+from holdspeak.inference_capabilities import (
+    InferenceCapabilityRegistry,
+    builtin_capability_definitions,
+    builtin_retry_policy_definitions,
+    process_inference_capability_registry,
+)
+from holdspeak.principals import Principal, PrincipalKind
+from holdspeak.services.errors import ServiceError
+from holdspeak.services.inference_assignment_service import InferenceAssignmentService
+from holdspeak.services.inference_adoption_service import RoutedInferenceCoordinator
+from holdspeak.services.model_profile_service import ModelProfileService
+
+OWNER = Principal(PrincipalKind.OWNER, "test-owner")
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    return Database(tmp_path / "wiring.db")
+
+
+def _make_library_service(db: Database) -> Any:
+    """Construct a ModelLibraryApplicationService with minimal stubs."""
+    from holdspeak.services.model_library_service import ModelLibraryApplicationService
+
+    class _StubSetup:
+        def get_model_library_facts(self, principal: Any) -> dict:
+            return {"catalog": {}, "local": {}}
+
+    class _StubAcquisition:
+        pass
+
+    return ModelLibraryApplicationService(
+        db,
+        setup_service=_StubSetup(),
+        acquisition_service=_StubAcquisition(),
+    )
+
+
+# ── Bug A: context_ceiling write path ──────────────────────────────────
+
+
+def test_define_endpoint_writes_nonzero_context_ceiling(db: Database) -> None:
+    """define-endpoint must store context_ceiling > 0 in deployment_revisions."""
+    svc = _make_library_service(db)
+    profile_id = "p0-test-endpoint"
+    svc.define_endpoint(OWNER, {
+        "request_id": f"req-{uuid.uuid4().hex[:8]}",
+        "profile_id": profile_id,
+        "expected_profile_revision": 0,
+        "label": "P0 Test Endpoint",
+        "provider_family": "openai_compatible",
+        "model": "qwen3.6",
+        "endpoint": "http://192.168.1.43:8080/v1",
+        "requires_key": False,
+    })
+    # Verify deployment_revisions.context_ceiling is NOT 0
+    with db._connection() as conn:
+        rows = conn.execute(
+            "SELECT id, context_ceiling FROM deployment_revisions"
+        ).fetchall()
+    assert len(rows) >= 1, "No deployment revision created"
+    for row in rows:
+        assert int(row["context_ceiling"]) > 0, (
+            f"deployment_revisions.context_ceiling is {row['context_ceiling']} "
+            f"for id={row['id']}; must be >0 after define-endpoint"
+        )
+    # Cross-check against inference_deployments
+    with db._connection() as conn:
+        dep_rows = conn.execute(
+            "SELECT deployment_id, context_ceiling, execution_revision_id "
+            "FROM inference_deployments"
+        ).fetchall()
+    assert len(dep_rows) >= 1
+    for dep in dep_rows:
+        rev_row = next(r for r in rows if r["id"] == dep["execution_revision_id"])
+        assert int(rev_row["context_ceiling"]) == int(dep["context_ceiling"]), (
+            "deployment_revisions.context_ceiling must match "
+            "inference_deployments.context_ceiling"
+        )
+
+
+# ── Bug A: context_ceiling read path ──────────────────────────────────
+
+
+def test_deployment_from_row_preserves_stored_context_ceiling(db: Database) -> None:
+    """The v1 read path must preserve the stored context_ceiling, not reset to 0."""
+    profiles = ModelProfileService(db)
+    # Seed a v1 deployment revision with a non-zero context_ceiling
+    from holdspeak.inference_targets import DeploymentIdentity
+    identity = DeploymentIdentity(
+        destination_id="test-dest",
+        kind="private_endpoint",
+        engine="openai_compatible",
+        model="test-model",
+        node="",
+        boundary="private_network",
+        endpoint="http://192.168.1.43:8080/v1",
+        model_path=None,
+        secret_slot="",
+    )
+    revision = _replace(
+        DeploymentRevision.from_identity(identity),
+        context_ceiling=16_384,
+    )
+    db.deployment_revisions.upsert(revision)
+    # Verify the read path preserves context_ceiling
+    with db._connection() as conn:
+        row = conn.execute(
+            "SELECT * FROM deployment_revisions WHERE id=?", (revision.id,)
+        ).fetchone()
+    rebuilt = profiles._deployment_from_row(row)
+    assert rebuilt.context_ceiling == 16_384, (
+        f"_deployment_from_row returned context_ceiling={rebuilt.context_ceiling}; "
+        f"expected 16384 (the stored value)"
+    )
+
+
+# ── Bug A: backfill ───────────────────────────────────────────────────
+
+
+def test_backfill_heals_poisoned_context_ceiling(tmp_path: Path) -> None:
+    """The reconcile backfill must heal context_ceiling=0 in deployment_revisions.
+
+    Seeds a pre-fix-shaped DB: deployment_revisions with context_ceiling=0 and
+    a matching inference_deployments row with context_ceiling=16384.  After
+    the backfill runs, the deployment_revisions row must have 16384.
+    """
+    db_path = tmp_path / "backfill.db"
+    db = Database(db_path)
+    # Seed a deployment revision with context_ceiling=0 (the pre-fix state)
+    from holdspeak.inference_targets import DeploymentIdentity
+    identity = DeploymentIdentity(
+        destination_id="test-backfill",
+        kind="private_endpoint",
+        engine="openai_compatible",
+        model="backfill-model",
+        node="",
+        boundary="private_network",
+        endpoint="http://192.168.1.43:8080/v1",
+        model_path=None,
+        secret_slot="",
+    )
+    revision = DeploymentRevision.from_identity(identity)
+    assert revision.context_ceiling == 0, "Sanity: from_identity produces context_ceiling=0"
+    db.deployment_revisions.upsert(revision)
+    # Seed a matching inference_deployments row with the correct context_ceiling.
+    # This requires an inference_model_artifacts row first (FK constraint).
+    artifact_id = f"artifact-backfill-{uuid.uuid4().hex[:8]}"
+    manifest_sha = "sha256:" + hashlib.sha256(b"backfill").hexdigest()
+    with db._connection() as conn:
+        conn.execute(
+            """INSERT INTO inference_model_artifacts
+               (artifact_id,format,source_kind,source_repository,source_revision,
+                manifest_json,manifest_sha256,installed_bytes,state,local_locator,
+                created_at,verified_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (artifact_id, "gguf", "test", "test", "r1", "{}", manifest_sha,
+             1, "verified", "", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            """INSERT INTO inference_deployments
+               (deployment_id,destination_id,runtime_id,runtime_revision,artifact_id,
+                model_identity,context_ceiling,recommended_context,capability_json,
+                capability_sha256,execution_revision_id,configuration_revision,active,
+                created_at,updated_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            ("head-backfill", "test-backfill", "", "", artifact_id,
+             "backfill-model", 16_384, 16_384, "{}", "", revision.id, 1, 0,
+             "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"),
+        )
+    # Run the backfill directly (the reconcile shape-changed gate
+    # would not fire on an already-current schema)
+    from holdspeak.db.reconcile import _backfill_deployment_revision_context_ceiling
+    with db._connection() as conn:
+        _backfill_deployment_revision_context_ceiling(conn)
+    # Verify the backfill healed the context_ceiling
+    with db._connection() as conn:
+        row = conn.execute(
+            "SELECT context_ceiling FROM deployment_revisions WHERE id=?",
+            (revision.id,),
+        ).fetchone()
+    assert int(row["context_ceiling"]) == 16_384, (
+        f"Backfill did not heal context_ceiling: got {row['context_ceiling']}, expected 16384"
+    )
+
+
+# ── Bug A: compatibility check ────────────────────────────────────────
+
+
+def test_defined_endpoint_is_not_context_unsupported(db: Database) -> None:
+    """A defined-endpoint profile must NOT be context_unsupported for chat.turn.
+
+    This is the end-to-end smoke test: define an endpoint, assign it to
+    chat.turn, and admit.  The admission must succeed (not fail with
+    context_unsupported).
+    """
+    # Define endpoint
+    lib = _make_library_service(db)
+    profile_id = "p0-compat-test"
+    lib.define_endpoint(OWNER, {
+        "request_id": f"req-compat-{uuid.uuid4().hex[:8]}",
+        "profile_id": profile_id,
+        "expected_profile_revision": 0,
+        "label": "P0 Compat Test",
+        "provider_family": "openai_compatible",
+        "model": "qwen3.6",
+        "endpoint": "http://192.168.1.43:8080/v1",
+        "requires_key": False,
+    })
+    # Assign to chat.turn
+    assignments = InferenceAssignmentService(db)
+    assignments.set_assignment(OWNER, {
+        "command_id": f"assign-compat-{uuid.uuid4().hex[:8]}",
+        "expected_revision": 0,
+        "scope": {"kind": "capability", "capability_id": "chat.turn"},
+        "entries": [{"profile_id": profile_id, "profile_revision": 1}],
+    })
+    # Admit
+    coordinator = RoutedInferenceCoordinator(db)
+    inv = "chat_turn_" + uuid.uuid4().hex
+    admitted = coordinator.admit(
+        OWNER,
+        command_id=f"admit-{inv}",
+        capability_id="chat.turn",
+        operation_id=inv,
+        payload={"messages": [{"role": "user", "content": "hello"}]},
+        invocation_id=inv,
+        reserved_output_tokens=512,
+    )
+    assert "route_plan" in admitted
+    assert "execution" in admitted
+    entries = admitted["route_plan"].get("entries", [])
+    assert len(entries) >= 1, "Route plan must have at least one entry"
+
+
+# ── Bug B: FK error handling ──────────────────────────────────────────
+
+
+def test_legacy_profile_admit_succeeds(db: Database) -> None:
+    """Legacy profile admission through chat.turn must succeed, not FK-fail."""
+    db.profiles.upsert(
+        profile_id="legacy-intel",
+        name="Legacy Intel Model",
+        kind="openAICompatible",
+        base_url="http://192.168.1.43:8080/v1",
+        model="qwen3.6",
+        requires_key=False,
+    )
+    # Set context_limit so the legacy path doesn't hit context_unsupported
+    with db._connection() as conn:
+        conn.execute(
+            "UPDATE profiles SET context_limit=? WHERE id=?",
+            (16384, "legacy-intel"),
+        )
+    svc = InferenceAssignmentService(db)
+    svc.set_assignment(OWNER, {
+        "command_id": f"assign-legacy-{uuid.uuid4().hex[:8]}",
+        "expected_revision": 0,
+        "scope": {"kind": "capability", "capability_id": "chat.turn"},
+        "entries": [{"profile_id": "legacy-legacy-intel"}],
+    })
+    coordinator = RoutedInferenceCoordinator(db)
+    inv = "chat_turn_" + uuid.uuid4().hex
+    admitted = coordinator.admit(
+        OWNER,
+        command_id=f"admit-{inv}",
+        capability_id="chat.turn",
+        operation_id=inv,
+        payload={"messages": [{"role": "user", "content": "hello"}]},
+        invocation_id=inv,
+        reserved_output_tokens=512,
+    )
+    assert "route_plan" in admitted
+    # Verify the stored deployment revision has the correct context_ceiling
+    with db._connection() as conn:
+        rows = conn.execute(
+            "SELECT id, context_ceiling FROM deployment_revisions"
+        ).fetchall()
+    for row in rows:
+        assert int(row["context_ceiling"]) == 16384, (
+            f"Legacy deployment revision context_ceiling={row['context_ceiling']}; expected 16384"
+        )
+
+
+def test_fk_error_returns_typed_service_error(db: Database) -> None:
+    """FK IntegrityError during admit must surface as a typed ServiceError,
+    not a raw sqlite3.IntegrityError / HTTP 500."""
+    coordinator = RoutedInferenceCoordinator(db)
+    # Monkey-patch the freeze to raise a FOREIGN KEY IntegrityError
+    original = coordinator.plans._freeze_one_shot_in_transaction
+
+    def _broken_freeze(*args: Any, **kwargs: Any) -> Any:
+        raise sqlite3.IntegrityError("FOREIGN KEY constraint failed")
+
+    coordinator.plans._freeze_one_shot_in_transaction = _broken_freeze
+    # Seed a minimal assignment
+    db.profiles.upsert(
+        profile_id="fk-test-profile",
+        name="FK Test",
+        kind="openAICompatible",
+        base_url="http://localhost:1234/v1",
+        model="test",
+        requires_key=False,
+    )
+    svc = InferenceAssignmentService(db)
+    svc.set_assignment(OWNER, {
+        "command_id": f"assign-fk-{uuid.uuid4().hex[:8]}",
+        "expected_revision": 0,
+        "scope": {"kind": "capability", "capability_id": "chat.turn"},
+        "entries": [{"profile_id": "legacy-fk-test-profile"}],
+    })
+    inv = "chat_turn_" + uuid.uuid4().hex
+    with pytest.raises(ServiceError, match="parent record is missing"):
+        coordinator.admit(
+            OWNER,
+            command_id=f"admit-{inv}",
+            capability_id="chat.turn",
+            operation_id=inv,
+            payload={"messages": [{"role": "user", "content": "hello"}]},
+            invocation_id=inv,
+            reserved_output_tokens=512,
+        )


### PR DESCRIPTION
Found live on the owner's desk by the concierge walk: `define-endpoint` wrote every deployment revision with `context_ceiling=0` (the `from_identity()` default), so profiles showed **ready** while being `context_unsupported` for every capability — no LAN server has ever been assignable through the new system. Fixed at all four sites (write path, read path, legacy path, plus an idempotent reconcile backfill that heals existing poisoned rows). The legacy route-freeze FK 500 becomes a typed 409 with detail (unreproducible on fresh DBs; defense in depth). Proof: define → assign → admit completes with `context_ceiling=16384` in the route plan against the real .43 endpoint.

Also diagnosed for Phase 156: catalog downloads never create an assignable v2 profile (missing activate step — the front-door apply covers packs); group-overrides-global is designed precedence with `preview-use-default` as the escape hatch.

38 scoped tests green (6 new regressions + chat capability + assignments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wvZJuEHkmosZR349Mv9J8