### PR TITLE
fix: 175 ruling R1 — the event→Room matcher requires the Room's full name; a generic one-word Room never links

### DIFF
--- a/holdspeak/calendar_ingest_conductor.py
+++ b/holdspeak/calendar_ingest_conductor.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import math
+import re
 import threading
 import time
 import urllib.error
@@ -37,6 +38,58 @@ from .logging_config import get_logger
 
 
 log = get_logger("calendar_ingest_conductor")
+
+
+# Ruled R1 (2026-09-06, on the owner's deferral): a ONE-WORD Room name
+# never auto-links a calendar event when that word is generic meeting
+# vocabulary.  Counsel showed a Room named "Design" linking a "401k
+# enrollment design review" webinar; a lone generic word is no signal.
+# Compared case-insensitively against the stripped Room name.  Multi-word
+# Room names are not subject to this list (their full phrase is the signal).
+GENERIC_MEETING_WORDS: frozenset[str] = frozenset({
+    "design", "review", "standup", "sync", "planning", "meeting", "weekly",
+    "daily", "update", "status", "call", "check", "chat", "notes", "general",
+    "misc", "team", "project", "retro", "demo", "office", "hours", "lunch",
+    "interview", "onboarding", "training", "workshop", "all-hands", "1:1",
+})
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _phrase_tokens(text: str) -> tuple[str, ...]:
+    """Lower-case word tokens; any punctuation run is a word boundary.
+
+    ``"q4-platform sync"`` and ``"Q4 Platform: Sync"`` both tokenize to
+    ``("q4", "platform", "sync")``, which is what makes the phrase match
+    whole-word bounded and punctuation-insensitive.
+    """
+    return tuple(_WORD_RE.findall(text.lower()))
+
+
+def room_name_matches_title(room_name: str, event_title: str) -> bool:
+    """Ruled R1 (2026-09-06): does this Room name auto-link this event title?
+
+    (1) The Room's FULL name must appear in the title as a contiguous
+        phrase -- case-insensitive, whole-word bounded, punctuation-
+        insensitive.  "Q4 Platform" matches "Q4 Platform Standup" and
+        "q4-platform sync"; it does NOT match "Platform review".
+    (2) A ONE-WORD Room name links only if the word is not in
+        ``GENERIC_MEETING_WORDS``.
+
+    Manual links and the durable Unlink suppression are not this function's
+    concern: it only says whether the matcher may propose a title link.
+    """
+    name = (room_name or "").strip()
+    if not name:
+        return False
+    if not any(ch.isspace() for ch in name) and name.lower() in GENERIC_MEETING_WORDS:
+        return False
+    needle = _phrase_tokens(name)
+    if not needle:
+        return False
+    haystack = _phrase_tokens(event_title or "")
+    n = len(needle)
+    return any(haystack[i:i + n] == needle for i in range(len(haystack) - n + 1))
 
 
 @dataclass(frozen=True)
@@ -278,9 +331,14 @@ class CalendarIngestConductor:
     def _run_event_room_matcher(self) -> None:
         """HS-175-02: match calendar events to Rooms by title.
 
-        H3 (counsel): a title match requires the Room name (>= 4 chars) as a
-        whole-word substring of the event title; one-word Room names of <= 3
-        chars never auto-match (too high false-positive risk).
+        Ruled R1 (2026-09-06, on the owner's deferral): a title match
+        requires the Room's FULL name as a contiguous whole-word phrase of
+        the event title (case- and punctuation-insensitive), and a ONE-WORD
+        Room name never links when it is generic meeting vocabulary
+        (``GENERIC_MEETING_WORDS``); see ``room_name_matches_title``.  The
+        longest Room name still wins when several full names appear.  This
+        supersedes H3's ">= 4-char whole-word substring" rule, under which
+        a Room named "Design" linked a "401k enrollment design review".
 
         Manual links are preserved (they override the matcher), and a pair
         the owner unlinked is never re-linked (C5, the suppression table).
@@ -294,8 +352,6 @@ class CalendarIngestConductor:
         whole-word contain), so it warned on every refresh per Room and
         could never match.  Dropped honestly rather than "fixed".
         """
-        import re
-
         db = self._get_db()
         events = db.calendar_events.list_all()
         if not events:
@@ -324,17 +380,11 @@ class CalendarIngestConductor:
             title = (event.title or "").strip()
             if not title:
                 continue
-            title_lower = title.lower()
             best_match: tuple[str, int] | None = None  # (project_id, match_length)
             for pid, candidate, _kind in room_candidates:
                 candidate_stripped = candidate.strip()
-                if len(candidate_stripped) < 4:
-                    # H3: skip short names (too high false-positive risk).
-                    continue
-                candidate_lower = candidate_stripped.lower()
-                # Whole-word substring match.
-                pattern = r'\b' + re.escape(candidate_lower) + r'\b'
-                if re.search(pattern, title_lower):
+                # R1: full-name phrase; a lone generic word never links.
+                if room_name_matches_title(candidate_stripped, title):
                     # Prefer the LONGEST matching Room name.
                     if best_match is None or len(candidate_stripped) > best_match[1]:
                         best_match = (pid, len(candidate_stripped))

--- a/holdspeak/db/calendar_event_projects.py
+++ b/holdspeak/db/calendar_event_projects.py
@@ -4,6 +4,12 @@ The matcher writes links after each calendar refresh; the Door reads them
 to project Room names onto upcoming event items.  Manual links are
 written by the link/unlink routes and survive matcher re-runs.
 
+Ruled R1 (2026-09-06, on the owner's deferral): a ``title`` link needs
+the Room's FULL name as a contiguous whole-word phrase of the event
+title, and a single generic word (``calendar_ingest_conductor.
+GENERIC_MEETING_WORDS``) never links.  ``Unlink`` stays the remedy for a
+wrong link; the suppression below is untouched by that ruling.
+
 HS-175 counsel C5 / C6(c):
 
 - An owner's ``unlink`` is durable.  It is recorded in

--- a/pm/roadmap/holdspeak/phase-175-calendar-and-the-clock/assets/settled-design-calendar-clock.md
+++ b/pm/roadmap/holdspeak/phase-175-calendar-and-the-clock/assets/settled-design-calendar-clock.md
@@ -393,6 +393,8 @@ calendar ingest refresh:
    strings). Case-insensitive substring match. Example: event "Q4
    Platform Standup" matches Room "Q4 Platform" because the Room name
    is a substring of the event title.
+   Ruled R1 (2026-09-06, on the owner's deferral): full-name phrase; a
+   single generic word never links.
 2. **Attendee match:** when the ICS carries attendee data (the existing
    parser extracts `location` and `meeting_url` but NOT attendees
    today -- this is a GAP; see D4 H3), compare attendee email/names
@@ -598,6 +600,9 @@ positive links the event to the wrong Room. Hunt:
   files a recording under the wrong Room; it never loses the
   recording. His word can flip V0 to suggestion-only (question 1 in
   the walk).
+- **Ruled R1 (2026-09-06, on the owner's deferral): full-name phrase; a
+  single generic word never links** (the ">= 4-character whole-word"
+  rule above is superseded; `calendar_ingest_conductor.room_name_matches_title`).
 
 ### H4: A week strip with a counter of zero
 

--- a/pm/roadmap/holdspeak/phase-175-calendar-and-the-clock/final-summary.md
+++ b/pm/roadmap/holdspeak/phase-175-calendar-and-the-clock/final-summary.md
@@ -27,9 +27,19 @@ The calendar gave the desk its clock: the arrival's WEEK strip and `NEXT · <tit
 - A worker's `git stash` in the shared tree wiped ten files; recovered from the dangling stash commit. Law in `.claude/agents/opus-worker.md` and memory: no git verb that moves the tree; the orchestrator reads `git reflog` before every verification run; rigs re-shoot other phases' assets — restore before staging.
 - Earlier walks (167/168) left seed meetings in the owner's real database; the 175 runner found them read-only. His rows; listed for his sitting.
 
-## Owed to the owner (his sitting)
+## The seven questions — RULED (2026-09-06, on the owner's deferral: "The decision is deferred to you")
 
-1. Auto-link vs suggestion-only (a Room named `Design` links a 401k webinar; Unlink is the remedy). 2. The toggle: consent to record at the event (built) or arm-and-wait. 3. Cancel on a recurring meeting: this one (built) or the series. 4. Remove means gone (built). 5. Whose clock: the hub's local (built). 6. The arrival's `THIS WEEK` caption vs the board's MEETINGS (B10). 7. The two `Sprint Review` seed rows are his to delete. Then: his attended walk (06), the close (09), #558 out of draft, merge on his word.
+| # | Question | Ruling |
+|---|---|---|
+| R1 | Auto-link vs suggestion-only | Auto-link stays (open throttle), tightened: a Room's FULL name must appear as a phrase; a one-word Room name links only if it is not a generic meeting word (design, review, standup, sync, …). Unlink stays the remedy. Shipped as a follow-up on main. |
+| R2 | The toggle: record at the event, or arm-and-wait | Record at the event, like every scheduled recording; OFF by default. A recording that waits for a hand is not a scheduled recording. |
+| R3 | Cancel on a recurring meeting | This occurrence. A series cancel is a later verb, if ever asked. |
+| R4 | Remove means gone | Yes — the source, its events, its armed recordings, a snapshot's generated file. |
+| R5 | Whose clock | The hub's local clock, per instant. |
+| R6 | `THIS WEEK` vs the board's MEETINGS | `THIS WEEK` stays; the recorded-meetings ledger owns MEETINGS. |
+| R7 | The two `Sprint Review` seed rows in his database | Deleted through the product's own meeting delete (receipted) after a read-only census confirmed they are the only walk seeds. |
+
+His attended walks (170–175) stay owed.
 
 ## Parked (BACKLOG.md)
 

--- a/tests/unit/test_hs175_calendar_wire.py
+++ b/tests/unit/test_hs175_calendar_wire.py
@@ -4,7 +4,8 @@ Tests:
 1. The sweep runs the calendar refresh once and receipts it (stub the fetch;
    a file source needs no network).
 2. No double refresh with the old thread gone.
-3. The matcher's title rule including the H3 negative (short names skip).
+3. The matcher's title rule as ruled R1 (2026-09-06): full-name phrase,
+   longest wins, a single generic word never links.
 4. The manual link overrides the matcher.
 5. `door.week` days/total.
 6. `upcoming` carries the room (project_id + project_name).
@@ -187,21 +188,84 @@ class TestTitleMatcher:
         assert len(links) >= 1
         assert links[0].match_source == "title"
 
-    def test_h3_short_name_never_matches(self, db: Database, ics_file: Path) -> None:
-        """H3: a Room name of <= 3 chars never auto-matches (false positive
-        risk). 'Q4' is too short to match 'Q4 Platform Standup'."""
+    def test_r1_short_one_word_name_links_when_its_whole_word_appears(
+        self, db: Database, ics_file: Path
+    ) -> None:
+        """R1 supersedes H3's >= 4-char floor: 'Q4' is a one-word Room name
+        that is NOT generic meeting vocabulary and appears whole in
+        'Q4 Platform Standup', so it links (the old rule refused it on
+        length alone)."""
         conductor = _make_conductor(db, str(ics_file))
-        with db._connection() as conn:
-            conn.execute(
-                "INSERT INTO projects (id, name) VALUES (?, ?)",
-                ("proj-short", "Q4"),
-            )
+        _seed_room(db, "proj-short", "Q4")
         conductor.refresh()
         links = db.calendar_event_projects.list_for_project("proj-short")
-        assert len(links) == 0, "short Room names must not auto-match"
+        assert [l.match_source for l in links] == ["title"]
+
+    def test_r1_generic_one_word_room_never_links(self, db: Database, tmp_path: Path) -> None:
+        """R1: counsel's false positive -- a Room named 'Design' must not
+        link a '401k enrollment design review' webinar."""
+        ics = tmp_path / "webinar.ics"
+        ics.write_bytes(_make_ics(title="401k enrollment design review"))
+        conductor = _make_conductor(db, str(ics))
+        _seed_room(db, "proj-design", "Design")
+        conductor.refresh()
+        assert db.calendar_event_projects.list_for_project("proj-design") == []
+
+    def test_r1_generic_stoplist_is_case_insensitive(self, db: Database, tmp_path: Path) -> None:
+        """R1: a Room named 'Sync' (any case) never links 'Payments sync'."""
+        ics = tmp_path / "payments.ics"
+        ics.write_bytes(_make_ics(title="Payments sync"))
+        conductor = _make_conductor(db, str(ics))
+        _seed_room(db, "proj-sync", "SYNC")
+        conductor.refresh()
+        assert db.calendar_event_projects.list_for_project("proj-sync") == []
+
+    def test_r1_non_generic_one_word_room_links(self, db: Database, tmp_path: Path) -> None:
+        """R1: 'Governance' is one word but not generic, so it links
+        'Governance sync'."""
+        ics = tmp_path / "gov.ics"
+        ics.write_bytes(_make_ics(title="Governance sync"))
+        conductor = _make_conductor(db, str(ics))
+        _seed_room(db, "proj-gov", "Governance")
+        conductor.refresh()
+        links = db.calendar_event_projects.list_for_project("proj-gov")
+        assert [l.match_source for l in links] == ["title"]
+
+    def test_r1_partial_phrase_never_links(self, db: Database, tmp_path: Path) -> None:
+        """R1: 'Q4 Platform' does NOT link 'Platform review' -- one word of a
+        multi-word Room name is not the Room's full name."""
+        ics = tmp_path / "partial.ics"
+        ics.write_bytes(_make_ics(title="Platform review"))
+        conductor = _make_conductor(db, str(ics))
+        _seed_room(db, "proj-1", "Q4 Platform")
+        conductor.refresh()
+        assert db.calendar_event_projects.list_for_project("proj-1") == []
+
+    def test_r1_phrase_match_is_punctuation_insensitive(self, db: Database, tmp_path: Path) -> None:
+        """R1: 'Q4 Platform' links 'q4-platform sync' (hyphen, lower case)."""
+        ics = tmp_path / "hyphen.ics"
+        ics.write_bytes(_make_ics(title="q4-platform sync"))
+        conductor = _make_conductor(db, str(ics))
+        _seed_room(db, "proj-1", "Q4 Platform")
+        conductor.refresh()
+        links = db.calendar_event_projects.list_for_project("proj-1")
+        assert [l.match_source for l in links] == ["title"]
+
+    def test_r1_whole_word_bounded(self, db: Database, tmp_path: Path) -> None:
+        """R1: whole-word bounded -- 'Platform' is not a phrase of
+        'Platforms roadmap', and 'Q4 Platform' is not one of 'Q4 Platforms'."""
+        ics = tmp_path / "plural.ics"
+        ics.write_bytes(_make_ics(title="Q4 Platforms roadmap"))
+        conductor = _make_conductor(db, str(ics))
+        _seed_room(db, "proj-plat", "Platform")
+        _seed_room(db, "proj-full", "Q4 Platform")
+        conductor.refresh()
+        assert db.calendar_event_projects.list_for_project("proj-plat") == []
+        assert db.calendar_event_projects.list_for_project("proj-full") == []
 
     def test_longest_match_wins(self, db: Database, tmp_path: Path) -> None:
-        """The matcher prefers the LONGEST matching Room name."""
+        """Two full names present ('Platform' and 'Q4 Platform' both appear
+        whole in 'Q4 Platform Architecture Review'): the LONGER wins."""
         ics = tmp_path / "cal2.ics"
         ics.write_bytes(_make_ics(title="Q4 Platform Architecture Review"))
         conductor = _make_conductor(db, str(ics))


### PR DESCRIPTION
Phase 175 follow-up on the owner's deferral of the seven questions ("The decision is deferred to you"). Ruling R1: auto-link stays, tightened — a Room's full name must appear in the event title as a phrase (whole-word bounded, punctuation-insensitive; longest wins); a one-word generic Room name (design, review, standup, sync, planning, …) never links. Counsel's `Design` / 401k-webinar false positive no longer links. Unlink stays durable.

Also records R1–R7 in `final-summary.md` (R7: the two walk-seed meetings deleted from the owner's database via the product's `meeting_delete`).

Tests: `tests/unit/test_hs175_calendar_wire.py::TestTitleMatcher` (9), the calendar / scheduled-recording set green with isolated HOME.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016siGSBgZph9EhEdGMoyWcu