### PR TITLE
docs: refresh product guides and establish STE writing policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,21 @@ env:
   UV_SYSTEM_PYTHON: 1
 
 jobs:
+  docs-navigation:
+    name: Documentation Navigation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check public documentation links and headings
+        run: |
+          python -m unittest discover -s tests/unit -p test_docs_navigation.py
+          python scripts/check_docs.py
+
   web-quality:
     name: DeskOS Web Quality
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,88 +1,136 @@
 # Contributing to HoldSpeak
 
-Thanks for your interest in HoldSpeak! This is a small, early-stage project —
-contributions, bug reports, and ideas are all welcome.
+Use this guide to prepare, verify, and submit a change.
+For installation without development tools, read [Getting Started](docs/GETTING_STARTED.md).
 
-## Setup
+## Set up a checkout
 
-HoldSpeak uses [`uv`](https://docs.astral.sh/uv/) for environment and dependency
-management.
+Install Python 3.10 or later, `uv`, and Node.js 22.12 or later first.
+Install the platform audio dependencies listed in Getting Started.
 
-```bash
-git clone https://github.com/karolswdev/HoldSpeak.git && cd HoldSpeak
+```sh
+git clone https://github.com/karolswdev/HoldSpeak.git
+cd HoldSpeak
+uv venv
+source .venv/bin/activate
 uv pip install -e '.[dev]'
-
-# One-time: enable the project's git hooks (see "Commit workflow" below).
 git config core.hooksPath .githooks
 ```
 
-Optional runtime extras (install what you're working on):
+The build hook installs Web dependencies and builds the bundled app.
+Use the `linux` extra on Linux when you need transcription.
+Install other runtime extras only for the capabilities you develop.
+See [Models](docs/MODELS.md) for model runtime requirements.
 
-- `.[meeting]` — meeting mode + local intel
-- `.[dictation-mlx]` / `.[dictation-llama]` / `.[dictation-openai]` — dictation LLM backends
-- `.[linux]` — `faster-whisper` for Linux transcription
+## Read the applicable contract
 
-The LLM is bring-your-own — see [`docs/MODELS.md`](docs/MODELS.md).
+| Change | Reference |
+| --- | --- |
+| Product behavior | [Constitution](docs/internal/CONSTITUTION.md) and the feature guide |
+| Web interface | [UX canon](docs/internal/UX-CANON.md) and [frontend architecture](docs/internal/ARCHITECTURE_WEB_FRONTEND.md) |
+| Runtime or meeting session | [Backend architecture](docs/internal/ARCHITECTURE_BACKEND_RUNTIME.md) |
+| Documentation | [Writing standard](docs/internal/DOCS_STYLE.md) and [terminology register](docs/internal/DOCS_TERMINOLOGY.md) |
+| API or MCP contract | [API surface](docs/API_SURFACE.md) and [MCP sidecar](docs/MCP_SIDECAR.md) |
 
-## Running the tests
+## Update documentation
 
-```bash
-# Full suite (the metal test hangs without a real mic — always exclude it):
-uv run pytest -q --ignore=tests/e2e/test_metal.py
+New and revised prose follows the ASD-STE100 reference and the repository's product terminology.
+The writing standard defines page structure, language review, and the limits of automated checks.
 
-# Lint:
-uv run ruff check holdspeak/
+1. Verify each changed procedure against the current control, command, or service contract.
+2. Update the relevant guide in the same change as the behavior.
+3. Add new guides to [the documentation index](docs/README.md).
+4. Review language and technical terms against the writing standard.
+5. Run the applicable documentation checks.
+6. Record the results and any remaining uncertainty in the PR.
+
+For documentation changes, run from the repository root:
+
+```sh
+python scripts/check_docs.py
+python -m unittest discover -s tests/unit -p test_docs_navigation.py
+python docs/internal/architect-assistant/proof/run_tests.py -q --tb=short tests/unit/test_doc_drift_guard.py tests/unit/test_mcp_sidecar_doc_drift.py tests/unit/test_api_surface.py
 ```
 
-Run the **whole** suite before sending changes — `-k` filters miss real
-regressions. If you touch anything under `web/`, rebuild the static bundle
-(`cd web && npm run build`; Node ≥ 22.12) since some tests read the built JS.
-Before changing web pages or their scripts, read
-[`docs/internal/ARCHITECTURE_WEB_FRONTEND.md`](docs/internal/ARCHITECTURE_WEB_FRONTEND.md)
-— it records the React/Vite source boundaries, Desk surface-core pattern,
-runtime bus, design-token contract, and the architectural guards. Before changing `web_runtime.py` or
-`meeting_session/`, read
-[`docs/internal/ARCHITECTURE_BACKEND_RUNTIME.md`](docs/internal/ARCHITECTURE_BACKEND_RUNTIME.md)
-— the backend twin: the mixin pattern, where patch targets live, and the
-backend density budgets.
+The proof driver isolates Python home/path resolution before it imports pytest.
+It avoids the owner's application database without changing the shell's home variable.
+It is suitable for the listed Python documentation checks.
+It does not isolate arbitrary subprocesses for every possible test suite.
 
-For the runtime view — how the pieces connect and how an utterance flows
-through them, with diagrams — start at
-[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md); the two docs above are the
-module-structure detail beneath it.
+The navigation checker verifies local links and heading targets in public Markdown.
+The drift guards compare documented counts, product terms, and generated contracts with their sources.
+These checks do not certify STE vocabulary or meaning.
+Review those manually with the official standard and the terminology register.
 
-Beyond the unit suites there is a whole-product exercise:
-[`dogfood/`](dogfood/README.md) is a self-contained harness (isolated sandbox,
-three mock repos with `.hs/` context, `say`-rendered meetings and dictation)
-with a fillable protocol ([`dogfood/PROTOCOL.md`](dogfood/PROTOCOL.md)) that
-walks every user-facing surface across a no-LLM tier and a real-metal tier.
-Run it before a release, or when you want to feel the product end to end the
-way a user does.
+After changing HTTP routes or MCP tools, regenerate the relevant reference:
+
+```sh
+python scripts/gen_api_surface.py
+python scripts/gen_mcp_sidecar_doc.py
+```
+
+Run generators and application tests in an isolated development or CI environment.
+The existing generator fixtures use temporary databases for their inventories.
+Do not use an owner's live database as test data.
+
+## Test implementation changes
+
+Run the tests that exercise the changed behavior and its integration boundaries.
+Run the complete relevant suite for broad runtime changes and release validation.
+Use the isolated CI jobs or a disposable development environment for tests that start product processes.
+
+```sh
+python -m pytest -q --ignore=tests/e2e/test_metal.py
+ruff check holdspeak/
+```
+
+The excluded test requires microphone, model, and desktop hardware.
+A type check alone does not validate runtime behavior.
+
+For changes under `web/`, run the complete Web contract from that directory:
+
+```sh
+npm ci
+npm run check
+```
+
+The command checks tokens, architecture, types, tests, the production build, and bundle limits.
+Some Python integration tests also require that built bundle.
+Use the [dogfood protocol](dogfood/PROTOCOL.md) for whole-product or release exercises.
 
 ## Commit workflow
 
-This repo gates every commit on a small "commit contract" via a pre-commit hook
-(installed by the `git config core.hooksPath .githooks` step above). Before each
-commit, write `.tmp/CONTRACT.md` from the template in
-[`pm/roadmap/PMO-CONTRACT.md`](pm/roadmap/PMO-CONTRACT.md) and check each box only
-after honestly verifying it. The hook validates and deletes the file on success;
-if it blocks you, its stderr says exactly which rule failed.
+Every commit requires a generated contract tied to the staged tree.
+Read [the contract rules](pm/roadmap/PMO-CONTRACT.md) before certifying the change.
 
-A few house rules the hook (and reviewers) expect:
+1. Stage the intended files with `git add`.
+2. Generate the contract.
 
-- **Tests ran** — actually run the suite and read the output; a type-check is not
-  validation.
-- **Docs updated** — if you change behavior, update the relevant doc in the same
-  commit.
-- No `--no-verify`.
+   ```sh
+   .githooks/dw contract new
+   ```
 
-The project's planning of record lives under
-[`pm/roadmap/holdspeak/`](pm/roadmap/holdspeak/); the documentation index is
-[`docs/README.md`](docs/README.md).
+3. Read `.tmp/CONTRACT.md`.
+4. Mark each box only after you verify its statement.
+5. Commit normally with `git commit`.
 
-## Reporting issues
+The hooks validate the staged facts and archive the successful contract.
+If you change the staged files, regenerate the contract with `--force` before committing.
+A hand-written contract or `--no-verify` bypass is not an accepted workflow.
 
-Open an issue at
-[github.com/karolswdev/HoldSpeak/issues](https://github.com/karolswdev/HoldSpeak/issues).
-For anything security- or privacy-sensitive, see
-[`docs/SECURITY.md`](docs/SECURITY.md) first.
+For roadmap work, update the associated tracking and evidence in the same commit.
+For other work, include the actual validation results in the commit or PR description.
+The [repository working agreements](CLAUDE.md) describe the complete process.
+
+## Report a problem
+
+Use the [issue tracker](https://github.com/karolswdev/HoldSpeak/issues) for reproducible product problems.
+Include the version, relevant setup, steps, expected result, and observed result.
+Remove secrets and private source content before attaching logs.
+For a security issue, read [Security & Privacy](docs/SECURITY.md) first.
+
+## See also
+
+- [Documentation index](docs/README.md): user guides and technical references.
+- [Writing standard](docs/internal/DOCS_STYLE.md): controlled English and source review.
+- [Architecture](docs/ARCHITECTURE.md): runtime and data flow.

--- a/README.md
+++ b/README.md
@@ -1,619 +1,138 @@
 # HoldSpeak
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/holdspeak-mark.png" alt="HoldSpeak logo, a held key with rising soundwaves" width="120">
-</p>
+HoldSpeak connects voice typing, meetings, project records, and AI work on one Desk.
+You choose the models, data sources, and authority for each kind of work.
 
-<p align="center"><strong>A local-first voice desk: dictate a thought, edit it, then copy it or keep it. HoldSpeak keeps work on this device unless you configure a destination; its boundary badge names any configured egress.</strong></p>
+Use it to dictate into an editor, prepare a decision brief, review a meeting, or direct a Coder session.
+The **Interview** mode helps you describe your work and develop useful suggestions through a conversation.
 
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/karolswdev/HoldSpeak/blob/main/LICENSE)
-[![Tests](https://github.com/karolswdev/HoldSpeak/actions/workflows/test.yml/badge.svg)](https://github.com/karolswdev/HoldSpeak/actions/workflows/test.yml)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
-[![Platform: macOS | Linux](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)](#platform-support)
+These documents describe the code on `main`. A published release can have fewer features.
+See the [change history](CHANGELOG.md) for release information.
 
-HoldSpeak starts with one short loop: launch `holdspeak`, choose **Dictate one
-sentence**, edit the text, then **Copy** it or **Keep as Note**. Your first
-completion furnishes the Desk automatically with Inbox, Personal, Work,
-Meetings, Decisions, and Reference; a Start here note; and editable prompts in
-**Everyday context**. Its shipped default is unused: explicitly attach it for
-one Thought, or explicitly make an attached set the default for future local
-Thoughts. No extra setup is required before this first value.
+## Start here
 
-After that, HoldSpeak can type into another app or keep work on the Desk as
-notes, meetings, decisions, and artifacts. Transcription runs on this machine.
-Optional model-backed features use models you make available and assign under
-Settings, Models. The badge in the corner names what can leave this machine and
-where it goes.
+Read [Getting Started](docs/GETTING_STARTED.md) for platform requirements and installation options.
+For a source installation, install Python 3.10 or later, `uv`, and Node.js 22.12 or later first.
+The Python build hook also builds the Web app.
 
-A meeting should change what happens next, not disappear into an archive.
-When a Room-linked meeting ends, meeting intelligence runs automatically on the
-model you assigned. Decisions and action items arrive as proposals you confirm,
-not as committed records: the extraction arms, your **Confirm** fires (Article
-IV in plain words). Before a 1:1, the person's card carries what waits on them
-(PRs, assignments, overdue commitments). A meeting transcript that names a
-repository suggests it as a source for the Room.
-HoldSpeak keeps decisions as durable records with transcript moments, lets you
-accept or supersede them, and promotes the ones that stand into ADRs, notes, or
-decision announcements. Project Memory finds the text years later across the
-local material you kept, while Ask this project answers from cited sources and
-states how many matches fit its prompt. The read-only Process window shows what
-the kernel journal says is running, waiting, unknown, or finished without
-controlling the work.
-
-The steward drafts the weekly project update with the
-model you assigned, every sentence grounded in the claim schema (unverified
-claims marked, the model and its host named beside the draft). The Room reads
-its health from what it already watches: review wait, issue aging, CI, release
-readiness (present when the source has entities, absent when it does not). When
-a reviewer is the bottleneck and you armed the reviewer nudge on that project,
-the steward proposes a comment on the waiting PR. You see the exact text and
-`GITHUB.COM` before Send. The comment posts from your own `gh` identity, and
-the receipt names who, which PR, when, and where. Nothing posts without your
-word on that one.
-
-The hub speaks Streamable HTTP on the tailnet, off until
-you turn it on, with no relay. A scoped credential carries a palette (which tool
-families it may call) and a TTL; the token is shown once at issue time. Every
-receipt from a remote caller wears the `REMOTE` badge with the caller's address.
-A second machine on the tailnet (the `.43` box, for example) runs the sweep and
-the steward's drafter overnight while the Mac stays awake. Confluence joins
-GitHub and Jira on the Door for blog posts and pages by known ID.
-
-**Every model attempt has one door and one receipt.** HoldSpeak freezes an
-assigned compatible route before it executes a physical provider attempt. Each
-attempt uses one immutable deployment revision and receives one terminal receipt.
-Cancellation fences late output, and uncertain execution stays `indeterminate`.
-Read [Models](docs/MODELS.md) for setup or the internal
-[Intelligence Router architecture](docs/internal/ARCHITECTURE_INTELLIGENCE_ROUTER.md)
-for the technical mechanics.
-
-> **Status: 0.x, early but real.** The latest published release is
-> `holdspeak==0.4.0` on PyPI. This README tracks `main`, which includes
-> unreleased work after `0.4.0`; install from a checkout when you need exact
-> documentation parity. APIs, config, and defaults can still change before
-> 1.0. Shape-changing database upgrades create a backup first.
-
-## The two modes
-
-| Dictate | Meet |
-| --- | --- |
-| ![Pixel art microphone with hold-to-talk waves](https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/hold-to-talk-microphone.png) | ![Pixel art meeting notebook with action items](https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/meeting-intelligence-notebook.png) |
-| Hold the hotkey, speak, release: the text goes into the active app. The dictation pipeline is on: configure a model-backed rewrite to route rough speech by intent, enrich it with your project's context, and shape it for its target (Codex, Claude, the terminal, the browser, your editor). Every run lands in the dictation journal; one tap on a wrong result teaches the correction memory. Voice commands map a spoken keyword to a real action (open a URL, launch an app, run a command). Say the wake phrase and it listens hands-free, with the result previewed, never typed, until you confirm; an optional preview mode does the same for every dictation (the card shows the text first, Type it commits, Discard drops it). The spoken language setting pins any of Whisper's 99 languages, and the spoken-symbol dictionary types your own vocabulary ("double colon" becomes `::`). Activity pre-briefing offers what you touched recently as dictation context, source-cited. | Capture mic and system audio live with speaker labels, or import a recording or a transcript file you already have (vtt and srt keep their real timestamps and speaker names). 14 built-in plugins submit admitted model attempts to pull typed artifacts out of the transcript: decisions, action items, ADRs, risk registers, incident timelines. Meeting aftercare then shows what is open, decided, and changed since last time; an accepted action can become a filed issue, and the digest or follow-up draft can go to your team through Send to Slack. Fresh installs use YOLO: eligible configured actions execute with a receipt. Secure and Normal retain per-action approval. The archive is searchable and filterable by date, speaker, tag, and open actions. |
-
-This is what they look like in the product, not in pixel art. A saved meeting
-comes back as typed, reviewable artifacts:
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/history.png" alt="A saved meeting open at /history: the transcript on the left, and on the right a stack of artifact cards (a Risk register table with impact, likelihood, mitigation, and owner; Decisions and open questions; typed Requirements), each with a confidence score and a copy button." width="760">
-</p>
-<p align="center"><em>A meeting after intelligence ran: a risk register, decisions, and requirements, each extracted by an LLM-backed plugin and rendered read-only at /history.</em></p>
-
-## The Desk
-
-Launch `holdspeak` and the browser opens on the Desk: everything the two
-modes produce, living as objects in one spatial world. Meetings, notes,
-Knowledge, Agents, Threads, and their Artifacts appear on the Desk as
-working icons that carry their state (member counts, freshness, needs-you);
-Zones are drawers that open into remembering windows; drop an object
-onto an Agent or a Knowledge crystal and the named verb under the
-cursor says exactly what release does; right-click anything for Info.
-Click selects, double-click opens.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/desk.png" alt="The HoldSpeak Desk: pixel-art objects (meetings as cassettes, notes, a Knowledge plant, an Artifact page) floating on a warm dark stage; a Q3 release Zone tray holding one filed Meeting; Coder session avatars on a right-edge rail; a record orb bottom-center; a compact HoldSpeak menu and an egress badge top-left." width="760">
-</p>
-<p align="center"><em>The Floor: the spatial world your voice work lives in. The orb records, the rail asks, the tray files.</em></p>
-
-**The arrival is home after first value.** Its headline tells you what needs
-you across your projects, or says so when nothing does. The **NEEDS YOU**
-section lists the items, each with its source and a one-tap **Open**. Below
-it: **THOUGHTS** (unfinished work with **Continue** on the first),
-**BRIEF** (waiting items with **Ack** / **Defer**), **MEETINGS** (recent
-meetings with their state: **SAVED**, **OFF** with **Run intelligence**,
-**REC**). Empty sections are absent; the agents' window stays one tap
-away in the dock. The capture bar at the foot carries **Talk**, **Develop a
-thought**, and **Record meeting**. On a phone, **Go** is the compact
-application menu. The **Floor** button in the dock opens the spatial object
-world. A toggle in Settings, Sounds & Presence controls **Desk Sounds**.
-
-**The desk reaches you.** The Heartbeat runs a sweep every 15 minutes,
-evaluates your project Watches, and caches the needs-you aggregate. When
-the count rises, a macOS notification banner reads the count
-(`3 need you across 2 projects`); the shade's **PROJECTS** section and
-the dock badge carry the same number. Quiet hours (default 22:00 to
-08:00) suppress notifications; the Monday brief regenerates once a day
-after quiet hours close. The notification is a local `osascript` banner
-posted through the system's notification center; click-to-open is not
-yet wired (the packaged app bundle is a later phase). Configure the
-interval, quiet hours, and notification mode under **Settings, Rhythm**.
-
-The Desk is where the loops close. Press the orb and the hub records a
-meeting; when it ends, the meeting lands on the stage as an object. Rope a
-few objects together with the lasso and **Ask AI** about exactly that pile:
-the answer prints as a card you keep or bin, and a kept card records every
-object it read plus your instruction. The boundary badge names This device,
-a paired device, a private endpoint, or an external service. See
-[The Desk](https://github.com/karolswdev/HoldSpeak/blob/main/docs/WEB_DESK.md).
-
-**Ground this ask.** The composer carries an attach control: pick meetings,
-expand each one to its digest, its transcript, or any artifact it produced,
-and the gauge measures the selection against the model's window before you
-run. The question is answered from those records (the hub reads them from
-its own store), the kept card names them, and an unknown reference refuses
-with its id instead of guessing.
-
-**Develop the thought without hiding the context.** Any kept or ordinary Note
-can become one resumable Thought while its original bytes remain preserved.
-It opens as a real Thought Workbench: a full document plane with a compact
-Markdown formatting rail beside a focused AI interview on desktop, and
-Note/Interview panes on a phone. **Ask AI**
-starts one explicit refinement turn. **Add & ask next** atomically adds the
-answer to the Note and authorizes exactly one next turn; **Add to Note** stops
-there. **Finish Thought** is always direct. The Workbench names where each turn
-will run and shows the actual placement receipt when it returns.
-Without a runnable model, **Set up AI** opens the exact Models settings surface;
-the Workbench rechecks readiness after configuration instead of leaving a dead
-AI button.
-
-Context begins empty. The Attach control puts pinned Everyday context first,
-with recent/search and the full Note catalog progressively disclosed. The hub
-resolves qualified refs and freezes exact Note versions; the browser never
-posts copied context. A stale source is named and must be updated or removed
-before another turn. Opening, editing, attaching, or reading Original never
-starts AI by itself.
-
-If you want that same context on future work, open **Attach context** and choose
-**Use these by default** for the complete set attached to this Thought. The
-default is empty until you do. It applies only to Thoughts created or adopted
-later on this hub; it never changes an existing Thought, syncs to another hub,
-or starts a model turn. **Remove from this Thought** changes only the open
-Thought. **Stop using by default** clears the future set without detaching
-anything already attached. If one configured source is unavailable at birth,
-the Thought still opens with no AI context and a receipt names why the whole set
-was skipped.
-
-**Talk to your Agents.** Tap an avatar on the rail and it opens a
-conversation, not a one-shot prompt: turns accumulate, the thread survives a
-reload, each reply wears the badge for where that turn actually ran, and any
-reply can be kept on the Desk as an Artifact. The attach control rides the
-chat composer too, so a conversation can be grounded on the meetings it is
-about.
-
-**Threads.** Open a new Thread from the Desk or choose **Continue in thread**
-on any object to seed it as a reference. Type or dictate with the mic, attach
-`@`-references to meetings, notes, or people, and press Send. The reply
-streams token by token over the bus; each turn wears one egress badge and one
-receipt. Stop a running turn, branch it (`< n/m >`), or keep any reply as a
-Note or Artifact. Threads live in the hub's SQLite (never the browser), so
-desk search finds them alongside everything else.
-
-Bind a mode (Desk, Chase, Draft, Plan, or your own) to steer what tools
-the thread may call and how it speaks. Save prompts and guardrails as Notes
-(tags `prompt`, `guardrail`); `/prompt` inserts, `/guardrail` toggles. Select
-assistant text to annotate by voice (chips above the composer, promoted with
-the next turn). `/compact` summarises earlier turns behind a cut marker.
-`/todo` writes an action item to the Door with thread provenance.
-
-Start a call on any thread to hear every reply spoken aloud and talk back
-hands-free. The default voice is the browser's own speech synthesis (zero
-deps, zero egress). Install `holdspeak[tts]` for server-side kokoro-onnx
-voices (GPL-3.0; phonemizer + espeak-ng). Click the call chip to stop.
-
-**Set up models.** Open **Settings, Models**. The Concierge detects what you
-have (local engines, LAN endpoints, cloud keys) and proposes one set covering
-every capability group. Choose **Use these** to apply it in one step. For
-manual control, choose **Adjust** to edit individual capability assignments.
-
-**The gate: your agent asks first.** Off by default, and armed only by two
-deliberate steps of yours, a Claude Code session's risky Bash call can stop
-and ask the Desk before it runs: the held call rises in the shade with a
-redacted preview, Approve lets it run, and Deny sends your one-line reason
-back to the agent verbatim. Armed, the gate fails closed: an unreachable hub
-means a denied call, never a silent pass. The work your sessions ship shows
-up beside them as receipts too: registered repositories' pull requests as
-honest rows (state, CI conclusion, when observed, and how the match was made),
-and a one-line session receipt whose every number states its provenance.
-
-**Follow a pull request without leaving the Desk.** Send a Coder session into
-the matched worktree, keep a model-written review as an Artifact, or prepare a
-GitHub comment whose complete text waits for your approval. The pull request
-row shows the result as a Receipt, while merge, close, and force push stay out
-of reach by design.
-
-## Data boundaries
-
-- **Every run names its boundary.** Model-backed work can use a local model, a
-  paired device, a private endpoint, or an external OpenAI-compatible service.
-  Open **Settings, Models** and let the Concierge propose an assignment set, or
-  choose **Adjust** to edit individual capability assignments. Connection
-  secrets stay in local custody and readiness is checked against the exact
-  bound model. See
-  [Security & privacy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/SECURITY.md)
-  and [Models](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md).
-- **It learns how you work, and shows you the receipts.** The dictation
-  journal records what you said, what it typed, where it routed, and how long
-  it took. Fix a wrong result in one tap and the correction memory learns; the
-  learning digest reports a real "learned from N similar" count, honest at
-  zero; replay an old utterance through the updated pipeline and watch the
-  routing change. See [the learning loop](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md#12-dictation-journal-corrections--replay).
-- **Meetings end with their loops closed.** A meeting produces artifacts,
-  an aftercare digest, and receipted actions where most tools stop at a
-  transcript. Fresh installs use YOLO with actuators enabled and a wildcard
-  allowlist: eligible actions to configured destinations execute immediately.
-  Secure and Normal retain per-action approval. Every execution remains bound
-  to its configured destination and recorded as a receipt. See
-  [meeting intelligence](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md).
-- **Honest by construction.** `holdspeak doctor` reports what is actually
-  broken. The import panel says which timestamps are approximate. The learning
-  digest never inflates a count. A database shape change creates a backup
-  before the additive reconcile runs, and a newer informational schema stamp
-  is not mistaken for corruption. The docs hold themselves to the same bar.
-
-## See it learn
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/operator-working-loop.gif" alt="Animated pixel art operator working at a terminal while companion and task cards update" width="280">
-</p>
-
-Because every dictation is recorded, you can look back at what it heard, fix
-a mistake in one tap (which teaches it), and replay the utterance through the
-updated pipeline. Instead of trusting that it improved, you watch it happen.
-[See the full walkthrough](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_COPILOT.md).
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/journal.png" alt="The HoldSpeak dictation journal: a said-to-typed timeline of recent dictations, each card showing the spoken transcript, the typed result, its routing target, and a per-utterance latency strip; one row marked corrected." width="760">
-</p>
-<p align="center"><em>The dictation journal. Every utterance, with what you said, what it typed, where it routed, and how long it took.</em></p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/learning-digest-week.png" alt="The 'What HoldSpeak learned' digest: a this-week / all-time toggle, headline counts for corrections made, dictations corrected, and utterances nudged, a breakdown by block and target, and per-correction 'learned from N similar' rows." width="760">
-</p>
-<p align="center"><em>The learning digest. Honest, windowed counts from the same matcher that nudges your routing.</em></p>
-
-## Meet Qlippy
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/presence/qlippy-avatar.png" alt="Qlippy, HoldSpeak's pixel-art paperclip mascot: an orange paperclip with big expressive eyes and skeptical eyebrows." width="160">
-</p>
-
-Yes, he is a paperclip. The famous one had two problems: he interrupted you,
-and he could not actually do anything. Qlippy is the apology for both. He
-lives on the desktop presence surface (opt-in, two switches deep), spends
-most of his time as a tiny animated dock sprite mirroring what the runtime is
-doing, and slides out a card only for the few moments that genuinely need
-you: an action awaiting your approval, a correction that actually reached
-past dictations, a meeting that ended with open items.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/presence/qlippy-native-overlay.png" alt="The native Linux overlay on a real desktop: Qlippy in an alert pose beside the headline 'A decision needs you', the exact preview of a proposed GitHub issue, the egress badge naming the destination, and Approve and Decline buttons, floating over a browser window." width="420">
-</p>
-<p align="center"><em>The marquee moment, on a real desktop: a proposed GitHub issue waiting for a decision. The native panel takes pointer clicks only while a card shows and can never steal keyboard focus.</em></p>
-
-**He never acts on his own.** Approving on his card sends the identical
-audited request the dashboard sends. Every card carries the egress badge,
-one small pill that says at a glance whether its data stays local or goes
-out, and to where. Dismissing him is always safe, and he is honest to a
-fault: the "Learned from you" card only ever appears when a correction
-really reached past dictations, with the real count.
-
-| A decision needs you | Learned from you |
-| --- | --- |
-| ![Qlippy's decision card: the alert-pose mascot, the exact preview of a proposed GitHub issue, the egress badge naming the destination, and Approve and Decline buttons.](https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/presence/qlippy-decision-card.png) | ![Qlippy's learned card: the mascot with a lightbulb, reporting that a correction was applied and matches 2 past dictations, with its local badge and a View digest button.](https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/presence/qlippy-learned-card.png) |
-| The exact preview, the destination on the badge, your call. | Only when a correction really reached past dictations, with the honest count. Local only. |
-
-Off by default, like everything ambient here. Turn him on under
-**Settings, Desktop presence, "Qlippy, the mascot"**.
-
-## How it compares (as of mid-2026)
-
-Honest comparisons, architecture-level on purpose: where your audio goes,
-what the tool spans, and whether it learns. These tools are good at what
-they do; pick the one that fits.
-
-| Tool | What it does better | What HoldSpeak does better |
-|---|---|---|
-| **OS dictation** (Apple Dictation, Windows Voice Typing) | Zero setup, free, always available | Your own models, LLM rewriting with project context, the learning loop, meetings |
-| **Local Whisper apps** (superwhisper, MacWhisper, VoiceInk) | Simpler setup, polished single-purpose UX | Owner-chosen model endpoints, a visible learning loop, meeting intelligence, Linux support |
-| **AI dictation services** (Wispr Flow, Aqua Voice) | Out-of-box accuracy and editing polish, no model management | Local transcription, explicit destination boundaries, open source, no subscription, meetings |
-| **Talon** | The deepest hands-free coding and computer control there is | Prose-first dictation with LLM rewriting, lower learning curve, meeting intelligence |
-| **Raw Whisper tooling** (whisper.cpp scripts) | Total control, minimal surface | A product: typing integration, routing, the journal, meetings, a web UI |
-
-And the trade-offs in the other direction: HoldSpeak is 0.x, the smart parts
-need a model you provide, setup is heavier than a menu-bar app, there is no
-Windows build today, and Wayland limits global hotkeys to best effort.
-
-## Quickstart
-
-For the latest published release:
-
-```bash
-pip install holdspeak
-holdspeak          # launch the web runtime (the browser opens on the Desk)
-```
-
-Prefer [`uv`](https://docs.astral.sh/uv/)? `uv pip install holdspeak`.
-
-The documentation on `main` includes features added after the `0.4.0` release.
-For exact parity with these docs, install from a current checkout:
-
-```bash
+```sh
 git clone https://github.com/karolswdev/HoldSpeak.git
 cd HoldSpeak
+uv venv
+source .venv/bin/activate
 uv pip install -e .
 holdspeak
 ```
 
-The install script creates an isolated venv and a `holdspeak` launcher. It pins
-the latest release by default; set `HOLDSPEAK_REF=main` only when you
-deliberately want the unreleased source state:
+On Linux, use `uv pip install -e '.[linux]'` for the transcription backend.
+System audio dependencies and desktop permissions depend on your platform.
 
-```bash
-# one-line install
-curl -fsSL https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/scripts/install.sh | bash
+1. Open the local URL that HoldSpeak prints.
+2. Select **Dictate one sentence**.
+3. Edit the transcript if necessary.
+4. Select **Copy** or **Keep as Note**.
 
-# unreleased main in the same isolated layout
-curl -fsSL https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/scripts/install.sh | HOLDSPEAK_REF=main bash
-```
+This first result creates the initial Desk contents.
+If capture fails, use the recovery action on the screen or run `holdspeak doctor`.
 
-### Your first sentence
+## What you can do
 
-In the browser, choose **Dictate one sentence**, edit the text, then choose
-**Copy** or **Keep as Note**. That first completion furnishes your Desk
-automatically. It includes six drawers: Inbox, Personal, Work, Meetings,
-Decisions, and Reference; a Start here note; and five editable prompts in
-**Everyday context**: About me, Current priorities, How I like help, People &
-vocabulary, and Meeting preferences. The prompts contain questions and
-examples, not facts about you. Everyday context is never sent to AI
-automatically; attach it only when you want it used.
+| Task | How HoldSpeak helps | Guide |
+| --- | --- | --- |
+| Dictate into another app | Hold the global hotkey, speak, then release it to insert text. | [Voice typing](docs/USER_GUIDE.md#voice-typing) |
+| Refine a coding prompt | Use project facts, project context, and an optional model in the dictation pipeline. | [Dictation pipeline](docs/DICTATION_PIPELINE_GUIDE.md) |
+| Review a meeting | Record or import a meeting. Review the transcript, decisions, action items, and artifacts. | [Meeting mode](docs/MEETING_MODE_GUIDE.md) |
+| Develop your working context | Revisit Interview sections for goals, Projects, cadences, decisions, and delegation. | [Interview](docs/INTERVIEW.md) |
+| Prepare architecture work | Draft a decision brief, review questions, or an agent brief from available records. | [Architecture work recipes](docs/ARCHITECTURE_WORK.md) |
+| Follow project changes | Connect Project sources and configure supported Watches. | [Project Rooms](docs/PROJECT_ROOMS.md) |
+| Direct AI work | Use Threads, Workflows, Coder steering, or an MCP client. | [Automation](docs/AUTOMATION.md) |
+| Change your workspace | Select a place, save favorites, or use **Settle in**. | [Places](docs/ENVIRONMENTS.md) |
 
-If microphone permission or transcription needs attention, the first-sentence
-surface tells you the one recovery to take. `holdspeak doctor` is also available
-when you want diagnostics for microphone permissions and backends; it is not a
-first-value prerequisite.
+## The Desk
 
-### Set up models
+The **arrival** shows work that needs you, unfinished Thoughts, a brief, and recent Meetings.
+The **Floor** shows your records as objects that you can open, move, and file in Zones.
+Speak, Meetings, Settings, and other tools open in Desk windows.
 
-Open **Settings, Models**. The Concierge scans your machine and any known
-endpoints, lists every engine it found, and proposes one assignment per
-capability group. Choose **Use these** and the entire set applies. A catalog
-preset you do not have yet shows **Download** with its file size; cloud keys
-show **KEY SET** or **KEY NOT SET**. Every engine row names its host
-(`THIS DEVICE`, a LAN address, or the cloud service).
+Threads save your conversation on the hub.
+Your sent prompt appears before the answer arrives. Routine tool calls stay inside the collapsed **Actions** control.
+Requests for a decision, tool questions, and failures remain visible.
+You can keep a reply as a separate Note or Artifact.
 
-That is the whole A path. Talk to the desk: open a Thread, ask a question,
-and the reply streams with its receipt.
+Interview uses the existing Thread conversation and MCP tools.
+It saves context with source references and records suggestions that you can revisit.
+**Try draft** sends a request for a manual draft. **Keep idea** saves your choice about a suggestion.
+Neither action installs a recurring automation.
 
-### Later: voice typing, repairs, and advanced model setup
+The current Interview supports manual preparation and the existing Project setup path.
+General agent delegation and recurring setup through Interview remain outside this increment.
+Model quality also varies. Check source claims, assumptions, and draft placeholders before you use a result.
 
-For voice typing in another app, hold the global hotkey (Right Option on macOS,
-Right Alt on Linux), speak, and release. **Speak** also has that action with
-an explicit Aim picker and a **DRY RUN** toggle. The **ENGINE** row names
-the model and its host; when unset, its state reads **NOT SET**.
+## Models and data
 
-Automatic furnishing is the ordinary first-run path. For repair, `holdspeak
-seed` creates only starter objects HoldSpeak has never seen, preserving your
-edits and deletions. To deliberately restore the default Desk, use the
-destructive, confirmed **Settings, Desk, Reset to seed** action.
+Open **Settings > Models** to use the **Concierge**.
+It detects engines and proposes an assignment for each capability group.
+Check the engine and host for each group before you select **Use these**.
+Use **Adjust** for individual capability assignments.
+See [Models](docs/MODELS.md) for local runtimes and endpoint setup.
 
-For manual model control, choose **Adjust** under the Concierge's proposed set.
-The capability table unfolds in place, showing every assignment with its
-engine and host. `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless key fallback.
-See [Models (bring your own)](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md).
+HoldSpeak stores its database on the hub. Whisper transcription runs on the hub.
+Configured model endpoints, providers, remote clients, and outbound actions can transfer data to other systems.
+The boundary and Receipt for a run identify where that work went.
+See [Security & Privacy](docs/SECURITY.md) for storage, credentials, and network boundaries.
 
-Install only the extras you need for later features:
-
-```bash
-pip install 'holdspeak[meeting]'          # meeting mode and AI intelligence
-pip install 'holdspeak[dictation-mlx]'    # the dictation pipeline on Apple Silicon (MLX)
-pip install 'holdspeak[dictation-llama]'  # the dictation pipeline, cross-platform (GGUF)
-pip install 'holdspeak[dictation-openai]' # the dictation pipeline via an OpenAI-compatible endpoint
-```
-
-(From a clone, use the editable form instead, e.g. `uv pip install -e '.[meeting]'`.)
-
-### Prerequisites for Project Rooms
-
-Project Rooms connect a Project to external providers. Each provider
-requires its own CLI:
-
-- **GitHub:** [`gh`](https://cli.github.com/) (`brew install gh`, then `gh auth login`).
-- **Jira:** [`acli`](https://acli.atlassian.com/) (`brew tap atlassian/homebrew-acli && brew install acli`, then `acli jira auth login --site <yoursite>.atlassian.net --email <you> --token`).
-- **Confluence:** the same `acli` binary (`acli confluence auth login --site <yoursite>.atlassian.net --email <you> --token`). V0 watches blog posts and pages by known ID; no page search until the CLI supports it.
-
-Open **Settings, Connections** to see each tool's readiness, run
-`Recheck`, and follow the recovery command when needed. Jira and
-Confluence access is read-only and contacts `<site>.atlassian.net` from
-this device. HoldSpeak stores no token; `gh` and `acli` hold credentials
-on this machine.
-
-### Upgrading and your data
-
-Your whole HoldSpeak database is a single SQLite file. Before a version jump you
-can snapshot it with `holdspeak backup`, and put one back with `holdspeak
-restore`. On open, HoldSpeak reconciles missing tables and columns additively.
-It backs up an existing database before a real shape change and never drops an
-unknown table, column, or row. The schema stamp is informational, so a database
-stamped by a newer build opens without a version-gate refusal. `holdspeak
-doctor` reports the schema and config state it found. The full policy is in
-[`docs/RELEASING.md`](https://github.com/karolswdev/HoldSpeak/blob/main/docs/RELEASING.md).
+The default Control mode is **YOLO**.
+Eligible actions to configured destinations can execute without another HoldSpeak approval prompt.
+**Secure** and **Normal** provide different approval rules.
+See [Control modes](docs/AUTHORITY.md) before you configure actions with external effects.
 
 ## Platform support
 
-| Capability | macOS 14+ (Apple Silicon) | Linux X11 | Linux Wayland |
-|---|---|---|---|
-| Voice typing | ✅ | ✅ | ✅ |
-| Global hotkey | ✅ | ✅ | ⚠️ Best effort |
-| Cross-app typing | ✅ | ✅ | ⚠️ Best effort |
-| Meeting mode | ✅ | ✅ | ✅ |
-| System audio capture | ✅ BlackHole | ✅ Pulse/PipeWire | ✅ Pulse/PipeWire |
+| Capability | macOS on Apple Silicon | Linux X11 | Linux Wayland |
+| --- | --- | --- | --- |
+| Whisper transcription | MLX Whisper | faster-whisper | faster-whisper |
+| Global hotkey and text insertion | Requires desktop permissions | Supported | Depends on compositor restrictions |
+| Meeting capture | Microphone and optional BlackHole system audio | Microphone and PulseAudio/PipeWire system audio | Microphone and PulseAudio/PipeWire system audio |
 
-Wayland often blocks global hooks and synthetic typing, so HoldSpeak falls back to clipboard paste for injection.
+The Web app also accepts browser microphone input.
+On Wayland, clipboard paste can provide an alternative when direct text insertion is unavailable.
+See [Getting Started](docs/GETTING_STARTED.md) for setup and recovery.
 
-## Meeting intelligence, a little deeper
+## Extend HoldSpeak
 
-Record a meeting live, or bring one you already have: import a recording
-(WAV out of the box; compressed formats with ffmpeg) or a transcript file
-(`.vtt`, `.srt`, `.txt`) from the archive page or with `holdspeak import
-call.wav`, and it becomes a real meeting, run through the same intelligence.
-The transcript is scored for intent (architecture, delivery, product,
-incident, comms), a sequence of plugins runs, and each model attempt enters the
-admitted path before it can produce a typed artifact. The results render read-only in the Meetings window on the Desk. A meeting
-that has a transcript but never ran intelligence shows **Run intelligence**
-on its row. HoldSpeak ships 14 built-in plugins, all real and backed by an
-LLM.
+The [MCP sidecar](docs/MCP_SIDECAR.md) exposes 222 tools across 40 families.
+It shares the product service layer. A tool name does not grant permission to execute it.
+Some live delivery operations require the running Web runtime and are absent from the sidecar.
 
-Plugins can also propose actions. An actuator can produce an external side
-effect, like filing a ticket or posting an update. Fresh installs use YOLO with
-actuators enabled: eligible configured destinations execute immediately and
-write a receipt; Secure and Normal retain per-action approval. Write your own
-with the [Plugin Authoring guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/PLUGIN_AUTHORING.md); for endpoints and routing, see
-the [Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md).
-
-Then close the loop. Meeting aftercare shows what is still open (by owner),
-what was decided, and what changed since the last meeting. Jump to the
-transcript moment that justifies any result, file an accepted action as an
-issue, or draft a copyable follow-up. Under the default YOLO posture, eligible
-configured sends execute with a receipt; Secure and Normal keep the approval
-step. See the
-[Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md#meeting-aftercare-close-the-loop).
+Meeting intelligence includes 14 built-in plugins.
+You can add [meeting plugins](docs/PLUGIN_AUTHORING.md) or [activity connectors](docs/CONNECTOR_DEVELOPMENT.md).
+[Automation](docs/AUTOMATION.md) explains the available triggers, execution paths, and limits.
 
 ## Companions
 
-HoldSpeak runs as a desktop hub, and a companion on another device drives it
-over the same local HTTP API your browser uses, on your own network (LAN or
-Tailscale), with no hosted relay. Two companions exist today.
+The [iPad app](apple/README.md) connects to a HoldSpeak hub for capture and review.
+[AIPI-Lite](docs/AIPI_LITE_DEV_WORKFLOW.md) provides a portable device for meeting controls and spoken replies.
+Both depend on the hub and its configured capabilities.
 
-### The iPad app
+## Configuration and recovery
 
-The iPad is a first-class client of both modes, not a remote control for one.
-It talks to the hub through typed clients over the existing API: it dictates an
-answer into your desk (the hub runs that text through the full dictation
-pipeline, applying your corrections and routing, and types the result, and a
-matching voice command fires there too), previews the rewrite before anything
-types (an opt-in receipt: what you approve is exactly what lands, verbatim),
-authors the voice command board itself (every action still runs on the Mac,
-and the board says so), pins your spoken language and your spoken-symbol
-dictionary on that dictation path, reads a meeting back with its artifacts,
-confidence, and sources, closes the meeting's loop from the aftercare digest
-(an accepted action item becomes a GitHub issue proposal, typed against a
-repo you name inline), reviews every pending proposal for a meeting wherever
-it was created (Secure and Normal keep the human authorization step; default
-YOLO can execute an eligible configured destination immediately), searches and
-filters the archive with the same facets the web has (narrowed on the hub,
-never a stale page filtered locally), imports a recording or transcript file
-into the hub's full intelligence pipeline (the new meeting appears
-immediately, honestly marked importing), reads the learning digest and the
-dictation journal with their real "learned from N similar" reach, and pulls
-activity pre-briefing nudges whose "Dictate with this" grounds the next
-utterance in the cited record. Live Coder sessions appear on its Desk too:
-with the hooks installed (one command, reversible), every running Claude Code
-or Codex session appears as an object with its current status and question. You
-can answer by typing, speaking, or using a Meeting or Note as grounding so the
-reply is grounded in that record, or by letting the AI draft the reply for
-you (on this device or a configured endpoint, with the destination named).
-Nothing sends itself: a draft lands editable, and only your explicit send
-delivers it into the live session on your Mac. Its trust surface is the same one badge the
-desktop wears: every desk object carries its real posture (a connector reads
-an external service with its target named, dictation to your desktop names the
-paired device, and a Note stored here reads This device), the app's header states the desktop's
-posture in the web chip's own four words, and a guard holds Apple product
-copy to the same canonical names and no-privacy-prose rule as the docs and
-the web. Its on-device storage is schema safe the same
-way the desktop is: it backs an older database up before migrating, and
-refuses to open one written by a newer build. A readiness section in its
-Settings states that store's health (schema version, integrity, a refused
-newer database named as exactly that) beside your desktop's own doctor
-readout, section by section, so the iPad can tell you it is healthy without
-a trip to the Mac. The app itself is not released
-yet; the screens and the typed client layer they ride on are built and tested.
-
-### AIPI-Lite
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/pixellab/aipi-lite-companion.png" alt="Pixel art AIPI-Lite companion device" width="220">
-</p>
-
-AIPI-Lite is an optional ESPHome-based device you can carry between rooms. Put it
-on Wi-Fi (a phone hotspot works), and it gives you meeting-capture controls and
-status feedback. With Claude/Codex hooks on, it shows when a Coder session is waiting
-so you can speak the reply back into the coding session. Buy the hardware from the
-[official page](https://aipi.com/products/aipi-lite) or the
-[Amazon listing](https://www.amazon.com/dp/B0FQNNVV36); firmware and bridge setup
-are in the [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AIPI_LITE_DEV_WORKFLOW.md).
-
-## MCP sidecar
-
-The MCP sidecar (`holdspeak-mcp`) is the desk's programmable surface over
-stdio. It exposes 201 tools across 36 families and 34 default, non-owner
-resources, so any MCP client can read and drive the desk without the web UI.
-The Concierge family adds five tools (`concierge.detect`, `concierge.propose`,
-`concierge.probe`, `concierge.apply`, `concierge.download`) for engine
-detection and model assignment.
-
-Claude Code discovers the sidecar automatically: the repo ships a
-`.mcp.json` that wires it. For other MCP clients, the entry point is one
-command:
-
-```bash
-uv run holdspeak-mcp
-```
-
-Model-invoking tools use the same admitted routing path and return their
-receipt. The sidecar names the verbs it deliberately excludes (live-runtime
-delivery paths it does not own) so an MCP client discovers the boundary at
-tool-listing time.
-
-See [MCP sidecar](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MCP_SIDECAR.md) for the full
-reference: families, model-invoking tools, trust model, resources, and
-deliberate absences.
-
-## Where to go next
-
-| I want to… | Read this |
-|---|---|
-| Browse all the docs | [Documentation index](https://github.com/karolswdev/HoldSpeak/blob/main/docs/README.md) |
-| Understand how it works, with diagrams | [Architecture](https://github.com/karolswdev/HoldSpeak/blob/main/docs/ARCHITECTURE.md) |
-| Get it running and verify my setup | [Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) |
-| Take the first-sentence loop or repair/deploy later | [Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) |
-| Use the Concierge to set up models | [User Guide, Models](https://github.com/karolswdev/HoldSpeak/blob/main/docs/USER_GUIDE.md#models) |
-| Manual model setup (Adjust, Library, Assignments) | [Models (bring your own)](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md) |
-| Understand technical routing and receipts | [Intelligence Router architecture](https://github.com/karolswdev/HoldSpeak/blob/main/docs/internal/ARCHITECTURE_INTELLIGENCE_ROUTER.md) |
-| Live on the Desk (the web front door) | [The Desk](https://github.com/karolswdev/HoldSpeak/blob/main/docs/WEB_DESK.md) |
-| See speech become a project-grounded task | [The Dictation Copilot](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_COPILOT.md) |
-| Set up the dictation pipeline for Codex / Claude | [Dictation Pipeline Setup](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md) |
-| Review, correct, and replay past dictations | [The dictation journal & replay](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md#12-dictation-journal-corrections--replay) |
-| Map spoken keywords to real actions | [Voice Commands](https://github.com/karolswdev/HoldSpeak/blob/main/docs/VOICE_COMMANDS.md) |
-| Turn on Qlippy, the mascot | [Qlippy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/DICTATION_PIPELINE_GUIDE.md#qlippy-the-mascot-optional) |
-| Use meeting mode and configure AI intelligence | [Meeting Mode Guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MEETING_MODE_GUIDE.md) |
-| Drive HoldSpeak from another device | [Companions](#companions) |
-| Wire up the AIPI-Lite companion | [AIPI-Lite Developer Workflow](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AIPI_LITE_DEV_WORKFLOW.md) |
-| Put Coder sessions on the Desk | [Claude/Codex automation hooks](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AGENT_HOOK_INSTALL.md) |
-| Install Claude / Codex automation hooks | [Claude/Codex automation hooks](https://github.com/karolswdev/HoldSpeak/blob/main/docs/AGENT_HOOK_INSTALL.md) |
-| Hold an agent's risky calls for my approval | [The Gate](https://github.com/karolswdev/HoldSpeak/blob/main/docs/USER_GUIDE.md#the-gate-a-steered-agent-asks-first) |
-| Drive the desk from Claude Code or another MCP client | [MCP sidecar](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MCP_SIDECAR.md) |
-| Understand what's stored and what can leave my machine | [Security & Privacy](https://github.com/karolswdev/HoldSpeak/blob/main/docs/SECURITY.md) |
-
-## Configuration
-
-Config lives at `~/.config/holdspeak/config.json`, but you rarely edit it by hand.
-The Settings window on the Desk exposes the hotkey, meeting intelligence,
-dictation pipeline, and presence options. **Settings, Models** opens the
-Concierge: it detects engines, proposes one set, and applies with **Use
-these**. Choose **Adjust** for individual capability assignments. The full
-owner guide is
-[Models (bring your own)](https://github.com/karolswdev/HoldSpeak/blob/main/docs/MODELS.md).
-The full reference is in
-[Getting Started](https://github.com/karolswdev/HoldSpeak/blob/main/docs/GETTING_STARTED.md) and the guides above.
+The main configuration file is `~/.config/holdspeak/config.json`.
+Use Settings for normal configuration changes.
+Run `holdspeak backup` before an upgrade when you need a recoverable snapshot.
+See [Release and recovery](docs/RELEASING.md) before you use `holdspeak restore`.
 
 ## Contributing
 
-Contributions are welcome. See [`CONTRIBUTING.md`](https://github.com/karolswdev/HoldSpeak/blob/main/CONTRIBUTING.md) for setup
-(`uv`, the git hooks, the test command) and the commit-contract workflow. Recent
-changes are in [`CHANGELOG.md`](https://github.com/karolswdev/HoldSpeak/blob/main/CHANGELOG.md). If you want to build on
-HoldSpeak rather than just use it, the
-[Plugin Authoring guide](https://github.com/karolswdev/HoldSpeak/blob/main/docs/PLUGIN_AUTHORING.md) and
-[Connector Development](https://github.com/karolswdev/HoldSpeak/blob/main/docs/CONNECTOR_DEVELOPMENT.md) are the doors in.
+See [Contributing](CONTRIBUTING.md) for development setup, documentation rules, checks, and the commit workflow.
+The [documentation index](docs/README.md) links the user guides and technical references.
 
 ## License
 
-Licensed under the Apache License 2.0. See [`LICENSE`](https://github.com/karolswdev/HoldSpeak/blob/main/LICENSE).
+HoldSpeak uses the [Apache License 2.0](LICENSE).
+
+## See also
+
+- [Getting Started](docs/GETTING_STARTED.md): install and capture your first sentence.
+- [User Guide](docs/USER_GUIDE.md): operate the product each day.
+- [Architecture](docs/ARCHITECTURE.md): understand the runtime and data flow.
+- [Documentation index](docs/README.md): find a task, reference, or internal specification.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,13 +11,49 @@ The diagrams are Mermaid and render on GitHub. A guard
 (`tests/e2e/test_mermaid_renders.py`) checks that every block in the docs
 still renders, so a broken diagram cannot ship.
 
+## Interview and Thread state
+
+Interview composes the existing Thread conversation, model routing, and MCP services.
+It does not create a separate model runtime or a universal automation engine.
+
+| Component | Responsibility |
+| --- | --- |
+| Thread window and store | Display sent messages, streamed replies, references, and tool activity. |
+| Thread service | Run the model conversation and its tool loop. |
+| Interview section descriptors | Declare each section's purpose, tool set, and handoff. |
+| Interview service | Validate and persist facts, suggestion choices, section changes, and revisions. |
+| MCP family | Expose Interview operations through the common service contract. |
+| Existing Project services | Perform supported setup operations under their own policy. |
+
+The model chooses its question or proposed tool call.
+The controller validates the resulting operation and state change.
+These checks make state transitions predictable. They do not make model recommendations deterministic or necessarily correct.
+
+Interview state belongs to a Thread.
+Each change includes an expected revision and a command identity.
+A stale revision refuses the change. A repeated command cannot substitute a different payload.
+Source references distinguish stated facts from inferred context.
+Changed or removed facts invalidate or remove dependent suggestions.
+
+The initial capability prepares manual drafts and supports the existing Project setup path.
+General scheduled work and agent assignment through Interview remain target requirements.
+See [Interview](INTERVIEW.md) for user behavior and the
+[specification package](internal/architect-assistant/README.md) for requirements and verification limits.
+
+Implementation references:
+
+- [Section descriptors](../holdspeak/services/interview_contracts.py).
+- [Interview service](../holdspeak/services/interview_service.py).
+- [MCP family](../holdspeak/mcp/families/interview.py).
+- [Thread service](../holdspeak/services/thread_service.py).
+
 ## The shape of it
 
-HoldSpeak is one process. A web runtime (`WebRuntime`, the
-mixin-composed orchestrator in `holdspeak/web_runtime.py`) owns the
-hardware-facing pieces and a local FastAPI server (`MeetingWebServer`) that
-serves the web UI and the API. Two modes run on top of the same building
-blocks:
+The Web runtime is the main runtime process.
+`WebRuntime` owns the hardware-facing components and the local FastAPI server
+(`MeetingWebServer`) that serves the Web app and API.
+Supporting processes include the MCP sidecar and the isolated desktop typing executor.
+Dictation and Meetings use the shared runtime components:
 
 - **Dictation** turns held-key or wake-word speech into typed text. Its
   always-on pipeline routes it through local stages and uses a model only for

--- a/docs/ARCHITECTURE_WORK.md
+++ b/docs/ARCHITECTURE_WORK.md
@@ -1,0 +1,154 @@
+# Architecture work recipes
+
+Use these recipes to prepare decisions and direct work during an architecture transformation.
+They produce manual drafts from the records and context available to HoldSpeak.
+
+Each example is a suggested working method.
+It is not a claim that HoldSpeak can discover your organization or execute every part of its transformation.
+
+## Prepare the working context
+
+1. Open an [Interview](INTERVIEW.md) Thread.
+2. Describe one outcome in **Goals**.
+3. Identify the relevant Project in **Projects**.
+4. Explain your constraints in **What matters**.
+5. Check the facts saved under **Context**.
+
+Example outcome: “Make architecture decisions easier to review and revisit.”
+
+Useful constraints include a decision deadline, required evidence, and the types of work you can delegate.
+Label uncertain information as an assumption.
+
+## Recipe: prepare a decision review
+
+**Input:** a named Project, available decision records, and the question under review.
+**Output:** a draft review brief with sources and unresolved questions.
+
+1. Select **Decision log** in Interview.
+2. Request a review of the relevant recorded decisions.
+
+   > Prepare a decision review for the selected Project.
+   > Separate recorded facts from assumptions.
+   > Include the rationale, unresolved questions, and conditions for review.
+   > Identify missing evidence without inventing records.
+
+3. Inspect the returned sources.
+4. Request corrections for unsupported claims.
+5. Keep the final reply as a Note or Artifact.
+
+Use this outline to review the draft:
+
+| Field | Required content |
+| --- | --- |
+| Question | The decision to make, in one sentence |
+| Context | Relevant facts and their source references |
+| Options | Recorded options, plus clearly labeled new proposals |
+| Constraints | Stated requirements and unresolved assumptions |
+| Rationale | The reasons for the recorded or proposed choice |
+| Authority | The decision owner, if known |
+| Review condition | The change that would require another review |
+| Gaps | Evidence or input still required |
+
+A saved brief does not approve a decision.
+Use your organization's decision process to establish acceptance and decision rights.
+HoldSpeak must not infer those rights from a job title or a Project name.
+
+## Recipe: prepare for a transformation meeting
+
+**Input:** a meeting purpose and selected Notes, decisions, or previous Meeting records.
+**Output:** an agenda and a list of questions supported by those records.
+
+1. Open a Thread.
+2. Attach the relevant records with `@`.
+3. Request an agenda from the attached records.
+
+   > Prepare an agenda for this review.
+   > Identify open decisions, changed assumptions, and questions that need an owner.
+   > Cite the attached records.
+   > Leave unprovided dates and owners as placeholders.
+
+4. Check each question against its source.
+5. Keep the agenda as a Note.
+
+After the meeting, use [meeting intelligence](MEETING_MODE_GUIDE.md) to review the transcript and extracted results.
+Compare those results with the agenda before you update a decision or send a follow-up.
+Use the protected [People](PEOPLE_INTEGRATION.md) surface for confidential relationship context.
+
+## Recipe: prepare a manual agent brief
+
+**Input:** a specific task, an existing Project, and explicit execution constraints.
+**Output:** a brief that you can review before you give it to a Coder session or another agent.
+
+1. Select **Delegation** in Interview.
+2. Describe the task and its allowed scope.
+3. Request a manual agent brief.
+
+   > Prepare a brief to investigate the stated architecture question.
+   > Include the available sources, expected output, and validation method.
+   > List assumptions and missing prerequisites.
+   > Keep execution and configuration changes as proposals.
+
+4. Add the repository, branch, and paths if the task requires code access.
+5. Specify the actions that require your decision.
+6. Keep the reviewed brief.
+
+Before you deliver the brief, verify these fields:
+
+| Field | Question |
+| --- | --- |
+| Objective | What result must the worker produce? |
+| Scope | Which systems, repositories, and files are included? |
+| Sources | Which records can the worker use? |
+| Authority | Which actions can the worker perform? |
+| Checkpoint | When must the worker return for a decision? |
+| Validation | What evidence will show that the result works? |
+| Completion | What must be present before you accept the result? |
+
+Interview prepares the brief. It does not start a worker for this recipe.
+For actual delivery, use an existing [Coder steering](USER_GUIDE.md#steer-a-session-from-the-desk) path or your external agent client.
+Check the applicable [authority rules](AUTHORITY.md) before delivery.
+
+## Recipe: test a recurring review manually
+
+**Input:** an output that already helped once, a review frequency, and its source requirements.
+**Output:** a repeatable recipe and a decision about whether automation is useful.
+
+1. Select **Cadences** in Interview.
+2. Describe the result you want to repeat.
+3. Specify the intended day, time, and time zone.
+4. Request a manual trial with the available sources.
+5. Review the draft and record corrections.
+6. Keep the recipe if the trial is useful.
+
+For example: “Every Friday, prepare unresolved decisions for my Monday architecture review.”
+That sentence describes a desired cadence. It does not install one.
+Use [Automation](AUTOMATION.md) to determine whether an existing execution path supports it.
+
+For an automated version, verify the configured trigger, source scope, destination, authority, and stop control.
+If a required capability is absent, retain the manual recipe and name the missing capability.
+
+## Assess daily usefulness
+
+Keep a short review Note after each trial.
+Record the task, source coverage, corrections, and whether the result helped the decision.
+Compare preparation time only when you have measured it.
+
+Use these observations to change the same Interview context.
+Retain useful suggestions with **Keep idea**.
+Defer or dismiss suggestions that do not help.
+
+## Troubleshooting
+
+| Problem | Action |
+| --- | --- |
+| The Project contains few records | Add or attach the required sources. Request a template with explicit gaps until the evidence exists. |
+| The draft sounds plausible but lacks evidence | Request source references for factual claims. Remove unsupported claims. |
+| The suggested workflow needs an unsupported tool | Keep it as a manual recipe or an unavailable idea. |
+| A recurring result creates too much work | Revisit **What matters** and **Cadences**. Reduce the scope before you automate it. |
+
+## See also
+
+- [Interview](INTERVIEW.md): context, suggestions, and repeat visits.
+- [Project Rooms](PROJECT_ROOMS.md): project records and source connections.
+- [Automation](AUTOMATION.md): execution paths and current limits.
+- [Meeting mode](MEETING_MODE_GUIDE.md): capture and review after a meeting.

--- a/docs/AUTHORITY.md
+++ b/docs/AUTHORITY.md
@@ -1,15 +1,19 @@
 # Control modes, decisions, and grants
 
-HoldSpeak separates three questions that used to hide behind one proposal
-status:
+Use Control mode to choose how future operations request authority.
+The default is **YOLO**, which permits eligible effects within configured scope without another HoldSpeak approval prompt.
 
-- `ReviewDecision`: is the content accepted or dismissed?
-- `AuthorizationState`: may the described effect happen?
-- `ExecutionState`: has an executor started, succeeded, failed, or become unavailable?
+HoldSpeak records content review, authorization, and execution separately:
 
-Approving an effect does not claim that it ran. Every proposed action API returns
-all three axes, its typed operation, the policy snapshot used for the decision,
-and a commitment label such as **Approve and send to Slack**.
+| State | Question |
+| --- | --- |
+| `ReviewDecision` | Is the proposed content accepted or dismissed? |
+| `AuthorizationState` | May this effect occur? |
+| `ExecutionState` | Did execution start, complete, fail, or become unavailable? |
+
+An accepted proposal does not prove that its effect ran.
+Inspect the execution state and Receipt before you report completion.
+The operation's commitment label describes the intended effect, such as **Approve and send to Slack**.
 
 ## Control mode
 
@@ -74,3 +78,18 @@ Authentication, secret custody, destination binding, payload binding, pane
 identity, audit receipts, configuration integrity, and schema safety run in all
 three modes. YOLO reduces repeated confirmation only inside authority the owner
 already bounded; it is not a bypass.
+
+## Troubleshooting
+
+| Problem | Action |
+| --- | --- |
+| Approval did not produce the expected result | Inspect execution state and the terminal Receipt. Resolve the named executor failure. |
+| A reusable grant stopped working | Check expiry, use count, destination changes, revocation, and Control mode changes. |
+| A Coder delivery is refused | Check the current pane identity and the applicable grant or mode. |
+| YOLO does not admit an operation | Read the refusal. Unsupported families and hard invariants still apply. |
+
+## See also
+
+- [Automation](AUTOMATION.md): triggers and execution paths.
+- [Threads](USER_GUIDE.md#the-thread-has-hands): per-tool policy and Thread admission.
+- [Security & Privacy](SECURITY.md): credentials and data boundaries.

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -1,0 +1,125 @@
+# Automation
+
+HoldSpeak provides several ways to prepare and execute work.
+Choose the path that matches the trigger, required tools, and authority of your task.
+
+An MCP tool exposes an operation to a client.
+It does not by itself provide a scheduler, a running worker, or permission to execute an effect.
+The client, runtime, model assignment, and operation policy still matter.
+
+## Choose an execution path
+
+| Path and guide | Trigger | Result |
+| --- | --- | --- |
+| [Interview](INTERVIEW.md) | You send an answer or select **Try draft** | Saved context, suggestions, manual drafts, and supported Project setup |
+| [Thread tools](USER_GUIDE.md#threads) | A model requests a permitted tool during a turn | Tool execution within the Thread mode and its policy |
+| [Agent or Ask](WEB_DESK.md) | You submit an instruction | A model result from selected context |
+| [Sequence or Workflow](MCP_SIDECAR.md#sequence) | You start a configured run | Existing multi-step processing with run results |
+| [Project Watches and Steward](PROJECT_ROOMS.md) | A supported source change and configured Project behavior | Project-scoped observation, proposals, and supported effects |
+| [Heartbeat](USER_GUIDE.md#rhythm) | A configured unattended sweep | Evaluation of available work under the Heartbeat policy |
+| [Cadence](CADENCE.md) | **run-now** or an enabled runtime loop | Review of unresolved work and preparation of next actions |
+| [Scheduled recording](USER_GUIDE.md#schedule-a-recording) | A configured recording time | Meeting capture when the hub can run it |
+| [Voice commands](VOICE_COMMANDS.md) | A keyword that you configured | The specific action mapped to that keyword |
+| [Coder steering](USER_GUIDE.md#steer-a-session-from-the-desk) | You deliver text or an allowed key | Input to an identified live Coder pane |
+| [External MCP client](MCP_SIDECAR.md) | Your client calls a tool | The operation exposed by the sidecar or Reach transport |
+
+Cadence and Heartbeat are distinct systems.
+An Interview cadence preference is context until you configure a supported recurring operation.
+The remote [Reach Runner](REACH_RUNNER.md) also depends on an external scheduler when you want it to repeat.
+
+## Complete a manual trial first
+
+1. Identify one output and its intended use.
+2. Select the source records for that output.
+3. Configure the required model assignment.
+4. Run the task once through the applicable surface.
+5. Inspect the result and its Receipt.
+6. Correct the source selection or instruction if necessary.
+
+For architecture work, start with a [decision or agent brief](ARCHITECTURE_WORK.md).
+Manual results help you determine the required scope before you configure unattended work.
+
+## Configure recurring work
+
+Use the owning feature's setup controls.
+Each recurring task needs a supported trigger and an available runtime.
+
+Before you rely on the task, verify:
+
+- The event or time that starts it, including the time zone when applicable.
+- The Project and source scope.
+- The model assignment and its execution host.
+- The output location or fixed external destination.
+- The authority for each effect.
+- The control that pauses or disables the task.
+- A completed trial with a result and an execution record.
+
+A saved instruction or suggestion is insufficient proof that recurring work exists.
+Read the actual configuration and the relevant run history.
+If the feature exposes a next trigger, check that value too.
+
+## Understand authority
+
+The default Control mode is **YOLO**.
+Eligible operations can execute directly within configured scope.
+**Normal** and **Secure** hold different classes of work for a decision or a scoped grant.
+See [Control modes](AUTHORITY.md) for the exact operation families.
+
+A Thread also has mode-specific tools and per-tool policies.
+**Allow always** records a Thread tool policy. It does not remove the called service's own checks.
+A tool can still refuse because its destination, credential, source scope, or runtime is invalid.
+
+Content review, authorization, and execution are separate states.
+An accepted proposal can remain unexecuted.
+Use the execution result and Receipt to determine whether an effect occurred.
+
+## Use an MCP client
+
+The [MCP reference](MCP_SIDECAR.md) lists the tools, transports, resources, and deliberate exclusions.
+Use its generated roster to verify that the required operation exists.
+The Thread mode can expose a smaller selection than the server's full catalog.
+
+The local sidecar opens the hub database through the product services.
+It does not provide the Web runtime's live event connection or every live delivery path.
+Reach provides a separate remote transport with scoped credentials.
+
+For an external orchestrator, implement the control loop in that client:
+
+1. Read the relevant state.
+2. Select a supported operation.
+3. Submit its required arguments.
+4. Handle a refusal, question, or approval request.
+5. Inspect the terminal result.
+6. Read the affected record when the operation changes state.
+
+Use documented operation identities when a service supports safe retries.
+After an uncertain write result, inspect the affected record before you repeat the write.
+An external client must not claim completion from a model's narrative alone.
+
+## Current Interview boundary
+
+Interview can prepare manual results and use its supported Project setup operations.
+Its **Delegation** section prepares briefs. Its **Cadences** section explores recurring work.
+Neither section installs a general agent assignment or an arbitrary schedule in the current increment.
+
+A model can suggest combinations beyond the available adapters.
+Treat such a suggestion as an idea until the required tools and execution path exist.
+Model-generated dates, permissions, source coverage, and completion claims need verification.
+
+## Troubleshooting
+
+| Problem | Action |
+| --- | --- |
+| A saved idea never runs | Configure a supported trigger in its owning feature. **Keep idea** does not create one. |
+| A configured task does not start | Check the enable state, Control mode, trigger, and runtime availability. |
+| A tool is absent from a Thread | Check the selected mode and its permitted tool set. |
+| A tool returns success but no external result appears | Distinguish proposal creation from execution. Inspect the execution state and destination record. |
+| A remote run fails | Check the hub connection and the scoped credential. Use the runner's exit code. |
+| A worker cannot continue | Resolve the named source, model, permission, or runtime prerequisite. |
+
+## See also
+
+- [Interview](INTERVIEW.md): manual discovery and supported setup.
+- [Control modes](AUTHORITY.md): operation policy and grants.
+- [MCP sidecar](MCP_SIDECAR.md): callable contracts and transport limits.
+- [Cadence](CADENCE.md): unresolved work and recurring review.

--- a/docs/CADENCE.md
+++ b/docs/CADENCE.md
@@ -1,99 +1,115 @@
-# The Cadence Engine
+# Cadence
 
-> HoldSpeak's local-first technical chief-of-staff. It turns your meetings, activity,
-> dictation, and coding-agent state into **evidence-backed nudges** and
-> **nearly-complete next actions**, then pushes you at a useful cadence until each loop
-> is done, snoozed, killed, or delegated. Qlippy does not interrupt to say something
-> vague. He interrupts only when he has done enough work that your next decision is a
-> single tap.
+Cadence reviews unresolved work and prepares next actions.
+It can use meeting action items, proposed actions, and Coder sessions that need a reply.
 
-**Off by default.** Nothing runs, nudges, or leaves your machine until you turn it on.
+The background Cadence loop is off by default.
+Manual commands can still inspect work or request an evaluation.
+Cadence is separate from the [Heartbeat](USER_GUIDE.md#rhythm) and from preferences saved in [Interview](INTERVIEW.md).
 
----
+## Inspect work manually
 
-## The shape
+Run these commands from your HoldSpeak environment:
 
+```sh
+holdspeak cadence status
+holdspeak cadence loops
+holdspeak cadence run-now
+holdspeak cadence brief
 ```
-Open Loop  ->  Next Best Action  ->  Nudge  ->  Decision
-```
 
-- **Open Loop:** an unresolved item. A meeting action item, a pending proposal, or a
-  coding agent waiting on your answer. Loops are *projected* from those sources, so they
-  stay in sync. But your decisions are remembered: a killed loop stays killed even if its
-  source still exists.
-- **Next Best Action:** the prepared move. A proposal becomes *Approve*. An owned action
-  becomes a drafted *issue*. An unowned one becomes *Assign an owner*. A waiting agent
-  becomes *Reply*. Deterministic by default. An LLM can *draft* the wording when you
-  enable it (it never executes, you approve).
-- **Nudge:** the move surfaced somewhere. The web page, the CLI, Telegram, or the
-  desktop tick.
-- **Decision:** one tap. Snooze, mark done, kill, delegate, approve, or send a reply.
+`status` reports the engine state.
+`loops` lists unresolved work.
+`run-now` requests one evaluation, including when background Cadence is disabled.
+`brief` shows the current brief.
 
-## Surfaces
+The Web Cadence surface also provides current work, open loops, review, and history.
+Open it through Studio or the `/cadence` address.
 
-| Surface | How |
-|---------|-----|
-| **CLI** | `holdspeak cadence status`, `loops`, `run-now`, `brief`, `closeout`, `audit` |
-| **Web** | the `/cadence` coach page (Now, Open loops, the end-of-day review, History) |
-| **Telegram** | pair a chat, then `/brief`, `/loops`, `/status`, plus inline-button decisions |
-| **Desktop** | the in-runtime tick pushes due nudges and the morning brief to paired chats |
+## Understand the records
 
-## Turning it on
+| Record | Meaning |
+| --- | --- |
+| Open loop | Unresolved work derived from a source record |
+| Next action | A prepared response to that work, such as an owner assignment or issue draft |
+| Nudge | A presentation of the next action through an enabled delivery surface |
+| Decision | Your response, such as snooze, completion, dismissal, or delegation |
 
-Everything lives under `cadence` (and `cadence_telegram`) in your HoldSpeak config, all
-**off by default**:
+Cadence retains your decisions about a loop.
+A dismissed loop stays dismissed unless its source materially changes.
+The optional model can draft wording. Execution still requires the applicable operation authority.
 
-```jsonc
+## Configure background Cadence
+
+The configuration uses the `cadence` object in `~/.config/holdspeak/config.json`.
+These example values keep background work and model drafts disabled:
+
+```json
 {
   "cadence": {
-    "enabled": false,            // the master switch — the in-runtime tick
-    "pressure": "normal",        // gentle | normal | aggressive (timing only)
-    "use_llm": false,            // LLM-DRAFT next actions (fail-closed to deterministic)
+    "enabled": false,
+    "pressure": "normal",
+    "use_llm": false,
     "quiet_hours_start": 22,
     "quiet_hours_end": 8,
     "max_nudges_per_day": 12
-  },
-  "cadence_telegram": {
-    "enabled": false,
-    "bot_token": "",             // a credential — never logged or stored in a message
-    "allowed_chat_ids": [],      // the hard pairing allow-list
-    "pairing_code": ""           // /pair <code> self-pairs a chat
   }
 }
 ```
 
-`holdspeak cadence run-now` and the other read commands work even when the master switch
-is off. The switch only governs the autonomous in-runtime tick.
+Set `enabled` to `true` when you want the runtime loop.
+The runtime must be available for background evaluation.
+**Secure** Control mode permits explicit `run-now` but prevents the background loop.
+See [Control modes](AUTHORITY.md) for precedence and effects.
 
-## The trust boundary
+`pressure` accepts `gentle`, `normal`, or `aggressive` and changes timing.
+It does not add authority.
+`use_llm` permits model-generated draft wording.
+If that draft fails validation, Cadence uses its deterministic next action.
 
-This is a *pressure system*, not an autonomous agent. The guarantees, enforced by tests
-rather than good intentions:
+## Deliver through Telegram
 
-1. **No external side effect without audited authority.** Any outbound action (a
-   GitHub issue, a Slack post) goes through HoldSpeak's proposal, authority, and
-   guarded-execution path. Eligible fixed destinations can execute under the
-   captured YOLO posture; Normal/Secure require a decision or bounded grant.
-   Cadence never calls a connector directly.
-2. **The cadence core is pure.** It performs no network, terminal, subprocess, or
-   connector execution. A test fails the build if that ever changes. Every surface that
-   does reach out (the Telegram bot, the agent-reply delivery, the LLM provider) lives
-   outside the core or takes an injected helper.
-3. **The LLM only drafts.** When `use_llm` is on, a model may draft the wording of a next
-   action. The output is structured JSON, validated, and fail-closed: any failure falls
-   back to the deterministic action. Your transcripts are always treated as data, never
-   as instructions.
-4. **Honest egress.** Every nudge carries a badge. Most of cadence is local. A Telegram
-   push is the one thing that leaves, and only to your paired chat.
-5. **Telemetry-free audit.** `holdspeak cadence audit --out audit.json` writes a complete
-   local snapshot (every loop, its evidence, the nudge history) so what Qlippy did, and
-   why, is provable after the fact, with nothing leaving the machine.
-6. **Your decisions stick.** Snooze and dismissal are respected. A killed loop is never
-   resurrected unless its source materially changes.
+Telegram delivery has a separate `cadence_telegram` configuration.
+It is disabled by default and requires a bot token plus permitted chat IDs or the pairing flow.
+Only configured, permitted chats receive delivery.
+Keep the token in the credential configuration, not in a Note or Thread.
 
-## What it is not
+The Telegram controls include `/brief`, `/loops`, and `/status`.
+Inline controls can record decisions about the presented work.
+Telegram configuration does not replace authority checks for a proposed external action.
 
-Not a chatbot, not an autonomous shell executor, not a second runtime, not a cloud-first
-memory, not a surveillance daemon, not a nag machine with vague reminders. It is one
-thing: a local-first chief-of-staff that pushes with receipts, restraint, and a ready
-next move.
+## Inspect outcomes
+
+Use the action's execution state and Receipt to determine whether an effect occurred.
+Accepting content does not prove that an executor completed it.
+Eligible configured destinations can execute directly under YOLO.
+Normal and Secure require the applicable decision or scoped grant.
+
+To export a local audit file, run:
+
+```sh
+holdspeak cadence audit --out audit.json
+```
+
+The audit includes loops, supporting records, and nudge history.
+Model drafts can send context to the configured model endpoint.
+Telegram delivery sends content to the configured chat.
+Authorized outbound actions can contact their configured destinations.
+See [Security & Privacy](SECURITY.md) for the complete data boundary.
+
+## Troubleshooting
+
+| Problem | Action |
+| --- | --- |
+| No background evaluation occurs | Check `enabled`, the runtime state, and Control mode. |
+| Manual evaluation works but no Telegram message arrives | Check Telegram enablement, credentials, pairing, and timing limits. |
+| A discarded loop returns | Check whether its source materially changed. Inspect the audit history. |
+| A next action exists but has no external result | Inspect its authorization and execution states. |
+| An Interview cadence preference never runs | Configure a supported recurring path. Interview context alone does not enable Cadence. |
+
+## See also
+
+- [Automation](AUTOMATION.md): triggers and execution paths.
+- [Rhythm](USER_GUIDE.md#rhythm): Heartbeat configuration.
+- [Control modes](AUTHORITY.md): approval and grant rules.
+- [Security & Privacy](SECURITY.md): data and credential boundaries.

--- a/docs/DICTATION_COPILOT.md
+++ b/docs/DICTATION_COPILOT.md
@@ -183,10 +183,11 @@ at any local or LAN [OpenAI-compatible / GGUF / MLX endpoint](./MODELS.md)):
 ```
 
 The endpoint and model are not dictation config fields. Add the endpoint once
-in **Settings > Models > Model Library** and select it for **Writing &
-dictation** in **Assignments**; assigning it also selects the
-`openai_compatible` backend. Set or replace its key in Model Library; the environment
-variable `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless fallback.
+in **Settings > Models** and select it for **Writing &
+dictation** in the Concierge set. Apply the set with **Use these**.
+The assignment also selects the
+`openai_compatible` backend. For keyed providers, use the owner Model Library API described in [Models](MODELS.md).
+The environment variable `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless fallback.
 
 </details>
 

--- a/docs/DICTATION_PIPELINE_GUIDE.md
+++ b/docs/DICTATION_PIPELINE_GUIDE.md
@@ -126,12 +126,14 @@ Config file shape:
 ```
 
 The endpoint and model are not dictation config fields. Add the endpoint once
-in **Settings > Models > Model Library** and select it for **Writing &
-dictation** in **Assignments**; assigning it also selects the
+in **Settings > Models** and select it for **Writing &
+dictation** in the Concierge set. Apply the set with **Use these**.
+The assignment also selects the
 `openai_compatible` backend. See
 [MODELS.md](./MODELS.md).
 
-Set the model profile's key in Model Library. For a headless hub,
+For keyed providers, use the owner Model Library API. See [Models](MODELS.md).
+For a headless hub,
 `HOLDSPEAK_PROFILE_<ID>_KEY` remains the fallback. Do not put API keys in
 `.hs/` files.
 

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -1,156 +1,85 @@
-# Places to think: the night collection
+# Places
 
-Eight authored Three.js worlds form one collection: the original Rainy City and
-Lantern Garden alongside six interiors. Quiet Desk remains a separate still option.
+Choose an environment for the Floor and save your favorites.
+Use **Settle in** when you want fewer navigation controls around your open work.
 
-| Environment | Setting and ambient movement | Product-linked detail |
-| --- | --- | --- |
-| Rainy City | Rain, neon, steam and warm street reflections | Streetlamp gently warms during real capture |
-| Lantern Garden | Wet flagstones, planted borders, drifting drizzle and warm lanterns | Lanterns gently brighten with real capture |
-| After-Hours Radio | Walnut booth, rainy skyline, warm desk lamp | On-air light, recording tape reels, capture-level meters |
-| Midnight Archive | Receding card cabinets, green banker lamps, dust | Pneumatic-tube lamp acknowledges newly added Desk objects |
-| Night Train | Green compartment seats, passing trees and station lights | Quiet capture indicator |
-| Deep-Sea Station | Blue observation port, drifting marine life, sonar | Sonar intensity responds to capture |
-| Storm Greenhouse | Iron rafters, terracotta pots, rain, violet cloud light | Subtle capture-level reflection |
-| Last Laundromat | Mint tiles, moving drums, fluorescent and vending-machine light | Quiet capture indicator |
+## Change places
 
-These are decorative scenes, not new object models. Existing Pixi objects,
-selection, dragging, and windows remain above the non-interactive background.
-Scenes observe existing capture and Desk stores; they never acquire a microphone,
-fetch work data, or invent product events. The Chair is unchanged.
+1. Open **Places** from the dock or **Go > Change places**.
+2. Select an environment.
+3. Select **View on Floor** if you want to switch from Chair to Floor.
 
-## Controls
+The picker changes the Floor immediately.
+Selecting a place preserves your work and object positions.
+You can also open the picker with **Command/Ctrl+Shift+P** or **Settings > Wallpaper**.
+Arrow keys and Home/End change the selected place.
 
-**Places** in the Desk dock, **Go → Change places**, or **⌘/Ctrl+Shift+P** opens
-a native window with all nine choices, including Rainy City, Lantern Garden, and
-Quiet Desk. The same picker remains in Settings → Wallpaper. Rainy City is the
-default. Arrow keys and Home/End select scenes and update the Floor live.
+## Available places
 
-Star places to keep browser-local favorites, then use the Favorites filter.
-Favoriting does not switch scenes; selecting a scene does not rearrange work or
-switch from Chair to Floor. **View on Floor** makes that switch explicitly.
+Rainy City is the default. Eight animated scenes and one still option are available.
 
-- Animation can be paused. OS reduced-motion preferences take precedence.
-- Room sound is off by default. Opting in enables quiet locally synthesized room
-  tone; there are no downloaded sound samples. It fades out while the browser
-  microphone is open or the hub reports recording, and suspends in hidden tabs.
-- Quiet Desk has no animated scene or room sound.
-- Scene, favorites, animation, and sound choices are browser-local, not hub settings.
+| Place | Scene |
+| --- | --- |
+| Rainy City | Rain, neon signs, steam, and street reflections |
+| Lantern Garden | Wet stone paths, plants, drizzle, and lanterns |
+| After-Hours Radio | A walnut radio booth with a rainy skyline |
+| Midnight Archive | Card cabinets, green lamps, and dust |
+| Night Train | A green train compartment with passing trees and station lights |
+| Deep-Sea Station | An observation port with marine life and sonar |
+| Storm Greenhouse | Iron rafters, terracotta pots, rain, and cloud light |
+| Last Laundromat | Mint tiles, moving drums, and fluorescent light |
+| Quiet Desk | A still background without room sound |
 
-**Settle in**, in the same dock or Desk menu, quiets navigation and shelf chips.
-Use **⌘/Ctrl+Shift+F** to toggle it, or **Escape / Back to Desk** to restore the
-full chrome. The first Escape restores the Desk without also closing the focused
-window or draft. Open work and the existing recorder stay mounted. The mic lamp,
-connection/privacy indicators, recording state, and record/stop control remain
-available; phone sheets leave room for the quiet shelf. Settle in never starts or
-stops recording, enables sound, or moves work. It resets on reload or leaving the
-Desk; it is not a saved layout.
+The scenes are decorative. Capture indicators can respond to the existing recorder state.
+The scenes do not acquire a microphone or start product work.
 
-The common lifecycle suspends animation in hidden tabs and disposes GPU/audio
-resources on scene changes. Each scene is lazy-loaded and uses capped render
-resolution; interiors also batch static geometry by material. The outdoor scenes
-preserve their authored composition and independent weather while sharing the
-same selection, sound, capture observation, and reduced-motion lifecycle.
+## Save favorites
 
-## Review and verification
+Select the star beside a place to add or remove a favorite.
+Use the **Favorites** filter to show your selected places.
+The star changes the favorite state. It does not select the place.
 
-From `web/`, with a supported Node version:
+The selected place, favorites, animation preference, and sound preference are local to this browser.
+They survive a reload but do not become shared hub settings.
 
-```sh
-npm run dev -- --host 127.0.0.1 --port 4322
-```
+## Control motion and sound
 
-Open <http://127.0.0.1:4322/_built/atmospheres.html#rainy-city> to browse all
-eight scenes without a hub. Choosing a preview does not save it until **Use on my
-Floor** is pressed. This dev-only entry uses the actual production scene modules.
+You can pause animation in the picker.
+The operating system's reduced-motion preference takes precedence over the animation setting.
+Hidden tabs pause the scenes.
 
-In another terminal, from `web/`:
+Room sound is off by default.
+When enabled, HoldSpeak generates quiet room sound locally.
+It reduces the sound while the browser microphone is open or the hub reports recording.
+It suspends sound in hidden tabs.
+Quiet Desk has no room sound.
 
-```sh
-node scripts/shoot-atmospheres.mjs
-node scripts/check-atmospheres.mjs
-npm run test:web -- src/desk/gl/__tests__ src/pages/cores/__tests__/settingsWallpaper.test.tsx src/design/AtmospherePreview.test.tsx
-npm run test:web -- src/desk/__tests__/settle.test.tsx src/pages/cores/__tests__/ChangePlacesCore.test.tsx
-npm run tokens:check
-npm run tokens:gate
-npm run guard:architecture
-npm run build
-npm run bundle:gate
-```
+## Settle in
 
-The screenshot script writes full-size PNG review images and compressed WebP
-picker assets. Both the gallery and screenshot script use the registry's complete
-scenic collection. Browser checks exercise all eight animated and paused scenes,
-wraparound, local selection persistence, and both original worlds under reduced
-motion in a 393px-wide gallery.
-The observed frame rate is local headless-browser evidence, not a hardware-wide
-performance guarantee.
+1. Select **Settle in** in the dock or Desk menu.
+2. Continue your work in the open windows.
+3. Select **Back to Desk** to restore the navigation controls.
 
-For the production-bundle interaction walk, run the preview server and then the
-check in separate terminals from `web/`:
+**Command/Ctrl+Shift+F** toggles Settle in.
+The first **Escape** restores the Desk without also closing the focused window or draft.
+The recorder state and record/stop control remain available.
+Settle in does not change recording or enable room sound.
 
-```sh
-npm exec vite preview -- --host 127.0.0.1 --port 4323
-node scripts/check-environments-floor.mjs
-node scripts/check-environments-floor.mjs --settle
-```
+Settle in resets when you reload or leave the Desk.
+It is a temporary view state, not a saved layout.
 
-This walk intercepts HTTP APIs with explicit test fixtures in an isolated browser.
-It verifies real Pixi object selection through the atmosphere layer and live
-Settings selection at desktop and phone widths. It does not test a live hub,
-authentication, or WebSocket delivery, and never writes owner Desk data.
-The `--settle` walk also verifies favorites across reload, native shortcuts,
-Escape preserving the same window and recorder nodes, and hit-tested access to
-Back to Desk and Stop above the phone sheet. Its recording state is an explicit
-external-recording fixture, not a real session. It asserts zero microphone
-requests and zero capture-action API writes.
+## Troubleshooting
 
-Evidence lives in [assets/screenshots/environments](assets/screenshots/environments/),
-including the contact sheet, desktop/phone images, and JSON browser reports.
+| Problem | Action |
+| --- | --- |
+| An animated scene stays still | Check the animation control and the operating system's reduced-motion setting. |
+| There is no room sound | Enable sound in the picker. Check whether recording or a hidden tab has suspended it. |
+| Favorites are absent in another browser | Set favorites in that browser. The preference does not synchronize through the hub. |
+| Navigation controls are absent | Select **Back to Desk** or press **Escape**. |
+| A scene is too distracting or slow | Select Quiet Desk or pause animation. |
 
-Full TypeScript checking currently encounters pre-existing errors in
-`ProjectRoomCore.tsx` and `features/project-room/setup/__tests__/model.test.ts`;
-the environment changes add no errors to that output.
+## See also
 
-## Main integration verification — 2026-09-05
-
-Refreshed PR #528 onto main `855b34cb` while preserving its original history and the newer Concierge/Settings behavior. The Settings hub now exposes Wallpaper and its live selected-place fact. Production controls use the shared Button; favorites use a decorative SVG. The browser harness includes the current Thoughts, needs-you, and Settings hub responses and opens Wallpaper through the current row UI.
-
-Actual output from the complete `npm run check`:
-
-```text
-tokens.css and tokens.gen.ts match design-tokens.json
-token gate: clean (11 allow-listed exceptions, all in use)
-React architecture guard passed (703 source files; zero framework residue).
- Test Files  233 passed (233)
-      Tests  2220 passed (2220)
-bundle gate passed (Desk JS 1255406 B; Desk CSS 297160 B; source maps 0)
-```
-
-After the final shared-control and Settings-row corrections: 16 focused control tests passed; TypeScript and a fresh production build passed. The production-browser checks were rerun at 1440 and 393 against that build:
-
-```json
-{
-  "bundle": "production",
-  "backend": "isolated HTTP fixtures",
-  "pixiSelection": true,
-  "settingsLiveSelection": true,
-  "selectedPreviewsLoaded": true,
-  "originalWorldsIncluded": true,
-  "phoneOverflow": false,
-  "errors": []
-}
-{
-  "bundle": "production",
-  "backend": "isolated HTTP fixtures",
-  "preservedWindow": true,
-  "preservedCaptureControl": true,
-  "captureReachableOverPhoneSheet": true,
-  "favoritesPersist": true,
-  "nativeShortcuts": true,
-  "escapeRestores": true,
-  "phoneOverflow": false
-}
-```
-
-Screenshots in this directory's linked assets were refreshed and inspected. Logs are in the desktop-delivery worktree's `.tmp/desktop-*` files. The browser checks use isolated HTTP fixtures and do not establish microphone hardware readiness or live-model quality. GitHub's broader Python/macOS jobs run separately; this local evidence does not claim they passed.
+- [The Desk](WEB_DESK.md): objects, windows, and navigation.
+- [Getting Started](GETTING_STARTED.md): installation and first capture.
+- [User Guide](USER_GUIDE.md): daily work on the Desk.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,343 +1,197 @@
-# HoldSpeak Getting Started
+# Getting Started
 
-<p align="center">
-  <img src="assets/pixellab/hold-to-talk-microphone.png" alt="Pixel art microphone with hold-to-talk waves" width="128">
-</p>
+Install HoldSpeak and keep your first sentence as text.
+Then configure models for Threads, Interview, and other AI work.
 
-This guide starts with one useful loop: open HoldSpeak, **Dictate one sentence**,
-edit it, then **Copy** or **Keep as Note**. Your first completion furnishes the
-Desk automatically. No extra setup is required before that first value.
+## Requirements
 
-## 1. Install
+- Python 3.10 or later.
+- A microphone and permission to use it.
+- A supported transcription backend: MLX Whisper on Apple Silicon, or faster-whisper on Linux.
+- For a source installation: Git, `uv`, npm, and Node.js 22.12 or later.
 
-The latest published release is `0.4.0`:
+The transcription backend can download model files on first use.
+A text model is a separate requirement for AI work.
 
-```bash
+On macOS, grant microphone access to the process that starts HoldSpeak.
+Global hotkeys and text insertion can also require Accessibility and Input Monitoring permissions.
+If PortAudio is missing, install it with `brew install portaudio`.
+
+On Debian or Ubuntu, install the system audio dependencies:
+
+```sh
+sudo apt-get install portaudio19-dev ffmpeg xclip pulseaudio-utils
+```
+
+Linux packages and desktop permissions differ by distribution.
+Wayland can restrict global hotkeys and direct text insertion.
+
+## Install from source
+
+This path provides the features documented on `main`.
+The Python build hook installs the Web dependencies and builds the Web app.
+
+1. Clone the repository.
+
+   ```sh
+   git clone https://github.com/karolswdev/HoldSpeak.git
+   cd HoldSpeak
+   ```
+
+2. Create a virtual environment.
+
+   ```sh
+   uv venv
+   ```
+
+3. Activate the environment.
+
+   ```sh
+   source .venv/bin/activate
+   ```
+
+4. Install HoldSpeak with the applicable command.
+
+   ```sh
+   # Apple Silicon
+   uv pip install -e .
+
+   # Linux
+   uv pip install -e '.[linux]'
+   ```
+
+Run only the command for your platform.
+Keep this environment active for the commands in this guide.
+
+## Install a published package
+
+A published package can differ from these documents.
+Use this path when you want a release instead of a source checkout.
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
 python -m pip install holdspeak
 ```
 
-This guide tracks `main`, which includes unreleased work after `0.4.0`. For
-exact parity with the screens and features described below, install from a
-checkout. Building the bundled Web app requires npm and a Vite-compatible
-Node.js release (20.19+ or 22.12+):
+On Linux, replace the last command with `python -m pip install 'holdspeak[linux]'`.
+A prebuilt wheel includes the Web app. A source package requires npm to build it.
 
-```bash
-uv pip install -e .
-```
+## Start HoldSpeak
 
-Linux users should install system audio dependencies first:
+1. Start the runtime.
 
-```bash
-sudo apt-get install portaudio19-dev ffmpeg xclip pulseaudio-utils
-uv pip install -e '.[linux]'
-```
+   ```sh
+   holdspeak
+   ```
 
-If you want meeting intelligence or local llama.cpp meeting analysis:
+2. Open the URL printed in the terminal.
 
-```bash
-uv pip install -e '.[meeting]'
-```
+The default listener uses loopback (`127.0.0.1`).
+Use the printed URL because the port and access parameters can differ.
+See [Security & Privacy](SECURITY.md) before you enable remote access.
 
-## 2. Optional diagnostics
+## Keep your first sentence
 
-Run:
+1. Select **Dictate one sentence** on the Desk.
+2. Grant browser microphone access if requested.
+3. Dictate a short sentence.
+4. Edit the transcript if necessary.
+5. Select **Copy** or **Keep as Note**.
 
-```bash
-holdspeak doctor
-```
+The first completion creates six drawers: Inbox, Personal, Work, Meetings, Decisions, and Reference.
+It also creates a Start here Note and the **Everyday context** prompts.
+These prompts contain questions and examples. They contain no inferred personal facts.
 
-Use this when first capture needs repair; it is not a first-value prerequisite.
-Fix anything marked as failing before debugging higher-level features.
-The most important checks are microphone access, transcription backend,
-hotkey support, text insertion support, web runtime, and optional LLM
-runtime status. `doctor` also reports the database schema and config state,
-so you know it is healthy before and after an upgrade.
+Everyday context starts unused.
+Attach it when you want a model to use it.
+You can also choose an explicit default for future Thoughts.
+See [Develop a thought](USER_GUIDE.md#develop-a-thought) for those controls.
 
-Later, when you upgrade HoldSpeak, you can snapshot your data first with
-`holdspeak backup` and put a snapshot back with `holdspeak restore`. Upgrades
-are safe by default; see [`RELEASING.md`](RELEASING.md) for what happens to your
-data on a version change.
+## Find your work
 
-## 3. Start HoldSpeak
+The **arrival** shows items that need you, unfinished Thoughts, a brief, and recent Meetings.
+Use **Floor** to open the spatial Desk.
+Use the **Desk** menu to create records and the **Go** menu to open tools.
+On phones, use the compact **Go** menu.
 
-Run:
-
-```bash
-holdspeak
-```
-
-This starts the local web runtime on loopback (`127.0.0.1`). On a fresh install
-the terminal points you at the Desk and your first words:
-
-```text
-HoldSpeak web runtime is running at: http://127.0.0.1:PORT
-  → Welcome! Say your first words on the Desk: open http://127.0.0.1:PORT/
-```
-
-## 4. Your first sentence and furnished Desk
-
-Choose **Dictate one sentence**, edit the text, then choose **Copy** or
-**Keep as Note**. The first completion automatically furnishes six drawers:
-**Inbox, Personal, Work, Meetings, Decisions,** and **Reference**. It also adds
-a **Start here** note and five editable prompts collected in **Everyday
-context**: About me, Current priorities, How I like help, People & vocabulary,
-and Meeting preferences. They contain questions and examples, not invented facts
-about you.
-
-Everyday context is never sent to AI automatically. Attach it in Ask, choose it
-as an Agent's Context, or attach it from a developing Thought only when you want
-it used. A new Thought says **AI context None**; its compact Attach picker puts
-Everyday context first so the explicit choice still takes one interaction. To
-reuse the complete attached set on later Thoughts created or adopted on this
-hub, choose **Use these by default** in that picker. This future-only default is
-empty until you set it, never changes existing Thoughts, never syncs, and never
-starts AI. **Remove from this Thought** and **Stop using by default** are
-deliberately separate actions.
-
-Open a developing Thought from the Door's **Active** column to enter its
-Thought Workbench. The Note remains a full editable document; the Interview
-asks one focused question at a time. Use **Add & ask next** for the fast
-explicit loop, **Add to Note** to stop after the current answer, and **Finish
-Thought** when the Note is ready. Each turn names its intended boundary and
-records where it actually ran. No model call happens merely because the
-Workbench was opened.
-
-## 5. The Door, then the Floor
-
-After your first sentence, a returning user lands on the **Chair Door**
-(there is no wizard). Its server-derived board shows **Overdue, Now, Waiting,
-Unassigned,** and **Active**, followed by one upcoming timeline. The **Floor**
-remains the spatial world for your meetings, notes, knowledge bases, and
-agents. Tap an object to open it in place, drag it onto a zone to file it,
-press the orb to record, and ask an agent from the rail: its answer lands on
-the Floor as an artifact you can open, trace (`via` the agent that made it),
-and file. Every input takes speech: hold the mic, talk, release (the hub's own
-local Whisper transcribes; the boundary badge names any configured egress). If
-something later needs attention, the **Setup window** (deep link `/setup`) is
-the calm health surface, and the egress badge in the Desk's corner always
-shows what can leave your machine.
-
-The web surface carries the Chair Door and the Floor. The menu (top left) and
-the tool shelf open Dictation, Meetings, Studio, Settings, and the rest as
-floating windows you can drag, resize, snap to an edge, minimize to the dock,
-or maximize. Nothing navigates away from the Desk.
-
-Old route addresses still work as deep links; each lands on the Desk with
-the matching window open:
-
-| Deep link | Opens the window |
+| Address | Destination |
 | --- | --- |
-| `/welcome` | A compatibility route to the same first-words atom the Desk shows |
-| `/` | The Chair Door after first value: the board and upcoming rail. Use the Floor control for the spatial world (record, create, open, file, run). |
-| `/dictation` | Speak: the TALK key and its Aim row, the journal, learning, pre-briefing. An optional preview mode (Settings, Voice) shows each dictation on a card first: Type it commits, Discard drops it. |
-| `/history` | Meetings: capture or import, the archive, aftercare |
-| `/studio` | Studio: the advanced tier (Workbench, Cadence, Commands, and more) |
-| `/settings` | Settings (sectioned and searchable) |
-| `/setup` | Setup and health: readiness plus the single next step |
+| `/` | The Desk, including first capture on a new installation |
+| `/dictation` | Speak |
+| `/history` | Meetings |
+| `/studio` | Studio |
+| `/settings` | Settings |
+| `/setup` | Setup diagnostics and recovery |
 
-## 6. Voice typing beyond your first sentence
+These addresses open the corresponding surface within the Desk.
+See [The Desk](WEB_DESK.md) for windows, objects, and navigation.
 
-The flagship act, on the global hotkey:
+## Configure AI work
 
-1. Start HoldSpeak with `holdspeak`.
-2. Click into a text field in another app.
-3. Hold the configured hotkey.
-4. Speak.
-5. Release the hotkey.
+1. Open **Settings > Models**.
+2. Review the engines listed by the Concierge.
+3. Add an endpoint or download a supported model if no suitable engine exists.
+4. Check the host and engine proposed for each capability group.
+5. Select **Use these** when the required groups are ready.
 
-Default hotkey:
+Use **Adjust** when an individual capability needs a different assignment.
+A cloud **Check** can make a paid request. Its control shows the cost indicator.
+See [Models](MODELS.md) for setup requirements and readiness failures.
 
-- macOS: Right Option
-- Linux: Right Alt
+## Start an Interview
 
-If global hotkeys or synthetic typing are blocked, keep the HoldSpeak window
-focused and use the focused hold-to-talk fallback.
+1. Select **Desk > New Thread**.
+2. Select the **Interview** mode.
+3. Describe one outcome you want from HoldSpeak.
+4. Select **Send**.
 
-The same act has a face on the Desk. Open **Speak** (deep link `/dictation`)
-and it delivers for real through the same route, pipeline, journal, and
-kernel warrant as the hotkey:
+For example: “Help me prepare a weekly architecture decision review.”
+The model can ask questions, inspect permitted records, and save context or suggestions.
+Use **Section** to revisit a topic.
+See [Interview](INTERVIEW.md) for saved context, manual drafts, and current limits.
 
-- **Aim** says where a released **TALK** sends the words: `FOCUSED APP`
-  types into the app you were in, `AGENT` delivers into a coder session that
-  is waiting, and `THIS FIELD` just fills the well below. The pick is
-  remembered.
-- Aimed at `AGENT` it refuses when no session is awaiting (`NO AGENT
-  AWAITING`) rather than free-typing into whatever happens to be focused.
-  Other refusals read the same way: `NO FOCUSED APP`, `NO TYPING DRIVER`,
-  `KERNEL REFUSED`.
-- The receipt reports release-to-landed latency in milliseconds.
-- **REHEARSE** is the explicit dry run. It previews the pipeline and delivers
-  nothing, and it is never what a plain release does.
+## Dictate into another app
 
-### The open mic
+1. Place the cursor in a text field.
+2. Hold Right Option on macOS or Right Alt on Linux.
+3. Speak.
+4. Release the key.
 
-**OPEN MIC** is the latch next to TALK, for when you do not want to hold
-anything:
+These are the default hotkeys. Settings can specify a different key.
+The active Control mode and preview setting determine whether HoldSpeak types immediately or shows a preview.
+See [Voice typing](USER_GUIDE.md#voice-typing) for punctuation, clipboard insertion, and wake-word input.
 
-- **One grant.** The browser is asked for the microphone once and the grant is
-  kept. Between utterances the session suspends (the audio context suspends
-  and the tracks are disabled, so nothing is captured) rather than asking
-  again. A pause longer than 15 seconds releases the device on its own.
-- **Utterances land the same way.** A voice-activity detector on this machine
-  decides where each utterance starts and ends (energy with hysteresis and a
-  700 ms hangover, 300 ms of pre-roll so the first phoneme survives). Each one
-  goes through the same transcription route, the same Aim, and the same
-  delivery contract as a held release, so an ambient utterance and a held one
-  are indistinguishable downstream. Speech shorter than 350 ms is a cough, not
-  words: it is dropped. An empty transcript is dropped silently, without
-  spending a delivery, a journal row, or a receipt.
-- **Holding wins.** TALK, the global hotkey, and any mic on the Desk preempt
-  the open mic: while a hold is live the ambient path is gated off and its
-  in-flight utterance is discarded. One floor, one owner, the same as the
-  physical key.
-- **The lamp does not lie.** The Desk chrome carries a mic lamp that reads
-  `Mic idle`, `Mic open`, `Mic speech`, or `Mic held` from every room. It is
-  absent only when the device is genuinely released, so its presence is the
-  honest signal that audio is live. Pressing OPEN MIC again stops the tracks
-  for real; it does not mute them.
-- **The floor is shared with the rest of the machine.** The browser claims the
-  same one-at-a-time audio floor the hotkey, the meeting recorder, and the
-  wake listener use, on a lease it heartbeats. If a meeting holds it, the claim
-  is refused with the owner named (`FLOOR HELD MEETING`) and the device never
-  opens. If a meeting takes it mid-session, the mic goes down first and the
-  room tells you who took it. The lease means a closed tab cannot wedge your
-  hotkey.
+## Add optional capabilities
 
-A browser that cannot capture audio shows OPEN MIC disabled with the reason on
-it, rather than hiding it. Serving the hub over plain HTTP to another machine
-is the usual cause: browsers withhold the microphone outside a secure origin,
-so reach it over localhost or HTTPS.
+From an active source environment, install only the extras you need:
 
-> **Tip: see what the copilot is doing without the dashboard.** Turn on **desktop
-> presence** in **Settings** (or set `presence.enabled` in your config) to get an
-> ambient, native surface (a floating HUD on macOS and X11, a tray glyph plus
-> notification everywhere). It shows whether it's listening, transcribing, or typing
-> while you dictate into another app, and it never takes keyboard focus. For a
-> headless launch you can force it on with `HOLDSPEAK_DESKTOP_PRESENCE=1 holdspeak`.
-> See [Desktop Presence](DICTATION_PIPELINE_GUIDE.md#11-desktop-presence-ambient-on-desktop-status).
-
-## 7. Use Punctuation Commands
-
-Say punctuation naturally:
-
-| Say | Inserts |
+| Capability | Command |
 | --- | --- |
-| `period` or `full stop` | `.` |
-| `comma` | `,` |
-| `question mark` | `?` |
-| `exclamation mark` | `!` |
-| `new line` | line break |
-| `new paragraph` | blank line |
+| Meeting analysis and optional meeting dependencies | `uv pip install -e '.[meeting]'` |
+| Local GGUF text runtime | `uv pip install -e '.[dictation-llama]'` |
+| MLX text runtime on Apple Silicon | `uv pip install -e '.[dictation-mlx]'` |
+| OpenAI-compatible dictation runtime | `uv pip install -e '.[dictation-openai]'` |
 
-You can add your own spoken symbols, and pin transcription to your
-language, under **Settings, Voice typing**. The
-[User Guide](USER_GUIDE.md) covers both.
-
-Example:
-
-```text
-hello comma can you review this question mark
-```
-
-becomes:
-
-```text
-Hello, can you review this?
-```
-
-## 8. Use Clipboard Insertion
-
-Say `clipboard` inside a dictated phrase when you want HoldSpeak to splice in
-the current clipboard text. The word `clipboard` is removed from the output and
-replaced with the clipboard contents.
-
-Example:
-
-```text
-Taking a look at this clipboard could you refactor it?
-```
-
-If the clipboard contains a code block, that code is inserted into the same
-dictated request before HoldSpeak types or pastes it.
-
-## 9. Set Up A Project Root
-
-Open:
-
-```text
-/dictation
-```
-
-Use the **Project root** bar to select the repository you are actively working
-in. This lets HoldSpeak find project blocks, project knowledge, `.hs/` context,
-and agent-hook state.
-
-Good project markers include:
-
-- `.git/`
-- `pyproject.toml`
-- `package.json`
-- `.holdspeak/`
-- `.hs/`
-
-## 10. Repair or deploy later
-
-Automatic furnishing is the ordinary first-run path. If you need to repair a
-Desk, `holdspeak seed` creates only starter objects HoldSpeak has never seen,
-preserving edits, filing, attachments, and deletions. To deliberately restore
-the furnished defaults, use the destructive, confirmed **Settings, Desk →
-Reset to seed** action.
-
-For model-backed work or headless deployment, open **Settings > Models > Model
-Library**. Add a local GGUF, preset, or compatible endpoint, then choose the
-ordered model list for each relevant job in **Assignments**. A
-`HOLDSPEAK_PROFILE_<ID>_KEY` environment variable remains the headless key
-fallback. See [Models (bring your own)](MODELS.md) and [Models and
-assignments](INFERENCE_TARGETS.md) for those optional contracts.
-
-## 11. Configure model-backed rewriting later
-
-The dictation pipeline is already part of HoldSpeak; model-backed rewriting is
-a later configuration, not a requirement for your first sentence. When ready,
-continue with:
-
-- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md)
-- [User Guide](USER_GUIDE.md)
-
-## 12. Where To Go Next
-
-Once hold-to-talk feels natural, the rest is one setting away each:
-
-- **Hands-free**: [the wake word](USER_GUIDE.md#the-wake-word) listens for a
-  phrase and previews the result before anything is typed.
-- **Your language**: [the spoken language setting](USER_GUIDE.md#speak-your-language) pins any of
-  Whisper's 99 languages, and [the spoken-symbol dictionary](USER_GUIDE.md#punctuation)
-  types your own vocabulary.
-- **Spoken actions**: [voice commands](VOICE_COMMANDS.md) map a keyword to a
-  real action.
-- **Meetings**: [the Meeting Mode Guide](MEETING_MODE_GUIDE.md) covers live
-  capture, importing recordings or transcripts you already have, and the
-  aftercare that closes the loop.
-- **From another device**: an iPad [companion](USER_GUIDE.md#companions) drives
-  both modes over the hub's local API: dictate into your desk, read a meeting
-  back with its artifacts and sources, and approve a proposal.
+The package form uses `holdspeak[extra]` in place of `.[extra]` and omits `-e`.
+See [Meeting mode](MEETING_MODE_GUIDE.md) for system audio setup.
+See [Project Rooms](PROJECT_ROOMS.md) for source-provider requirements.
 
 ## Troubleshooting
 
-| Symptom | Likely cause | First fix |
-| --- | --- | --- |
-| Hotkey does nothing | OS blocked global hooks | Run `holdspeak doctor`; try focused fallback |
-| Text does not appear | Synthetic typing blocked | Try clipboard/manual paste fallback |
-| Transcription is unavailable | Missing backend/model | Run `holdspeak doctor` |
-| Web UI does not open | Browser auto-open disabled or blocked | Visit the printed local URL manually |
-| Project is wrong | Started from another cwd | Set Project root in the Dictation window |
+| Problem | Action |
+| --- | --- |
+| Installation cannot build the Web app | Check `node --version` and `npm --version`. Install the required Node version, then repeat the installation. |
+| Capture cannot start | Check browser and operating-system microphone permissions. Run `holdspeak doctor`. |
+| Transcription fails | Read the reported backend or model error. Install the platform extra if it is missing. |
+| The hotkey works but text does not appear | Check desktop permissions and the preview setting. On Wayland, try clipboard paste. |
+| A Thread cannot run | Open **Settings > Models**. Repair the named assignment or engine. |
+| A documented control is absent | Compare your installed version with `main`. Check the guide for that feature. |
+| You need to restore data | Read [Release and recovery](RELEASING.md) before you run `holdspeak restore`. |
 
 ## See also
 
-- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md): once basic voice typing
-  works, turn on the project-aware copilot.
-- [Meeting Mode Guide](MEETING_MODE_GUIDE.md): meeting-specific setup and capture.
-- [Models (bring your own)](MODELS.md): pick and point at an LLM.
-- [Models and assignments](INFERENCE_TARGETS.md): availability, job selection,
-  frozen plans, and secret custody.
-- [Security & Privacy](SECURITY.md): what's stored and what can leave your machine.
+- [User Guide](USER_GUIDE.md): daily tasks and detailed controls.
+- [Interview](INTERVIEW.md): repeatable context discovery and suggestions.
+- [Models](MODELS.md): engine availability and capability assignments.
+- [Control modes](AUTHORITY.md): approval rules and action limits.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,66 @@
+# Glossary
+
+Use these meanings when you read HoldSpeak guides.
+Capitalized product names identify specific records, modes, or controls.
+
+| Term | Meaning |
+| --- | --- |
+| agent | A saved persona with instructions and selected context. It is distinct from a live Coder session. |
+| Artifact | A saved output record with information about its source or creator. |
+| arrival | The Desk home screen for work that needs you, Thoughts, a brief, and recent Meetings. |
+| assignment | A model selection for a capability, group, or eligible saved item. |
+| automation | Work started by a configured trigger and executed through a supported path. A suggestion alone is not an automation. |
+| Automations | The product surface for watch/reaction configuration outside Project-scoped Watches. |
+| Cadence | The system that reviews unresolved work and prepares next actions. Its background loop is off by default. |
+| cadence | A desired repetition frequency. An Interview cadence preference does not configure the Cadence system. |
+| capability | A registered kind of work with model and execution requirements. |
+| Chair | The Desk view that contains the arrival. |
+| Coder session | A live coding session that HoldSpeak can observe or steer through supported controls. |
+| Concierge | The model setup window opened through Settings > Models. |
+| connector | A component that obtains context from a configured source. Its permissions and data boundary depend on that source. |
+| Control mode | The Secure, Normal, or YOLO policy preset for future operations. |
+| decision record | A durable record of a decision and its available rationale. It does not establish organizational acceptance by itself. |
+| Desk | The product's operating surface for records and tools. |
+| dictation pipeline | The stages that route or transform dictated text before delivery. |
+| egress | Transfer of data outside the current machine or applicable execution boundary. |
+| engine | A detected or configured model runtime, endpoint, or model option shown by the Concierge. |
+| Everyday context | The editable starter prompts that you can explicitly attach as AI context. |
+| Floor | The spatial Desk view where records appear as objects. |
+| grant | Bounded authority for an operation, destination, and scope, with expiry and use limits. |
+| grounding | Use of selected source records as context for a model result. A source reference does not prove the result is correct. |
+| Heartbeat | The unattended sweep configured through Rhythm. It is distinct from Cadence. |
+| hub | The HoldSpeak runtime and data host that the Web app or a paired device uses. |
+| inference | A model execution that produces a result from input. |
+| Interview | The Thread mode for repeatable context and suggestions. The Thought Workbench also has a separate Interview pane. |
+| MCP | Model Context Protocol. Clients use it to discover and call exposed tools and read resources. |
+| Model Library | The service that records model availability, deployment information, and readiness. |
+| Note | An editable text record. |
+| People | The protected surface for confidential relationship records and permitted shared intent. |
+| Places | The environment picker for the Floor. |
+| Project | A record that groups an outcome and related sources or work. |
+| Project facts | Exact values from the `kb:` map in `.holdspeak/project.yaml`, inserted into applicable dictation templates. |
+| Project context | The separate `.hs/` files that can guide an optional model rewrite. |
+| Project Room | The working surface for one Project, its sources, changes, decisions, and automation controls. |
+| proposal | A candidate action or decision that has its own review, authority, and execution states. |
+| Reach | The remote MCP transport with scoped credentials. |
+| Receipt | An execution record that identifies an operation, its boundary, and its result. |
+| Resourceful | The product's bounded overnight maintenance capability. |
+| Rhythm | The Settings module for the Heartbeat. |
+| Settle in | A temporary Desk view with reduced navigation controls. |
+| sidecar | The local MCP process that accesses HoldSpeak services without hosting the Web runtime. |
+| Speak | The voice-typing window. |
+| Steward | The Project component that evaluates observed work and produces supported results under its configured policy. |
+| suggestion | An Interview idea with a basis, feasibility, and recorded user choice. It is distinct from an executed action. |
+| sweep | One Heartbeat evaluation pass. |
+| Thought | A Note under development through the Thought Workbench. |
+| Thread | A saved conversation with model turns, references, and applicable tools. |
+| tool | A named callable operation. Its existence does not grant execution authority. |
+| Watch | A Project-scoped configuration that observes a source population and evaluates specified conditions. |
+| Zone | A Desk container for filed objects. |
+
+## See also
+
+- [Documentation index](README.md): guides organized by task.
+- [Automation](AUTOMATION.md): triggers, workers, and authority.
+- [Models](MODELS.md): engines, availability, and assignments.
+- [Control modes](AUTHORITY.md): review, authorization, and execution.

--- a/docs/INTERVIEW.md
+++ b/docs/INTERVIEW.md
@@ -1,0 +1,162 @@
+# Interview
+
+Use Interview to describe your work and develop useful ways to use HoldSpeak.
+You can revisit each topic as your goals, Projects, and working habits change.
+
+Interview runs inside a normal Thread.
+The model asks questions and proposes ideas. The controller checks tool access and saves structured context.
+The conversation can vary. The state and tool checks follow defined rules.
+
+## Before you start
+
+Configure a suitable model through [Settings > Models](MODELS.md).
+Tool use depends on the model, its assignment, and the current permissions.
+Existing Project records can provide context. You can also start by describing one outcome without a Project.
+
+There are two question-based surfaces in HoldSpeak:
+
+| Surface | Purpose |
+| --- | --- |
+| **Interview** mode in a Thread | Develop working context and suggestions across repeatable sections. |
+| **Interview** pane in the Thought Workbench | Refine one Note through focused questions. |
+
+This guide describes the Thread mode.
+See [Develop a thought](USER_GUIDE.md#develop-a-thought) for the Note workflow.
+
+## Start a conversation
+
+1. Select **Desk > New Thread**.
+2. Select **Interview** above the composer.
+3. Describe one outcome that would help your work.
+4. Select **Send**.
+
+Example: “I lead an architecture transformation. Help me prepare a decision review from the Projects already recorded here.”
+
+Your prompt appears in the conversation while the request starts.
+The model can inspect permitted records, save context, or ask a question.
+Routine calls remain inside **Actions**. Open that control to inspect them.
+Requests for a decision, tool questions, and failures remain visible.
+
+## Choose a section
+
+Use **Section** to change the topic. You can return to an earlier section in the same Thread.
+Selecting a section changes its available tools. It does not itself send a model request.
+
+| Section | What to discuss | Current capability |
+| --- | --- | --- |
+| **Goals** | Desired outcomes and signs of progress | Read existing Projects and save stated or inferred context. |
+| **Projects** | Project scope, outcomes, and source gaps | Read Projects and use the existing Project setup tools. |
+| **What matters** | Changes that deserve attention | Read Project and decision records to support suggestions. |
+| **Cadences** | Repeated preparation, reviews, and outputs | Read Cadence status and loops. Develop a manual recipe. |
+| **People** | Confidential relationship work | Open the protected People surface. The Thread composer is absent in this section. |
+| **Decision log** | Rationale, open decisions, and review conditions | Read decision records and prepare a manual brief. |
+| **Delegation** | Agent briefs, constraints, and expected results | Read Workbench records and prepare a manual brief. |
+| **Sources & models** | Missing connections or model readiness | Inspect connection and provider records. Continue setup in the existing controls. |
+
+The People handoff does not collect private relationship details in this Thread.
+Enter credentials through the relevant setup control, not in an Interview answer.
+
+## Review saved context
+
+1. Open **Context**.
+2. Expand **Known context**.
+3. Read the fact and its basis.
+4. Expand **Source** to inspect the quoted answer.
+
+**Your answer** identifies context based on a stated answer.
+**Inferred** identifies a model interpretation.
+The source reference helps you check what supports the fact. It does not prove that an inference is correct.
+
+To correct context, state the correction in the conversation.
+Then check **Known context** for the updated record.
+The model's statement that it remembered something is insufficient without a saved fact.
+
+To remove a fact, select its **Remove** control.
+The controller also removes suggestions that depend on that fact.
+A changed fact invalidates dependent ideas so they need reconsideration.
+Removing context does not erase earlier Thread messages, kept outputs, or backups.
+
+## Review a suggestion
+
+Open **Context** to see suggestions for the current section.
+Use **Reason & prerequisites** to inspect the basis and missing requirements.
+Use **All suggestions** to review ideas from other sections and earlier choices.
+
+| Label | Meaning |
+| --- | --- |
+| **Manual draft** | You can request a draft through this conversation. |
+| **Needs input** | The idea needs more information. |
+| **Needs connection** | The idea needs a source or service connection. |
+| **Idea · unavailable** | The proposed behavior is unavailable in the current capability set. |
+
+These labels describe feasibility. They do not establish that a task ran or an automation exists.
+
+| Control | Result |
+| --- | --- |
+| **Try draft** | Records the choice and immediately sends a model request to prepare a manual draft. |
+| **Keep idea** | Records that you want to retain the idea. |
+| **Later** | Defers the idea. |
+| **Dismiss** | Records that you declined the idea. |
+| **Explore** | Returns from draft preparation to exploration. |
+
+**Try draft** appears for a proposed manual suggestion.
+Its request asks the model to identify gaps and keep configuration changes as proposals.
+It does not schedule work or start a general-purpose worker.
+
+## Keep a useful result
+
+1. Read the completed draft in the Thread.
+2. Check source claims and assumptions.
+3. Correct unsupported details through the conversation.
+4. Use the reply's Keep control to save a Note or Artifact.
+5. Open the saved record to verify its contents.
+
+**Keep idea** and Keep on a reply have different purposes.
+The first records a suggestion choice. The second creates a separate output record.
+The Thread also retains the conversation itself.
+
+## Repeat or resume
+
+Reopen the same Thread to resume its saved sections, facts, and suggestion choices.
+Start a new Thread when you want separate context for a different purpose.
+Interview context belongs to its Thread. It is not a global personal profile.
+
+Switching between Chair and Floor preserves the open Thread and its current draft.
+An unsent composer draft has no durable-save guarantee across a reload.
+If sending fails, the composer retains the text for correction or retry.
+Review the visible failure before you submit again.
+
+## Project setup and automation limits
+
+In **Projects**, Interview can use the existing setup flow to select, test, and finalize the Project scope you choose.
+These operations can change Project configuration under the applicable authority rules.
+Check the resulting Project and its sources after setup.
+A proposal is not proof of a successful configuration change.
+
+The current Interview does not install arbitrary schedules, general agent assignments, or unsupported integrations.
+For available event and scheduled paths, see [Automation](AUTOMATION.md).
+Completing an Interview does not authorize recurring work.
+
+Model responses still need review.
+Observed limitations include repeated questions, overly broad missing-source claims, and unprovided details that need placeholder labels.
+Successful tool calls establish execution results. They do not establish recommendation quality.
+
+## Troubleshooting
+
+| Problem | Action |
+| --- | --- |
+| Interview is absent from the mode tabs | Check that your installation includes the repeatable Interview feature. |
+| The model says it saved a fact, but no fact appears | Inspect **Actions** for the write result. Request the missing save after any reported failure is resolved. |
+| A context update fails | Let the Thread reload its current state. Reapply your intended change against the displayed context. |
+| The model asks an answered question again | Refer to the existing answer and request the next unresolved question. |
+| A draft invents a date, owner, or decision ID | Correct the draft. Require an explicit placeholder where the record provides no value. |
+| The composer disappears in People | Select **Open People**, or select another Interview section. |
+| A long conversation cannot fit the model | Use the Thread's compaction control or configure a suitable model and context allowance. |
+| A suggestion needs a missing service | Use **Sources & models** to identify the prerequisite. Configure it through the named setup surface. |
+
+## See also
+
+- [Architecture work recipes](ARCHITECTURE_WORK.md): decision reviews and manual agent briefs.
+- [Threads](USER_GUIDE.md#threads): references, saved replies, tools, and conversation controls.
+- [Automation](AUTOMATION.md): supported triggers and execution paths.
+- [Control modes](AUTHORITY.md): approval rules and operation boundaries.

--- a/docs/MCP_SIDECAR.md
+++ b/docs/MCP_SIDECAR.md
@@ -57,13 +57,13 @@ default.
 
 ## Tool families
 
-The 214 tools are organized into domain families. Each tool follows the
+The registered tools are organized into domain families. Each tool follows the
 `domain.verb` naming convention. Tool descriptions are the per-tool
 reference; this page covers the families and the cross-cutting rules.
 
-### desk (52 tools)
+### desk
 
-The original surface. CRUD for desk primitives (meetings, notes, artifacts,
+The original tools cover CRUD for desk primitives (meetings, notes, artifacts,
 projects, decision records, zones, workbenches, recipes, agents, sequences,
 workflows), the pipeline observer, follow-through lanes, inference
 invocations, and the Monday Brief. Five of the `desk.*` tools
@@ -73,7 +73,7 @@ rows; the remaining 12 (including the singleton People surface) are computed,
 composite, or managed by a dedicated capability. Each description names
 which kinds it handles.
 
-### ask (4 tools)
+### ask
 
 Ask the desk a question. `ask.resolve_grounding` hydrates grounding references
 without running inference. `ask.run` submits a question through the admitted
@@ -81,7 +81,7 @@ inference path and returns the answer with its receipt. `ask.cancel` cancels an
 in-flight invocation. `ask.keep` persists an answer as a desk artifact (not
 model-invoking). Model selection is never an Ask-side MCP control.
 
-### door (2 tools)
+### door
 
 `door.get` returns one closed, read-only Dashboard Door aggregate: the board,
 active Thoughts, and a mixed upcoming timeline of calendar events (from all
@@ -97,7 +97,7 @@ Door has no MCP resource. Its
 Follow-Through People overlay respects `HOLDSPEAK_MCP_PEOPLE_ACCESS` and is
 safely empty when that encrypted disclosure capability is unavailable or off.
 
-### project (35 tools)
+### project
 
 Three read tools: `project.list` returns all projects (optionally
 including archived). `project.get` returns one project by id with room
@@ -130,12 +130,16 @@ PR number, reviewer, timestamp, and host. `nudge.dismiss` closes one pending
 nudge with no write; a 7-day cooldown starts. Both refuse nudges that are not
 in `proposed` state.
 
-Six setup interview drivers: `project.setup.start`, `project.setup.resume`,
-`project.setup.answer`, `project.setup.suggest`, `project.setup.finalize`,
-and `project.setup.clarify_jira_scope` (refines a Jira proposal's project
-keys and issue types within a setup session).
-The durable session resumes across tool calls; finalize activates atomically
-through the same ProjectService.create_from_setup seam as the web route.
+Project setup drivers include `project.setup.start`, `project.setup.resume`,
+`project.setup.answer`, and `project.setup.suggest`.
+Use `project.setup.select_proposal` and `project.setup.deselect_proposal` to
+record the chosen scope. `project.setup.test_proposal` tests it.
+`project.setup.clarify_repo_scope` and `project.setup.clarify_jira_scope`
+refine the provider scope. `project.setup.finalize` applies the chosen setup
+through the existing Project service.
+The durable session resumes across tool calls.
+The [Interview user guide](INTERVIEW.md) explains the conversation that uses
+these drivers. The generated roster below lists all current tool names.
 
 Seven graduated watch tools: `project.watch.inspect`, `project.watch.test`,
 `project.watch.evaluate`, `project.watch.set_rules`, `project.watch.pause`,
@@ -160,7 +164,7 @@ Five resource templates expose project data: `holdspeak://projects/{id}`,
 `.../room`, `.../delta`, `.../updates/{update_id}`, and
 `.../steward/runs/{run_id}`. Unknown ids refuse typed.
 
-### provider (10 tools)
+### provider
 
 Provider discovery and connection status for GitHub and Jira.
 
@@ -218,7 +222,7 @@ verification begins. It cannot change model availability or any assignment.
 Model acquisition enters through the seven Model Library commands below; model
 and agent principals receive no authority through this tool.
 
-### model library (7 tools)
+### model library
 
 Owner-only availability commands over the same Model Library application service
 as the HTTP owner API: `model_library.get`, `model_library.download`,
@@ -232,7 +236,7 @@ deletes it after the command; client paths are refused. Hosted-provider secrets
 have a dedicated write-only `secret` field and never appear in errors, logs, or
 receipts.
 
-### inference assignment (5 tools)
+### inference assignment
 
 Owner-only assignment projection and command twins over the same Assignment
 application service as HTTP: `inference_assignment.summary`,
@@ -243,7 +247,7 @@ clear preserve the canonical narrow CAS and stable command replay; replay
 returns the original committed-effect chain and hash, never a route, endpoint,
 path, secret, or binding detail.
 
-### thought (18 tools)
+### thought
 
 Develop a durable Thought through one explicit model turn. `thought.refine`
 asks one useful question using server-loaded authoritative material;
@@ -299,20 +303,20 @@ detail, `code` is the stable service code, and safe conflict context such as
 the current Thought projection is retained. Thought resource failures carry
 the same stable code in JSON-RPC `error.data`.
 
-### settings (2 tools)
+### settings
 
 `settings.get` returns the current configuration with secrets redacted
 and a `_revision` field for optimistic concurrency. `settings.update`
 applies a partial patch. Secrets and inference assignments cannot be written
 through this tool.
 
-### coder (3 tools)
+### coder
 
 Read-only inspection of coder sessions. `coder.list` lists sessions
 (optionally filtered by agent). `coder.get` returns one session by id.
 `coder.audit` reads the bounded steering audit trail.
 
-### concierge (5 tools)
+### concierge
 
 Engine detection and model assignment. `concierge.detect` returns every
 reachable engine (LAN, local, cloud, catalog presets) with hardware facts
@@ -324,7 +328,7 @@ writes the complete assignment set in one step (refuses while any group is
 WAITING and not OFF). `concierge.download` starts a catalog preset download
 through the existing Model Library download path.
 
-### cadence (11 tools)
+### cadence
 
 The cadence engine: reviews meetings, proposed actions, and waiting coder
 sessions, then prepares next actions. `cadence.status` returns the engine
@@ -335,13 +339,13 @@ closeout. `cadence.history` and `cadence.audit` read the event history.
 `cadence.apply_closeout` are safe write verbs that mutate only the local
 database.
 
-### sequence (2 tools)
+### sequence
 
 `sequence.run` runs a sequence (chain) through the admitted inference
 path. `sequence.cancel` cancels a running sequence by its parent operation
 id.
 
-### workflow (2 tools)
+### workflow
 
 `workflow.run` runs a workflow through the admitted inference path.
 `workflow.cancel` cancels a running workflow by its parent operation id.
@@ -372,7 +376,7 @@ record or commitment is created. A `proposal.dismissed` receipt is written.
 
 Both tools refuse proposals that are not `proposed`.
 
-### people (16 tools)
+### people
 
 The encrypted People ledger defaults to `write` for the local owner process.
 `people.readiness` is content-free and also works while access is explicitly
@@ -402,7 +406,7 @@ search, sync, export, connector, or employment-decision tool. Tool results are
 transient stdio disclosure to the explicitly trusted parent client; they are
 not written to HoldSpeak's plaintext database, observer, FTS, or Cadence.
 
-### heartbeat (4 tools)
+### heartbeat
 
 The Heartbeat sweep: the unattended cadence that evaluates due Watches and
 caches the needs-you aggregate. `heartbeat.status` reads the current
@@ -416,7 +420,7 @@ updates the sweep settings: `sweep_every_minutes` (1 to 1440, default
 from the notification aggregate). `heartbeat.notify_test` fires one test
 desktop notification and returns `{fired: boolean}`.
 
-### plugin_job (4 tools)
+### plugin_job
 
 `plugin_job.list` and `plugin_job.summary` read deferred plugin job state.
 `plugin_job.retry` re-queues a failed or completed job. `plugin_job.cancel`

--- a/docs/MEETING_MODE_GUIDE.md
+++ b/docs/MEETING_MODE_GUIDE.md
@@ -283,14 +283,15 @@ Notes:
 For local-first capture plus remote intel on your LAN:
 
 1. Run an OpenAI-compatible endpoint on homelab (for example vLLM/Ollama-compatible API).
-2. Add it in **Settings > Models > Model Library** with the endpoint's
-   `http://host:port/v1` URL.
-3. Select that model for **Meetings** in **Assignments**. Deferred intelligence
-   remains enabled, so meetings continue when the homelab is temporarily
-   unavailable.
-4. Set the model profile's key in Model Library and run `holdspeak doctor` to
-   preflight reachability and availability. `HOLDSPEAK_PROFILE_<ID>_KEY`
-   remains a headless fallback.
+2. Open **Settings > Models**.
+3. Add the endpoint through **Add an engine...** if it is a keyless compatible endpoint.
+4. Select the model for **Meetings** in the Concierge set.
+5. Select **Use these** to apply the set.
+6. Run `holdspeak doctor` to inspect readiness.
+
+For keyed providers, use the owner Model Library API or documented headless credential fallback.
+See [Models](MODELS.md) for those paths.
+Deferred intelligence remains enabled when the model host is temporarily unavailable.
 
 ### What It Extracts
 
@@ -563,8 +564,9 @@ Configuration file: `~/.config/holdspeak/config.json`
 
 The browser Settings surfaces are the preferred editor. This representative
 `meeting` block shows the supported low-level controls most often needed for
-capture, intelligence, routing, and connectors. Model placement itself belongs
-in Model Library and Assignments, not in hand-authored endpoint fields.
+capture, intelligence, routing, and connectors.
+The model services store availability and assignments.
+Use the Concierge for current model setup. See [Models](MODELS.md).
 
 ```json
 {
@@ -780,11 +782,10 @@ Send `"ping"` text message, receive `"pong"` response.
 
 1. Run `holdspeak doctor` and check the `Cloud intel preflight` line.
 2. If it reports DNS/connection failures, verify the homelab hostname/IP, LAN routing, and firewall.
-3. If it reports auth failures (HTTP 401/403), check the model profile's key in
-   **Settings > Models > Model Library**. For a headless hub, check its
-   `HOLDSPEAK_PROFILE_<ID>_KEY` fallback.
+3. If it reports an authentication failure, check the model profile's credential configuration.
+   See [Models](MODELS.md) for owner API and headless credential paths.
 4. If it reports model mismatch, set that profile's model to one of the model IDs exposed by `/models`.
-5. Verify that profile's base URL starts with `http://` or `https://` and includes the right API prefix (commonly `/v1`). **Probe** in Model Library tests reachability.
+5. Verify that profile's base URL starts with `http://` or `https://` and includes the right API prefix (commonly `/v1`). **Check** in the Concierge tests the selected engine.
 
 ### Transcription quality is poor
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,168 +1,130 @@
-# Models: bring your own
+# Models
 
-HoldSpeak uses models you choose. **Model Library** is where you make a model
-available. **Assignments** is where you choose the compatible ordered model list
-for a kind of work. This guide gets you set up. Read the internal
-[Intelligence Router architecture](internal/ARCHITECTURE_INTELLIGENCE_ROUTER.md)
-when you need the execution mechanics.
+Choose the engines that HoldSpeak uses for each capability.
+The **Concierge** combines engine discovery and model assignments in one window.
 
-> **Local-first.** Your model material and connection details stay on your hub.
-> Model material leaves only for the model endpoint you choose. Read
-> [Security & Privacy](SECURITY.md) for the complete egress boundary.
+## Configure an assignment set
 
-## Start here
+1. Open **Settings > Models**.
+2. Review the engines under **FOUND**.
+3. Add an engine or download a supported preset if necessary.
+4. Review the proposed engine for each group under **THE SET**.
+5. Select **Use these** when the set is ready.
 
-1. Open **Settings, Models**.
-2. In **Model Library**, add a model from the catalog, add a model file, connect
-   a provider, or connect a paired device.
-3. Check its readiness. A model that is present is not necessarily ready to run.
-4. Open **Assignments** and choose the compatible model list for the work you
-   want to run. Use **Use default** when the inherited choice is the right one.
+Each engine row identifies its host and current state.
+A file on disk or a saved credential does not prove that the engine can run.
+The set can include different engines for different kinds of work.
 
-Adding or connecting a model does not change an Assignment. Choosing or
-clearing an Assignment does not alter the Model Library. Keep those two actions
-separate when you repair setup.
+## Add or check an engine
 
-## Model Library: make models available
+Use **Add an engine...** for a keyless compatible endpoint.
+Enter its base URL in the endpoint field.
+Select **Check** to inspect it.
 
-The Model Library is the owner surface for availability. It can start a
-catalog-pinned model acquisition, adopt a detected or uploaded model file,
-connect a hosted provider, define an OpenAI-compatible endpoint, or connect an
-existing paired device. A provider key is submitted through a separate
-write-only field. The Library shows whether a required key is present, never its
-value.
+A catalog preset shows **Download** and its file size when the model is absent.
+Selecting **Download** starts acquisition through the Model Library service.
+Dependent assignments remain **WAITING** until the model is ready.
 
-You can use three practical sources:
+Cloud rows indicate whether a key is set.
+Their **Check** control shows `1 TOKEN · $` before a paid probe.
+The Concierge requires that explicit action for a paid cloud check.
+Normal model work can also incur provider charges.
 
-- **Local GGUF.** Install the `dictation-llama` extra when you want the local
-  runtime, then add a supported GGUF model to the Library. HoldSpeak detects
-  valid local artifacts and reports runtime readiness rather than treating a
-  filename as proof that a model will run.
-- **MLX on Apple Silicon.** Install the `dictation-mlx` extra for MLX text
-  support. Model Library can detect MLX safetensors artifacts. Today they remain
-  unavailable for Thoughts, even when the artifact is present, and stay useful
-  only on the paths that support them.
-- **A provider or another device.** Connect a hosted provider, define an
-  OpenAI-compatible endpoint, or connect a paired device. Install
-  `dictation-openai` when the dictation path needs an OpenAI-compatible
-  endpoint. A keyless self-hosted endpoint needs no key.
+The current Concierge URL field does not collect a provider key.
+For a keyed provider, use the owner Model Library API with its separate write-only secret field.
+The [Model Library contract](MCP_SIDECAR.md#model-library) describes the underlying owner operations.
+The [API surface](API_SURFACE.md) lists their HTTP routes.
 
-For a provider draft, enter its label, model identity, and required connection
-information in the Library. The Library creates the public model record,
-private deployment material, binding, and current readiness observation as one
-owner action. It reports an unavailable runtime honestly. For example, a stored
-key does not make an unsupported provider runtime ready.
+For headless provisioning, `HOLDSPEAK_PROFILE_<ID>_KEY` remains an environment fallback for the identified model profile.
+Do not place credentials in a Thread, Note, or shared model record.
+A cloud row showing **KEY NOT SET** requires credential setup before a paid check can succeed.
 
-### Readiness is current, not a promise
+## Understand readiness
 
-Use **Check** or **Try again** after changing a local runtime, model file,
-provider, key, endpoint, or paired machine. Readiness belongs to the exact
-bound deployment revision. It can report an unavailable artifact, missing
-credential, unreachable endpoint, unavailable runtime, or offline device.
-Fix the named issue in Model Library, then check again.
+| State | Meaning |
+| --- | --- |
+| **READY** | The engine passed the applicable readiness check. |
+| **CHECKING** | A check is in progress. |
+| **WAITING** | A download or prerequisite has not completed. |
+| **KEY NOT SET** | The cloud engine needs a configured key. |
+| **UNREACHABLE** | The engine did not respond as required. |
+| **OFF** | You explicitly disabled a capability group. |
 
-Availability is not routing. A model can stay in your Library while you choose
-another model list in Assignments. Removing or revising a model that is assigned
-may require you to repair the dependent Assignment first.
+**Use these** requires every group to be ready or explicitly off.
+A successful check establishes current availability. It does not guarantee future availability or model quality.
 
-## Assignments: choose where work runs
+## Adjust individual capabilities
 
-Assignments is the owner surface for selecting models for registered HoldSpeak
-jobs. Choose a compatible ordered model list of one to four models. The list is
-saved as a whole. HoldSpeak does not combine part of your new list with an
-inherited one or silently remove an incompatible entry.
+Select **Adjust** below the proposed set to open the capability table.
+Each row shows its group, assignment, and engine host.
+Use an individual assignment when the group choice does not suit that capability.
 
-You can set a model list for a capability group, an individual capability, or an
-eligible saved item. More specific scope wins. **Use default**
-clears the current row and reveals the next complete compatible model list. The
-editor previews compatibility before it saves. It can retain a valid choice
-that is temporarily not ready, then name the repair when work starts.
+The service resolves the applicable assignment when work starts.
+Changes to the model catalog or assignments affect later work.
+They do not move a run that has already started.
 
-You do not choose a model at the point of use. Saved work and meetings ask for
-their capability. HoldSpeak resolves the applicable Assignment and freezes the
-resulting route at admission. Later Library or Assignment edits affect later
-work, not a run already in progress.
+## Model Library and assignments
 
-## Provider and runtime notes
+**Model Library** names the underlying availability service.
+It records models, deployment information, and readiness observations.
+An **assignment** selects the compatible model list for a capability or eligible saved item.
+These are separate service contracts beneath the Concierge.
 
-HoldSpeak does not require a particular model family. Select a model that fits
-your hardware and the capability's requirements. Structured output, tool use,
-context size, supported modalities, runtime availability, and boundary are
-checked against the capability before a model list can execute.
+The current **Settings > Models** and assignment entry points open the Concierge.
+Older instructions that begin with separate Library and Assignments screens describe an earlier interface.
+Use the [MCP reference](MCP_SIDECAR.md) or [API surface](API_SURFACE.md) for programmatic access to those services.
 
-For local work, install only the optional runtime you use:
+The assignment service supports complete ordered lists of one to four compatible models.
+More specific assignment scope takes precedence over a group default.
+A missing or incompatible assignment produces a named failure when work starts.
 
-```bash
-uv pip install -e '.[dictation-llama]'   # local GGUF runtime
-uv pip install -e '.[dictation-mlx]'     # MLX text support on Apple Silicon
-uv pip install -e '.[dictation-openai]'  # OpenAI-compatible dictation path
-```
+## Local runtimes and endpoints
 
-For a headless provider key, `HOLDSPEAK_PROFILE_<ID>_KEY` remains a fallback.
-Use the Model Library for the ordinary owner workflow. It keeps secret material
-out of model records, Library projections, receipts, and error messages.
+Install the optional runtime that your chosen capability needs.
+From an active source environment:
 
-## Structured output for meeting intelligence
+| Runtime | Command |
+| --- | --- |
+| GGUF through llama.cpp | `uv pip install -e '.[dictation-llama]'` |
+| MLX text models on Apple Silicon | `uv pip install -e '.[dictation-mlx]'` |
+| OpenAI-compatible dictation endpoint | `uv pip install -e '.[dictation-openai]'` |
+| Optional meeting analysis dependencies | `uv pip install -e '.[meeting]'` |
 
-Meeting intelligence sends a request-level `response_format` with a JSON Schema
-derived from the one `INTEL_SCHEMA` constant in `holdspeak/intel/parsing.py`.
-The schema shape is:
+For a package installation, use the equivalent `holdspeak[extra]` package.
+See [Getting Started](GETTING_STARTED.md) for environment setup.
 
-```json
-{
-  "topics": ["<short topic>"],
-  "action_items": [
-    {
-      "task": "<task>",
-      "owner": "<person's name as spoken>|Me|Remote|null",
-      "due": "<date or null>"
-    }
-  ],
-  "summary": "<short summary>"
-}
-```
+Capability requirements include supported input types, tool use, structured output, and context size.
+A model that works for writing can still be unsuitable for Interview or meeting analysis.
+An available MLX artifact also requires a capability path that supports its runtime.
 
-`owner` is a literal person name as spoken in the transcript, or one of two
-reserved tokens: `Me` (the speaker or leader) and `Remote` (the counterpart).
-`null` means the transcript did not name an owner. Every other string is a
-literal name the model heard. `Me` and `Remote` are the only reserved tokens.
+The Concierge proposes local speech recognition.
+Other groups can use a local engine, LAN endpoint, or selected cloud service.
+Check each host before you apply the set.
+Model requests can send source context to that host.
 
-The prompt stringifies `INTEL_SCHEMA`, the `response_format` wraps
-`INTEL_JSON_SCHEMA` (the formal JSON Schema derived from it), and the semantic
-adapter references the same constant. If the endpoint returns a 400 naming
-`response_format` or `json_schema`, the dispatch treats the rejection as a
-dialect mismatch (like the `max_completion_tokens` compatibility pattern),
-records the endpoint's dialect, and raises a named signal for a second admitted
-child that omits `response_format`. The fallback is never a silent retry: the
-runner admits one physical request per child, and the prompt's "Return ONLY a
-single valid JSON object" instruction plus the `_extract_json` line-recovery
-heuristic remain the safety net.
+## Meeting output compatibility
 
-### The schema-pinned-server gotcha
+Meeting intelligence expects structured fields for topics, action items, and a summary.
+An endpoint must support the applicable request and response format.
+A server-wide schema setting can conflict with the requested meeting schema.
 
-A llama.cpp server launched with a server-level `--json-schema` flag pins every
-response to that schema regardless of what the request asks for. A prompt-level
-JSON plea or a request-level `response_format` override is silently swallowed,
-and the response conforms to the pinned schema instead. The product now sends
-request-level structured output, which overrides the server pin cleanly on
-llama.cpp builds that support it. If you run a llama.cpp server with
-`--json-schema`, verify that the model responds to the product's schema and not
-the server pin by checking the shape of the response (it should contain
-`topics`, `action_items`, and `summary`, not the pinned shape).
+For field definitions and compatibility behavior, see the [meeting output schema](internal/MEETING_OUTPUT_SCHEMA.md).
+Use the returned error and Receipt when you diagnose a failed request.
 
-## When a model will not run
+## Troubleshooting
 
-| What you see | What to do |
-|---|---|
-| A model is listed but not ready | Open Model Library, read the readiness reason, fix it, then check again. |
-| An Assignment needs attention | Choose a compatible, enabled model in Assignments or clear it with **Use default**. |
-| A local artifact is detected but unavailable | Install the required runtime and verify the artifact and runtime again. |
-| An endpoint is unavailable | Check the endpoint, required key, and network reachability, then run **Check**. |
-| A capability cannot use your model | Use a model whose declared modalities, context, structured output, tools, and boundary meet that capability. |
+| Problem | Action |
+| --- | --- |
+| No engine is available | Add a compatible endpoint or download a supported preset. |
+| A local model remains unavailable | Check the model file, optional runtime, and capability requirements. |
+| An endpoint is unreachable | Check its address, required credential, and network path. Repeat **Check**. |
+| An assignment cannot run | Use **Adjust** to select a compatible engine for that capability. |
+| **Use these** remains disabled | Resolve each waiting group or explicitly set an unneeded group to off. |
+| Tool results are unreliable | Review the sources and model output. A readiness check does not evaluate recommendation quality. |
 
 ## See also
 
-- [Intelligence Router architecture](internal/ARCHITECTURE_INTELLIGENCE_ROUTER.md): capability, routing, freeze, execution, and receipt mechanics.
-- [Security & Privacy](SECURITY.md): local custody and egress posture.
-- [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md): where a configured dictation model is used.
-- [Meeting Mode Guide](MEETING_MODE_GUIDE.md): where a configured meeting model is used.
+- [Getting Started](GETTING_STARTED.md): install the required environment.
+- [Interview](INTERVIEW.md): tool-based conversation and current quality limits.
+- [Security & Privacy](SECURITY.md): model data and credential boundaries.
+- [Intelligence Router architecture](internal/ARCHITECTURE_INTELLIGENCE_ROUTER.md): service routing and admission.

--- a/docs/PROJECT_ROOMS.md
+++ b/docs/PROJECT_ROOMS.md
@@ -1,231 +1,96 @@
 # Project Rooms
 
-A Project Room is the operational surface for one Project. It connects
-the Project to external providers (GitHub, Jira), installs Watches
-(Project-scoped) over pull requests and issues, and runs the Steward
-when conditions fire.
+Use a Project Room to review one Project, its sources, and the work that needs you.
+Configure Project-scoped Watches when you want HoldSpeak to observe supported source changes.
 
-## What a Project Room contains
+## Before you start
 
-When you open a Project Room you see the Project's identity, linked
-meetings, resources, the current Delta (what changed since the last
-update), and the installed Watches (Project-scoped) with their
-evaluation history. The Room is one coherent read: everything the
-Steward and the owner need to assess the Project's state.
+You can create a blank Project without external sources.
+A connected Project also needs a configured provider and access to its source scope.
 
-## Providers
+| Provider | Requirement | Data boundary |
+| --- | --- | --- |
+| GitHub | The `gh` CLI and an authenticated account | Calls contact GitHub from the hub. |
+| Jira | The `acli` CLI and the intended site/account | Calls contact the selected Atlassian site from the hub. Jira access is read-only. |
 
-A provider connects HoldSpeak to an external system. Each provider
-requires its own CLI, installed and authenticated separately.
+Open **Settings > Connections** to inspect readiness and the relevant recovery command.
+Use **Recheck** after you change the provider setup.
+The provider CLIs retain their credentials. Do not put tokens in a Project description or Thread.
 
-### GitHub
+A Jira connection identifies both the site and account.
+When multiple accounts exist, verify the selected identity before choosing a source scope.
 
-Requires [`gh`](https://cli.github.com/). Authenticate with
-`gh auth login`. HoldSpeak reads connection status, discovers
-repositories, and validates an owner/repo pair. Pull request
-observations feed Watches (Project-scoped) and the Delta.
+## Create a Project
 
-### Jira
+1. Select **Desk > New Project**.
+2. Enter the outcome in the **What are you delivering?** field.
+3. Select a source scope if the Project needs one.
+4. Review the enabled Watch controls and live counts.
+5. Select **Create Project**.
 
-Requires [`acli`](https://acli.atlassian.com/). Install with:
+The outcome supplies the Project's name and outcome text.
+The name uses the first 80 characters.
+A Project with no selected sources is a valid blank Project.
+The footer identifies that state before creation.
 
-```bash
-brew tap atlassian/homebrew-acli && brew install acli
-acli jira auth login --site <yoursite>.atlassian.net --email <you> --token
-```
+The **SOURCES** section contains a row for each supported provider.
+A connected row offers a repository or project picker.
+An unconnected row offers **Connect**, which opens the existing connection controls.
+The source row rechecks readiness when you return.
 
-A Jira connection is identified by (site, email). One owner may hold
-multiple connections across different `*.atlassian.net` sites or
-multiple accounts on one site. HoldSpeak never stores Jira credentials.
+Selecting a scope starts the live count check for enabled Watches.
+The row reports **CHECKING** while the request runs.
+A failed check reports its reason with **CAN'T CHECK**.
+The current Web setup does not require a separate test wizard.
 
-Every Jira call follows the switch-and-verify law: `acli jira auth
-switch` to the target account, then the command, then `acli jira auth
-status` read-back, under a cross-process file lock. A read-back
-mismatch is a typed error, never a silent wrong read.
+## Adjust the source population
 
-Issue types are enumerated from the Jira project. Statuses are observed
-from the issue population (labeled as observed); Jira's three status
-categories (new, indeterminate, done) are labeled as static.
+Use **Adjust** on a connected row to change its population filters.
+GitHub supports the base branch, labels, and draft inclusion.
+Jira supports issue types and an optional JQL filter.
 
-All Jira access is read-only. Jira calls contact
-`<site>.atlassian.net` from this device.
+The initial GitHub controls enable **OPEN PRS** and **CI**.
+The initial Jira controls enable **OVERDUE** and **DUE 7 DAYS**.
+**BLOCKED** starts off.
+Your selected controls determine the Watches created with the Project.
 
-## The walk: a first Project through the whole Room
+A source already used by another Project shows that relationship in the picker.
+Use the existing Project when it already represents the work you want to discuss.
+See [Interview](INTERVIEW.md) for discovery and setup through a Thread.
 
-This is what a Tuesday looks like with Project Rooms: one project
-created, connected, watched, reviewed, steward-run, and updated.
+## Review the Room
 
-### 1. Connect your tools (once)
+Open a Project to enter its Room.
+Use **ROOM** for current work and **HISTORY** for dated events.
 
-Before starting a Project, connect GitHub and Jira in **Settings,
-Connections**. Each tool is one card with one state and one verb.
-GitHub needs `gh auth login`; Jira needs
-`acli jira auth login --site <site> --email <email> --token`. The
-card shows `Connected` when the CLI is authenticated and `Sign in`
-when it is not; the fold opens with the command in a code well with
-`Copy`. Each `Recheck` contacts the named host from this device.
-HoldSpeak stores no token.
+| Section | What to inspect |
+| --- | --- |
+| Headline | The number of items that need you and the available health or target-date state |
+| **NEEDS YOU** | Review requests, failing CI, overdue work, and pending proposals |
+| **SOURCES** | Watch scope, current counts, last check, host, and pause/resume controls |
+| **SINCE YOU LOOKED** | Source changes since the saved read marker |
+| **DECISIONS & COMMITMENTS** | Available decisions and commitments from linked work |
+| Ask field | A question about the Project, with the configured model boundary |
 
-See [Connect your tools](./USER_GUIDE.md#connect-your-tools) for the
-full reference.
+Open a source item to inspect the original record.
+Read a proposal before using its decision control.
+Opening or refreshing the Room updates its read marker.
 
-### 2. Start the interview
+**HISTORY** groups events by date.
+Use the source filters or text search to find an event.
+The detailed [User Guide](USER_GUIDE.md#project-room) describes the individual controls.
 
-Open the desk, start a new Project. The interview asks for the outcome
-(what the Project is about) and a notice (what you want watched). Type
-or dictate both. The mic is on the well.
+## Control Watches
 
-![The interview question cards with answered rows collapsed](assets/project-rooms/interview-questions.png)
+Each Watch observes a defined population and evaluates its conditions.
+The Room exposes **Pause** and **Resume** for the applicable Watch state.
+A failed check identifies its reason.
+A suggested source remains a suggestion until you add it.
 
-### 3. Sources
-
-The Sources step shows a **TOOLS** row (`TOOLS 2`) above the
-suggestions. Each tool card reads its state from the hub's connections
-service. A connected tool shows `Connected` with no verb. A tool
-that is not connected shows `Sign in` with a `Connect GitHub` or
-`Connect Jira` verb that opens **Settings, Connections** in place;
-the interview session survives the round trip (the setup is
-server-side and resumes). `Recheck` is a quiet second action while
-the Connections window is open, so a user who signs in and comes back
-without closing Settings has a named way forward.
-
-![The Sources step with the TOOLS row and suggestion cards on a connected desk](assets/connections/sources-connected-1440.png)
-
-Below the TOOLS row, suggestion cards appear grouped by provider
-(up to 4 per provider; the cap prevents one provider from starving
-another). Each card carries a `CADENCE` token, an `ACTION` token,
-a provenance chip (`gh`, `acli`, or `local`), and the provider's
-connection state chip (`Connected` or `Sign in`). A card whose
-provider is not connected has no tier and its click scrolls the
-TOOLS row into view instead of opening a wizard.
-
-On a cold desk (no tool connected), the TOOLS row shows
-`Connect GitHub` and `Connect Jira` and no provider suggestion
-cards appear -- only native cards. The TOOLS row is the only place
-a cold user learns that GitHub and Jira exist.
-
-![The Sources step on a cold desk: TOOLS row with Connect GitHub and Connect Jira, native cards only](assets/connections/sources-cold-1440.png)
-
-Each interview answer you have already given (the outcome, what to
-notice) collapses to one row: the checkmark and your words on one
-line, with an `Edit` verb.
-
-![An answered interview row with the Edit verb](assets/connections/answered-row-1440.png)
-
-### 4. Scope and test
-
-Select a connected provider's suggestion card. The wizard asks scope
-and population only (no auth -- that was settled in step 1). The
-wizard's progress plan reads `Repository . Population . Test`
-(GitHub) or `Account . Project . Population . Test` (Jira; the
-Account step is skipped when exactly one connection exists).
-
-**GitHub.** Pick a repository (search or type `owner/repo`). When a
-scope was chosen for an earlier same-provider Watch in this session,
-the wizard offers that scope as a known-scope card at the top:
-summary `chosen for <earlier Watch name>`, verb `Use this repo`. The
-discovery list follows beneath it.
-
-![The GitHub wizard repository step with the known-scope card](assets/connections/github-wizard-known-scope-1440.png)
-
-The population sheet shows read-only facts: `SUBJECT` `pull requests`,
-`BASE` (the template's base-branch filter, when it carries one) and
-`QUERY` in plain words. Test runs the template against the live
-repository; the `MATCHES` ledger lists each matched pull request by
-number, title and state. The egress chip names `github.com`.
-
-![The GitHub wizard population facts and test plan with Use this Watch](assets/connections/github-wizard-test-1440.png)
-
-**Jira.** Pick the account (when more than one), the project, and
-the issue types. The known-scope card offers `Use this project` when
-a scope was chosen for an earlier same-provider Watch. Test runs the
-template against the project's issue population. The egress chip
-names `<site>.atlassian.net`.
-
-![The Jira wizard with a project picked and Test this Watch enabled](assets/connections/jira-wizard-scoped-1440.png)
-
-**The verbs.** The wizard footer carries the egress chip of the host,
-`Back` (leaves the Watch as it was before the wizard opened), and
-`Test this Watch` (primary). After a test passes, the primary verb
-becomes `Use this Watch`. `gh` and `acli` hold credentials on this
-machine; HoldSpeak stores no token.
-
-### 5. Activate
-
-The activation review shows what will run: two Watches (one per
-provider), each with its template, conditions, and target population.
-The footer's egress chips name both hosts. Activate baselines both
-Watches against the live population and activates them.
-
-![Activation review with two Watch rows showing their templates and egress chips](assets/project-rooms/activation-review.png)
-
-### 6. The Room
-
-The Room lands. The identity band shows the Project name, lifecycle,
-and revision. Four wings are visible: Timeline, Decisions, Search,
-and Ask. The posture strip's verbs (Review, Updates, Steward) switch
-the working view. The Watch ledger rows show
-each Watch's template and evaluation state.
-
-![The populated Room with identity band, Watch ledger rows, and the four wings](assets/project-rooms/room-populated.png)
-
-### 7. Review changes
-
-When a Watch evaluation finds transitions (a PR merged, an issue
-moved to a new status), the Delta shows them. Open a review to see
-the queue. Each row shows the current and proposed state. Accept,
-defer, or dismiss each observation. The footer shows the tally.
-
-![The review queue with current and proposed columns per observation](assets/project-rooms/review-queue.png)
-
-After accepting observations, the review summary shows what was
-accepted, deferred, and dismissed.
-
-![Review summary after decisions](assets/project-rooms/review-summary.png)
-
-### 8. Run the Steward
-
-Open the Steward posture. The policy editor sets whether the Steward
-runs unattended and at what cadence (evaluation interval in minutes,
-1 to 10080). Save the policy.
-
-![The Steward policy editor with unattended toggle and cadence field](assets/project-rooms/steward-policy.png)
-
-Start a manual run. The run plan shows phases (Observe, Assess,
-Record) with step counts, durations, and receipt chips. The Observe
-phase carries the API call count. The run detail shows each step's
-output. A second manual run at the same watermark reconciles (the
-Steward does not repeat work). Door items created by the Steward
-appear once on the Dashboard Door.
-
-![Steward run detail showing phases, steps, and receipt chips](assets/project-rooms/steward-run-detail.png)
-
-With unattended mode on and a cadence set, the Steward triggers
-automatically when Watch evaluations are due. The trigger route
-(`POST /api/steward/trigger`) fires evaluate_due and run_due through
-the conductor's scheduler seam. If the scheduler is not wired, the
-response is a typed 503 `scheduler_not_wired`.
-
-### 9. Draft and publish an update
-
-Draft an update from the week's accepted deltas. The editor shows
-citation rows under each section. An unverified claim shows as an
-action notice. The footer's egress chip is honest: it names
-`deterministic` for a deterministic draft, or the model host for a
-model draft.
-
-![The update editor with citation rows and egress chip](assets/project-rooms/update-editor.png)
-
-Save the draft, then publish. The published update is readable in
-the Room's timeline.
-
-![The published update in the timeline, read-only](assets/project-rooms/update-published.png)
-
-## Watches (Project-scoped)
-
-A Watch observes a population of entities (pull requests or issues)
-through a provider connection, evaluates conditions against each
-entity's transitions, and fires actions when conditions match.
+The evaluator compares the current population with the previous baseline.
+Supported conditions can describe transitions or current state, such as overdue work.
+The service uses operation identities to prevent duplicate effects for the same evaluated event.
+That protection does not make an arbitrary external client retry safe.
 
 ### GitHub templates
 
@@ -247,37 +112,46 @@ Five built-in templates for issue Watches:
 - `watch.jira.scope_intake`: observes newly discovered issues.
 - `watch.jira.transformation`: tracks priority escalations, reassignments, and staleness.
 
-### Evaluation
+## Use the Steward
 
-A Watch evaluation fetches the current population, computes transitions
-against the last baseline, matches conditions, and records effects.
-The evaluator is the same for both providers. Conditions compare at the
-change level (a field changed, changed to a value, entered a state) or
-at the snapshot level (overdue, due within N days, inactive for N days,
-older/newer than N days). Duplicate effects are prevented by
-idempotency keys.
+Open **Steward** from the Room to inspect its automation policy.
+Configure unattended behavior only for the required Project and scope.
+Use a manual run to inspect the available result before relying on unattended work.
 
-## MCP tools
+The run records its steps and results.
+Use its execution state and Receipts to determine what completed.
+The service can refuse disabled work, cooldown conflicts, or an unavailable scheduler.
+A configured policy alone does not prove that the scheduler ran.
 
-The MCP sidecar exposes the full Project Room surface as tools. Six
-Jira-specific tools (`provider.jira_connections`,
-`provider.jira_add_connection`, `provider.jira_connection`,
-`provider.jira_discover`, `provider.jira_search`,
-`provider.jira_validate_scope`) complement the four GitHub tools
-(`provider.github_connection`, `provider.github_discover`,
-`provider.github_validate_repo`, and the shared `provider.list`).
-Two connection tools (`connection.list`, `connection.recheck`) return
-the same readiness shape as `GET /api/connections` and
-`POST /api/connections/{provider}/recheck`.
-`project.steward.trigger` fires evaluate_due and run_due through the
-conductor seam; unwired returns a typed 503 `scheduler_not_wired`.
+Use **Draft update** to prepare an update from available Project evidence.
+Inspect citations and unsupported claims before you save or publish the update.
+The model boundary identifies where any model-generated wording ran.
+See [the drafted update](USER_GUIDE.md#the-drafted-update) for the current controls.
 
-See [MCP sidecar](./MCP_SIDECAR.md) for the full tool reference.
+## Use MCP or HTTP
 
-## HTTP routes
+The Project services also expose setup, observation, review, and Steward operations through MCP and HTTP.
+The conversation-based setup driver and the current Web setup share the underlying Project services.
+Their interfaces have different interaction steps.
 
-The provider routes are listed in [API surface](./API_SURFACE.md)
-under `web.routes.providers`. The connections routes
-(`GET /api/connections`, `POST /api/connections/{provider}/recheck`)
-are under `web.routes.connections`. The steward trigger route is
-`POST /api/steward/trigger`.
+Use the generated [MCP roster](MCP_SIDECAR.md#project) and [API surface](API_SURFACE.md) for exact operations.
+A tool call still requires the caller's permissions and the operation's prerequisites.
+A scheduler trigger can return `scheduler_not_wired` when the required runtime seam is unavailable.
+
+## Troubleshooting
+
+| Problem | Action |
+| --- | --- |
+| A provider cannot connect | Follow its recovery command in **Settings > Connections**. Run **Recheck** afterward. |
+| The count check fails | Verify source scope, provider identity, and access. Read the displayed reason. |
+| The Room has no decision records | Link the relevant work or keep a manual brief with explicit gaps. A blank Room does not prove that no decisions exist elsewhere. |
+| A Watch produces too much work | Adjust its population or pause it. Review the effect before resuming. |
+| Unattended work does not run | Check the policy, runtime, scheduler, and reported refusal. |
+| A draft contains unsupported facts | Correct the draft and inspect its sources before publishing. |
+
+## See also
+
+- [Interview](INTERVIEW.md): repeatable context and Project discovery.
+- [Architecture work recipes](ARCHITECTURE_WORK.md): decision and agent briefs.
+- [Automation](AUTOMATION.md): triggers and execution paths.
+- [Control modes](AUTHORITY.md): authority for effects.

--- a/docs/REACH_RUNNER.md
+++ b/docs/REACH_RUNNER.md
@@ -1,134 +1,119 @@
 # Reach Runner
 
-A dependency-light Python 3 MCP client that connects to a HoldSpeak
-hub's Streamable HTTP endpoint, triggers the sweep and the steward's
-drafter for each active Room, and disconnects.
+Use Reach Runner to request a Heartbeat sweep and Steward runs from another machine.
+The script uses the HoldSpeak remote MCP endpoint and Python's standard library.
 
-Runs on any machine with `python3` (stdlib only -- no pip install).
-Designed for the `.43` box on the tailnet.
+## Before you start
 
-## Install
+- Install Python 3 on the runner machine.
+- Keep the HoldSpeak hub running and reachable.
+- Enable Reach and issue a scoped credential for the required tools.
+- Configure the Projects and Steward policies that the run will use.
 
-Copy the script:
+The script does not wake an unavailable hub or configure its model assignments.
+An external scheduler is required when you want the script to repeat.
+See [Reach](USER_GUIDE.md#reach) for remote access setup.
 
-```
-scp scripts/reach_runner.py user@192.168.1.43:~/reach_runner.py
-```
+## Install the script
 
-## Credential
+Copy [reach_runner.py](../scripts/reach_runner.py) to the runner machine.
+For example, replace `RUNNER_HOST` with your SSH host:
 
-Issue a scoped credential in Settings > System > REMOTE ACCESS >
-Issue credential.  Copy the token into a file on the .43 box:
-
-```
-echo 'YOUR_TOKEN_HERE' > ~/.holdspeak-token
-chmod 600 ~/.holdspeak-token
+```sh
+scp scripts/reach_runner.py user@RUNNER_HOST:~/reach_runner.py
 ```
 
-The token is shown once at issue time.  If the hub restarts, the
-in-memory credential store is wiped -- re-issue.
+No additional Python packages are required by the script.
 
-## Run
+## Store the scoped credential
 
-```
-python3 ~/reach_runner.py \
-  --hub http://100.64.0.2:8765 \
-  --token-file ~/.holdspeak-token \
-  --rooms all \
-  --poll 5 \
-  --timeout 900
-```
+1. Open **Settings > System** on the hub.
+2. Use **REMOTE ACCESS > Issue credential** with the required scope.
+3. Save the displayed token in a private file on the runner machine.
+4. Restrict the file permissions.
 
-Arguments:
+   ```sh
+   chmod 600 ~/.holdspeak-token
+   ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--hub` | required | Hub URL (tailnet address + port) |
-| `--token-file` | required | Path to a file containing the bearer token |
-| `--rooms` | `all` | Comma-separated project IDs, or `all` |
-| `--poll` | `5` | Steward run poll interval (seconds) |
-| `--timeout` | `900` | Steward run timeout (seconds) |
+The command examples below pass the file path, not the token value.
+The token appears only once when issued.
+The hub stores Reach credentials in memory. A hub restart requires a new credential.
 
-## Schedule (cron)
+## Run once
 
-```cron
-0 22 * * * python3 /home/user/reach_runner.py --hub http://100.64.0.2:8765 --token-file /home/user/.holdspeak-token >> /home/user/reach.log 2>&1
+Replace `HUB_ADDRESS` and `PORT` with your reachable hub address and port.
+Replace `PROJECT_ID` with the Project you intend to run.
+
+```sh
+python3 ~/reach_runner.py --hub http://HUB_ADDRESS:PORT --token-file ~/.holdspeak-token --rooms PROJECT_ID --poll 5 --timeout 900
 ```
 
-Or with a systemd timer:
+Use HTTPS when your configured deployment terminates TLS.
+The access boundary is the one configured for Reach.
+See [Security & Privacy](SECURITY.md) for remote transport requirements.
 
-```ini
-# ~/.config/systemd/user/reach-runner.timer
-[Unit]
-Description=HoldSpeak overnight sweep
+| Argument | Default | Meaning |
+| --- | --- | --- |
+| `--hub` | Required | Reachable hub base URL |
+| `--token-file` | Required | File containing the scoped credential |
+| `--rooms` | `all` | Comma-separated Project IDs, or all Projects returned to the caller |
+| `--poll` | `5` | Seconds between Steward status reads |
+| `--timeout` | `900` | Maximum wait for each Steward run, in seconds |
 
-[Timer]
-OnCalendar=*-*-* 22:00:00
-Persistent=true
+The runner first calls `heartbeat.run_now` for a Heartbeat sweep.
+Its console label for that call is `cadence_run_now`.
+That label does not mean it invoked the separate Cadence system.
+It then requests the applicable Steward runs and polls their results.
+Each service still applies its own policy and permissions.
 
-[Install]
-WantedBy=timers.target
-```
+## Inspect the result
 
-```ini
-# ~/.config/systemd/user/reach-runner.service
-[Unit]
-Description=HoldSpeak reach runner
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/python3 /home/user/reach_runner.py --hub http://100.64.0.2:8765 --token-file /home/user/.holdspeak-token
-```
-
-```
-systemctl --user enable --now reach-runner.timer
-```
-
-## Prerequisites
-
-The hub must be awake when the runner connects.  macOS puts the machine
-to sleep when the lid closes.  Two options:
-
-1. System Settings > Energy Saver > "Prevent automatic sleeping when
-   the display is off" (requires AC power).
-2. `caffeinate -s` in a terminal before closing the lid (keeps the
-   system awake on AC power until killed).
-
-If the Mac is asleep, the runner prints `HUB ASLEEP OR OFF` and exits
-with code 2.  It does not retry.
-
-## Exit codes
+The script prints timestamped steps and the terminal outcome.
+Its exit code identifies the broad failure class:
 
 | Code | Meaning |
-|------|---------|
-| 0 | All calls succeeded |
-| 1 | One or more tool calls failed or a steward run timed out |
-| 2 | Connection refused (hub asleep or off) |
-| 3 | Credential refused (401/403 or missing token file) |
-| 4 | Palette refused (MCP-005) |
+| --- | --- |
+| `0` | All requested calls completed successfully |
+| `1` | A tool call failed or a Steward run exceeded the timeout |
+| `2` | The connection or initialization failed, including an unavailable hub |
+| `3` | The credential was missing or refused |
+| `4` | The tool palette was refused |
 
-## Transcript
+Inspect the terminal output for the specific reason.
+Use the hub's run and Receipt records to inspect the underlying work.
+A remote call carries its remote origin in the execution record.
 
-The runner prints one line per step with UTC timestamps:
+## Schedule repeated runs
 
+After a successful manual trial, configure your operating system's scheduler.
+The schedule uses the runner machine's time zone unless you configure a different one.
+The hub must remain available at the scheduled time.
+
+Example cron entry for 22:00 each day:
+
+```cron
+0 22 * * * python3 /home/user/reach_runner.py --hub http://HUB_ADDRESS:PORT --token-file /home/user/.holdspeak-token --rooms PROJECT_ID >> /home/user/reach.log 2>&1
 ```
-[2026-09-05 22:15:01] CONNECT hub=http://100.64.0.2:8765 protocol=2025-03-26 identity=holdspeak-mcp
-[2026-09-05 22:15:02] CALL cadence_run_now
-[2026-09-05 22:15:14] OK sweep completed
-[2026-09-05 22:15:15] CALL project_run_steward project=gov
-[2026-09-05 22:17:42] OK steward_run completed run_id=abc123 project=gov
-[2026-09-05 22:17:43] DISCONNECT
-```
 
-The token never appears in stdout or stderr.
+Replace the paths, address, port, and Project ID before installing the entry.
+Remove or disable that scheduler entry to stop future starts.
+Disabling the scheduler does not cancel a run that already started.
+Use the relevant run control on the hub for that operation.
 
-## Receipts on the desk
+## Troubleshooting
 
-Every remote call lands a kernel receipt with `origin: remote` and the
-caller's IP.  The receipt rows in the shade and the Room's observer
-carry the `REMOTE` badge:
+| Problem | Action |
+| --- | --- |
+| The hub cannot be reached | Check the process, network path, listener, and machine sleep state. |
+| The credential fails after restart | Issue a new scoped credential and replace the private token file. |
+| The palette is refused | Check that the credential permits the required tools. |
+| A Steward run is refused | Inspect the Project policy and the named service refusal. |
+| A timed-out run has an uncertain outcome | Inspect the run record before you repeat it. |
 
-```
-SWEEP -- 32 ENTITIES -- REMOTE -- 192.168.1.43 -- 22:15
-STEWARD RUN -- draft -- REMOTE -- 192.168.1.43 -- 22:17
-```
+## See also
+
+- [Automation](AUTOMATION.md): manual and recurring execution paths.
+- [Reach](USER_GUIDE.md#reach): transport and credential setup.
+- [MCP sidecar](MCP_SIDECAR.md): tool names and permission boundaries.
+- [Control modes](AUTHORITY.md): operation authority.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,150 +1,90 @@
 # HoldSpeak documentation
 
-HoldSpeak provides voice typing, meeting capture, retained results, and
-recovery. Work can run on this device, a paired device, a private endpoint, or
-an external service; each operational surface names the applicable boundary.
-
-After first value, the Web app opens on the **Chair Door**, where its board
-and upcoming rail put the next work first. The **Floor** remains the spatial
-Desk world for Meetings, Notes, Artifacts, Projects, Agents, Workflows,
-Integrations, Coder sessions, attention, and Receipts. Dictation, Meetings,
-Studio, and Settings are focused workrooms.
-
-> New here? Start with the [main README](../README.md) for the pitch and a
-> quickstart, then follow **Start here** below.
+Use these guides to install HoldSpeak, prepare work, and configure its tools.
+The guides describe `main`. Check your installed version when a control is absent.
 
 ## Start here
 
-- **[Getting Started](./GETTING_STARTED.md)**: install, grant permissions, and land
-  your first hold-to-talk dictation in another app.
-- **[The Door](./USER_GUIDE.md#the-door)**: the post-first-value arrival.
-  Its board (with person chips and per-person filter for mapped owners),
-  upcoming rail, and multi-source calendar with per-source provenance and
-  screenshot import.
-- **[The Desk](./WEB_DESK.md)**: the Floor's spatial world, its objects, and
-  every verb (create, open, file, record, ask, preview).
-- **[Desk memory](./DESK_MEMORY.md)**: the shared attention and receipt read
-  model, its privacy boundary, contextual badges, pagination, and source links.
+| You want to | Read |
+| --- | --- |
+| Install HoldSpeak and capture a sentence | [Getting Started](GETTING_STARTED.md) |
+| Find a daily task or product control | [User Guide](USER_GUIDE.md) |
+| Use Desk objects and windows | [The Desk](WEB_DESK.md) |
+| Select an environment or use Settle in | [Places](ENVIRONMENTS.md) |
+| Understand product terms | [Glossary](GLOSSARY.md) |
 
-## Understand the system
+## Prepare your work
 
-- **[API surface](./API_SURFACE.md)**: every HTTP route the runtime serves,
-  generated from the app with per-route consumers. Regenerate with
-  `uv run python scripts/gen_api_surface.py` after any route change.
-- **[Architecture](./ARCHITECTURE.md)**: how the pieces fit and how a single
-  utterance flows through them, with diagrams. The map to read before the code.
+| You want to | Read |
+| --- | --- |
+| Describe goals, Projects, cadences, and decisions | [Interview](INTERVIEW.md) |
+| Prepare an architecture decision or agent brief | [Architecture work recipes](ARCHITECTURE_WORK.md) |
+| Continue a conversation with tools and sources | [Threads](USER_GUIDE.md#threads) |
+| Refine a Note through questions | [Develop a thought](USER_GUIDE.md#develop-a-thought) |
+| Connect project sources and configure Watches | [Project Rooms](PROJECT_ROOMS.md) |
+| Use confidential relationship records | [People integration](PEOPLE_INTEGRATION.md) and [People security](PEOPLE_SECURITY.md) |
 
-## Dictate: voice typing and the intelligent copilot
+## Dictate and meet
 
-- **[User Guide](./USER_GUIDE.md)**: the day-to-day. Workflows, the web runtime, and
-  how the two halves (typing and meetings) fit together. Also home to the wake
-  word (hands-free entry, previewed before it types), the spoken language
-  setting (any of Whisper's 99 languages), and the spoken-symbol dictionary.
-- **[Dictation Pipeline Setup](./DICTATION_PIPELINE_GUIDE.md)**: the project-aware
-  pipeline. Intent routing, project facts, model assignments, and LLM rewriting.
-- **[Project knowledge: facts + context](./DICTATION_PIPELINE_GUIDE.md#5-set-up-project-knowledge)**:
-  teach the copilot about a repo. Facts (the `project.yaml` KB, stamped in verbatim)
-  and context (the `.hs/` files an optional rewrite reads) are two different things;
-  this is what each is and how to set up both.
-- **[The Dictation Copilot](./DICTATION_COPILOT.md)**: see it work. Rough speech
-  becomes a project-grounded task for a Coder session, with a demo you can reproduce.
-- **[Voice Commands](./VOICE_COMMANDS.md)**: map a spoken keyword to a real action.
-  Say a keyword while dictating and HoldSpeak opens a URL, launches an app, runs a
-  shell command, or types a snippet instead of typing the words. Off by default, you
-  configure every command, and each one is limited to exactly the action you gave it.
-- **[Activity Pre-Briefing](./ACTIVITY_PREBRIEFING.md)**: a quiet read of what you
-  touched recently, above the dictation cockpit. At most three source-cited cards,
-  dismissible, never acting on their own. One action pins a record so your next
-  dictation can use it as context. Gated by the activity tracking toggle: off means
-  no cards.
+| You want to | Read |
+| --- | --- |
+| Dictate into another app | [Voice typing](USER_GUIDE.md#voice-typing) |
+| Configure project facts and optional model rewriting | [Dictation pipeline](DICTATION_PIPELINE_GUIDE.md) |
+| Follow a coding prompt example | [Dictation Copilot](DICTATION_COPILOT.md) |
+| Map spoken keywords to configured actions | [Voice commands](VOICE_COMMANDS.md) |
+| Review recent activity before dictation | [Activity pre-briefing](ACTIVITY_PREBRIEFING.md) |
+| Record, import, or review a meeting | [Meeting mode](MEETING_MODE_GUIDE.md) |
+| Review attention items and Receipts | [Desk memory](DESK_MEMORY.md) |
 
-- **[Cadence](./CADENCE.md)**: reviews Meetings, proposed actions, and waiting
-  Coder sessions, then prepares source-linked next actions. It is off by
-  default and records each use.
-- **[The learning loop: journal, correct, see what it learned, replay](./DICTATION_PIPELINE_GUIDE.md#12-dictation-journal-corrections--replay)**:
-  the local-only loop that gets better at your voice. Fix a misfire in one tap, see
-  the honest "learned from N similar" count in the "What HoldSpeak learned" digest,
-  and replay an utterance to watch the routing change. The proof, not the promise.
-- **[Desktop Presence](./DICTATION_PIPELINE_GUIDE.md#11-desktop-presence-ambient-on-desktop-status)**:
-  an opt-in, native, focus-safe status surface (a macOS HUD, a Linux tray and
-  notification) that shows whether it's listening, transcribing, or typing while you
-  dictate elsewhere. Optionally with
-  **[Qlippy](./DICTATION_PIPELINE_GUIDE.md#qlippy-the-mascot-optional)**:
-  an optional visual presence for one source-linked attention card at a time.
-  Operational copy and authority remain the same as other Desk surfaces.
-- **[Models (bring your own)](./MODELS.md)**: the model contract. GGUF in-process,
-  MLX on Apple Silicon, or any OpenAI-compatible endpoint.
+## Configure models and automation
 
-## Meet: meeting intelligence
+| You want to | Read |
+| --- | --- |
+| Select engines and assign capabilities | [Models](MODELS.md) |
+| Choose a manual, event, or scheduled execution path | [Automation](AUTOMATION.md) |
+| Review unresolved work and prepare next actions | [Cadence](CADENCE.md) |
+| Understand permissions before an effect | [Control modes](AUTHORITY.md) |
+| Connect Claude Code or Codex sessions | [Agent hooks](AGENT_HOOK_INSTALL.md) |
+| Run a remote sweep and Project Steward | [Reach Runner](REACH_RUNNER.md) |
 
-- **[Meeting Mode Guide](./MEETING_MODE_GUIDE.md)**: capture mic and system audio
-  together, get a live transcript with speaker labels, review AI-extracted topics,
-  actions, and artifacts at `/history`, then close the loop with aftercare: see
-  what is still open, decided, or changed since last time, jump to the transcript
-  moment that justifies a result, file an accepted action as an authorized
-  issue, draft the follow-up, or send the digest to your team with Send to
-  Slack. Under the default YOLO control mode, an eligible configured destination
-  executes with a Receipt; Secure and Normal keep per-action approval. Import recordings and transcripts you
-  already have (web upload or `holdspeak import`; vtt and srt keep their real
-  timestamps and speaker names) and filter the archive by date, speaker, tag,
-  and open actions.
+## Build and integrate
 
-## Extend: build on it
+The MCP sidecar exposes 222 tools across 40 families.
+Its generated roster is the reference for tool names and membership.
+Discovery and execution also depend on the caller's permissions.
 
-- **[MCP sidecar](./MCP_SIDECAR.md)**: the desk's programmable surface over
-  stdio. 214 tools across 39 domain families, with 34 resources in default
-  non-owner discovery and 37 for the owner, wired automatically
-  in Claude Code via the repo's `.mcp.json`. The reference for families,
-  model-invoking tools, trust model, resources, and the explicit opt-in,
-  shared-intent-only People boundary.
-- **[Project Rooms](./PROJECT_ROOMS.md)**: connect a Project to GitHub
-  repositories and Jira sites, install Watches (Project-scoped) over pull
-  requests and issues, and let the Steward act on what changes.
-- **[The Desk](./WEB_DESK.md)**: work with Meetings, Notes, Knowledge,
-  Agents, Sequences, Workflows, Artifacts, and Coder sessions; place durable
-  items in Zones and inspect their results and Receipts.
-- **[Plugin Authoring](./PLUGIN_AUTHORING.md)**: write a meeting-intel plugin. The
-  `HostPlugin` contract, prompt to LLM to structured output, rendering, sequences, and
-  the actuator proposal, authority, and execution flow.
-- **[Connector Development](./CONNECTOR_DEVELOPMENT.md)**: build a local activity
-  connector (the `cli_enrichment` / `pipeline` / other kinds).
-- **[Claude/Codex automation hooks](./AGENT_HOOK_INSTALL.md)**: wire Claude/Codex automation hooks
-  into the dictation pipeline.
-- **[Firefox Extension Guide](./FIREFOX_EXTENSION_GUIDE.md)**: the browser activity
-  connector.
-- **[AIPI-Lite Developer Workflow](./AIPI_LITE_DEV_WORKFLOW.md)** and **[Device
-  Protocol](./DEVICE_PROTOCOL.md)**: the portable companion device. The firmware and
-  bridge workflow, and the remote-audio WebSocket protocol.
+| You want to | Read |
+| --- | --- |
+| Use the MCP service contract | [MCP sidecar](MCP_SIDECAR.md) |
+| Find an HTTP route and its consumers | [API surface](API_SURFACE.md) |
+| Understand the runtime and data flow | [Architecture](ARCHITECTURE.md) |
+| Write a meeting plugin | [Plugin authoring](PLUGIN_AUTHORING.md) |
+| Write an activity connector | [Connector development](CONNECTOR_DEVELOPMENT.md) |
+| Install the browser activity connector | [Firefox extension](FIREFOX_EXTENSION_GUIDE.md) |
+| Develop a portable device | [AIPI-Lite workflow](AIPI_LITE_DEV_WORKFLOW.md) and [Device protocol](DEVICE_PROTOCOL.md) |
 
-## Operate & Trust
+## Operate and recover
 
-- **[Security & Privacy](./SECURITY.md)**: the threat model. What's stored, the trust
-  boundaries, and exactly what can (and can't) leave your machine.
-- **[Control modes, decisions, and grants](./AUTHORITY.md)**: what Secure, Normal,
-  and YOLO change, how review/authority/execution stay separate, and which hard
-  invariants no mode can weaken.
+- [Security & Privacy](SECURITY.md): storage, network boundaries, and secret handling.
+- [Release and recovery](RELEASING.md): backups, restore, packaging, and release checks.
+- [Inference placement](INFERENCE_TARGETS.md): current terminology and model routing references.
 
-## Internal / historical plans
+## Documentation and specifications
 
-Design RFCs, phase specs, and cross-platform/port planning live in
-**[`internal/`](./internal/)**. They're kept for provenance and contributor
-context, not as user-facing guides, and some describe work in progress or already
-shipped. Also there: the docs working notes,
-**[`internal/DOCS_STYLE.md`](./internal/DOCS_STYLE.md)** (voice and page skeleton)
-and **[`internal/DOC_AUDIT_2026-08.md`](./internal/DOC_AUDIT_2026-08.md)** (the
-current accuracy audit and canonical facts). The
-**[June audit](./internal/DOC_AUDIT_2026-06.md)** remains a historical snapshot.
-A few highlights:
+User guides describe implemented behavior. Internal specifications can also describe planned behavior.
+Read each specification's status and verification record before you treat it as an available capability.
 
-- **[Project Rooms SRS suite](./internal/project-rooms/README.md)**: the integrated
-  product, Web, domain, MCP/driver, validation, and interview-installed Watch
-  contract for issue #514.
-- `internal/PLAN_ARCHITECT_PLUGIN_SYSTEM.md`: the parent plugin-system RFC.
-- `internal/PLAN_PHASE_DICTATION_INTENT_ROUTING.md`: the DIR-01 dictation pipeline spec.
-- `internal/PLAN_PHASE_MULTI_INTENT_ROUTING.md`: the MIR-01 meeting-side routing spec.
-- `internal/PLAN_PHASE_WEB_FLAGSHIP_RUNTIME.md`: the web-first runtime migration.
-- `internal/CROSS_PLATFORM_ROADMAP.md`, `internal/LINUX_PORT_PLAN.md`: platform work.
-- `internal/RELEASE_HARDENING_CHECKLIST.md`: the release-gate checklist.
+- [Interview specification package](internal/architect-assistant/README.md): requirements, contracts, recipes, delivery status, and verification limits.
+- [Project Rooms specification package](internal/project-rooms/README.md): product, Web, domain, and MCP contracts.
+- [Contributing](../CONTRIBUTING.md): documentation changes and required checks.
+- [Writing standard](internal/DOCS_STYLE.md): ASD-STE100 reference, page structure, and review requirements.
+- [Documentation review](internal/DOC_AUDIT_2026-09.md): this refresh's scope, source checks, and remaining language review.
 
-> The project's planning of record (roadmap, phases, evidence) lives under
-> [`pm/roadmap/holdspeak/`](../pm/roadmap/holdspeak/), not here.
+Historical plans and design records remain under [internal](internal/).
+Historical evidence does not establish the current product state.
+
+## See also
+
+- [Product overview](../README.md): capabilities and platform support.
+- [Getting Started](GETTING_STARTED.md): the first successful task.
+- [Glossary](GLOSSARY.md): product terms and their meanings.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,13 +1,28 @@
 # HoldSpeak Security & Privacy Posture
 
 **Status:** living document.
-**Last updated:** 2026-08-29 (YOLO default posture, actuators on, People MCP
-default write; hard boundary unchanged).
+**Last updated:** 2026-09-05 (Interview context and retention clarification).
 
 This document is the threat model for HoldSpeak: what data it holds, where that
 data lives, what can leave the machine, and the decisions behind its at-rest
 posture. If code and this document disagree, that is a bug in one of them;
 file it.
+
+## Interview context and model work
+
+Interview facts and suggestions belong to a saved Thread on the hub.
+A stated fact includes a source quote. An inference has an explicit inferred classification.
+A model turn can send permitted context to its assigned model endpoint.
+Review the run boundary and Receipt when the execution host matters.
+
+Removing a fact also removes its dependent suggestions.
+It does not erase earlier Thread messages, separate kept outputs, or backups.
+Use the relevant record and retention controls for those copies.
+
+Interview's People section opens the protected People surface and omits the Thread composer.
+Enter confidential relationship material through that surface.
+Enter credentials through the configured credential controls.
+The [Interview guide](INTERVIEW.md) describes the complete current workflow.
 
 ## Kernel boundary: cooperating code, not a sandbox
 
@@ -454,8 +469,8 @@ machine except via the connector CLIs above (entity IDs only).
 
 ## 5. Secrets handling
 
-- **Cloud API key**: Set, replace, or remove it on the model profile in
-  **Settings > Models > Model Library**.
+- **Cloud API key**: Use the owner Model Library secret API for the identified model profile.
+  The current Concierge URL field does not collect a key. See [Models](MODELS.md).
   The value travels only through an owner-only secret write/delete subresource,
   never a general model-management resource, sync, DTOs, the database, read
   responses, logs, or receipts. The hub stores it locally in owner-only `0600` custody; reads report

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,31 +1,29 @@
 # HoldSpeak User Guide
 
-Start with one useful loop: open HoldSpeak, **Dictate one sentence**, edit it,
-then **Copy** or **Keep as Note**. The first completion furnishes the Desk
-automatically with Inbox, Personal, Work, Meetings, Decisions, and Reference;
-a Start here note; and editable prompts in **Everyday context**. Its shipped
-default is unused: explicitly attach it for one Thought, or explicitly make an
-attached set the default for future local Thoughts. No extra setup is required
-for this first value.
+Use this guide as a reference for daily work on the Desk.
+For installation and first capture, read [Getting Started](GETTING_STARTED.md).
 
-HoldSpeak is one local copilot with two modes, and this guide is the day-to-day
-map of both:
+HoldSpeak connects voice typing, Meetings, saved records, Threads, and supported automation.
+The [documentation index](README.md) groups the guides by task.
+These documents describe `main`, which can differ from your installed release.
 
-- **Dictate:** hold a hotkey, speak, and insert useful text into the active app. With the dictation pipeline on, HoldSpeak uses project context and recent Claude/Codex state to rewrite rough speech into better prompts, and the dictation journal records every run so corrections teach it.
-- **Meet:** record conversations (or import recordings and transcripts), transcribe them, and extract topics, actions, summaries, and reviewable artifacts, with meeting aftercare showing what is still open when it ends.
-
-HoldSpeak is private by default. Audio capture, transcription, project context, and session metadata are stored locally unless you explicitly configure a cloud or OpenAI-compatible endpoint.
+Configured models, connectors, remote clients, and outbound actions have separate data boundaries.
+See [Security & Privacy](SECURITY.md) for the full contract.
+The default Control mode is **YOLO**. Read [Control modes](AUTHORITY.md) before configuring external effects.
 
 ## Start Here
 
-Use these guides when you are ready for more than the first sentence:
-
-| Goal | Guide |
+| Task | Guide |
 | --- | --- |
-| Install HoldSpeak and take the first-sentence loop | [Getting Started](GETTING_STARTED.md) |
-| Configure the project-aware dictation pipeline | [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md) |
-| Record and review meetings | [Meeting Mode Guide](MEETING_MODE_GUIDE.md) |
-| Configure local/LAN dictation models | `/docs/dictation-runtime` in the local web UI |
+| Install and capture a sentence | [Getting Started](GETTING_STARTED.md) |
+| Describe goals and receive suggestions | [Interview](INTERVIEW.md) |
+| Prepare a decision review or manual agent brief | [Architecture work recipes](ARCHITECTURE_WORK.md) |
+| Choose an automation path | [Automation](AUTOMATION.md) |
+| Configure model engines | [Models](MODELS.md) |
+| Record or review a meeting | [Meeting mode](MEETING_MODE_GUIDE.md) |
+| Configure coding dictation | [Dictation pipeline](DICTATION_PIPELINE_GUIDE.md) |
+| Use Desk windows and objects | [The Desk](WEB_DESK.md) |
+| Select an environment | [Places](ENVIRONMENTS.md) |
 
 ## Product Map
 
@@ -40,11 +38,16 @@ Use these guides when you are ready for more than the first sentence:
 | Meeting intelligence | Produces transcript, topics, summaries, actions, artifacts; **Run intelligence** on any meeting that never ran | Meetings |
 | iPad app | Drives both modes from another device over the hub's HTTP API: dictate into the desk, read a meeting back with its artifacts and sources, approve a proposal, browse the archive | [Companions](#companions) |
 | AIPI-Lite companion | Portable ESPHome device for meeting controls, status, and spoken replies to waiting Claude/Codex sessions | [AIPI-Lite Developer Workflow](AIPI_LITE_DEV_WORKFLOW.md), `/companion` |
-| Threads | Multi-turn streamed conversations grounded on desk material with `@`-refs, receipts, and search | The Desk, **Continue in thread** on any object |
+| Threads | Saved conversations with sources, model replies, and applicable tools | **Desk > New Thread** or **Continue in thread** on a supported object |
+| Interview | Repeatable sections, saved context, and contextual suggestions | The **Interview** Thread mode |
+| Places | Floor environments, favorites, and Settle in | The dock or **Go > Change places** |
 | Connections | See each external tool's readiness (GitHub, Jira, Calendar, Models), run Recheck, and follow the recovery command when a tool is not connected | Settings, Connections |
 | Models | The Concierge detects engines, proposes one assignment set, and applies with **Use these**; choose **Adjust** for individual capability assignments | Settings, Models |
 
 ## Develop a thought
+
+The Interview pane described here refines one Note.
+The separate [Interview Thread mode](INTERVIEW.md) develops working context across repeatable sections.
 
 Keep a rough sentence as a Note, then choose **Develop this thought**. HoldSpeak
 preserves the original bytes and opens a dedicated Thought Workbench. Its Note
@@ -112,27 +115,9 @@ or remove the selection explicitly.
 
 ## Install And Start
 
-Install from this checkout:
-
-```bash
-uv pip install -e .
-```
-
-If first capture needs repair, run diagnostics:
-
-```bash
-holdspeak doctor
-```
-
-Start the local web runtime:
-
-```bash
-holdspeak
-```
-
-By default, the web server binds to loopback only (`127.0.0.1`). The browser
-opens on the first-sentence surface before the broader Desk, meeting, and
-advanced dictation controls.
+Follow [Getting Started](GETTING_STARTED.md) for platform dependencies, environment setup, and the first capture.
+Start `holdspeak` from the installed environment.
+Open the URL printed by the runtime.
 
 ## Voice Typing
 
@@ -356,11 +341,13 @@ Use `openai_compatible` when the model is served somewhere else:
 - LiteLLM
 - OpenAI or another hosted compatible API
 
-The one path: add the endpoint once under **Settings > Models > Model Library**,
-then choose it for **Writing & dictation** under **Assignments**.
+The one path: add the endpoint once under **Settings > Models**,
+then select it for **Writing & dictation** in the Concierge set.
+Select **Use these** to apply the set.
 Assigning a model is itself the "run it there" instruction, so the
-dictation backend follows. Set
-or replace its key on the model profile in Model Library; the environment variable
+dictation backend follows.
+For keyed providers, use the owner Model Library API described in [Models](MODELS.md).
+The environment variable
 `HOLDSPEAK_PROFILE_<ID>_KEY` remains a headless fallback.
 
 The old `dictation.runtime.openai_compatible_*` fields no longer configure
@@ -1029,7 +1016,7 @@ its refreshed entry. The MCP twins are `connection.list` and
 
 ## New Project
 
-Open **New Project** from the Door. The screen has three parts: the
+Select **Desk > New Project**. The screen has three parts: the
 outcome line, the **SOURCES** section, and the footer.
 
 ![New Project with nothing typed and both sources unpicked](assets/project-rooms/new-project-empty.png)
@@ -1224,6 +1211,7 @@ Each module is a row with its name, its state tokens, and **Open**:
 | **CONNECTIONS** | `N CONNECTED` (absent at zero) |
 | **VOICE** | `LIVE` + the current target name |
 | **MEETINGS** | `INTELLIGENCE ON` or `INTELLIGENCE OFF` |
+| **WALLPAPER** | The selected place |
 | **RHYTHM** | `EVERY 15 MIN . NEXT hh:mm` when the sweep runs; `NO LOOPS` at zero |
 | **SOUNDS & PRESENCE** | `ON` or `OFF` |
 | **SYSTEM** | `THIS DEVICE` + `MESH ON` or `MESH OFF` |
@@ -1535,176 +1523,176 @@ sidecar and the dev sidecar exist, doctor warns: "BOTH WORLDS EXIST."
 
 ## Threads
 
-A Thread is a multi-turn conversation that lives on the Desk as a first-class
-object. Unlike the old one-shot Ask loop, a Thread persists in the hub's
-SQLite, streams token by token, and can be grounded on desk material through
-`@`-references.
+A Thread is a saved conversation on the hub.
+It contains your sent messages, model replies, source references, and tool results.
+Use a Thread when you want to continue work across multiple turns.
 
 ### Start a Thread
 
-Open a new Thread from the Desk menu or choose **Continue in thread** on any
-desk object (a meeting, a note, a person, a decision). The object becomes a
-frozen reference: its content at the moment you ask is what the model sees.
+1. Select **Desk > New Thread**.
+2. Select a mode if the task requires one.
+3. Enter your request.
+4. Select **Send**.
+
+You can also select **Continue in thread** on a supported Desk object.
+That object becomes a source reference for the conversation.
+The hub resolves the referenced content for the turn.
 
 ### The composer
 
-The Thread composer sits at the foot of the pullout. Type or tap the mic
-(click-to-toggle, never hold-to-talk). `@` opens the reference picker:
-meetings, notes, artifacts, decisions, and people by title. Each picked
-reference appears as a chip above the field. Enter sends, Shift+Enter inserts
-a newline, Esc stops a running turn. The Send button flips to Stop while the
-model is streaming.
+Type your request or use the click-to-toggle microphone control.
+Use `@` to attach supported records such as Meetings, Notes, Artifacts, and decisions.
+Each attachment appears as a chip above the field.
+
+**Enter** sends the request. **Shift+Enter** inserts a new line.
+The Send control becomes Stop during generation.
+Your prompt appears immediately while the request starts.
+A failed send retains the text for correction or retry.
+
+Chair/Floor changes preserve the open Thread and its current draft.
+An unsent composer draft has no durable-save guarantee across a reload.
+Sent messages are separate from that temporary draft state.
 
 ### Streaming, receipts, and egress
 
-Each assistant turn streams over the WebSocket bus. One egress badge and one
-receipt appear per turn. The badge names where the turn ran (this device, a
-private endpoint, or an external service). A turn that errors shows its
-failure in flow, never overlapping the UI. A turn whose stream stalls
-(no update for 10 s) renders as CRASHED with a Retry verb.
+Replies stream into the conversation.
+The turn's boundary and Receipt identify where it ran and the reported result.
+A failure appears with the affected turn.
+
+Routine tool calls remain collapsed under **Actions**, including before the final answer arrives.
+Open **Actions** when you want to inspect them.
+An explicit choice to open the details remains in effect as the turn updates.
+Approval requests, tool questions, failures, and denials remain visible outside the routine group.
 
 ### Branch, keep, and search
 
-Edit a past user message or regenerate an assistant reply to create a branch.
-The pullout shows siblings as `< n/m >`. Keep any reply as a Note or Artifact
-with its provenance recorded. Desk search federates Threads alongside meetings,
-notes, and decisions through `memory.search` (kind `thread`).
+Editing a past user message or regenerating a reply creates a conversation branch.
+The branch controls let you inspect sibling branches.
+Keep a useful reply as a separate Note or Artifact with its provenance.
+Desk search includes saved Threads.
 
 ### People boundary
 
-When a Thread references a People record, those parts are marked sensitive.
-If the thread's model assignment resolves to a cloud endpoint, the assembler
-redacts sensitive content before it reaches the provider.
+People source parts have a sensitive classification.
+The context assembler redacts those parts before a cloud model turn.
+The People tools expose only the permitted shared-intent data for the authenticated caller.
+See [People security](PEOPLE_SECURITY.md) for the complete confidentiality boundary.
+
+In Interview's **People** section, use **Open People** for relationship work.
+That section omits the Thread composer.
 
 ### The Thread has hands
 
-During a turn the model may call the desk's own tools. Each call
-renders as a tool row: name, class glyph, arguments head, state.
+A model can request tools exposed by the current mode.
+The Thread tool gate checks the tool class, Control mode, and any recorded tool policy.
+The called service also applies its own operation rules.
 
-In yolo mode every call executes immediately and the row shows DONE
-with a receipt short-id. In safe mode, effect tools are held. Three
-verbs appear:
+Without an explicit per-tool policy:
 
-- **Allow once.** Executes this call. No policy row written.
-- **Allow always.** Writes a per-thread policy row so future calls
-  to the same tool auto-admit. No "Never" is offered.
-- **Deny.** Refuses this call only. No row written.
+| Control mode | Tool admission |
+| --- | --- |
+| **Secure** | Evidence reads proceed. Candidate builders and effect proposals wait for a decision. |
+| **Normal** | Evidence reads and candidate builders proceed. Effect proposals wait for a decision. |
+| **YOLO** | Classified, offered tools can proceed through the Thread gate. Service-level authority checks still apply. |
 
-A tool may ask a question mid-call (elicitation). The row renders a
-JSON-Schema form: string, number, boolean, and enum fields. Submit
-sends the answer; Decline refuses.
+A held call offers these controls:
 
-Results from `people.*` tools carry a PEOPLE badge. These parts are
-marked sensitive and never leave the machine on a cloud turn.
+- **Allow once** admits this call.
+- **Allow always** records a policy for this tool in this Thread.
+- **Deny** refuses this call.
 
-Every receipted row carries a collapsed **RAW** fold with the full
-JSON payload. A TRUNCATED tag appears when the result exceeded the
-32 KB byte cap.
+A recorded per-tool policy takes precedence at the Thread gate.
+It does not bypass destination, credential, or permission checks in the service.
+See [Control modes](AUTHORITY.md) for central operation policy.
 
-`thread.set_status` writes the status line shown under the thread
-title in the pullout head.
+A tool can also request structured input during a call.
+Submit the requested values or decline the question.
+The tool result includes execution state and available Receipt information.
+The collapsed raw-result view exposes the returned payload, subject to the tool result size limit.
 
 ### Modes
 
-Bind a mode to steer the thread's tool palette and system prompt. Four
-built-in modes ship as seeds:
+Modes select a system instruction and a tool set for the Thread.
+The built-in modes include:
 
-| Mode | Tools |
-|---|---|
-| **Desk** | Evidence reads, candidate builder (no effects) |
-| **Chase** | Desk + People effects, follow-through, `door.add_item` |
-| **Draft** | No tools (writing model only) |
-| **Plan** | `thought.*` reads, `door.get`, `memory.search`, `decision_record.*` reads |
+| Mode | Purpose |
+| --- | --- |
+| **Desk** | Read Desk evidence and prepare candidates. |
+| **Chase** | Use broader Desk and People operations for follow-through. |
+| **Draft** | Write without tools. |
+| **Plan** | Read Thoughts, decisions, and relevant Desk context. |
+| **Project** | Use the Project-oriented mode and its existing MCP path. |
+| **Interview** | Revisit sections, save working context, and develop suggestions. |
 
-Mode tabs render above the composer. Click a tab to bind; click the
-active tab to unbind. A mode change applies from the next turn.
+Select a mode above the composer.
+A mode change applies to the next turn.
+Selecting the active mode again removes that binding.
+For Interview's sections, suggestion controls, and limits, read [Interview](INTERVIEW.md).
 
 ### Saved prompts
 
-A prompt is a Note tagged `prompt`. `/prompt <name>` inserts the note
-body at the caret. Seed prompts ship with the desk (Weekly update,
-1:1 prep).
+A saved prompt is a Note tagged `prompt`.
+Use `/prompt <name>` to insert its text into the composer.
+Review the inserted text before you send it.
 
 ### Guardrails
 
-A guardrail is a Note tagged `guardrail` with a YAML front matter
-block (instruction, trigger tools, N messages). Two seeds ship:
-`effect-guard` (flags an effect touching a person's ledger without a
-named source) and `egress-guard` (flags cloud egress of a `people.*`
-read).
-
-Guardrails are enabled per mode. The guardrail assignment runs once
-per tool-requesting pass, before the per-call admission. It returns
-violations and warnings rendered as a row above the pending-tool
-box. It never auto-denies; in safe mode a violation flips the decision
-box default to Deny. `/guardrail <name>` toggles a guardrail on the
-thread's mode.
+A guardrail is a Note tagged `guardrail` with configuration in its front matter.
+Guardrails can review tool-requesting passes and display violations or warnings.
+They do not automatically deny every flagged request.
+The normal tool and operation gates remain responsible for execution authority.
 
 ### Annotations
 
-Select text in any assistant part to open an in-flow popover (comment
-field with mic). Save adds an annotation chip above the composer.
-Chips are draft parts on a pending user message; Send promotes them
-with the next turn as a prefix ("The owner annotated: ..."). Chips
-survive a reload.
+Select text in an assistant reply to add a comment.
+Saved annotation chips become part of the next message when you send it.
+These saved annotations can survive reload independently of the unsent text draft.
 
 ### Compaction
 
-`/compact` summarises earlier turns into a cut marker. The assembler
-includes only the summary and what follows. A cut marker row renders
-in the pullout with a RAW fold showing the summary text. Earlier
-messages fold behind a toggle.
+Use `/compact` to summarize earlier turns into a cut marker.
+Later model context includes that summary and subsequent messages.
+Earlier messages remain behind the conversation's history control.
+Review the summary when the omitted detail matters to your task.
 
 ### Todo
 
-`/todo <text>` writes an action item to the Door with
-`source_type='thread'`. The Door card shows a "from a thread" chip
-that opens the thread pullout.
+Use `/todo <text>` to create an action item from the Thread.
+The item retains a source reference to the conversation.
+An action item does not configure an automation.
 
 ### Slash commands
 
-`/` at the start of a line opens the verb palette. Mid-line `/` types
-a literal slash.
+Enter `/` at the start of a line to open the command palette.
 
 | Command | Action |
-|---|---|
-| `/mode <name>` | Bind or switch the thread's mode |
-| `/prompt <name>` | Insert a saved prompt at the caret |
-| `/tools` | List the mode's tool palette |
+| --- | --- |
+| `/mode <name>` | Select a Thread mode |
+| `/prompt <name>` | Insert a saved prompt |
+| `/tools` | List the mode's tools |
 | `/guardrail <name>` | Toggle a guardrail on the mode |
-| `/todo <text>` | Write an action item to the Door |
-| `/compact` | Summarise earlier turns behind a cut |
+| `/todo <text>` | Create an action item |
+| `/compact` | Summarize earlier turns |
 | `/keep` | Keep the last reply as a Note |
 | `/fork` | Branch the conversation |
-| `/stop` | Stop a running turn |
-| `/new` | Start a new thread |
+| `/stop` | Stop generation |
+| `/new` | Create a Thread |
 
 ### The Call
 
-Start a call on any thread to hear every reply and talk back hands-free.
-The call chip in the thread head shows four states: OFF, LISTENING,
-THINKING, SPEAKING. Click the chip in any non-OFF state to stop (TTS
-stops, mic closes, call ends). A fresh thread is always OFF.
+Call mode combines spoken replies with microphone input for the Thread.
+A new Thread starts with Call off.
+The Call control reports listening, thinking, or speaking while active.
+Select the active control to stop the call.
 
-Every assistant turn shows a speaker glyph. Click the glyph to replay
-the turn through the voice. In call mode, speech starts at sentence
-boundaries while the reply is still streaming (auto-speak). Barge-in
-(speak or click) stops TTS immediately and returns to LISTENING.
+The reply's speaker control can replay an answer.
+Browser speech synthesis is the default voice path.
+The optional `tts` extra supplies server voices through kokoro-onnx.
+Voice availability depends on the configured path and runtime.
 
-**Default voice.** The browser's Web Speech API (`speechSynthesis`):
-zero dependencies, zero egress, instant.
-
-**Server voice.** Install the optional extra for kokoro-onnx voices:
-
-```
-pip install holdspeak[tts]
-```
-
-The `phonemizer` and `espeak-ng` dependencies are GPL-3.0. When
-enabled, Settings shows the server voice block. When absent, the
-route answers 404 and the client stays on the browser voice. If the
-server voice's first chunk exceeds 2 s, that utterance falls back to
-the browser voice (R4).
+The server voice dependencies include GPL-3.0 components.
+See the package and Settings voice information when you enable that extra.
+Call hardware and voice quality require validation on the actual device.
 
 ## Schedule A Recording
 
@@ -1716,7 +1704,7 @@ path a manual recording uses; no browser needs to be open.
 
 Use any of four paths:
 
-1. **The Chair Door.** In **Upcoming**, choose **Schedule recording**. The
+1. **The arrival.** Select **Schedule** in the capture bar. The
    in-world schedule window lets you name the recording, choose **Once** or
    **Recurring**, and set a duration (default 60 minutes).
 2. **From a calendar event.** Tap **Record this** on any event in the
@@ -1763,8 +1751,8 @@ Local-first behavior:
 Cloud or homelab behavior:
 
 - If you set `meeting.intel_provider` to `cloud` (or `auto`, which can fall back to it), meeting text may be sent to the model endpoint you picked for analysis.
-- The one path: add the endpoint once under **Settings > Models > Model Library**,
-  then choose it for **Meetings** under **Assignments**. The
+- The one path: add the endpoint once under **Settings > Models**,
+  then select it for **Meetings** in the Concierge set and apply **Use these**. The
   `intel_cloud_*` fields are legacy migration inputs and do not configure runs.
 - Use `holdspeak doctor` from the same shell environment to verify endpoint, model, TLS, DNS, and authentication; its placement line names the model each pipeline resolves to.
 
@@ -2214,7 +2202,7 @@ Sensitive files:
 
 - Do not place secrets in `.hs/`.
 - Use `.hs/ignore` to document paths and topics that should not be injected.
-- Set model-profile keys in **Model Library**; use environment variables
+- Set model-profile keys in the configured credential controls; use environment variables
   when provisioning a headless hub.
 
 ## Troubleshooting
@@ -2251,7 +2239,9 @@ Common issues:
 ## See also
 
 - [README](../README.md): install, platform notes, configuration reference.
-- [Getting Started](GETTING_STARTED.md): first-run setup and basic voice typing.
+- [Getting Started](GETTING_STARTED.md): first capture and installation.
+- [Interview](INTERVIEW.md): saved context, suggestions, and manual drafts.
+- [Automation](AUTOMATION.md): triggers, tools, and execution limits.
 - [Dictation Pipeline Setup](DICTATION_PIPELINE_GUIDE.md): dictation pipeline, project context, output-target override, OpenAI-compatible endpoints, and automation hooks.
 - [Dictation runtime setup](../web/src/pages/cores/RuntimeDocsCore.tsx): source for the local Web runtime setup page.
 - [Meeting Mode Guide](MEETING_MODE_GUIDE.md): meeting-specific setup and troubleshooting.

--- a/docs/WEB_DESK.md
+++ b/docs/WEB_DESK.md
@@ -1,238 +1,140 @@
 # The Desk
 
-The Chair Door is HoldSpeak's post-first-value arrival at `/`. Its board and
-upcoming rail put the next work first. The **Floor** is the Desk's spatial
-object world, reached through the existing **Floor** control. There you work
-with Meetings, Notes, Knowledge, Agents, Sequences, Workflows, Artifacts, and
-live Coder sessions. Zones provide placement for durable work. The Floor
-renders on a WebGL stage; every product surface (Dictation, Meetings, Settings,
-Workbench, and the rest) opens as a window, so nothing navigates away.
+The Desk holds your records and opens the tools you use to work with them.
+Use the arrival for current work and the Floor for spatial organization.
 
-Behind the Floor, a procedural Three.js atmosphere turns the stage into a rainy
-city at night: a block-built but human-scaled skyline, wet street, lamplit
-puddle, depth-layered rain, irregular ripples and splash arcs, drifting cloud
-banks, reflected city light, and occasional distant lightning. The off-axis
-street canyon adds façade-aligned buildings, storefronts, a fire escape,
-receding sidewalks and curbs, a two-lane road, a crosswalk, gutter furniture,
-and seeded steam that curls from a foreground manhole into the wind-driven
-rain. A recessed late-night storefront on the right holds a hand-bent cafe
-neon behind rain-streaked glass. It flickers on its own seeded electrical
-rhythm, casting synchronized bloom into nearby rain trajectories and a muted
-color falloff across the wet asphalt.
-Generated high-frequency masonry, asphalt, and concrete maps provide surface
-scale beneath the procedural lighting without turning the world into a painted
-backdrop; all composition, weather, street motion, and light behavior remains
-code.
-A screen-space
-bloom pass, formula-generated radial falloff, and a seeded local rain volume
-make precipitation catch the streetlamp without relying on painted glow or
-weather assets. Pixel art comes from the modeled forms and restrained
-materials rather than an enlarged low-resolution framebuffer, so the scene
-stays crisp at the display's real size. It is decorative and
-pointer-transparent—the Pixi world above it still owns every object and
-gesture.
+## Start a task
 
-The second rendered mood, **Lantern Garden**, looks from a rain-darkened patio
-down a winding flagstone path toward a timber gate. Warm path lanterns cast
-bounded light onto the stone and planting beds; a house edge, downspout,
-violet flowers, tree canopy, and the restrained edge of an above-ground pool
-keep the proportions grounded in an ordinary lived-in yard. Leaf movement,
-foliage drips, water rings, lamp variation, and pointer parallax provide quiet
-motion. A very fine drizzle is nearly lost in the dark except
-where sparse drops cross each lantern's local glow. Its mulch grain and every
-glow texture are generated at runtime, so the atmosphere remains procedural
-rather than shipping a painted backdrop or source photograph.
+1. Open the URL printed by `holdspeak`.
+2. Select an item on the arrival, or select **Floor**.
+3. Open the **Desk** menu to create a record.
+4. Open the **Go** menu to select a tool.
 
-The atmosphere host is also a personalization primitive. A registry entry owns
-the background's stable id, user-facing metadata, seed, visual grade, and lazy
-scene loader. The shared runtime owns resize quality, normalized pointer input,
-visibility suspension, reduced-motion behavior, frame clamping, and teardown.
-A new atmosphere therefore supplies one isolated scene factory instead of
-reimplementing Desk integration or joining the initial bundle. The current
-default is `rainy-city`; **Settings → Wallpaper** renders catalog previews and
-switches the Floor live between Rainy City, Lantern Garden, and the no-WebGL
-Quiet Desk. The selection is a browser-local Desk view preference, survives
-reloads, and falls back safely when a retired or unknown atmosphere id is
-found. Future worlds only add a registry entry and isolated scene factory; the
-picker and Floor do not need another integration path.
+On a new installation, the Desk first offers **Dictate one sentence**.
+See [Getting Started](GETTING_STARTED.md) for that first capture.
 
-When the tab is hidden, the runtime pauses every atmosphere. The operating
-system's reduced-motion setting freezes weather, ambient particles, foliage,
-water, and camera drift while preserving each composition. Lightning is visual
-and deliberately moderate; the decorative layer never starts ambient audio on
-its own.
+## The arrival and Floor
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/desk.png" alt="The HoldSpeak Desk: pixel-art objects floating on a warm dark stage; a Zone tray holding a filed Meeting; Coder session avatars on a right-edge rail; a record orb bottom-center; the compact HoldSpeak menu and an egress badge top-left; Create controls top-right." width="760">
-</p>
+The **arrival** is the Desk's home screen.
+It shows items that need you, unfinished Thoughts, a brief, and recent Meetings when those records exist.
+Its capture bar provides **Talk**, **Develop a thought**, and **Record meeting**.
+See [The Arrival](USER_GUIDE.md#the-arrival) for the individual controls.
 
-It serves at `/`. On a fresh install the first-run guard sends you to the
-`/welcome` wizard instead, and a hard-blocked setup goes to `/setup`; after
-first value, everyone else arrives at the Chair Door. (`/desk`, the old
-address, redirects home.)
+The **Floor** shows Meetings, Notes, Artifacts, Projects, and other records as objects.
+You can open these objects or file durable work in Zones.
+Changing between Chair and Floor preserves an open Thread and its current draft.
 
-## What you see
+## Create and open work
 
-Desk items use distinct visual forms:
+Use the **Desk** menu for **New Note**, **New Decision**, **New Thread**, and other creation controls.
+**New Project** opens the Project setup surface.
+The Floor's context menu also exposes creation and launch controls.
 
-- **meetings** are cassette tapes,
-- **notes** are notepads,
-- **Knowledge** collections are crystals,
-- **Agents** and **Coder sessions** are characters,
-- **Sequences** and **Workflows** are cartridges,
-- **artifacts** are typed pages, each carrying its lineage.
+Select an object to work with it.
+Use the **Object** menu for applicable operations such as **Open**, **Rename**, **Move to Zone**, or **Continue in thread**.
+An unavailable operation shows its reason.
+A live Coder session can have different controls from a saved Note.
 
-A freshly created object arrives at the center of the stage with a short
-glow and a NEW mark, then settles.
+## File and arrange objects
 
-## The chrome
+Drag an object to change its position.
+Use **Move to Zone** or the supported drag target to file an object in a Zone.
+Open a Zone to work with its contents.
 
-Primary controls stay compact:
+Object positions are view preferences on this device.
+The underlying records remain on the hub.
+Use **Arrange desk** when you want the automatic arrangement.
 
-- **Top left**: the HoldSpeak mark opens the menu; each room (Dictation,
-  Meetings, Studio, Settings) opens as a window in place. Beside it, the
-  hub dot (green when connected) and the current data-boundary badge.
-- **Top right**: **Dictate**, **Record**, and one **Create** menu for Note,
-  Zone, Knowledge, Agent, and Workflow.
-- **Tool shelf**: advanced Desk tools and Runs on destinations.
-- **Right edge**: the Agent rail.
+## Use windows
 
-## Windows, the dock, and tiles
+Speak, Meetings, Settings, and other tools open in Desk windows.
+You can drag a window by its title bar or resize it with its handle.
+Minimize it to the dock when you want to keep it available.
+Select its dock entry to return to it.
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/karolswdev/HoldSpeak/main/docs/assets/screenshots/desk-windows.png" alt="Two windows on the Desk: the Dictation cockpit and the Meetings memory, cascaded over floating meeting cassettes and workflow cartridges, with dock chips bottom left." width="760">
-</p>
+The **Window** menu provides focus, snap, and maximize controls with their shortcuts.
+On phones, windows use sheets fitted to the available space.
+Saved window arrangement and saved product records are separate kinds of state.
 
-Every surface is a window with one chrome: drag it by its head, resize it
-by the corner grip, minimize it to the dock, maximize it to the full
-stage, or close it. Releasing a drag at a screen edge snaps a half or
-quarter tile. The dock (bottom left) lists every open window; a dimmed
-chip is parked and a tap brings it back; the ⟲ chip resets the layout.
-`Ctrl+\`` cycles windows in most-recently-used order. Your arrangement
-persists on this device. On phones a window presents as a bottom sheet.
+Existing addresses open the corresponding Desk surface:
 
-Old page addresses (`/dictation`, `/history`, `/settings`, ...) are deep
-links: each lands on the Desk with the matching window open, at the same
-scope the link named.
+| Address | Surface |
+| --- | --- |
+| `/dictation` | Speak |
+| `/history` | Meetings |
+| `/studio` | Studio |
+| `/settings` | Settings |
+| `/setup` | Setup diagnostics and recovery |
 
-## Create, in place
+## Record a meeting
 
-Choose **Create**, then select Note, Zone, Knowledge, Agent, or Workflow.
-The new item opens in context. Agent and Workflow editors expose their Runs
-on destination and Knowledge only when those settings are relevant.
+Use **Record meeting** or the Floor recorder control to start hub meeting capture.
+This uses the hub recorder. It is separate from microphone input in a browser text field.
+The recorder state also reflects a meeting started from another supported surface.
 
-## Open, in place
+Use the visible stop control to end recording.
+Then open the Meeting to inspect its transcript and results.
+See [Meeting mode](MEETING_MODE_GUIDE.md) for microphone selection, system audio, and import.
 
-Select an object to open its contextual panel. A Meeting shows
-its summary, action items, and artifacts; tapping an artifact opens it in
-the same panel. An Artifact's lineage names its source and capability.
-Focused actions such as **Review meeting** and **Edit Workflow** enter the
-relevant workroom and retain the Desk subject for return.
+## Use a Thread
 
-## File and dive
+1. Select **Desk > New Thread**.
+2. Enter your request in the composer.
+3. Attach relevant records with `@` if required.
+4. Select **Send**.
 
-A Zone is a findable placement for Desk items:
+Your prompt appears while the request starts.
+Routine tool calls remain collapsed under **Actions**, including while the reply streams.
+Tool questions, approval requests, and failures remain visible.
+The Thread stores sent messages on the hub.
+Keep a reply separately when you want a Note or Artifact outside the conversation.
 
-- **File**: drag an object onto a zone (the tray lifts as you hover), or
-  use **Move to…** in its panel. Filing again from the panel un-files it.
-- **Dive**: click a zone and the camera moves in; only its members remain
-  on stage. **All** surfaces back out.
-- **Rename**: click a zone's title and type. A new zone arrives with its
-  name field already focused.
+Use **Interview** mode to develop repeatable working context.
+See [Interview](INTERVIEW.md) for its sections, saved facts, and suggestions.
+See [Threads](USER_GUIDE.md#threads) for all conversation controls.
 
-## Record from the orb
+## Ask with selected context
 
-Press the orb and the hub starts recording a meeting (the same recorder
-the Live meeting window drives; never the browser's microphone). While
-recording, the orb pulses with the elapsed time; a meeting started
-anywhere else shows here too, marked "live elsewhere", and the orb can
-only stop it. When the recording ends, the finished meeting lands on the
-stage as an object.
+Select the relevant Floor objects and use **Ask AI**.
+The supported selection tools include the selection rectangle and modifier-click selection.
+An Ask can use selected records as source context.
 
-## Converse from the rail
+Inspect the result and its sources before you keep it.
+A kept result becomes an Artifact with its lineage.
+The Ask result and the Thread conversation have different persistence rules.
+Keeping an Artifact is separate from saving Thread messages.
 
-The right-edge rail holds Agents, each with its Runs on status. Select one
-to open its **conversation**, a docked thread rather than a one-shot prompt.
-Turns accumulate, the
-thread survives a reload (it lives on this device; Agents sync, threads
-stay yours), and **Clear** empties it when you want a fresh start.
+## Use speech input
 
-Each reply names where that turn ran. **Keep as Artifact** stores the Result
-as an Artifact on the Desk with lineage naming the Agent. Nothing is
-stored until you save it.
+Microphone controls differ by surface.
+The Thread composer uses click-to-toggle microphone input.
+Voice typing uses the configured global hold-to-talk hotkey.
+Follow the control shown on the current surface.
 
-Below the Agents, the rail lists available models from each Runs on
-destination. Select one to open a conversation pinned to that model. If the
-model is unavailable, the run fails before execution and lists available
-alternatives.
+Browser microphone input sends audio to the configured hub for transcription.
+A Coder reply can then deliver the resulting text to a live session under the applicable authority.
+See [Coder steering](USER_GUIDE.md#steer-a-session-from-the-desk) before you deliver session input.
 
-## Ground this ask
+## Change the environment
 
-Both composers (the Ask AI panel and any conversation) carry an attach
-control: **Ground this ask**. Open it and pick meetings; each one
-expands to its digest, its transcript, and every artifact it produced,
-each independently toggleable. A gauge prices the selection against the
-model's window from the records' real sizes, and a selection past the
-window refuses before anything runs.
+Open **Places** to select one of eight animated scenes or Quiet Desk.
+You can save favorites, pause animation, and enable optional room sound.
+Use **Settle in** to reduce navigation controls around your work.
+See [Places](ENVIRONMENTS.md) for shortcuts and persistence details.
 
-The run sends references, not copies: the hub reads the selected records
-from its own store and answers from them. A kept answer names the
-meetings and artifacts that grounded it, and an unknown reference
-refuses with its id instead of silently guessing. In a conversation the
-selection sticks, so every following turn stays grounded on the same
-records.
+## Troubleshooting
 
-## Rope things together and Ask AI
+| Problem | Action |
+| --- | --- |
+| A window seems absent | Check its dock entry and the **Window** menu. |
+| A tool cannot run | Read its reason. Check the connection, required selection, or model assignment. |
+| A Thread send fails | Read the failure before retrying. The composer retains failed text. |
+| Navigation is reduced | Exit Settle in with **Back to Desk** or **Escape**. |
+| A result is absent from Notes | Open the Thread. Use Keep on the reply if you need a separate Note. |
 
-Contextual Ask needs no saved Agent. Drag on the
-empty desk and a rope follows your pointer; everything inside it is
-selected (shift-click or cmd-click ropes objects one at a time). A bar
-rises with the count and one action: **Ask AI**.
+## See also
 
-The composer docks at the edge with the desk still alive behind it. Pick
-a lens (Summarize, Action items, Risks, Decisions, Draft email) or speak
-your own instruction with the mic, choose where it runs (the hub's
-default or another Runs on destination), and Ask. The hub reads the selected
-objects from its own store (a note's body, an artifact's text, a
-meeting's summary and actions) and runs your instruction over exactly
-that pile.
-
-The answer prints as a card wearing an honest badge: which model ran it
-and, for an endpoint run, which host it went to. This run, not the app
-default. Then you judge it:
-
-- **Keep** makes it a real artifact on the stage, and its lineage names
-  every object it read plus the exact instruction you gave.
-- **Bin** closes it. Nothing is stored.
-
-A kept ask syncs like any other artifact, so the card you keep here
-shows the same lineage on the iPad, and one kept there lands here.
-
-## Talk, don't type
-
-Every text input on the Desk carries a mic: hold it, speak, release, and
-the words land in the field. The browser sends audio to the configured hub;
-the applicable Runs on and boundary labels state where transcription occurs.
-
-A waiting Coder session takes speech too: its panel shows the Coder's
-question, and **Hold to answer** sends your spoken reply straight into
-the session. **Use the hotkey** instead selects it as your dictation
-target for the held-key flow.
-
-## The preview card
-
-If you turn on **Preview before it types** (Settings, Voice), every
-finished dictation appears on a card above the orb instead of typing:
-**Type it** commits, **Discard** or Escape drops it. The card follows you
-to every room, not just the desk.
-
-## Arrange the desk
-
-Drag any object to move it. The layout is stored on this device
-and never syncs; **Tidy** snaps everything back to the automatic layout.
-
-## Qlippy
-
-Qlippy is an optional visual presence for contextual attention. It is off by
-default and uses the same action, authority, and Receipt copy as other Desk
-surfaces.
+- [User Guide](USER_GUIDE.md): individual features and advanced controls.
+- [Interview](INTERVIEW.md): repeatable context and manual drafts.
+- [Places](ENVIRONMENTS.md): scenes, favorites, and Settle in.
+- [Control modes](AUTHORITY.md): authority for tool effects and Coder input.

--- a/docs/internal/DOCS_STYLE.md
+++ b/docs/internal/DOCS_STYLE.md
@@ -1,168 +1,139 @@
-# HoldSpeak docs style guide
+# Documentation writing standard
 
-HoldSpeak's live guides were written across many releases and can drift in tone
-and shape.
-This is the **floor** they should all clear — a shared voice and a standard page
-skeleton — so the set reads as one product, not an anthology. It is a floor, not
-a cage: reference docs keep their depth; a doc may add sections, just not skip the
-spine.
+Use this policy for new and revised HoldSpeak documentation.
+It combines controlled English with source checks, task-oriented structure, and maintained navigation.
 
-Companion to [`DOC_AUDIT_2026-08.md`](./DOC_AUDIT_2026-08.md) (accuracy) — this
-one is **voice + structure + navigation**.
+## Language standard
 
-## Voice
+The language reference is **ASD-STE100 Simplified Technical English, Issue 9, 2025-01-15**.
+Use the [official ASD standard](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf) for exact rules and dictionary meanings.
+The request named ASD-DTE100. This refresh provisionally interprets that name as ASD-STE100.
+The [September review](DOC_AUDIT_2026-09.md) records this assumption and the verification limits.
 
-- **Direct and second-person.** "Hold your hotkey, speak, release." Address the
-  reader as *you*; HoldSpeak is *it*. Prefer the imperative for steps.
-- **Confident, not breathless.** State what it does plainly. No marketing
-  superlatives in the guides (the README carries the pitch; guides carry the
-  truth).
-- **Honest over hype.** Pre-release is pre-release; off-by-default is stated as
-  such; "100% local" only where literally true (the model endpoint you point at is
-  yours). If a claim isn't true today, don't write it — file it. Canon wins over a
-  drifted doc; every claim is grounded in live code.
-- **Active and tight.** Cut hedging and repetition. One idea per sentence; one job
-  per paragraph.
-- **Terms, consistently:** *dictation* (not "voice typing" mid-guide once you've
-  introduced it), *meeting mode*, *the dictation pipeline*, *intel* for LLM meeting
-  extraction, *actuator* for the propose→approve→execute kind, *desktop presence*
-  for the ambient HUD, and *project knowledge* for the whole capability of
-  teaching the copilot about a repo. Project knowledge has two parts. *Project
-  facts* (UI tab **Project Facts**, formerly "Project KB") is the
-  `.holdspeak/project.yaml` `kb:` map: exact values the `kb-enricher` stage stamps
-  into block templates verbatim via `{project.kb.*}` placeholders, no LLM.
-  *Project context* (UI tab **Project Context**) is the **separate** `.hs/`
-  Markdown files: background the optional `project-rewriter` LLM stage reads. The
-  two are distinct and easily confused, so gloss them on first use and never use
-  one to mean the other (facts are stamped in verbatim; context guides a rewrite).
-  The on-disk names (`.holdspeak/project.yaml`, `.hs/`, `kb-enricher`,
-  `project-rewriter`, `{project.kb.*}`) are unchanged; "facts" and "context" are
-  the user-facing names. Code identifiers in `backticks`.
+Apply these language controls:
 
-## Product-tense, not roadmap vocabulary (guard-enforced)
+| Rule group | Editorial check |
+| --- | --- |
+| 1 | Check vocabulary, word function, and meaning. Register necessary domain terms separately. Use American spelling. |
+| 2 | Limit noun clusters. Identify longer technical names clearly. |
+| 3 | Prefer direct verbs and active constructions. Check tense and verb form. |
+| 4 | Keep sentences explicit. Expand contractions. |
+| 5 | Limit procedural sentences to 20 words. Give one instruction per sentence. Put prerequisites before actions. |
+| 6 | Limit descriptive sentences to 25 words and paragraphs to six sentences. Keep one topic per paragraph. |
+| 7 | State a relevant hazard, required action, and consequence when a safety instruction is necessary. |
+| 8 | Check punctuation and the standard's word-count rules. Avoid semicolons. |
+| 9 | Rewrite unsuitable constructions. Check meaning and terminology in context. |
 
-User-facing docs describe the product as it is, not the project's build history. A
-reader installing HoldSpeak has never heard of a "phase" and does not know what
-`HS-17-05` means, so the guides never carry the internal roadmap or process
-vocabulary.
+A word-count tool cannot establish dictionary compliance, permitted meaning, or technical accuracy.
+The [official download guidance](https://www.asd-ste100.org/STE_downloads.html) also distinguishes AI assistance from verified compliance.
+Do not label a document certified or fully compliant without the required substantive review.
+Do not copy the standard or its full dictionary into this repository.
 
-**Banned in user-facing docs** (the root README and `docs/*.md`):
+## Product terms and labels
 
-- Phase tags: `Phase 14`, `phase-37`, "the next phase".
-- Story ids: `HS-17-05`, `HS-25-03`.
-- Process words: `PMO`, "closeout", "the current roadmap", "evidence snapshot".
-- Phase-relative tense. Rewrite "Phase 11 shipped the connector contract" as
-  "HoldSpeak's connector contract is ...", and "Phase 15 will add TLS" as "TLS is
-  future work".
+Use the [terminology register](DOCS_TERMINOLOGY.md) for domain nouns and verbs.
+Use the [public glossary](../GLOSSARY.md) for reader-facing definitions.
+The [canonical-name table](POSITIONING.md#canonical-feature-names) owns product names.
 
-**Kept** (these are product, not roadmap):
+Preserve exact UI labels in bold and exact code identifiers in backticks.
+For example, **Keep idea** records a suggestion choice. Keep on a reply saves a separate output.
+Explain that difference instead of using one vague verb for both.
 
-- Product nouns: `actuator`, `connector`, `artifact_generator`, the dictation
-  pipeline.
-- Named architecture specs: `MIR-01`, `DIR-01`, `WFS-01`. They are spec names, not
-  phase tags.
+Do not replace an API field or command to make it sound simpler.
+Explain the identifier in ordinary prose instead.
+Use **Interview mode** for the repeatable Thread capability and **Interview pane** for Thought refinement when the distinction matters.
 
-**Exempt corpus.** This rule is for what a user reads. The internal record keeps its
-phase/story vocabulary by design and is never scrubbed or scanned: `docs/internal/`
-(including this guide, which is why it can list the banned tokens above),
-`docs/evidence/`, `docs/assets/`, and `pm/roadmap/`.
+## Describe the available product
 
-**Enforced.** A case-insensitive guard in `tests/unit/test_doc_drift_guard.py`
-(`test_no_user_facing_doc_leaks_roadmap_vocabulary`) fails the build when a
-user-facing doc carries a numbered or tagged leak. It catches the high-signal tags;
-bare process-speak with no number ("a separate phase") is on you and the reviewer to
-keep out.
+A public guide describes implemented behavior.
+A target requirement belongs in a specification with a status and an acceptance method.
+Implementation, successful execution, model quality, and owner acceptance are different claims.
+State a limitation next to the capability it qualifies.
 
-## The standard page skeleton
+For each procedural change, inspect the control or command in the current source.
+For a permission claim, inspect the operation policy and applicable tests.
+For a saved-state claim, identify which store owns the state and which events preserve it.
+For an automation claim, identify its actual trigger, executor, authority, and result record.
 
-Every user-facing guide clears this spine, in this order:
+Use specific data boundaries.
+Configured models, connectors, remote clients, and outbound actions can each transfer data.
+Do not use a blanket assurance that only a model endpoint can receive data.
+Link [Security & Privacy](../SECURITY.md) for the full contract.
 
-1. **Title** (`# …`) + an optional pixellab graphic.
-2. **Lede** — one or two sentences: *what this does* and *why you'd read it*. No
-   throat-clearing. Link the prerequisite doc if there is one ("read [Getting
-   Started] first").
-3. **Quickstart / TL;DR** — the shortest path to a working result (a command
-   block, a numbered list, or a "see it work" pointer).
-4. **Reference** — the depth: configuration, options, the contract. Sectioned with
-   `##`/`###`; a long doc may open with a table of contents.
-5. **Troubleshooting** — a symptom → cause → fix table where the surface has common
-   failure modes.
-6. **`## The voice guard (POSITIONING.md is the canon)
+## Organize a user guide
 
-User-facing prose follows the voice rules in
-[`POSITIONING.md`](./POSITIONING.md), and three of them are enforced by
-`tests/unit/test_doc_drift_guard.py` over the same corpus as the vocabulary
-guard (root README + non-recursive `docs/*.md`, fenced code blocks exempt):
+This structure is a HoldSpeak documentation convention.
+ASD-STE100 supplies the language rules, not the product's information architecture.
 
-- **No em/en dashes in prose.** Use a period, comma, colon, or parentheses.
-  A doc line that quotes a real UI string containing a dash must match the
-  UI verbatim and be added to the guard's `_VERBATIM_UI_QUOTES` allowlist.
-- **No AI-vocabulary tells** (delve, seamless, the verb leverage,
-  supercharge, effortless, game-changing, cutting-edge, "is a testament",
-  the "it's not just X" tic). Compounds and plain logical uses
-  ("highest-leverage", "every meeting, not just the visible page") stay
-  legal; the patterns are tuned for zero false positives on the corpus.
-- **Canonical feature names only.** One name per surface, declared in the
-  POSITIONING.md table; the guard bans the drift-prone synonyms (e.g.
-  "voice macros" for voice commands). New surfaces add a canon row in the
-  phase that ships them.
+1. State the task and result below one level-one title.
+2. State the prerequisites that affect the task.
+3. Give the shortest complete procedure.
+4. Describe the expected result and how to inspect it.
+5. Explain persistence, permissions, or limits when they affect use.
+6. Add a problem/action table for common failures.
+7. End with **See also** and a small set of useful links.
 
-## See also`** — 2–4 cross-links, each with a short value prop (see below).
+Use numbered steps for actions and tables for parallel comparisons.
+Keep examples clearly distinguishable from actual user records.
+Use explicit placeholders for unprovided IDs, names, dates, and requirements.
+A screenshot must represent the described interface and have useful alternative text.
+Remove a misleading screenshot from the current guide instead of treating it as evidence of current behavior.
 
-Reference/developer docs (Plugin Authoring, Connector Development, Device
-Protocol) keep their own deep structure but still carry a one-line lede and a
-`## See also` footer.
+## Organize a specification or technical reference
 
-## The privacy / local-first callout
+A specification identifies its status, scope, requirement IDs, acceptance criteria, and verification evidence.
+Keep target behavior distinct from implemented behavior.
+The [Interview package](architect-assistant/README.md) is an example of that separation.
 
-When a doc touches what's stored or what can leave the machine, state it inline
-with a blockquote, in the same shape everywhere:
+Technical references can use schema tables, examples, and architecture diagrams.
+Generated API and MCP inventories retain their machine-generated regions.
+Change their source or generator and regenerate the output when a contract changes.
+Do not hand-edit a generated roster to make a test pass.
 
-> **Local-first.** <what stays local>. Nothing leaves your machine except the
-> model endpoint you point at (local or LAN is fine).
+Historical evidence retains its original observations and dates.
+Move it with a provenance note when it obstructs a public task guide.
+Do not rewrite an old result to imply that a new test ran.
 
-The authoritative version is [`SECURITY.md`](../SECURITY.md); guides summarize and
-link, not re-derive.
+## Links and formatting
 
-## Cross-links & anchors (what the link-check enforces)
+Use relative repository links and existing heading anchors.
+Use direct external links for authoritative standards and external documentation.
+Use **See also** as the footer heading.
+Separate a link from its description with a colon.
 
-- **Relative links only** between docs (`FILE.md`, `./FILE.md`,
-  `../README.md`) — never an absolute repository path. A sibling bare filename
-  and its `./` form are both valid. The dangling-link guard
-  (`tests/unit/test_doc_drift_guard.py`) fails the build on a path that doesn't
-  resolve.
-- **Anchors** follow GitHub's slugger: lowercase, punctuation `().,&` stripped,
-  spaces → hyphens. A heading like `## 11. Desktop Presence (ambient, on-desktop
-  status)` slugs to `#11-desktop-presence-ambient-on-desktop-status` (the
-  parenthetical *words* stay). Verify a deep link against the actual heading — do
-  not hand-guess a shorter slug.
-- **`## See also` footer** — the standard footer. Use that exact heading (not
-  "Related Docs" / "Where to go next"). Each line: a link + an em-dash + a
-  one-line value prop:
-  ```markdown
-  ## See also
+Use periods, commas, colons, or parentheses in public prose.
+The repository also disallows em and en dashes in that prose.
+A literal UI string can retain its exact punctuation under the existing narrow guard exception.
 
-  - [The doc audit](DOC_AUDIT_2026-06.md) — accuracy + the canonical facts.
-  - [The plugin RFC](PLAN_ARCHITECT_PLUGIN_SYSTEM.md) — design rationale.
-  ```
+Keep headings in order, code fences closed, and tables aligned by column count.
+Keep Markdown examples separate from executable commands.
+Never include real credentials or private data in an example.
 
-  Targets are relative to the *linking* doc: a sibling in the same folder is a
-  bare `FILE.md` (as above — both siblings of this style guide); a guide in
-  `docs/` reaches `internal/` as `internal/FILE.md`, and `internal/` reaches a
-  guide as `../FILE.md`.
+## Review and maintain
 
-## The index is a map, not a list
+Every behavior change must update its user procedure and relevant reference in the same PR.
+Add new public guides to the documentation index.
+Update glossary entries when product terminology changes.
+Repair links to a changed heading in the same change.
 
-`docs/README.md` groups guides by **journey** (Start here · Dictate · Meet ·
-Extend · Operate & Trust), each entry a one-line value prop scannable in seconds.
-Keep its journeys and names in lockstep with the README's "Where to go next"
-table — same journeys, same names.
+The [contributor guide](../../CONTRIBUTING.md) gives the check commands.
+The navigation checker checks public guides, their local links, and Markdown heading targets.
+The existing drift guards check product terms, counts, generated contracts, and other repository rules.
+Neither check replaces the language review above.
+
+Before submitting a documentation PR, record:
+
+- The current implementation sources used to verify procedures.
+- The language and terminology review performed.
+- The exact checks and their results.
+- Any unverified behavior or remaining language review.
+
+The [September review](DOC_AUDIT_2026-09.md) separates fully rewritten entry guides from retained detailed references.
+It does not claim that every historical document has passed a complete STE review.
 
 ## See also
 
-- [`DOC_AUDIT_2026-08.md`](./DOC_AUDIT_2026-08.md) — the current accuracy audit + canonical
-  facts the guides are measured against.
-- [`../README.md`](../README.md) — the public entry; the index map mirrors its
-  "Where to go next" table.
-- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) — dev setup, the test command,
-  and the commit-contract workflow.
+- [Terminology register](DOCS_TERMINOLOGY.md): domain terms and editorial decisions.
+- [Public glossary](../GLOSSARY.md): definitions for users.
+- [Contributing](../../CONTRIBUTING.md): validation and commit workflow.
+- [September documentation review](DOC_AUDIT_2026-09.md): scope and verification record.

--- a/docs/internal/DOCS_TERMINOLOGY.md
+++ b/docs/internal/DOCS_TERMINOLOGY.md
@@ -1,0 +1,64 @@
+# Documentation terminology register
+
+This register records HoldSpeak's technical terms for documentation authors.
+It supplements the [public glossary](../GLOSSARY.md) and [canonical product names](POSITIONING.md#canonical-feature-names).
+It does not reproduce the ASD-STE100 dictionary or approve ordinary English words outside their permitted meanings.
+
+## Technical nouns
+
+The following groups use the subject-specific categories in ASD-STE100 Issue 9, Rule 1.5.
+The category numbers refer to the standard, not to HoldSpeak feature groups.
+
+| Terms | Category | Permitted meaning and source |
+| --- | --- | --- |
+| Desk, Chair, Floor, arrival, Speak, Places, Settle in, Concierge, Interview, Thought Workbench | 19: computer science and information technology | Named product surfaces and controls. Use the meanings in the public glossary. |
+| Thread, Note, Artifact, Project, Zone, decision record, Receipt, grant, Watch, assignment | 19 | Product records or contracts. Use the schema meaning, not a metaphor. |
+| agent, Coder session, Steward, Heartbeat, Cadence, Rhythm, Resourceful | 19 | Specific product components or execution concepts. Keep an agent distinct from a Coder session. |
+| Model Library, model, engine, runtime, endpoint, inference, capability, context, grounding | 19 | Model availability, input, routing, or execution concepts. Define ambiguous terms on first use. |
+| MCP, API, HTTP, JSON, SQLite, WebSocket, CLI, GGUF, MLX | 19 | Protocol, interface, format, database, or runtime identifiers. Expand an abbreviation when the reader needs its meaning. |
+| macOS, Linux, GitHub, Jira, Confluence, Whisper, HoldSpeak | 11: names of people, organizations, and products | Product or organization names. Preserve their spelling. |
+| ASD-STE100, SRS, acceptance test, specification | 15: documents and standards | Identified documents and their parts. Do not imply certification from a document title. |
+| Repository paths, command names, schema fields, environment variables | 19 | Literal software identifiers. Format them as code and preserve their exact bytes. |
+
+An ordinary noun does not become an allowed technical term merely because an author puts it in this table.
+New entries need a defined software meaning, a category, and a source in the product contract or interface.
+Use the glossary for the reader's definition and this register for the editorial decision.
+
+## Technical verbs
+
+These terms describe computer processes under Rule 1.12, category 2.
+Use them only for the listed actions and with the verb forms permitted by the standard.
+
+| Verb | Intended action |
+| --- | --- |
+| click, tap, type | Supply pointer, touch, or keyboard input. Prefer **select** when the input method does not matter. |
+| copy, paste | Use the clipboard controls. |
+| save, store | Persist the specified record or data. Do not use these verbs for an unsaved draft. |
+| open, close | Change the state of a window, record view, or file. |
+| drag, scroll, resize, minimize, maximize | Operate the corresponding interface control. |
+| install, download, upload | Perform the specified software or data transfer operation. |
+| configure, enable, disable, reset | Change a named setting or configuration. State the scope and result. |
+| encrypt, decrypt | Perform the named cryptographic operation. |
+| validate, invalidate | Apply a specified contract check or change the validity of a record. |
+| synchronize | Copy supported state between defined peers. Do not imply that every preference synchronizes. |
+
+## Literal labels
+
+Keep the exact control label when an instruction must identify a button or field.
+For example, **Try draft**, **Keep idea**, and **Use these** have different effects.
+Treat a label as a technical name. Write the surrounding instruction in controlled English.
+An unusual label does not authorize the same wording throughout ordinary prose.
+
+## Add a term
+
+1. Check the public glossary and canonical-name table for an existing term.
+2. Check the official dictionary for the intended word, part of speech, and meaning.
+3. If a technical term is necessary, record its category and software meaning here.
+4. Add or update the public definition when users need it.
+5. Update the referring guides in the same change.
+
+## See also
+
+- [Writing standard](DOCS_STYLE.md): language review and page structure.
+- [Public glossary](../GLOSSARY.md): reader-facing meanings.
+- [ASD-STE100](https://www.asd-ste100.org/): authoritative standard and downloads.

--- a/docs/internal/DOC_AUDIT_2026-09.md
+++ b/docs/internal/DOC_AUDIT_2026-09.md
@@ -1,0 +1,162 @@
+# Documentation review: September 2026
+
+Review date: 2026-09-05. Implementation baseline: `075d6833` on `main`.
+Change branch: `docs/product-documentation-refresh`.
+This is one documentation maintenance change outside the roadmap story workflow.
+
+## Requirement and interpretation
+
+The owner requested an overall documentation refresh PR and named ASD-DTE100.
+A search found no authoritative standard under that exact identifier.
+The authoritative ASD site identifies ASD-STE100 Simplified Technical English, Issue 9, dated 2025-01-15.
+The owner clarification remains pending. This change provisionally uses ASD-STE100.
+
+Sources consulted:
+
+- [Official standard and dictionary](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf).
+- [Official overview](https://www.asd-ste100.org/about_STE.html).
+- [Download and compliance guidance](https://www.asd-ste100.org/STE_downloads.html).
+
+The private working copy of the standard is not part of the commit.
+The repository contains its own writing policy and technical terminology register.
+It does not redistribute the standard's dictionary.
+
+## Documentation model
+
+The refresh uses three distinct layers:
+
+1. User guides describe tasks, current controls, expected results, and recovery.
+2. Technical references describe contracts, architecture, and programmatic interfaces.
+3. Specifications and evidence distinguish target requirements from implemented and verified behavior.
+
+This organization is a HoldSpeak convention. It is not a document-structure mandate from ASD-STE100.
+The language policy supplies controlled-English review requirements within those layers.
+
+## Scope
+
+| Area | Treatment |
+| --- | --- |
+| Root README, docs index, Getting Started | Rewritten around installation, daily tasks, current controls, and version boundaries. |
+| Interview | New public guide for all sections, source-backed context, suggestion choices, Try draft, repeat visits, and limits. |
+| Architecture work | New manual recipes for decision reviews, meeting preparation, agent briefs, and recurring-review trials. |
+| Automation | New map of triggers, clients, runtime dependencies, authority, and supported execution paths. |
+| Desk, Places, Models, Cadence, Project Rooms | Rewritten for current behavior. Obsolete UI instructions and screenshots removed from these guides. |
+| User Guide | Revised entry map, installation pointer, Threads, Interview distinction, Settings entries, and related links. Detailed existing sections retained. |
+| Dictation and Meeting guides | Corrected model setup links and keyed-provider instructions to match the current Concierge and owner API. Other detailed procedures retained. |
+| Authority, Security, Architecture | Added current default, Interview state/retention, and conversation/controller boundaries. Existing deep contracts retained. |
+| MCP reference | Corrected narrative totals and setup drivers. Removed duplicate numeric heading claims. Generated roster retained. |
+| Reach Runner | Replaced machine-specific setup with explicit placeholders and corrected the Heartbeat operation behind its legacy log label. |
+| Contributor workflow | Corrected environment setup and generated commit contract. Added documentation review and validation commands. |
+| Editorial policy | Replaced malformed style guide, added ASD reference and technical terms, and updated canonical feature names. |
+| Navigation maintenance | Added an independent local-link/heading checker, regression tests, and a CI job. |
+
+The public glossary defines product terms. The internal terminology register records their editorial scope.
+The index links current user guides and the existing Interview specification package in both directions.
+
+## Source review
+
+| Claim | Implementation or contract inspected |
+| --- | --- |
+| Installation and Web build | [Package contract](../../pyproject.toml), [build hook](../../hatch_build.py), [Web scripts](../../web/package.json) |
+| Current menus and creation | [Verb registry](../../web/src/desk/verbRegistry.ts), [menu bar](../../web/src/desk/components/DeskMenuBar.tsx) |
+| Interview sections and limits | [Descriptors](../../holdspeak/services/interview_contracts.py), [service](../../holdspeak/services/interview_service.py), [MCP family](../../holdspeak/mcp/families/interview.py) |
+| Try draft and saved context | [Interview panel](../../web/src/desk/components/InterviewPanel.tsx), [Thread window](../../web/src/desk/pullouts/ThreadPullout.tsx) |
+| Thread policies and modes | [Tool gate](../../holdspeak/services/thread_tools.py), [mode seeds](../../holdspeak/services/thread_modes.py) |
+| Models and current entry points | [Concierge](../../web/src/features/concierge/ConciergeCore.tsx), [controller](../../web/src/features/concierge/useConciergeController.ts), [Settings](../../web/src/pages/cores/SettingsCore.tsx) |
+| Current Project creation and Room controls | [Project creation](../../web/src/features/project-room/door/DoorCore.tsx), [source controller](../../web/src/features/project-room/door/useDoorController.ts), [Room](../../web/src/features/project-room/ProjectRoomCore.tsx) |
+| Model quality and delivery limits | [Interview delivery record](architect-assistant/DELIVERY_STATUS.md), [verification](architect-assistant/VALIDATION.md) |
+| Authority and default | [Control mode configuration](../../holdspeak/config/core.py), [authority guide](../AUTHORITY.md), Thread gate |
+| Remote runner | [Runner implementation](../../scripts/reach_runner.py), including `heartbeat.run_now`, arguments, and exit codes |
+| Cadence behavior | [Cadence service](../../holdspeak/services/cadence_service.py), [Cadence package](../../holdspeak/cadence/), [Telegram surface](../../holdspeak/cadence_telegram.py) |
+
+No feature delivery, owner acceptance, live microphone readiness, or model-quality improvement is claimed by this documentation change.
+The running owner preview and original feature checkout are outside this PR's mutations.
+
+## Preserved technical and historical material
+
+[Environment verification](ENVIRONMENT_VERIFICATION.md) retains the previous public guide's implementation and test record with a provenance note.
+Its recorded output remains historical. It is not a new execution claim.
+[Meeting output schema](MEETING_OUTPUT_SCHEMA.md) retains the technical schema material moved from the Models user guide.
+
+The existing Interview SRS, contracts, delivery plans, and failed live-model observations remain intact.
+This refresh does not mark later Interview releases or autonomous orchestration complete.
+
+## Language review and limits
+
+The rewritten guides use short sentences, direct instructions, explicit conditions, consistent names, and separate task/result explanations.
+The glossary and terminology register distinguish labels, technical nouns, verbs, and ordinary prose.
+Procedural and descriptive sentence lengths were reviewed during the editorial pass.
+Exact code, schema, and UI labels retain their required spelling.
+
+The retained long references and historical corpus have not received a complete dictionary and semantic review.
+Automated navigation, count, and vocabulary checks are not an STE conformance assessment.
+This PR claims an STE-based documentation policy and a substantial editorial refresh, not certified conformance of the entire repository.
+A full conformance claim requires review against the official dictionary, approved meanings, and every applicable writing rule.
+
+## Verification
+
+Baseline documentation contract run:
+
+```text
+2 failed, 33 passed in 19.69s
+FAILED test_mcp_tool_count_claims_match_registry
+FAILED test_no_user_facing_doc_uses_dashes_in_prose
+```
+
+The baseline index stated 214 tools while the registry contained 222.
+The Places guide contained an internal verification heading, and the Desk guide contained a disallowed prose dash.
+The refresh corrects those defects without weakening the existing guards.
+
+Final verification used the isolated Python driver and included the new navigation regression suite:
+
+```sh
+python docs/internal/architect-assistant/proof/run_tests.py -q --tb=short tests/unit/test_doc_drift_guard.py tests/unit/test_mcp_sidecar_doc_drift.py tests/unit/test_api_surface.py tests/unit/test_docs_navigation.py
+```
+
+Observed output:
+
+```text
+............................................                             [100%]
+44 passed in 6.70s
+```
+
+The new CI job also runs the nine navigation regressions through standard-library unittest.
+That independent invocation passed locally.
+Additional observed checks:
+
+```text
+Documentation navigation: 37 files checked; local targets and Markdown headings resolve.
+Documentation navigation: 6 files checked; local targets and Markdown headings resolve.
+All checks passed!
+Documentation CI job: valid YAML and expected standalone check commands.
+Markdown parse review: 37 public files parsed with CommonMark and tables.
+All public pages have one top-level title.
+```
+
+The lint result covers `scripts/check_docs.py` and `tests/unit/test_docs_navigation.py`.
+The six-file link run covers the new editorial, review, moved-reference, and Interview-package navigation.
+`git diff --check` produced no errors.
+
+A local CommonMark preview rendered Interview, Getting Started, and Automation at widths 1440 and 393.
+The final six render checks reported no page overflow.
+The initial Automation table overflowed at phone width, so its guide links moved into the path column.
+The final Interview desktop preview and Automation phone preview were visually inspected.
+This preview uses local review CSS. It does not assert identical layout in every Markdown host.
+
+An approximate sentence scan of the 14 rewritten guides found no over-limit review candidates before the final keyed-provider clarification.
+The scan counted procedural and descriptive sentences separately and supported the manual review.
+It did not validate approved dictionary meanings or establish STE conformance.
+The substantive language-review limits above still apply.
+
+## Maintenance
+
+For future behavior changes, update the owning user procedure and technical contract in the same PR.
+Run the navigation and existing drift checks from [Contributing](../../CONTRIBUTING.md).
+Use the [writing standard](DOCS_STYLE.md) and [terminology register](DOCS_TERMINOLOGY.md) for the language review.
+Record any remaining uncertainty instead of changing a target requirement into a present-tense capability claim.
+
+## See also
+
+- [Documentation index](../README.md): current task map.
+- [Writing standard](DOCS_STYLE.md): language and maintenance requirements.
+- [August audit](DOC_AUDIT_2026-08.md): previous historical review.

--- a/docs/internal/ENVIRONMENT_VERIFICATION.md
+++ b/docs/internal/ENVIRONMENT_VERIFICATION.md
@@ -1,0 +1,108 @@
+# Environment verification record
+
+Historical implementation and verification material moved from the public Places guide.
+The original observations below are retained as recorded. They are not current test results.
+See [Places](../ENVIRONMENTS.md) for user controls.
+
+## Review and verification
+
+From `web/`, with a supported Node version:
+
+```sh
+npm run dev -- --host 127.0.0.1 --port 4322
+```
+
+Open <http://127.0.0.1:4322/_built/atmospheres.html#rainy-city> to browse all
+eight scenes without a hub. Choosing a preview does not save it until **Use on my
+Floor** is pressed. This dev-only entry uses the actual production scene modules.
+
+In another terminal, from `web/`:
+
+```sh
+node scripts/shoot-atmospheres.mjs
+node scripts/check-atmospheres.mjs
+npm run test:web -- src/desk/gl/__tests__ src/pages/cores/__tests__/settingsWallpaper.test.tsx src/design/AtmospherePreview.test.tsx
+npm run test:web -- src/desk/__tests__/settle.test.tsx src/pages/cores/__tests__/ChangePlacesCore.test.tsx
+npm run tokens:check
+npm run tokens:gate
+npm run guard:architecture
+npm run build
+npm run bundle:gate
+```
+
+The screenshot script writes full-size PNG review images and compressed WebP
+picker assets. Both the gallery and screenshot script use the registry's complete
+scenic collection. Browser checks exercise all eight animated and paused scenes,
+wraparound, local selection persistence, and both original worlds under reduced
+motion in a 393px-wide gallery.
+The observed frame rate is local headless-browser evidence, not a hardware-wide
+performance guarantee.
+
+For the production-bundle interaction walk, run the preview server and then the
+check in separate terminals from `web/`:
+
+```sh
+npm exec vite preview -- --host 127.0.0.1 --port 4323
+node scripts/check-environments-floor.mjs
+node scripts/check-environments-floor.mjs --settle
+```
+
+This walk intercepts HTTP APIs with explicit test fixtures in an isolated browser.
+It verifies real Pixi object selection through the atmosphere layer and live
+Settings selection at desktop and phone widths. It does not test a live hub,
+authentication, or WebSocket delivery, and never writes owner Desk data.
+The `--settle` walk also verifies favorites across reload, native shortcuts,
+Escape preserving the same window and recorder nodes, and hit-tested access to
+Back to Desk and Stop above the phone sheet. Its recording state is an explicit
+external-recording fixture, not a real session. It asserts zero microphone
+requests and zero capture-action API writes.
+
+Evidence lives in [assets/screenshots/environments](../assets/screenshots/environments/),
+including the contact sheet, desktop/phone images, and JSON browser reports.
+
+Full TypeScript checking currently encounters pre-existing errors in
+`ProjectRoomCore.tsx` and `features/project-room/setup/__tests__/model.test.ts`;
+the environment changes add no errors to that output.
+
+## Main integration verification — 2026-09-05
+
+Refreshed PR #528 onto main `855b34cb` while preserving its original history and the newer Concierge/Settings behavior. The Settings hub now exposes Wallpaper and its live selected-place fact. Production controls use the shared Button; favorites use a decorative SVG. The browser harness includes the current Thoughts, needs-you, and Settings hub responses and opens Wallpaper through the current row UI.
+
+Actual output from the complete `npm run check`:
+
+```text
+tokens.css and tokens.gen.ts match design-tokens.json
+token gate: clean (11 allow-listed exceptions, all in use)
+React architecture guard passed (703 source files; zero framework residue).
+ Test Files  233 passed (233)
+      Tests  2220 passed (2220)
+bundle gate passed (Desk JS 1255406 B; Desk CSS 297160 B; source maps 0)
+```
+
+After the final shared-control and Settings-row corrections: 16 focused control tests passed; TypeScript and a fresh production build passed. The production-browser checks were rerun at 1440 and 393 against that build:
+
+```json
+{
+  "bundle": "production",
+  "backend": "isolated HTTP fixtures",
+  "pixiSelection": true,
+  "settingsLiveSelection": true,
+  "selectedPreviewsLoaded": true,
+  "originalWorldsIncluded": true,
+  "phoneOverflow": false,
+  "errors": []
+}
+{
+  "bundle": "production",
+  "backend": "isolated HTTP fixtures",
+  "preservedWindow": true,
+  "preservedCaptureControl": true,
+  "captureReachableOverPhoneSheet": true,
+  "favoritesPersist": true,
+  "nativeShortcuts": true,
+  "escapeRestores": true,
+  "phoneOverflow": false
+}
+```
+
+Screenshots in this directory's linked assets were refreshed and inspected. Logs are in the desktop-delivery worktree's `.tmp/desktop-*` files. The browser checks use isolated HTTP fixtures and do not establish microphone hardware readiness or live-model quality. GitHub's broader Python/macOS jobs run separately; this local evidence does not claim they passed.

--- a/docs/internal/MEETING_OUTPUT_SCHEMA.md
+++ b/docs/internal/MEETING_OUTPUT_SCHEMA.md
@@ -1,0 +1,58 @@
+# Meeting output schema
+
+Technical reference retained from the Models guide.
+For owner setup, read [Models](../MODELS.md).
+
+## Structured output for meeting intelligence
+
+Meeting intelligence sends a request-level `response_format` with a JSON Schema
+derived from the one `INTEL_SCHEMA` constant in `holdspeak/intel/parsing.py`.
+The schema shape is:
+
+```json
+{
+  "topics": ["<short topic>"],
+  "action_items": [
+    {
+      "task": "<task>",
+      "owner": "<person's name as spoken>|Me|Remote|null",
+      "due": "<date or null>"
+    }
+  ],
+  "summary": "<short summary>"
+}
+```
+
+`owner` is a literal person name as spoken in the transcript, or one of two
+reserved tokens: `Me` (the speaker or leader) and `Remote` (the counterpart).
+`null` means the transcript did not name an owner. Every other string is a
+literal name the model heard. `Me` and `Remote` are the only reserved tokens.
+
+The prompt stringifies `INTEL_SCHEMA`, the `response_format` wraps
+`INTEL_JSON_SCHEMA` (the formal JSON Schema derived from it), and the semantic
+adapter references the same constant. If the endpoint returns a 400 naming
+`response_format` or `json_schema`, the dispatch treats the rejection as a
+dialect mismatch (like the `max_completion_tokens` compatibility pattern),
+records the endpoint's dialect, and raises a named signal for a second admitted
+child that omits `response_format`. The fallback is never a silent retry: the
+runner admits one physical request per child, and the prompt's "Return ONLY a
+single valid JSON object" instruction plus the `_extract_json` line-recovery
+heuristic remain the safety net.
+
+### The schema-pinned-server gotcha
+
+A llama.cpp server launched with a server-level `--json-schema` flag pins every
+response to that schema regardless of what the request asks for. A prompt-level
+JSON plea or a request-level `response_format` override is silently swallowed,
+and the response conforms to the pinned schema instead. The product now sends
+request-level structured output, which overrides the server pin cleanly on
+llama.cpp builds that support it. If you run a llama.cpp server with
+`--json-schema`, verify that the model responds to the product's schema and not
+the server pin by checking the shape of the response (it should contain
+`topics`, `action_items`, and `summary`, not the pinned shape).
+
+
+## See also
+
+- [Models](../MODELS.md): current setup controls.
+- [Parsing contract](../../holdspeak/intel/parsing.py): schema constants and response handling.

--- a/docs/internal/POSITIONING.md
+++ b/docs/internal/POSITIONING.md
@@ -177,6 +177,9 @@ left column is the name; do not alternate with the synonyms.
 | agents (tailored personas you author) | "bots", "assistants" |
 | coders (live coding sessions awaiting you) | "agents" for this concept, "companions" (the word is retired: an agent is a persona you author; a coder is a live Claude or Codex session) |
 | the iPad app | "the companion", "the companion app" |
+| Interview (repeatable Thread mode) | "the onboarding wizard" for the entire capability; distinguish the Thought Workbench Interview pane |
+| Places (Floor environment picker) | "desktop themes" for this surface |
+| Settle in (temporary quiet Desk view) | "saved focus layout" |
 | Threads (multi-turn desk conversations) | "chat", "chat app", "PersonaChat" |
 | Automations (the watch/reaction surface) | "event triggers", "webhooks", "watches" (except the Project-scoped Watches of Project Rooms) |
 | Watches (Project-scoped) | "event triggers", "monitors", "subscriptions" |
@@ -208,6 +211,11 @@ left column is the name; do not alternate with the synonyms.
 | the Confluence connector (blog posts + pages by ID) | "the wiki connector", "the Confluence integration", "the Confluence plugin" |
 
 ## Voice rules (the editing standard for every user-facing doc)
+
+The controlled-English policy is [DOCS_STYLE.md](DOCS_STYLE.md), using
+ASD-STE100 Issue 9 as its language reference. The rules below continue to
+govern product voice and names. [DOCS_TERMINOLOGY.md](DOCS_TERMINOLOGY.md)
+records the domain terms used with that policy.
 
 - **The humanizer standard applies** (the vendored skill): no AI-vocab
   (delve, seamless, leverage, robust, comprehensive, supercharge…), no

--- a/docs/internal/architect-assistant/README.md
+++ b/docs/internal/architect-assistant/README.md
@@ -2,6 +2,11 @@
 
 Status: target specification with an implemented first manual Interview increment. Version 0.2, 2026-09-05. See [delivery status and evidence](DELIVERY_STATUS.md) for implemented behavior and remaining work.
 
+For daily use, read the [Interview user guide](../../INTERVIEW.md),
+[architecture work recipes](../../ARCHITECTURE_WORK.md), and
+[automation boundaries](../../AUTOMATION.md). This package retains the target
+requirements and implementation evidence.
+
 HoldSpeak shall help a Senior Software Architect preserve context, make and recover decisions, follow through on commitments, and direct agent work during an organizational transformation. Success means useful work completed and time recovered across an ordinary working week.
 
 The primary conversational entry is a repeatable interview: explore goals, Projects, concerns, Cadences, People, Decisions, or delegation; receive contextual LLM suggestions; and turn a chosen suggestion into a tested supported setup. Revisit any section as work changes. Intelligent conversation guides discovery; deterministic state, existing service contracts, and actual tool results govern execution.

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Check public Markdown navigation without importing the HoldSpeak runtime.
+
+Checks inline/reference links to local files and GitHub-style heading anchors.
+External URLs and code examples are not fetched or executed. This is a
+navigation check, not an ASD-STE100 language or conformance checker.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import sys
+import unicodedata
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+FENCE = re.compile(r"^\s*(`{3,}|~{3,})")
+INLINE_CODE = re.compile(r"(`+).*?\1")
+INLINE_LINK = re.compile(
+    r"!?\[[^\]\n]*\]\(\s*(?:<([^>\n]+)>|([^\s)]+))"
+    r"(?:\s+[\"'][^\n]*?[\"'])?\s*\)"
+)
+REFERENCE = re.compile(r"^\s{0,3}\[[^\]]+\]:\s*(?:<([^>]+)>|(\S+))")
+ATX = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)(?:\s+#+\s*)?$")
+HTML_ANCHOR = re.compile(r"\b(?:id|name)=[\"']([^\"']+)[\"']")
+
+
+def prose_lines(text: str) -> list[tuple[int, str]]:
+    """Retain source line numbers while omitting fenced code blocks."""
+    lines = []
+    fence = ""
+    for number, line in enumerate(text.splitlines(), 1):
+        match = FENCE.match(line)
+        if match:
+            marker = match.group(1)
+            if not fence:
+                fence = marker
+            elif marker[0] == fence[0] and len(marker) >= len(fence):
+                fence = ""
+            continue
+        if not fence:
+            lines.append((number, line))
+    return lines
+
+
+def slug(text: str) -> str:
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"!?\[([^\]]+)\]\([^)]*\)", r"\1", text)
+    text = html.unescape(text).lower().strip()
+    return "".join(
+        ch for ch in text
+        if ch in " _-" or unicodedata.category(ch)[0] in "LNM"
+    ).replace(" ", "-")
+
+
+def anchors(text: str) -> set[str]:
+    found: set[str] = set()
+    generated: set[str] = set()
+    previous = ""
+    previous_number = 0
+    for number, line in prose_lines(text):
+        found.update(HTML_ANCHOR.findall(line))
+        match = ATX.match(line)
+        title = match.group(1) if match else None
+        if (
+            title is None and previous.strip() and number == previous_number + 1
+            and re.fullmatch(r"\s{0,3}(?:=+|-+)\s*", line)
+        ):
+            title = previous
+        if title:
+            base = slug(title)
+            candidate = base
+            suffix = 0
+            while candidate in generated:
+                suffix += 1
+                candidate = f"{base}-{suffix}"
+            generated.add(candidate)
+            found.add(candidate)
+        previous, previous_number = line, number
+    return found
+
+
+def links(text: str) -> list[tuple[int, str]]:
+    found = []
+    for number, line in prose_lines(text):
+        line = INLINE_CODE.sub("", line)
+        for match in INLINE_LINK.finditer(line):
+            found.append((number, match.group(1) or match.group(2)))
+        reference = REFERENCE.match(line)
+        if reference:
+            found.append((number, reference.group(1) or reference.group(2)))
+    return found
+
+
+def public_documents(root: Path) -> list[Path]:
+    return [root / "README.md", root / "CONTRIBUTING.md", *sorted((root / "docs").glob("*.md"))]
+
+
+def check_documents(paths: list[Path], root: Path) -> list[str]:
+    errors = []
+    cache: dict[Path, set[str]] = {}
+    for path in paths:
+        label = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+        if not path.is_file():
+            errors.append(f"{label}: missing document")
+            continue
+        for number, target in links(path.read_text(encoding="utf-8")):
+            try:
+                url = urlsplit(html.unescape(target))
+            except ValueError:
+                errors.append(f"{label}:{number}: invalid link {target}")
+                continue
+            if url.scheme or url.netloc or url.path.startswith("/"):
+                continue
+            destination = (path.parent / unquote(url.path)).resolve() if url.path else path.resolve()
+            if not destination.exists():
+                errors.append(f"{label}:{number}: missing target {target}")
+                continue
+            if url.fragment and destination.suffix.lower() == ".md" and destination.is_file():
+                if destination not in cache:
+                    cache[destination] = anchors(destination.read_text(encoding="utf-8"))
+                fragment = unquote(url.fragment)
+                if fragment not in cache[destination]:
+                    errors.append(f"{label}:{number}: missing heading {target}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Optional Markdown files; default: all public guides")
+    args = parser.parse_args(argv)
+    paths = [Path(p).resolve() for p in args.paths] if args.paths else public_documents(ROOT)
+    errors = check_documents(paths, ROOT)
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        print(f"Documentation navigation: {len(errors)} error(s)", file=sys.stderr)
+        return 1
+    print(f"Documentation navigation: {len(paths)} files checked; local targets and Markdown headings resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docs_navigation.py
+++ b/tests/unit/test_docs_navigation.py
@@ -1,0 +1,77 @@
+"""Regression checks for broken or falsely accepted documentation navigation."""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_docs.py"
+spec = importlib.util.spec_from_file_location("check_docs", SCRIPT)
+assert spec and spec.loader
+docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(docs)
+
+
+class DocumentationNavigationTests(unittest.TestCase):
+    def test_heading_formatting_and_duplicate_suffixes(self):
+        text = "# A `Thread` (with tools)\n## Again\n## Again\n## Again-1\n## Again\n"
+        self.assertEqual(docs.anchors(text), {
+            "a-thread-with-tools", "again", "again-1", "again-1-1", "again-2",
+        })
+
+    def test_unicode_setext_and_explicit_anchors(self):
+        text = '# Café & API\nA second title\n---\n<a id="custom"></a>\n'
+        self.assertEqual(docs.anchors(text), {"café--api", "a-second-title", "custom"})
+
+    def test_code_samples_do_not_supply_real_headings_or_links(self):
+        text = '# Real\n```md\n# Fake\n[bad](missing.md)\n```\n`[sample](missing.md)`\n'
+        self.assertEqual(docs.anchors(text), {"real"})
+        self.assertEqual(docs.links(text), [])
+
+    def test_long_fence_is_not_closed_by_short_fence(self):
+        text = '````md\n```\n# Fake\n````\n# Real\n'
+        self.assertEqual(docs.anchors(text), {"real"})
+
+    def test_links_keep_source_lines_and_reference_definitions(self):
+        text = '# Title\n\n[Guide](guide.md#start)\n[ref]: <file name.md#section>\n'
+        self.assertEqual(docs.links(text), [(3, "guide.md#start"), (4, "file name.md#section")])
+
+    def test_missing_file_and_anchor_fail_with_location(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            page = root / "README.md"
+            page.write_text('[a](absent.md)\n[b](guide.md#missing)\n')
+            (root / "guide.md").write_text('# Present\n')
+            self.assertEqual(docs.check_documents([page], root), [
+                'README.md:1: missing target absent.md',
+                'README.md:2: missing heading guide.md#missing',
+            ])
+
+    def test_same_page_encoded_paths_and_external_links(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            page = root / "README.md"
+            page.write_text('# Local\n[a](#local)\n[b](a%20file.md#caf%C3%A9)\n'
+                            '[web](https://example.test/no-request)\n[app](/settings)\n')
+            (root / "a file.md").write_text('# Café\n')
+            self.assertEqual(docs.check_documents([page], root), [])
+
+    def test_only_public_markdown_is_in_default_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs/internal").mkdir(parents=True)
+            (root / "docs/A.md").touch()
+            (root / "docs/internal/evidence.md").touch()
+            self.assertEqual([p.relative_to(root).as_posix() for p in docs.public_documents(root)],
+                             ['README.md', 'CONTRIBUTING.md', 'docs/A.md'])
+
+    def test_missing_document_is_not_silently_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertEqual(docs.check_documents([root / 'gone.md'], root),
+                             ['gone.md: missing document'])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The documentation did not provide a public path into repeatable Interview, and several guides described retired setup screens. This refresh makes current tasks discoverable and explains what HoldSpeak can save, draft, configure, and execute.

- Add a public Interview guide, architecture work recipes, an automation map, and a glossary. Cover repeat visits, fact sources, suggestions, immediate Try draft execution, kept results, People handoff, and current orchestration limits.
- Refresh the README, documentation index, installation, Desk, Places, Models, Cadence, Project Rooms, and Reach Runner guides. Correct Thread behavior, model setup instructions, MCP narrative counts, and Interview architecture/privacy boundaries.
- Replace the malformed writing guide with an ASD-STE100-based policy, a technical terminology register, and a maintainable contributor review process. Preserve moved schema details and historical desktop verification with provenance.
- Add a standalone local-link and heading checker, nine regression tests, and a Documentation Navigation CI job. Existing API/MCP and product-language guards remain intact.

The language reference is **ASD-STE100 Issue 9 (2025-01-15)**, provisionally interpreting the requested “ASD-DTE100.” The policy and audit distinguish mechanical checks from full dictionary/semantic review. This PR does not claim certified conformance of all retained references or historical documents.

Validation: **44 tests passed**, local links/headings passed for **37 public pages and 6 internal pages**, checker lint and diff checks passed, and all 37 public pages parsed. Local rendered previews of Interview, Getting Started, and Automation were checked at 1440 and 393 widths. Detailed scope, source references, actual test output, and review limits are in `docs/internal/DOC_AUDIT_2026-09.md`.

Prepared in an isolated worktree. This changes documentation and its checks; the owner's running preview and feature checkout were preserved.
