### PR TITLE
fix(web): restore integration quality checks and Chair retry receipts

### DIFF
--- a/docs/internal/web-integration-checks.md
+++ b/docs/internal/web-integration-checks.md
@@ -1,0 +1,33 @@
+# Web integration prerequisites
+
+Verified 2026-09-05 against main `d4fbfaca`. The existing web check stopped on 19 raw CSS values, four surface fence findings, eight TypeScript diagnostics, and swallowed Chair writes. This repair preserves the CSS values through shared tokens, uses public surface imports and feature-owned layout classes, restores typed native Button refs, supplies the Concierge choice label slot, and reports failed Chair writes with Retry. Guard ceilings and allowlists were not raised.
+
+Actual output from `npm run check` (bundled Node, isolated worktree):
+
+```text
+tokens.css and tokens.gen.ts match design-tokens.json
+token gate: clean (12 allow-listed exceptions, all in use)
+React architecture guard passed (663 source files; zero framework residue).
+ Test Files  220 passed (220)
+      Tests  2165 passed (2165)
+✓ built in 4.05s
+bundle gate passed (Desk JS 1248814 B; Desk CSS 292517 B; source maps 0)
+```
+
+The final Chair generation recovery change and native focus restoration were additionally verified with:
+
+```text
+> holdspeak-web@0.0.1 test:web
+> vitest run --maxWorkers=2 src/desk/chair/ChairHome.test.tsx src/components/signal/Signal.test.tsx src/desk/__tests__/writeReceiptGuard.test.ts
+
+
+ RUN  v4.1.9 /Users/karol/dev/alt/HoldSpeak-quality/web
+
+
+ Test Files  3 passed (3)
+      Tests  11 passed (11)
+   Start at  16:52:31
+   Duration  1.83s (transform 1.20s, setup 172ms, import 1.51s, tests 183ms, environment 585ms)
+```
+
+TypeScript and generated-token consistency were checked again after the final test. Full command output is retained in the quality worktree's `.tmp/web-check.log` and `.tmp/web-recovery-tests.log`. Canvas warnings from jsdom are not browser-rendering evidence. This repair does not claim the unrelated Python/model or E2E suites are green; those remain subject to the feature integration checks.

--- a/web/design-tokens.json
+++ b/web/design-tokens.json
@@ -805,6 +805,26 @@
         "name": "--wash-2",
         "value": "{primitive.color.wash.05}",
         "doc": "hover-weight white wash"
+      },
+      {
+        "name": "--bevel-light-strong",
+        "value": "rgba(255, 255, 255, 0.22)",
+        "doc": "Raised voice and chair control highlight; preserves the existing material."
+      },
+      {
+        "name": "--bevel-light-hover",
+        "value": "rgba(255, 255, 255, 0.18)",
+        "doc": "Hovered chrome control highlight."
+      },
+      {
+        "name": "--bevel-dark-soft",
+        "value": "rgba(0, 0, 0, 0.20)",
+        "doc": "Soft inner bevel for controls and gadgets."
+      },
+      {
+        "name": "--accent-tint-faint",
+        "value": "rgba(168, 110, 74, 0.08)",
+        "doc": "Faint accent wash for project controls."
       }
     ]
   },

--- a/web/src/components/signal/Signal.test.tsx
+++ b/web/src/components/signal/Signal.test.tsx
@@ -2,6 +2,7 @@
 // (Switch/Tabs/InlineMessage died; wings and FoldGadget carry the
 // keyboard grammar now — see desk/surface tests). What survives here
 // is the surviving roster: Field association and Button semantics.
+import { createRef } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { Button, Field, TextInput } from "./Signal";
@@ -23,6 +24,13 @@ describe("Signal React controls", () => {
     expect(input).toHaveAccessibleDescription(
       "Include the scheme. Could not connect.",
     );
+  });
+
+  it("forwards the native button ref for focus restoration", () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(<Button ref={ref}>Return</Button>);
+    ref.current?.focus();
+    expect(screen.getByRole("button", { name: "Return" })).toHaveFocus();
   });
 
   it("exposes semantic busy and disabled states", () => {

--- a/web/src/components/signal/Signal.tsx
+++ b/web/src/components/signal/Signal.tsx
@@ -10,7 +10,7 @@
 //   composes StringGadget/PadGadget/CycleGadget.
 // - Panel — the document-shell card (non-desk routes).
 import {
-  type ButtonHTMLAttributes,
+  type ComponentPropsWithRef,
   type InputHTMLAttributes,
   type ReactNode,
   type SelectHTMLAttributes,
@@ -26,7 +26,7 @@ export function Button({
   className = "",
   disabled,
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & {
+}: ComponentPropsWithRef<"button"> & {
   variant?: "primary" | "secondary" | "ghost" | "danger";
   dense?: boolean;
   loading?: boolean;

--- a/web/src/desk/chair/ChairHome.test.tsx
+++ b/web/src/desk/chair/ChairHome.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "../../lib/api";
+import { clearWriteFailure, useDeskWriteReceipt } from "../hooks/useWriteReceipt";
+import { ChairHome } from "./ChairHome";
+
+vi.mock("../../lib/api", async (original) => ({
+  ...await original<typeof import("../../lib/api")>(),
+  apiFetch: vi.fn(),
+}));
+vi.mock("../thoughts", () => ({ unfinishedThoughts: async () => ({ items: [] }) }));
+vi.mock("../components/MicButton", () => ({ MicButton: () => null }));
+
+function WithReceipt() {
+  const { receipt } = useDeskWriteReceipt();
+  return <><ChairHome />{receipt}</>;
+}
+
+describe("Chair write recovery", () => {
+  beforeEach(() => {
+    clearWriteFailure();
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("keeps a failed generation actionable and clears the receipt after retry", async () => {
+    let attempts = 0;
+    vi.mocked(apiFetch).mockImplementation(async (path) => {
+      if (path === "/api/brief/generate") {
+        if (++attempts === 1) throw new Error("Connection lost");
+        return { sections: {}, shelf: {} };
+      }
+      return null;
+    });
+    render(<WithReceipt />);
+    fireEvent.click(await screen.findByRole("button", { name: "Generate" }));
+    expect(await screen.findByText(/GENERATE BRIEF FAILED/)).toBeVisible();
+    expect(screen.getByRole("button", { name: "Generate" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    await waitFor(() => expect(attempts).toBe(2));
+    await waitFor(() => expect(screen.queryByText(/GENERATE BRIEF FAILED/)).not.toBeInTheDocument());
+  });
+});

--- a/web/src/desk/chair/ChairHome.tsx
+++ b/web/src/desk/chair/ChairHome.tsx
@@ -9,6 +9,7 @@ import { Chair } from "./Chair";
 import { FirstWords } from "../components/FirstWords";
 import { useDesk } from "../store";
 import { openSurface, openSurfaceOr, openCoderSession } from "../shell";
+import { reportWriteFailure, clearWriteFailure } from "../hooks/useWriteReceipt";
 import { apiFetch } from "../../lib/api";
 import { Button } from "../../components/signal/Signal";
 import { MicButton } from "../components/MicButton";
@@ -301,7 +302,10 @@ function Arrival() {
     try {
       const data = await apiFetch<MondayBrief>("/api/brief/generate", { method: "POST" });
       setBrief(data);
-    } catch { /* stays */ }
+      clearWriteFailure();
+    } catch (error) {
+      reportWriteFailure("Generate brief", error, () => void generateBrief());
+    }
     finally { setGenerating(false); }
   };
 
@@ -377,7 +381,10 @@ function Arrival() {
         else (updated as Record<string, string>)[itemId] = next;
         return { ...prev, shelf: updated };
       });
-    } catch { /* row stays */ }
+      clearWriteFailure();
+    } catch (error) {
+      reportWriteFailure(state === "acknowledged" ? "Acknowledge" : "Defer", error, () => void doBriefShelf(itemId, state));
+    }
     finally { setBusyBriefId(null); }
   };
 
@@ -394,7 +401,10 @@ function Arrival() {
       );
       setIntelReceipt({ meetingId, host: result.host || "THIS DEVICE" });
       void useDesk.getState().refresh();
-    } catch { /* receipt stays */ }
+      clearWriteFailure();
+    } catch (error) {
+      reportWriteFailure("Run intelligence", error, () => void runIntelligence(meetingId));
+    }
     finally { setRunningIntel(null); }
   };
 
@@ -687,7 +697,10 @@ function NeedsYouRowVerbs({
         );
         setDone(true);
         onProposalConfirm?.(item.proposalId!);
-      } catch { /* row stays */ }
+        clearWriteFailure();
+      } catch (error) {
+        reportWriteFailure("Confirm", error, () => void confirmProposal());
+      }
       finally { setBusy(false); }
     };
     if (done) return null;
@@ -733,7 +746,10 @@ function NeedsYouRowVerbs({
       try {
         await apiFetch(cmd.endpoint, { method: "POST", json: cmd.body });
         setDone(true);
-      } catch { /* receipt stays */ }
+        clearWriteFailure();
+      } catch (error) {
+        reportWriteFailure(labelFor(firstVerb), error, () => void fireVerb());
+      }
       finally { setBusy(false); }
     };
 

--- a/web/src/desk/chair/_parked/ThoughtEntry.tsx
+++ b/web/src/desk/chair/_parked/ThoughtEntry.tsx
@@ -5,7 +5,7 @@ import { useDurableDraft } from "../../lib/durableDraft";
 import { openSurfaceOr } from "../shell";
 import { useDesk } from "../store";
 import { createThought } from "../thoughts";
-import { PadGadget } from "../surface/gadgets";
+import { PadGadget } from "../../surface";
 import { micStreamSupported, startStreamSession, type StreamSession } from "../../lib/micStreamSession";
 
 function requestId(key: string): string {

--- a/web/src/desk/chair/chair.css
+++ b/web/src/desk/chair/chair.css
@@ -259,10 +259,10 @@
   background: var(--accent);
   border-color: var(--accent);
   color: var(--text-on-accent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22),
-              0 1px 2px rgba(0, 0, 0, 0.3),
-              inset 1px 1px 0 rgba(255, 255, 255, 0.14),
-              inset -1px -1px 0 rgba(0, 0, 0, 0.20);
+  box-shadow: inset 0 1px 0 var(--bevel-light-strong),
+              0 1px 2px var(--etch-dark),
+              inset 1px 1px 0 var(--bevel-light),
+              inset -1px -1px 0 var(--bevel-dark-soft);
 }
 .arrival-capture-bar .desk-mic.gadget-transport-key .gadget-transport-glyph svg {
   stroke: var(--text-on-accent);

--- a/web/src/desk/components/DeskComposer.tsx
+++ b/web/src/desk/components/DeskComposer.tsx
@@ -1,6 +1,6 @@
 import "./session-pullout.css";
 import { Button } from "../../components/signal/Signal";
-import { StringGadget, PadGadget } from "../surface/gadgets";
+import { StringGadget, PadGadget } from "../surface";
 import { MicButton } from "./MicButton";
 
 interface DeskComposerProps {

--- a/web/src/desk/components/chrome-menus.css
+++ b/web/src/desk/components/chrome-menus.css
@@ -501,7 +501,7 @@
 }
 .desk-next .desk-deck-row.is-selected .desk-deck-badge,
 .desk-next .desk-deck-row:hover:not(.is-ghost) .desk-deck-badge {
-  background: rgba(255, 255, 255, 0.18);
+  background: var(--bevel-light-hover);
   color: var(--text-on-accent);
 }
 .desk-next .desk-tool-empty {

--- a/web/src/desk/components/speak.css
+++ b/web/src/desk/components/speak.css
@@ -30,10 +30,10 @@
   background: var(--accent);
   border-color: var(--accent);
   color: var(--text-on-accent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22),
-              0 1px 2px rgba(0, 0, 0, 0.3),
-              inset 1px 1px 0 rgba(255, 255, 255, 0.14),
-              inset -1px -1px 0 rgba(0, 0, 0, 0.20);
+  box-shadow: inset 0 1px 0 var(--bevel-light-strong),
+              0 1px 2px var(--etch-dark),
+              inset 1px 1px 0 var(--bevel-light),
+              inset -1px -1px 0 var(--bevel-dark-soft);
 }
 .desk-next .speak-transport > .desk-mic.gadget-transport-key .gadget-transport-glyph svg {
   stroke: var(--text-on-accent);
@@ -236,7 +236,7 @@
     padding: 8px 0;
     border-top: 1px solid var(--border);
     background: var(--desk-window-bg, var(--surface-1));
-    z-index: 1;
+    z-index: var(--desk-z-local);
   }
   .desk-next .speak-lands-in {
     flex-wrap: wrap;

--- a/web/src/desk/surface/gadgets.css
+++ b/web/src/desk/surface/gadgets.css
@@ -187,15 +187,15 @@
   color: var(--ok, #34d399);
   border-color: color-mix(in srgb, var(--ok, #34d399) 40%, transparent);
   box-shadow:
-    inset 1px 1px 0 rgba(0, 0, 0, 0.30),
-    inset -1px -1px 0 rgba(255, 255, 255, 0.06);
+    inset 1px 1px 0 var(--etch-dark),
+    inset -1px -1px 0 var(--border-subtle);
 }
 .gadget-check-token.is-off .gadget-check-token-face {
   color: var(--text-faint, #767e8d);
   border-color: var(--border, #2a2e3e);
   box-shadow:
-    inset 1px 1px 0 rgba(255, 255, 255, 0.08),
-    inset -1px -1px 0 rgba(0, 0, 0, 0.20);
+    inset 1px 1px 0 var(--p-color-wash-08),
+    inset -1px -1px 0 var(--bevel-dark-soft);
 }
 .gadget-check-token input:focus-visible + .gadget-check-token-face {
   border-color: var(--accent);

--- a/web/src/desk/surface/patterns/StateChip.tsx
+++ b/web/src/desk/surface/patterns/StateChip.tsx
@@ -36,14 +36,16 @@ export function StateChip({
   state,
   label,
   icon,
+  className,
 }: {
   state: ChipState;
   label?: string;
   icon?: string;
+  className?: string;
 }) {
   return (
     <span
-      className="surface-state-chip"
+      className={className ? `surface-state-chip ${className}` : "surface-state-chip"}
       data-state={state}
       role="status"
       aria-label={label ?? DEFAULT_LABELS[state]}

--- a/web/src/features/concierge/ConciergeCore.tsx
+++ b/web/src/features/concierge/ConciergeCore.tsx
@@ -179,7 +179,7 @@ function PickerWell({ row, ctrl, engines }: { row: SetRow; ctrl: ConciergeContro
         const isPreset = alt.kind === "preset";
         const isCloud = alt.kind === "cloud";
         return (
-          <ChoiceCardShell key={alt.id} as="div" selected={row.engineId === alt.id}>
+          <ChoiceCardShell key={alt.id} as="div" selected={row.engineId === alt.id} label={
             <Button
               dense variant="ghost" className="concierge-picker-card"
               onClick={() => ctrl.pickEngine(row.group, alt.id)}
@@ -201,10 +201,10 @@ function PickerWell({ row, ctrl, engines }: { row: SetRow; ctrl: ConciergeContro
                 <EgressChip label={engineHostLabel(alt)} scope={engineHostScope(alt)} />
               ) : null}
             </Button>
-          </ChoiceCardShell>
+          } />
         );
       })}
-      <ChoiceCardShell as="div">
+      <ChoiceCardShell as="div" label={
         <Button
           dense variant="ghost" className="concierge-picker-card"
           onClick={() => ctrl.pickEngine(row.group, "OFF")}
@@ -212,7 +212,7 @@ function PickerWell({ row, ctrl, engines }: { row: SetRow; ctrl: ConciergeContro
         >
           <span className="concierge-picker-card-name">OFF</span>
         </Button>
-      </ChoiceCardShell>
+      } />
     </div>
   );
 }

--- a/web/src/features/concierge/api.ts
+++ b/web/src/features/concierge/api.ts
@@ -22,7 +22,6 @@ export interface Engine {
   legacyLabel?: string;
   keySet?: boolean;
   profileId?: string;
-  legacyLabel?: string;
   presetId?: string;
   installed?: boolean;
   path?: string;

--- a/web/src/features/concierge/concierge.css
+++ b/web/src/features/concierge/concierge.css
@@ -302,10 +302,6 @@
     var(--ease-quart, cubic-bezier(0.25, 1, 0.5, 1)) both;
 }
 
-.concierge-picker-well .surface-choice-card-shell {
-  cursor: pointer;
-}
-
 .concierge-picker-card {
   display: flex !important;
   align-items: center;

--- a/web/src/features/project-room/door/DoorCore.tsx
+++ b/web/src/features/project-room/door/DoorCore.tsx
@@ -163,10 +163,10 @@ function ConnectedRow({ row, ctrl }: { row: SourceRow; ctrl: DoorController }) {
           ))}
 
           {row.state === "checking" ? (
-            <StateChip state="working" label="CHECKING" icon="○" />
+            <StateChip className="door-row-status" state="working" label="CHECKING" icon="○" />
           ) : row.state === "cant_check" ? (
             <>
-              <StateChip state="warning" label="CAN'T CHECK" />
+              <StateChip className="door-row-status" state="warning" label="CAN'T CHECK" />
               {row.reason ? (
                 <span className="door-count-line door-count-reason">
                   {row.reason}
@@ -181,7 +181,7 @@ function ConnectedRow({ row, ctrl }: { row: SourceRow; ctrl: DoorController }) {
 
           {/* HS-174-07: Confluence shows SIGNED IN AS <email> */}
           {row.provider === "confluence" && row.connectionEmail ? (
-            <StateChip state="success" label={`SIGNED IN AS ${row.connectionEmail.toUpperCase()}`} />
+            <StateChip className="door-row-status" state="success" label={`SIGNED IN AS ${row.connectionEmail.toUpperCase()}`} />
           ) : null}
         </span>
       }

--- a/web/src/features/project-room/door/door.css
+++ b/web/src/features/project-room/door/door.css
@@ -22,8 +22,8 @@
   background: var(--surface-well, #1c1f27);
   border-radius: 2px;
   box-shadow:
-    inset 1px 1px 0 rgba(255, 255, 255, 0.14),
-    inset -1px -1px 0 rgba(0, 0, 0, 0.40);
+    inset 1px 1px 0 var(--bevel-light),
+    inset -1px -1px 0 var(--bevel-dark);
   padding: 0 12px;
   min-height: 44px;
 }
@@ -170,7 +170,7 @@
 }
 
 /* CHECKING and CAN'T CHECK chips also wrap to line 2. */
-.door-row-cells > .surface-state-chip {
+.door-row-status {
   flex: 1 0 300px;
   margin-left: 38px;
 }
@@ -212,7 +212,7 @@
     flex-basis: 100%;
     margin-left: 0;
   }
-  .door-row-cells > .surface-state-chip {
+  .door-row-status {
     flex-basis: 100%;
     margin-left: 0;
   }
@@ -282,7 +282,7 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--accent, #a86e4a);
-  background: rgba(168, 110, 74, 0.12);
+  background: var(--accent-tint);
   padding: 2px 6px;
   border-radius: 2px;
 }

--- a/web/src/features/project-room/project-room.css
+++ b/web/src/features/project-room/project-room.css
@@ -279,14 +279,14 @@
 .room-ask-container {
   position: sticky;
   bottom: 0;
-  z-index: 1;
+  z-index: var(--desk-z-local);
   background: var(--surface-1, #15171d);
   padding-bottom: 8px;
 }
 
 /* ── moment 4: new needs-you row accent fade ── */
 @keyframes room-needs-you-accent {
-  from { background: rgba(168, 110, 74, 0.08); }
+  from { background: var(--accent-tint-faint); }
   to   { background: transparent; }
 }
 .room-needs-you-new { animation: room-needs-you-accent 1.2s ease-out; }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -228,6 +228,10 @@
   --shadow-ink-6: rgba(0, 0, 0, 0.7);
   --wash-1: rgba(255, 255, 255, 0.035); /* faintest white wash (hairline fills) */
   --wash-2: rgba(255, 255, 255, 0.05); /* hover-weight white wash */
+  --bevel-light-strong: rgba(255, 255, 255, 0.22); /* Raised voice and chair control highlight; preserves the existing material. */
+  --bevel-light-hover: rgba(255, 255, 255, 0.18); /* Hovered chrome control highlight. */
+  --bevel-dark-soft: rgba(0, 0, 0, 0.20); /* Soft inner bevel for controls and gadgets. */
+  --accent-tint-faint: rgba(168, 110, 74, 0.08); /* Faint accent wash for project controls. */
 
   /* ============================================================
    * 3. COMPONENT TOKENS (the Desk OS chrome — HS-95 values)


### PR DESCRIPTION
Main’s web contract failed on raw CSS values, surface boundaries, typing errors, and swallowed Chair writes. This prerequisite repair restores the checks, preserves the visual token values, and gives failed Chair actions a visible Retry.

Validation: complete `npm run check` passed (2,165 tests, production build, bundle gate); 11 focused recovery/ref/guard tests passed after the final change. TypeScript and token consistency passed. Actual output is in `docs/internal/web-integration-checks.md`. No guard ceiling was raised.

Prepared in an isolated worktree for the authorized desktop/Interview delivery; the running preview is unchanged.
